### PR TITLE
fix: sum all active spend limits in admin display queries

### DIFF
--- a/crates/database/src/repositories/admin_composite.rs
+++ b/crates/database/src/repositories/admin_composite.rs
@@ -411,12 +411,10 @@ impl AdminRepository for AdminCompositeRepository {
                     ob.total_tokens
                 FROM organizations o
                 LEFT JOIN LATERAL (
-                    SELECT spend_limit
+                    SELECT SUM(spend_limit) as spend_limit
                     FROM organization_limits_history
                     WHERE organization_id = o.id
                       AND effective_until IS NULL
-                    ORDER BY effective_from DESC
-                    LIMIT 1
                 ) olh ON true
                 LEFT JOIN organization_balance ob ON o.id = ob.organization_id
                 WHERE o.is_active = true

--- a/crates/database/src/repositories/user.rs
+++ b/crates/database/src/repositories/user.rs
@@ -324,12 +324,10 @@ impl UserRepository {
             LEFT JOIN organization_members om ON u.id = om.user_id AND om.role = 'owner'
             LEFT JOIN organizations o ON om.organization_id = o.id AND o.is_active = true
             LEFT JOIN LATERAL (
-                SELECT spend_limit
+                SELECT SUM(spend_limit) as spend_limit
                 FROM organization_limits_history
                 WHERE organization_id = o.id
                   AND effective_until IS NULL
-                ORDER BY effective_from DESC
-                LIMIT 1
             ) olh ON true
             LEFT JOIN organization_balance ob ON o.id = ob.organization_id
             WHERE u.is_active = true


### PR DESCRIPTION
## Summary
- Admin display queries (`list_all_organizations`, `list_with_organizations`) used `LIMIT 1 ORDER BY effective_from DESC` to fetch org spend limits, showing only the most recent active record
- When an org has both a **payment** credit ($25) and a **grant** ($45), the admin showed $25 instead of the correct total $70
- Changed lateral joins to use `SUM(spend_limit)` across all active limits, matching the runtime enforcement in `organization_limits_repository_impl.rs:18` which already correctly SUMs

## Root Cause
The DB schema (migration V0044) supports one active limit per `(organization_id, credit_type)` — so `payment` and `grant` can coexist. The runtime enforcement correctly SUMs both, but the admin display only picked the newest record.

## Files Changed
- `crates/database/src/repositories/admin_composite.rs` — `list_all_organizations()` lateral join
- `crates/database/src/repositories/user.rs` — `list_with_organizations()` lateral join

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --lib` — 171 tests pass
- [ ] Manual verification: org with payment + grant should show SUM in admin
- [ ] Verify orgs with only one credit type still display correctly
- [ ] Verify orgs with no active limits show NULL (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)