### PR TITLE
refactor: remove result_filter parameter from service responses

### DIFF
--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -1197,7 +1197,6 @@ impl ResponseServiceImpl {
                                     \n\nIMPORTANT PARAMETERS TO CONSIDER:\
                                     \n- Use 'freshness' for time-sensitive queries (news, recent events, current trends)\
                                     \n- Use 'country' for location-specific information\
-                                    \n- Use 'result_filter' to focus on specific content (news, videos, discussions)\
                                     \n- Use 'count' to limit results when user asks for specific number\
                                     \n- Use 'safesearch' when dealing with sensitive topics".to_string()
                                 ),
@@ -1248,10 +1247,6 @@ impl ResponseServiceImpl {
                                         "spellcheck": {
                                             "type": "boolean",
                                             "description": "Enable spellcheck on query (default: true)"
-                                        },
-                                        "result_filter": {
-                                            "type": "string",
-                                            "description": "Comma-delimited result types: 'news' (for news/updates), 'videos' (for tutorials/demos), 'discussions' (for community opinions/Q&A), 'faq' (for how-to questions). Use to focus on most relevant content type."
                                         },
                                         "units": {
                                             "type": "string",
@@ -1518,11 +1513,6 @@ impl ResponseServiceImpl {
                         if let Some(spellcheck) = params.get("spellcheck").and_then(|v| v.as_bool())
                         {
                             search_params.spellcheck = Some(spellcheck);
-                        }
-                        if let Some(result_filter) =
-                            params.get("result_filter").and_then(|v| v.as_str())
-                        {
-                            search_params.result_filter = Some(result_filter.to_string());
                         }
                         if let Some(units) = params.get("units").and_then(|v| v.as_str()) {
                             search_params.units = Some(units.to_string());

--- a/crates/services/src/responses/tools/brave.rs
+++ b/crates/services/src/responses/tools/brave.rs
@@ -125,12 +125,6 @@ impl WebSearchProviderTrait for BraveWebSearchProvider {
             query_params.push(("spellcheck", spellcheck));
         }
 
-        let result_filter;
-        if let Some(ref rf) = params.result_filter {
-            result_filter = rf.clone();
-            query_params.push(("result_filter", result_filter));
-        }
-
         let units;
         if let Some(ref u) = params.units {
             units = u.clone();

--- a/crates/services/src/responses/tools/ports.rs
+++ b/crates/services/src/responses/tools/ports.rs
@@ -53,10 +53,6 @@ pub struct WebSearchParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spellcheck: Option<bool>,
 
-    /// Comma-delimited string of result types: "discussions", "faq", "infobox", "news", "videos", "web", "locations"
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result_filter: Option<String>,
-
     /// Measurement units: "metric" or "imperial"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub units: Option<String>,


### PR DESCRIPTION
Poor search engine perfomance with result_filter flag. Very few results, most of the time empty response.

* Removed the 'result_filter' parameter from the ResponseServiceImpl and related structures, simplifying the query parameters for web search.
* Updated documentation and code references to reflect this change.