### PR TITLE
fix: reproducible build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/repro-build
     tags:
       - 'v*'
 


### PR DESCRIPTION
It's required to set `SOURCE_DATE_EPOCH=0` for some crates. 

The docker image digest `db6effdef6c139e45b680be9f3c40def73847ea08ac93629fcacb6969be113b0` is now reproducible.