### PR TITLE
fix: set `/etc/shadow` file last password change date to `0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,11 +73,9 @@ RUN --mount=type=bind,source=pinned-packages-runtime.txt,target=/tmp/pinned-pack
         && rm -rf /var/lib/apt/lists/* /var/log/* /var/cache/ldconfig/aux-cache
 
 # Create app user
-RUN useradd -m -u 1000 app
-# Normalize /etc/shadow file last password change date to 0
-RUN awk -F: 'BEGIN{OFS=FS} {$3=0}1' /etc/shadow > /etc/shadow.fixed \
-    && install -m 600 /etc/shadow.fixed /etc/shadow \
-    && rm /etc/shadow.fixed
+# Normalize /etc/shadow file last password change date to 0 for app user
+RUN useradd -m -u 1000 app \
+    && sed -i -r 's/^(app:[^:]*:)[0-9]+/\10/' /etc/shadow
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
We have encountered a reproducible build issue that the `/etc/shadow` file contains the last password change date (days since 1970/01/01, e.g. `20403`) of the `app` user created in Dockerfile. 

The Docker image digest will change if the image is rebuilt on another day after the image is created, because the last password change date is different. The reason that we didn't notice this issue earlier is that we have tried testing the reproducible build on the single day when it's pushed to Docker Hub, but didn't rebuild it in next few days.

This is now fixed by setting the `last password change date` of the `app` user to `0`.

A patch to v0.1.3 has been released from this branch: [v0.1.3-p1](https://github.com/nearai/cloud-api/releases/tag/v0.1.3-p1)

##### `/etc/shadow` from docker image built by CI on Nov 11th, 2025

```
root:*:20381:0:99999:7:::
daemon:*:20381:0:99999:7:::
bin:*:20381:0:99999:7:::
sys:*:20381:0:99999:7:::
sync:*:20381:0:99999:7:::
games:*:20381:0:99999:7:::
man:*:20381:0:99999:7:::
lp:*:20381:0:99999:7:::
mail:*:20381:0:99999:7:::
news:*:20381:0:99999:7:::
uucp:*:20381:0:99999:7:::
proxy:*:20381:0:99999:7:::
www-data:*:20381:0:99999:7:::
backup:*:20381:0:99999:7:::
list:*:20381:0:99999:7:::
irc:*:20381:0:99999:7:::
_apt:*:20381:0:99999:7:::
nobody:*:20381:0:99999:7:::
app:!:20403:0:99999:7:::
```

##### `/etc/shadow` from docker image built by CI on Nov 6th, 2025
```
root:*:20381:0:99999:7:::
daemon:*:20381:0:99999:7:::
bin:*:20381:0:99999:7:::
sys:*:20381:0:99999:7:::
sync:*:20381:0:99999:7:::
games:*:20381:0:99999:7:::
man:*:20381:0:99999:7:::
lp:*:20381:0:99999:7:::
mail:*:20381:0:99999:7:::
news:*:20381:0:99999:7:::
uucp:*:20381:0:99999:7:::
proxy:*:20381:0:99999:7:::
www-data:*:20381:0:99999:7:::
backup:*:20381:0:99999:7:::
list:*:20381:0:99999:7:::
irc:*:20381:0:99999:7:::
_apt:*:20381:0:99999:7:::
nobody:*:20381:0:99999:7:::
app:!:20398:0:99999:7:::
```

##### `/etc/shadow` from docker image after the fix

```
root:*:20381:0:99999:7:::
daemon:*:20381:0:99999:7:::
bin:*:20381:0:99999:7:::
sys:*:20381:0:99999:7:::
sync:*:20381:0:99999:7:::
games:*:20381:0:99999:7:::
man:*:20381:0:99999:7:::
lp:*:20381:0:99999:7:::
mail:*:20381:0:99999:7:::
news:*:20381:0:99999:7:::
uucp:*:20381:0:99999:7:::
proxy:*:20381:0:99999:7:::
www-data:*:20381:0:99999:7:::
backup:*:20381:0:99999:7:::
list:*:20381:0:99999:7:::
irc:*:20381:0:99999:7:::
_apt:*:20381:0:99999:7:::
nobody:*:20381:0:99999:7:::
app:!:0:0:99999:7:::
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize the `app` user's `/etc/shadow` last password change date to `0` during Docker image build.
> 
> - **Dockerfile**:
>   - Modify app user creation to also normalize `/etc/shadow` entry: run `sed` to set the `app` user's last password change date to `0` after `useradd`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ccf8a8a359ebe2b8e0b9c940cabfd735559deeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->