### PR TITLE
fix: parallel tool calls by deferring citation instructions

### DIFF
--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -1227,7 +1227,15 @@ impl ResponseServiceImpl {
                         // Continue processing tool calls
                     }
                     tools::ToolExecutionResult::ApprovalRequired => {
-                        // MCP tool requires approval - pause the agent loop
+                        // MCP tool requires approval - flush any deferred instructions before pausing
+                        if !deferred_instructions.is_empty() {
+                            messages.push(CompletionMessage {
+                                role: "system".to_string(),
+                                content: std::mem::take(&mut deferred_instructions).join("\n\n"),
+                                tool_call_id: None,
+                                tool_calls: None,
+                            });
+                        }
                         return Ok(AgentLoopResult::ApprovalRequired);
                     }
                 }


### PR DESCRIPTION
For parallel tool calls (e.g., multiple web searches), all providers (OpenAI, Anthropic, Gemini) require tool results to be consecutive after the assistant message with tool_calls.

Previously, citation instructions were added immediately after each tool result, which broke the consecutive sequence:
- tool result 1
- system message (citation)  <-- breaks sequence
- tool result 2

Now, citation instructions are collected during tool execution and added AFTER all tool results:
- tool result 1
- tool result 2
- system message (citation)