### PR TITLE
fix: support legacy mime types for file upload

### DIFF
--- a/crates/services/src/files/mod.rs
+++ b/crates/services/src/files/mod.rs
@@ -72,9 +72,12 @@ pub const ALLOWED_MIME_TYPES: &[(&str, bool)] = &[
     ("text/plain", true),
     // Markup / documentation
     ("application/xml", true),      // .xml, .xhtml
+    ("text/xml", true),             // .xml (alternative MIME type)
     ("application/x-bibtex", true), // .bib
     // YAML
-    ("application/yaml", true), // .yaml, .yml
+    ("application/yaml", true), // .yaml, .yml (RFC 9512 standard)
+    ("text/yaml", true),        // .yaml, .yml (deprecated but still used)
+    ("text/x-yaml", true),      // .yaml, .yml (deprecated but still used)
     // Web manifests
     ("application/manifest+json", true), // .webmanifest
     // PHP alternative


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands accepted MIME types for uploads to cover common legacy/alternative labels.
> 
> - Adds `text/xml`, `text/yaml`, and `text/x-yaml` to `ALLOWED_MIME_TYPES`
> - Notes `application/yaml` as RFC 9512 standard in comments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f8133fcd4d6f32255540ac9a5e3b8137d1b7b0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->