### PR TITLE
fix(completions): eliminate race condition in signature storage

### DIFF
--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -367,6 +367,9 @@ where
                             self.state = StreamState::Finalizing(signature_future);
                         }
                         Poll::Ready(Some(Err(ref err))) => {
+                            // Capture error for stop_reason in usage recording (handled in Drop)
+                            // Note: We intentionally skip Finalizing state (attestation) for errors
+                            // because partial completions cannot be verified by clients
                             self.last_error = Some(err.clone());
                             return Poll::Ready(Some(Err(err.clone())));
                         }


### PR DESCRIPTION
Previously, signature and usage data were stored to the database in the
Drop handler after the stream returned None. This created a race condition
where clients could receive [DONE] and immediately try to fetch signatures
before they were persisted, resulting in 404 errors.

This commit introduces a state machine (StreamState) that ensures signature
and usage are stored BEFORE the stream returns None. The stream now:

1. Transitions to a Finalizing state when the inner stream completes
2. Stores signature and usage to DB in parallel (for performance)
3. Only returns None (triggering [DONE]) after finalization completes
4. Includes timeout handling (5s) to prevent indefinite blocking

The Drop handler now only handles abnormal disconnects (client disconnect
mid-stream), where we still record usage for billing but skip signature
storage (incomplete streams have no valid signature).

Additional changes:
- Refactor error handling to be more consistent
- Improve logging for timeout scenarios

This ensures clients can reliably fetch signatures immediately after
receiving [DONE], eliminating the race condition.
