### PR TITLE
fix: add failed conversation item when response initially failed

### DIFF
--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -988,6 +988,8 @@ impl ResponseServiceImpl {
             Err(e)
                 if final_response.output.is_empty() && final_response.usage.total_tokens == 0 =>
             {
+                // Include error message in content so users can understand why it failed
+                let error_message = e.to_string();
                 let failed_item = models::ResponseOutputItem::Message {
                     id: format!("msg_{}", Uuid::new_v4().simple()),
                     response_id: ctx.response_id_str.clone(),
@@ -996,7 +998,11 @@ impl ResponseServiceImpl {
                     created_at: ctx.created_at,
                     status: models::ResponseItemStatus::Failed,
                     role: "assistant".to_string(),
-                    content: vec![],
+                    content: vec![models::ResponseContentItem::OutputText {
+                        text: error_message,
+                        annotations: vec![],
+                        logprobs: vec![],
+                    }],
                     model: ctx.model.clone(),
                     metadata: None,
                 };


### PR DESCRIPTION
Fix #405 

## Summary

When inference **fails at the start** (no output, no usage), we used to emit an empty `response.completed`. We now emit `response.failed` and keep DB and stream events consistent.

## Changes

- **Events**: When there is no output and no usage, `process_response_stream` returns `Err(e)` so the caller sends `response.failed` instead of an empty `response.completed`.
- **DB**: In that case we set the response **status to Failed** and create one assistant message item with **status=Failed, content=[]**, so the response has an output item instead of only input items.
- **Optimization**: Use `is_initial_failure` so the first update (Completed + usage) runs only when it’s not an initial failure; for initial failure we do a single update to Failed and avoid updating twice (Completed then Failed).

## Behavior

| Scenario           | Event                | Response status | Output item       |
|--------------------|----------------------|-----------------|-------------------|
| Fail at start      | response.failed      | Failed          | 1 failed item     |
| Midway failure     | response.completed  | Completed       | Partial items     |
| Normal completion  | response.completed  | Completed       | Full items            |