### PR TITLE
fix: gateway attestation report data format

### DIFF
--- a/crates/services/src/attestation/models.rs
+++ b/crates/services/src/attestation/models.rs
@@ -14,6 +14,9 @@ pub enum AttestationError {
     #[error("Client error: {0}")]
     ClientError(String),
 
+    #[error("Invalid parameter: {0}")]
+    InvalidParameter(String),
+
     #[error("Internal error: {0}")]
     InternalError(String),
 }


### PR DESCRIPTION
Fixes #130 

The report data should be in 64 bytes: 
- the first 32 bytes are 0s
- the last 32 bytes are converted from the `nonce` parameter in 64 hex chars
