### PR TITLE
fix: get model attestation with signing algo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,6 +3340,7 @@ dependencies = [
  "reqwest 0.12.24",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",

--- a/crates/inference_providers/Cargo.toml
+++ b/crates/inference_providers/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = "0.3"
 tracing = "0.1"
 dstack-sdk = "0.1.2"
 dstack-sdk-types = "0.1.2"
+serde_urlencoded = "0.7.1"
 
 # Dev dependencies for testing and examples
 [dev-dependencies]


### PR DESCRIPTION
Fix #199

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds signing_algo support and URL-encoded query building to vLLM attestation report request.
> 
> - **Inference Providers (vLLM)**:
>   - Update `get_attestation_report` to accept `signing_algo` and build the query string via `serde_urlencoded` from a serialized `Query` struct (`model`, `signing_algo`, `nonce`, `signing_address`).
>   - Adjust 404 handling to reference `query.signing_address`.
> - **Dependencies**:
>   - Add `serde_urlencoded` to `crates/inference_providers/Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b74ff1a4fca9168f579988bbb1d67be88d219483. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->