### PR TITLE
refactor: update conversation title generation logic

### DIFF
--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -2307,11 +2307,11 @@ DO NOT USE THESE FORMATS:
             .first()
             .and_then(|choice| choice.message.content.as_ref())
             .map(|content| content.trim().to_string());
-        let raw_title = if raw_title.is_none() {
+        let raw_title = if let Some(title) = raw_title {
+            title
+        } else {
             tracing::warn!("LLM response doesn't contain title, using default");
             "Conversation".to_string()
-        } else {
-            raw_title.unwrap().to_string()
         };
 
         // Strip reasoning tags from title


### PR DESCRIPTION
- Removed the model parameter from the conversation title generation function to streamline the process.
- Introduced a new environment variable for the title generation model, enhancing flexibility.
- Adjusted the completion request parameters to increase max tokens and temperature for better title generation.
- Improved error handling for title generation, ensuring a default title is used when generation fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches conversation title generation to an env-configured model, adjusts completion params, and adds safer fallbacks.
> 
> - **Conversation Title Generation (`crates/services/src/responses/service.rs`)**:
>   - Remove `model` arg from `maybe_generate_conversation_title` and `generate_and_update_title`; source model from `TITLE_GENERATION_MODEL` (default `Qwen/Qwen3-30B-A3B-Instruct-2507`).
>   - Update completion request for title generation:
>     - `max_tokens: 150`, `temperature: 1.0`.
>     - Add `extra["chat_template_kwargs"] = { enable_thinking: false }`.
>   - Improve extraction/fallback:
>     - If no title in LLM response, log warning and default to `"Conversation"`.
>   - Clean up: remove now-unused local `model` variable and related parameter wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ba1a3f9702b4c8cc6915222cc28846101136fc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->