### PR TITLE
docs: image generations endpoint

### DIFF
--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -139,6 +139,8 @@ use utoipa::{Modify, OpenApi};
             // Core API models
             ChatCompletionRequest, ChatCompletionResponse, Message,
             CompletionRequest, ModelsResponse, ModelInfo, ModelPricing, ErrorResponse,
+            // Image generation models
+            ImageGenerationRequest, ImageGenerationResponse, ImageData,
             // Organization models
             CreateOrganizationRequest, OrganizationResponse,
             UpdateOrganizationRequest, CreateApiKeyRequest, ApiKeyResponse,


### PR DESCRIPTION
Add the `/images/generations` endpoint to API docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates OpenAPI to include image generation documentation.
> 
> - Adds `Images` tag to categorize image generation endpoints
> - Registers `crate::routes::completions::image_generations` to expose `/images/generations`
> - Includes `ImageGenerationRequest`, `ImageGenerationResponse`, and `ImageData` in components schemas
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5b995872c696ac0e2e9dd314d7edfcc6fab3878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->