### PR TITLE
fix: prevent infinite SSE error loop and remove aggressive read_timeout

### DIFF
--- a/crates/inference_providers/src/sse_parser.rs
+++ b/crates/inference_providers/src/sse_parser.rs
@@ -446,10 +446,8 @@ mod tests {
             state: Arc::new(AtomicU8::new(0)),
         };
 
-        let parser = BufferedSSEParser::<_, OpenAIEventParser>::new(
-            stream,
-            OpenAIParserState::new(true),
-        );
+        let parser =
+            BufferedSSEParser::<_, OpenAIEventParser>::new(stream, OpenAIParserState::new(true));
         let events: Vec<_> = parser.collect().await;
 
         // Should have exactly 1 event (the good chunk).

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -288,6 +288,7 @@ impl InferenceProvider for VLlmProvider {
             .post(&url)
             .headers(headers)
             .json(&streaming_params)
+            .timeout(Duration::from_secs(self.config.timeout_seconds as u64))
             .send()
             .await
             .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
@@ -397,6 +398,7 @@ impl InferenceProvider for VLlmProvider {
             .post(&url)
             .headers(headers)
             .json(&streaming_params)
+            .timeout(Duration::from_secs(self.config.timeout_seconds as u64))
             .send()
             .await
             .map_err(|e| CompletionError::CompletionError(e.to_string()))?;


### PR DESCRIPTION
## Summary

- **SSE parser terminates after stream errors** — Added `finished` flag to `BufferedSSEParser` that prevents polling a broken byte stream repeatedly. Before this fix, a single read timeout would cause the parser to infinitely emit error lines, producing multi-GB responses of repeated `data: error: Failed to perform completion: error decoding response body` messages.
- **Removed `read_timeout` from vLLM HTTP client** — The 30s `read_timeout` applied to every individual chunk read during SSE streaming. Under concurrent load, inter-chunk gaps can exceed this threshold, causing spurious failures. External providers (Anthropic, OpenAI, Gemini) do not set `read_timeout`, only `connect_timeout` and `pool_idle_timeout`.
- **Added per-request timeouts to non-streaming methods** — After removing the client-level `read_timeout`, added explicit `.timeout()` to `get_signature`, `get_attestation_report`, `models`, and `chat_completion` to prevent hanging connections. Streaming methods intentionally omit per-request timeout since it would kill long-running SSE streams.

## Root cause analysis

Tested all 5 direct sglang backends with 20 concurrent requests each (100 total) — **0 errors**. Same test through the gateway — **4/20 errors (20%)**. The gateway's `read_timeout` was triggering under load, and the SSE parser was then stuck in an infinite error loop.

## Test plan

- [x] All 78 `inference_providers` lib tests pass (including new `test_sse_parser_terminates_after_stream_error`)
- [x] All 190 `services` lib tests pass
- [x] `api` crate compiles cleanly
- [x] Manual load test: 20 concurrent streaming requests through local gateway — 0 errors
- [x] Manual load test: 20 concurrent streaming requests through production gateway (unfixed) — 4 errors (confirms fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)