### PR TITLE
ci: allow force push to staging during freeze window

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build & Deploy
 on:
   workflow_dispatch:
+    inputs:
+      force_staging:
+        description: 'Force push to staging even during freeze window'
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -54,9 +60,10 @@ jobs:
           # Skip staging tag on Tuesday (2) and Wednesday (3) — staging is frozen
           # for prod-candidate testing until Thursday promotion
           if [[ "${GITHUB_REF_NAME}" == 'main' ]]; then
+            FORCE_STAGING="${{ github.event.inputs.force_staging }}"
             DAY_OF_WEEK=$(date -u +%u)
-            if [[ "$DAY_OF_WEEK" -ge 2 && "$DAY_OF_WEEK" -le 3 ]]; then
-              echo "Staging frozen (day $DAY_OF_WEEK) — skipping :staging tag"
+            if [[ "$DAY_OF_WEEK" -ge 2 && "$DAY_OF_WEEK" -le 3 ]] && [[ "$FORCE_STAGING" != 'true' ]]; then
+              echo "Staging frozen (day $DAY_OF_WEEK) — skipping :staging tag (use force_staging to override)"
             else
               echo "ALSO_TAG_STAGING=true" >> "$GITHUB_ENV"
             fi


### PR DESCRIPTION
## Summary
- Adds `force_staging` boolean input to the Build & Deploy workflow_dispatch trigger
- When `true`, overrides the Tue/Wed staging freeze and pushes the `:staging` tag
- Normal push-to-main behavior is unchanged (freeze still applies automatically)

## Test plan
- [ ] Run workflow_dispatch on a Tue/Wed with `force_staging=true` and verify `:staging` tag is pushed
- [ ] Run workflow_dispatch on a Tue/Wed without the flag and verify freeze still applies