### PR TITLE
feat: rename `quote` to `intel_quote` in gateway attestation

### DIFF
--- a/crates/api/src/routes/attestation.rs
+++ b/crates/api/src/routes/attestation.rs
@@ -95,7 +95,7 @@ pub struct NvidiaPayload {
 /// Response for attestation report endpoint
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct DstackCpuQuote {
-    pub quote: String,
+    pub intel_quote: String,
     pub event_log: String,
     pub report_data: String,
     pub request_nonce: String,
@@ -105,7 +105,7 @@ pub struct DstackCpuQuote {
 impl From<services::attestation::models::DstackCpuQuote> for DstackCpuQuote {
     fn from(quote: services::attestation::models::DstackCpuQuote) -> Self {
         Self {
-            quote: quote.quote,
+            intel_quote: quote.intel_quote,
             event_log: quote.event_log,
             report_data: quote.report_data,
             request_nonce: quote.request_nonce,
@@ -182,7 +182,7 @@ pub struct VerifyRequest {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct QuoteResponse {
     /// The attestation quote in hexadecimal format
-    pub quote: String,
+    pub intel_quote: String,
     /// The event log associated with the quote
     pub event_log: String,
 }
@@ -190,7 +190,7 @@ pub struct QuoteResponse {
 impl From<services::attestation::models::DstackCpuQuote> for QuoteResponse {
     fn from(response: services::attestation::models::DstackCpuQuote) -> Self {
         Self {
-            quote: response.quote,
+            intel_quote: response.intel_quote,
             event_log: response.event_log,
         }
     }

--- a/crates/services/src/attestation/mod.rs
+++ b/crates/services/src/attestation/mod.rs
@@ -147,7 +147,7 @@ impl ports::AttestationServiceTrait for AttestationService {
         let gateway_attestation;
         if let Ok(_dev) = std::env::var("DEV") {
             gateway_attestation = DstackCpuQuote {
-                quote: "0x1234567890abcdef".to_string(),
+                intel_quote: "0x1234567890abcdef".to_string(),
                 event_log: "0x1234567890abcdef".to_string(),
                 report_data: "0x1234567890abcdef".to_string(),
                 request_nonce: nonce.clone(),

--- a/crates/services/src/attestation/models.rs
+++ b/crates/services/src/attestation/models.rs
@@ -34,7 +34,7 @@ pub struct ChatSignature {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DstackCpuQuote {
     /// The attestation quote in hexadecimal format
-    pub quote: String,
+    pub intel_quote: String,
     /// The event log associated with the quote
     pub event_log: String,
     /// The report data
@@ -53,7 +53,7 @@ impl DstackCpuQuote {
         nonce: String,
     ) -> Self {
         Self {
-            quote: quote.quote,
+            intel_quote: quote.quote,
             event_log: quote.event_log,
             report_data: quote.report_data,
             request_nonce: nonce,


### PR DESCRIPTION
This unify the response format of gateway attestation with model attestation. See the schemas below in TypeScript as a reference.

```ts
const recordSchema = v.record(v.string(), v.unknown());

const gatewayAttestationSchema = v.object({
  request_nonce: v.string(),
  intel_quote: v.string(),
  event_log: v.array(recordSchema),
  info: recordSchema,
});

const attestationSchema = v.object({
const modelAttestationSchema = v.object({
  request_nonce: v.optional(v.string()),
  intel_quote: v.string(),
  event_log: v.optional(v.array(recordSchema)),
  info: v.optional(recordSchema),
  nvidia_payload: v.string(),
  signing_address: v.string(),
});
```