### PR TITLE
Chore: better log format for datadog.

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -75,12 +75,17 @@ fn init_tracing(logging_config: &LoggingConfig) {
             tracing_subscriber::fmt()
                 .json()
                 .with_env_filter(filter)
+                .with_current_span(false)
+                .with_span_list(false)
                 .init();
         }
         "compact" => {
             tracing_subscriber::fmt()
                 .compact()
                 .with_env_filter(filter)
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_thread_names(false)
                 .init();
         }
         "pretty" => {
@@ -90,9 +95,12 @@ fn init_tracing(logging_config: &LoggingConfig) {
                 .init();
         }
         _ => {
+            // Default to JSON format for containerized environments (Datadog friendly)
             tracing_subscriber::fmt()
-                .pretty()
+                .json()
                 .with_env_filter(filter)
+                .with_current_span(false)
+                .with_span_list(false)
                 .init();
         }
     }

--- a/env.example
+++ b/env.example
@@ -29,14 +29,17 @@ MODEL_INFERENCE_TIMEOUT=18000
 # Logging Configuration
 # =============================================================================
 # Global log level: trace, debug, info, warn, error
-LOG_LEVEL=debug
+LOG_LEVEL=info
 
 # Log format: json, compact, pretty
-LOG_FORMAT=compact
+# Use 'json' for containerized environments with Datadog agent
+# Use 'compact' for local development
+# Use 'pretty' for debugging
+LOG_FORMAT=json
 
 # Module-specific log levels (optional)
-LOG_MODULE_API=debug
-LOG_MODULE_SERVICES=debug
+LOG_MODULE_API=info
+LOG_MODULE_SERVICES=info
 
 # =============================================================================
 # DStack Client Configuration


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch logging to Datadog-friendly JSON by default, reduce noise in compact format, and update env.example to info/json defaults.
> 
> - **Logging/Tracing**:
>   - Default fallback format changed to `json` (was `pretty`), with `with_current_span(false)` and `with_span_list(false)` for JSON outputs.
>   - `compact` formatter refined: disable target, thread IDs, and thread names.
> - **Configuration (`env.example`)**:
>   - Set `LOG_LEVEL=info`, `LOG_FORMAT=json`, and module log levels (`LOG_MODULE_API`, `LOG_MODULE_SERVICES`) to `info`.
>   - Add guidance comments for format selection; ensure trailing newline for `BRAVE_SEARCH_PRO_API_KEY`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e67d822251092dac9b13df38eb3c751d30b4a78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->