### PR TITLE
feat: accept developer message role, mapping to system for providers

### DIFF
--- a/crates/api/src/conversions.rs
+++ b/crates/api/src/conversions.rs
@@ -21,7 +21,7 @@ impl From<crate::models::Message> for ChatMessage {
 
         Self {
             role: match msg.role.as_str() {
-                "system" => MessageRole::System,
+                "system" | "developer" => MessageRole::System,
                 "user" => MessageRole::User,
                 "assistant" => MessageRole::Assistant,
                 "tool" => MessageRole::Tool,
@@ -628,6 +628,20 @@ mod tests {
             back_to_http.content,
             Some(crate::models::MessageContent::Text("Hello".to_string()))
         );
+    }
+
+    #[test]
+    fn test_developer_role_maps_to_system() {
+        let http_msg = crate::models::Message {
+            role: "developer".to_string(),
+            content: Some(crate::models::MessageContent::Text(
+                "You are helpful.".to_string(),
+            )),
+            name: None,
+        };
+
+        let domain_msg: ChatMessage = http_msg.into();
+        assert!(matches!(domain_msg.role, MessageRole::System));
     }
 
     #[test]

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -780,7 +780,9 @@ impl ChatCompletionRequest {
             if message.role.is_empty() {
                 return Err("message role is required".to_string());
             }
-            if !["system", "user", "assistant", "tool"].contains(&message.role.as_str()) {
+            if !["system", "developer", "user", "assistant", "tool"]
+                .contains(&message.role.as_str())
+            {
                 return Err(format!("invalid message role: {}", message.role));
             }
             // Validate message content can be serialized (catches malformed multimodal content)

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -625,7 +625,7 @@ impl CompletionServiceImpl {
 
                 ChatMessage {
                     role: match msg.role.as_str() {
-                        "system" => MessageRole::System,
+                        "system" | "developer" => MessageRole::System,
                         "assistant" => MessageRole::Assistant,
                         "tool" => MessageRole::Tool,
                         _ => MessageRole::User,


### PR DESCRIPTION
The OpenAI API introduced the "developer" role as a replacement for "system" starting with o1 models. This accepts "developer" as a valid role in chat completions and maps it to system internally, ensuring compatibility with all inference providers (vLLM, Anthropic, Gemini).