### PR TITLE
fix: enhance replica state handling in PatroniDiscovery

### DIFF
--- a/crates/database/src/cluster_manager.rs
+++ b/crates/database/src/cluster_manager.rs
@@ -130,6 +130,7 @@ impl ClusterManager {
     /// Update read pools based on current replicas
     async fn update_read_pools(&self) -> Result<()> {
         let replicas = self.discovery.get_replicas().await;
+        debug!("Updating read pools for {} replicas", replicas.len());
         let mut read_pools = self.read_pools.write().await;
 
         // Remove pools for replicas that no longer exist

--- a/crates/database/src/patroni_discovery.rs
+++ b/crates/database/src/patroni_discovery.rs
@@ -107,8 +107,11 @@ impl PatroniDiscovery {
         let mut leader = None;
         let mut replicas = Vec::new();
 
+        // Accept both "running" and "streaming" states as valid for member selection,
+        // since Patroni nodes may report "streaming" when actively replicating data,
+        // and both states indicate a healthy, participating cluster member.
         for member in cluster_info.members {
-            if member.state == "running" {
+            if member.state == "running" || member.state == "streaming" {
                 match member.role.as_str() {
                     "leader" | "master" => {
                         leader = Some(member);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Accepts Patroni members in "streaming" state during discovery and adds a debug log when updating read pools.
> 
> - **PatroniDiscovery (`crates/database/src/patroni_discovery.rs`)**:
>   - Treat `state` of `"streaming"` as valid (in addition to `"running"`) when selecting leader/replicas.
>   - Add clarifying comment about accepted states.
> - **ClusterManager (`crates/database/src/cluster_manager.rs`)**:
>   - Add debug log showing replica count when updating read pools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0486eb73deda3517a345f47192b39a697d8b8a98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->