### PR TITLE
Fix panic on multi byte utf8.

### DIFF
--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -2129,8 +2129,9 @@ impl ResponseServiceImpl {
 
         // Truncate user message for title generation (max 500 chars for context)
         // Use iterator to safely handle UTF-8 (cannot panic)
-        let truncated_message: String = user_message.chars().take(500).collect();
-        let truncated_message = if truncated_message.len() < user_message.len() {
+        let mut chars = user_message.chars();
+        let truncated_message: String = chars.by_ref().take(500).collect();
+        let truncated_message = if chars.next().is_some() {
             format!("{truncated_message}...")
         } else {
             truncated_message
@@ -2209,8 +2210,9 @@ impl ResponseServiceImpl {
         };
 
         // Truncate to max 60 characters (iterator approach cannot panic)
-        let title: String = generated_title.chars().take(57).collect();
-        let title = if title.len() < generated_title.len() {
+        let mut chars = generated_title.chars();
+        let title: String = chars.by_ref().take(57).collect();
+        let title = if chars.next().is_some() {
             format!("{title}...")
         } else {
             generated_title
@@ -3172,8 +3174,9 @@ mod tests {
 
         // Helper mimicking the fixed truncation logic
         fn truncate_safe(s: &str, max_chars: usize) -> String {
-            let truncated: String = s.chars().take(max_chars).collect();
-            if truncated.len() < s.len() {
+            let mut chars = s.chars();
+            let truncated: String = chars.by_ref().take(max_chars).collect();
+            if chars.next().is_some() {
                 format!("{truncated}...")
             } else {
                 truncated


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens conversation title generation to be UTF-8 safe and adds regression coverage.
> 
> - Replace byte-slice truncation with character-iterator truncation for `user_message` (500 chars) and generated titles (60 chars) to avoid panics on multi-byte characters; append `...` only when actually truncated
> - Add `test_utf8_truncation_does_not_panic` covering Chinese characters and emoji boundaries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ce48cb89b2d3b260b20574936c3c4a3d19b595d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->