### PR TITLE
feat: TDX attestation verification + TLS SPKI fingerprint pinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -166,7 +166,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "serde",
  "serde_with",
@@ -220,7 +220,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -250,7 +250,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 2.1.1",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
@@ -443,7 +443,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
- "derive_more",
+ "derive_more 2.1.1",
  "nybbles",
  "serde",
  "smallvec",
@@ -494,7 +494,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-test",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "config",
@@ -800,6 +800,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "asn1_der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
 name = "async-lock"
@@ -1414,6 +1420,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -2121,6 +2133,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "dcap-qvl"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e7842b81018f3b991dc65ec0a95ff347332de58478c4ac43459095af00cc89"
+dependencies = [
+ "anyhow",
+ "asn1_der",
+ "base64 0.22.1",
+ "borsh",
+ "byteorder",
+ "chrono",
+ "const-oid",
+ "dcap-qvl-webpki",
+ "der 0.7.10",
+ "derive_more 2.1.1",
+ "futures",
+ "hex",
+ "log",
+ "p256 0.13.2",
+ "parity-scale-codec",
+ "pem",
+ "reqwest 0.12.28",
+ "ring",
+ "rustls-pki-types",
+ "scale-info",
+ "serde",
+ "serde-human-bytes",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "tracing",
+ "urlencoding",
+ "wasm-bindgen-futures",
+ "x509-cert",
+]
+
+[[package]]
+name = "dcap-qvl-webpki"
+version = "0.103.4+dcap.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0af040afe66c4f26ca05f308482d98bd75a35a80a227d877c2e28c9947a9fa6"
+dependencies = [
+ "ecdsa 0.16.9",
+ "ed25519-dalek",
+ "p256 0.13.2",
+ "p384",
+ "ring",
+ "rsa",
+ "rustls-pki-types",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "untrusted",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,11 +2307,31 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2548,7 +2635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3010,7 +3097,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.4.0",
@@ -3327,7 +3414,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3338,7 +3425,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3539,8 +3626,11 @@ dependencies = [
  "dstack-sdk-types",
  "futures-core",
  "futures-util",
+ "hex",
  "regex",
  "reqwest 0.12.28",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3551,6 +3641,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "uuid",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -3680,7 +3771,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.16",
  "hmac 0.12.1",
@@ -3994,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42e581e637caa8ca9f3dc86936606f3a87ab55211fbf76dcf98725c4f4854211"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bip39",
  "borsh",
  "futures",
@@ -4019,7 +4110,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "676c29c763f46fa05bdbc113e1f83ed22f328038f74a5730989aa163de6fb83c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "borsh",
  "bs58",
  "ed25519-dalek",
@@ -4236,7 +4327,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http 1.4.0",
@@ -4536,7 +4627,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -4701,7 +4792,7 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbef655056b916eb868048276cfd5d6a7dea4f81560dfd047f97c8c6fe3fcfd4"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -4945,7 +5036,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4982,7 +5073,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5221,7 +5312,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -5273,7 +5364,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5368,7 +5459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "http 1.4.0",
@@ -5414,6 +5505,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -5518,7 +5610,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5589,7 +5681,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5651,6 +5743,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5881,6 +5998,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-human-bytes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a091af6294712930d01e375cce513e4ac416f823e033e8991ec4e5d6e6ef4c0"
+dependencies = [
+ "base64 0.13.1",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5927,6 +6055,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -5972,7 +6101,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -6042,11 +6171,12 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
- "base64",
+ "base64 0.22.1",
  "bloomfilter",
  "bytes",
  "chrono",
  "config",
+ "dcap-qvl",
  "dstack-sdk",
  "dstack-sdk-types",
  "ed25519-dalek",
@@ -6442,7 +6572,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6807,7 +6937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -7425,7 +7555,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -592,11 +592,11 @@ impl ExternalProvidersConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(300);
 
-        // Refresh interval for external providers (default 15 minutes)
+        // Refresh interval for external providers (default 5 minutes)
         let refresh_interval_secs = env::var("EXTERNAL_PROVIDER_REFRESH_INTERVAL")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(900);
+            .unwrap_or(300);
 
         Self {
             openai_api_key,

--- a/crates/inference_providers/Cargo.toml
+++ b/crates/inference_providers/Cargo.toml
@@ -18,6 +18,10 @@ tokio-stream = "0.1"
 tokio = { version = "1.50", features = ["full"] }
 thiserror = "2.0"
 reqwest = { version = "0.12", features = ["json", "stream", "multipart", "rustls-tls-native-roots"] }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+rustls-native-certs = "0.8"
+x509-parser = "0.18"
+hex = "0.4"
 futures-util = "0.3"
 tracing = "0.1"
 dstack-sdk = "0.1.2"

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -57,6 +57,7 @@ pub mod chunk_builder;
 pub mod external;
 pub mod mock;
 pub mod models;
+pub mod spki_verifier;
 pub mod sse_parser;
 pub mod vllm;
 

--- a/crates/inference_providers/src/spki_verifier.rs
+++ b/crates/inference_providers/src/spki_verifier.rs
@@ -131,7 +131,11 @@ pub fn build_rustls_config_with_verifier(
     expected_fingerprints: Arc<RwLock<HashSet<String>>>,
 ) -> rustls::ClientConfig {
     let mut root_store = rustls::RootCertStore::empty();
-    for cert in rustls_native_certs::load_native_certs().expect("failed to load native certs") {
+    let native = rustls_native_certs::load_native_certs();
+    for err in &native.errors {
+        tracing::warn!("error loading native root cert: {err}");
+    }
+    for cert in native.certs {
         root_store.add(cert).ok();
     }
 

--- a/crates/inference_providers/src/spki_verifier.rs
+++ b/crates/inference_providers/src/spki_verifier.rs
@@ -4,9 +4,10 @@
 //! and additionally checks the server certificate's SPKI SHA-256 fingerprint against
 //! a dynamically-updatable set of expected fingerprints.
 //!
-//! Bootstrap mode: when the expected fingerprints set is empty, fingerprint checking
-//! is skipped and any valid (WebPKI-verified) certificate is accepted. Once attestation
-//! verification populates the set, all new TLS connections are pinned.
+//! States:
+//! - Bootstrap: no fingerprints known yet, accept any valid (WebPKI) cert
+//! - Pinned: only accept certs whose SPKI fingerprint is in the verified set
+//! - Blocked: attestation failed, reject all connections
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
@@ -14,6 +15,56 @@ use rustls::{DigitallySignedStruct, Error as TlsError, SignatureScheme};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
+
+/// TLS fingerprint verification state.
+#[derive(Debug, Clone)]
+pub enum FingerprintState {
+    /// Initial state — accept any valid (WebPKI-verified) certificate.
+    /// Used during the first attestation fetch before fingerprints are known.
+    Bootstrap,
+    /// Attestation verified — only accept certificates with these SPKI fingerprints.
+    Pinned(HashSet<String>),
+    /// Attestation failed — reject all TLS connections.
+    Blocked,
+}
+
+impl FingerprintState {
+    /// Add a verified fingerprint. Transitions Bootstrap → Pinned, or adds to existing Pinned set.
+    pub fn add_fingerprint(&mut self, fingerprint: String) {
+        match self {
+            FingerprintState::Bootstrap => {
+                let mut set = HashSet::new();
+                set.insert(fingerprint);
+                *self = FingerprintState::Pinned(set);
+            }
+            FingerprintState::Pinned(set) => {
+                set.insert(fingerprint);
+            }
+            FingerprintState::Blocked => {
+                // Unblock: attestation succeeded after earlier failure
+                let mut set = HashSet::new();
+                set.insert(fingerprint);
+                *self = FingerprintState::Pinned(set);
+            }
+        }
+    }
+
+    /// Block all connections (attestation failed).
+    pub fn block(&mut self) {
+        if matches!(self, FingerprintState::Bootstrap) {
+            *self = FingerprintState::Blocked;
+        }
+        // Don't block if already Pinned — keep existing verified fingerprints
+    }
+
+    /// Number of pinned fingerprints (0 for Bootstrap/Blocked).
+    pub fn pinned_count(&self) -> usize {
+        match self {
+            FingerprintState::Pinned(set) => set.len(),
+            _ => 0,
+        }
+    }
+}
 
 /// Compute SHA-256 of the SPKI (Subject Public Key Info) DER from an X.509 certificate.
 pub fn compute_spki_fingerprint_from_der(cert_der: &[u8]) -> Result<String, String> {
@@ -25,39 +76,30 @@ pub fn compute_spki_fingerprint_from_der(cert_der: &[u8]) -> Result<String, Stri
 }
 
 /// A TLS certificate verifier that wraps WebPKI verification and additionally
-/// checks the server certificate's SPKI SHA-256 fingerprint against an expected set.
-///
-/// When `expected_fingerprints` is empty, fingerprint checking is skipped (bootstrap mode).
-/// When populated, the server cert's SPKI fingerprint must be in the set.
+/// checks the server certificate's SPKI SHA-256 fingerprint against a typed state.
 pub struct SpkiFingerprintVerifier {
     inner: Arc<dyn ServerCertVerifier>,
-    expected_fingerprints: Arc<RwLock<HashSet<String>>>,
+    state: Arc<RwLock<FingerprintState>>,
 }
 
 impl std::fmt::Debug for SpkiFingerprintVerifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SpkiFingerprintVerifier")
             .field(
-                "expected_fingerprints_count",
+                "state",
                 &self
-                    .expected_fingerprints
+                    .state
                     .read()
-                    .map(|s| s.len())
-                    .unwrap_or(0),
+                    .map(|s| format!("{s:?}"))
+                    .unwrap_or_default(),
             )
             .finish()
     }
 }
 
 impl SpkiFingerprintVerifier {
-    pub fn new(
-        inner: Arc<dyn ServerCertVerifier>,
-        expected_fingerprints: Arc<RwLock<HashSet<String>>>,
-    ) -> Self {
-        Self {
-            inner,
-            expected_fingerprints,
-        }
+    pub fn new(inner: Arc<dyn ServerCertVerifier>, state: Arc<RwLock<FingerprintState>>) -> Self {
+        Self { inner, state }
     }
 }
 
@@ -79,26 +121,27 @@ impl ServerCertVerifier for SpkiFingerprintVerifier {
             now,
         )?;
 
-        // Check SPKI fingerprint against expected set
-        let fps = self
-            .expected_fingerprints
-            .read()
-            .unwrap_or_else(|e| e.into_inner());
+        let state = self.state.read().unwrap_or_else(|e| e.into_inner());
 
-        if fps.is_empty() {
-            // Bootstrap mode: no fingerprints known yet, accept any valid cert
-            return Ok(ServerCertVerified::assertion());
-        }
+        match &*state {
+            FingerprintState::Bootstrap => Ok(ServerCertVerified::assertion()),
+            FingerprintState::Blocked => Err(TlsError::General(
+                "TLS connections blocked: attestation verification failed".to_string(),
+            )),
+            FingerprintState::Pinned(fps) => {
+                let spki_hash =
+                    compute_spki_fingerprint_from_der(end_entity.as_ref()).map_err(|e| {
+                        TlsError::General(format!("failed to compute SPKI fingerprint: {e}"))
+                    })?;
 
-        let spki_hash = compute_spki_fingerprint_from_der(end_entity.as_ref())
-            .map_err(|e| TlsError::General(format!("failed to compute SPKI fingerprint: {e}")))?;
-
-        if fps.contains(&spki_hash) {
-            Ok(ServerCertVerified::assertion())
-        } else {
-            Err(TlsError::General(format!(
-                "TLS certificate SPKI fingerprint {spki_hash} does not match any attested fingerprint"
-            )))
+                if fps.contains(&spki_hash) {
+                    Ok(ServerCertVerified::assertion())
+                } else {
+                    Err(TlsError::General(format!(
+                        "TLS certificate SPKI fingerprint {spki_hash} does not match any attested fingerprint"
+                    )))
+                }
+            }
         }
     }
 
@@ -126,9 +169,9 @@ impl ServerCertVerifier for SpkiFingerprintVerifier {
 }
 
 /// Build a `rustls::ClientConfig` using native root certificates and a custom
-/// `SpkiFingerprintVerifier` that pins to the given set of expected fingerprints.
+/// `SpkiFingerprintVerifier` that pins to the given fingerprint state.
 pub fn build_rustls_config_with_verifier(
-    expected_fingerprints: Arc<RwLock<HashSet<String>>>,
+    state: Arc<RwLock<FingerprintState>>,
 ) -> rustls::ClientConfig {
     let mut root_store = rustls::RootCertStore::empty();
     let native = rustls_native_certs::load_native_certs();
@@ -148,7 +191,7 @@ pub fn build_rustls_config_with_verifier(
     .build()
     .expect("failed to build WebPKI verifier");
 
-    let verifier = SpkiFingerprintVerifier::new(default_verifier, expected_fingerprints);
+    let verifier = SpkiFingerprintVerifier::new(default_verifier, state);
 
     let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
         .with_safe_default_protocol_versions()
@@ -170,5 +213,35 @@ mod tests {
     fn test_compute_spki_fingerprint_invalid_der() {
         let result = compute_spki_fingerprint_from_der(b"not a cert");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fingerprint_state_transitions() {
+        let mut state = FingerprintState::Bootstrap;
+        assert_eq!(state.pinned_count(), 0);
+
+        state.add_fingerprint("abc".to_string());
+        assert_eq!(state.pinned_count(), 1);
+        assert!(matches!(state, FingerprintState::Pinned(_)));
+
+        state.add_fingerprint("def".to_string());
+        assert_eq!(state.pinned_count(), 2);
+
+        // Block doesn't override Pinned
+        state.block();
+        assert_eq!(state.pinned_count(), 2);
+    }
+
+    #[test]
+    fn test_fingerprint_state_block_from_bootstrap() {
+        let mut state = FingerprintState::Bootstrap;
+        state.block();
+        assert!(matches!(state, FingerprintState::Blocked));
+        assert_eq!(state.pinned_count(), 0);
+
+        // Adding a fingerprint unblocks
+        state.add_fingerprint("abc".to_string());
+        assert!(matches!(state, FingerprintState::Pinned(_)));
+        assert_eq!(state.pinned_count(), 1);
     }
 }

--- a/crates/inference_providers/src/spki_verifier.rs
+++ b/crates/inference_providers/src/spki_verifier.rs
@@ -1,0 +1,167 @@
+//! TLS SPKI fingerprint verification for inference provider connections.
+//!
+//! Provides a custom rustls `ServerCertVerifier` that wraps the default WebPKI verifier
+//! and additionally checks the server certificate's SPKI SHA-256 fingerprint against
+//! a dynamically-updatable set of expected fingerprints.
+//!
+//! Bootstrap mode: when the expected fingerprints set is empty, fingerprint checking
+//! is skipped and any valid (WebPKI-verified) certificate is accepted. Once attestation
+//! verification populates the set, all new TLS connections are pinned.
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, Error as TlsError, SignatureScheme};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+
+/// Compute SHA-256 of the SPKI (Subject Public Key Info) DER from an X.509 certificate.
+pub fn compute_spki_fingerprint_from_der(cert_der: &[u8]) -> Result<String, String> {
+    let (_, cert) = x509_parser::parse_x509_certificate(cert_der)
+        .map_err(|e| format!("failed to parse X.509 DER: {e}"))?;
+    let spki_der = cert.tbs_certificate.subject_pki.raw;
+    let hash = Sha256::digest(spki_der);
+    Ok(hex::encode(hash))
+}
+
+/// A TLS certificate verifier that wraps WebPKI verification and additionally
+/// checks the server certificate's SPKI SHA-256 fingerprint against an expected set.
+///
+/// When `expected_fingerprints` is empty, fingerprint checking is skipped (bootstrap mode).
+/// When populated, the server cert's SPKI fingerprint must be in the set.
+pub struct SpkiFingerprintVerifier {
+    inner: Arc<dyn ServerCertVerifier>,
+    expected_fingerprints: Arc<RwLock<HashSet<String>>>,
+}
+
+impl std::fmt::Debug for SpkiFingerprintVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpkiFingerprintVerifier")
+            .field(
+                "expected_fingerprints_count",
+                &self
+                    .expected_fingerprints
+                    .read()
+                    .map(|s| s.len())
+                    .unwrap_or(0),
+            )
+            .finish()
+    }
+}
+
+impl SpkiFingerprintVerifier {
+    pub fn new(
+        inner: Arc<dyn ServerCertVerifier>,
+        expected_fingerprints: Arc<RwLock<HashSet<String>>>,
+    ) -> Self {
+        Self {
+            inner,
+            expected_fingerprints,
+        }
+    }
+}
+
+impl ServerCertVerifier for SpkiFingerprintVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, TlsError> {
+        // First, run the standard WebPKI verification (CA chain, expiry, etc.)
+        self.inner
+            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)?;
+
+        // Check SPKI fingerprint against expected set
+        let fps = self
+            .expected_fingerprints
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+
+        if fps.is_empty() {
+            // Bootstrap mode: no fingerprints known yet, accept any valid cert
+            return Ok(ServerCertVerified::assertion());
+        }
+
+        let spki_hash = compute_spki_fingerprint_from_der(end_entity.as_ref()).map_err(|e| {
+            TlsError::General(format!("failed to compute SPKI fingerprint: {e}"))
+        })?;
+
+        if fps.contains(&spki_hash) {
+            Ok(ServerCertVerified::assertion())
+        } else {
+            Err(TlsError::General(format!(
+                "TLS certificate SPKI fingerprint {spki_hash} does not match any attested fingerprint"
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TlsError> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.inner.supported_verify_schemes()
+    }
+}
+
+/// Build a `rustls::ClientConfig` using native root certificates and a custom
+/// `SpkiFingerprintVerifier` that pins to the given set of expected fingerprints.
+pub fn build_rustls_config_with_verifier(
+    expected_fingerprints: Arc<RwLock<HashSet<String>>>,
+) -> rustls::ClientConfig {
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in rustls_native_certs::load_native_certs().expect("failed to load native certs") {
+        root_store.add(cert).ok();
+    }
+
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+
+    let default_verifier =
+        rustls::client::WebPkiServerVerifier::builder_with_provider(
+            Arc::new(root_store),
+            Arc::new(provider.clone()),
+        )
+        .build()
+        .expect("failed to build WebPKI verifier");
+
+    let verifier = SpkiFingerprintVerifier::new(default_verifier, expected_fingerprints);
+
+    let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+        .with_safe_default_protocol_versions()
+        .expect("failed to set protocol versions")
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(verifier))
+        .with_no_client_auth();
+
+    // reqwest negotiates ALPN; without this, HTTP/2 and HTTP/1.1 won't work
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_spki_fingerprint_invalid_der() {
+        let result = compute_spki_fingerprint_from_der(b"not a cert");
+        assert!(result.is_err());
+    }
+}

--- a/crates/inference_providers/src/spki_verifier.rs
+++ b/crates/inference_providers/src/spki_verifier.rs
@@ -71,8 +71,13 @@ impl ServerCertVerifier for SpkiFingerprintVerifier {
         now: UnixTime,
     ) -> Result<ServerCertVerified, TlsError> {
         // First, run the standard WebPKI verification (CA chain, expiry, etc.)
-        self.inner
-            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)?;
+        self.inner.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        )?;
 
         // Check SPKI fingerprint against expected set
         let fps = self
@@ -85,9 +90,8 @@ impl ServerCertVerifier for SpkiFingerprintVerifier {
             return Ok(ServerCertVerified::assertion());
         }
 
-        let spki_hash = compute_spki_fingerprint_from_der(end_entity.as_ref()).map_err(|e| {
-            TlsError::General(format!("failed to compute SPKI fingerprint: {e}"))
-        })?;
+        let spki_hash = compute_spki_fingerprint_from_der(end_entity.as_ref())
+            .map_err(|e| TlsError::General(format!("failed to compute SPKI fingerprint: {e}")))?;
 
         if fps.contains(&spki_hash) {
             Ok(ServerCertVerified::assertion())
@@ -133,13 +137,12 @@ pub fn build_rustls_config_with_verifier(
 
     let provider = rustls::crypto::aws_lc_rs::default_provider();
 
-    let default_verifier =
-        rustls::client::WebPkiServerVerifier::builder_with_provider(
-            Arc::new(root_store),
-            Arc::new(provider.clone()),
-        )
-        .build()
-        .expect("failed to build WebPKI verifier");
+    let default_verifier = rustls::client::WebPkiServerVerifier::builder_with_provider(
+        Arc::new(root_store),
+        Arc::new(provider.clone()),
+    )
+    .build()
+    .expect("failed to build WebPKI verifier");
 
     let verifier = SpkiFingerprintVerifier::new(default_verifier, expected_fingerprints);
 

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -89,6 +89,16 @@ impl VLlmProvider {
     /// Create a new vLLM provider with the given configuration
     pub fn new(config: VLlmConfig) -> Self {
         let fingerprint_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
+        Self::new_with_fingerprint_state(config, fingerprint_state)
+    }
+
+    /// Create a new vLLM provider sharing an existing fingerprint state.
+    /// Used to create a fresh connection pool after TLS pinning is established,
+    /// ensuring all new connections go through the SPKI verifier.
+    pub fn new_with_fingerprint_state(
+        config: VLlmConfig,
+        fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
+    ) -> Self {
         let tls_config =
             spki_verifier::build_rustls_config_with_verifier(fingerprint_state.clone());
 
@@ -114,6 +124,16 @@ impl VLlmProvider {
             signature_clients: Arc::new(std::sync::Mutex::new(HashMap::new())),
             fingerprint_state,
         }
+    }
+
+    /// Access the provider's configuration.
+    pub fn config(&self) -> &VLlmConfig {
+        &self.config
+    }
+
+    /// Get a reference to the shared fingerprint state.
+    pub fn fingerprint_state(&self) -> Arc<std::sync::RwLock<FingerprintState>> {
+        self.fingerprint_state.clone()
     }
 
     /// Create a dedicated reqwest::Client for a single completion.

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
-    models::StreamOptions, sse_parser::new_sse_parser, ImageEditError, ImageGenerationError,
-    RerankError, ScoreError, *,
+    models::StreamOptions, spki_verifier, sse_parser::new_sse_parser, ImageEditError,
+    ImageGenerationError, RerankError, ScoreError, *,
 };
 use async_trait::async_trait;
 use reqwest::{header::HeaderValue, Client};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -79,11 +79,19 @@ pub struct VLlmProvider {
     /// → moves client to `signature_clients[chat_id]` → `get_signature` uses it.
     pending_clients: Arc<std::sync::Mutex<HashMap<String, Client>>>,
     signature_clients: Arc<std::sync::Mutex<HashMap<String, Client>>>,
+    /// Shared set of expected SPKI fingerprints for TLS verification.
+    /// Empty = bootstrap mode (accept any valid cert). Populated after attestation
+    /// verification pins the fingerprint from the attested TDX report.
+    expected_fingerprints: Arc<std::sync::RwLock<HashSet<String>>>,
 }
 
 impl VLlmProvider {
     /// Create a new vLLM provider with the given configuration
     pub fn new(config: VLlmConfig) -> Self {
+        let expected_fingerprints = Arc::new(std::sync::RwLock::new(HashSet::new()));
+        let tls_config =
+            spki_verifier::build_rustls_config_with_verifier(expected_fingerprints.clone());
+
         // connect_timeout: 5s is generous for local-network backends. A backend behind a
         // firewall-drop (not RST) is the worst case; 5s catches it without penalising
         // fallback latency. Connection-refused is instant regardless.
@@ -92,6 +100,7 @@ impl VLlmProvider {
         // heavy load vLLM can stall between chunks during decode when KV cache is under
         // pressure, causing premature stream termination and lost usage stats.
         let client = Client::builder()
+            .use_preconfigured_tls(tls_config)
             .connect_timeout(std::time::Duration::from_secs(5))
             .pool_idle_timeout(std::time::Duration::from_secs(90))
             .read_timeout(std::time::Duration::from_secs(300))
@@ -103,20 +112,43 @@ impl VLlmProvider {
             client,
             pending_clients: Arc::new(std::sync::Mutex::new(HashMap::new())),
             signature_clients: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            expected_fingerprints,
         }
     }
 
     /// Create a dedicated reqwest::Client for a single completion.
     /// This client has its own connection pool, ensuring the TLS connection
     /// used for the completion is reused for subsequent signature fetches.
-    fn create_dedicated_client() -> Client {
+    /// Shares the same SPKI fingerprint verification as the main client.
+    fn create_dedicated_client(&self) -> Client {
+        let tls_config =
+            spki_verifier::build_rustls_config_with_verifier(self.expected_fingerprints.clone());
         Client::builder()
+            .use_preconfigured_tls(tls_config)
             .pool_max_idle_per_host(1)
             .connect_timeout(std::time::Duration::from_secs(5))
             .pool_idle_timeout(std::time::Duration::from_secs(90))
             .read_timeout(std::time::Duration::from_secs(300))
             .build()
             .expect("Failed to create dedicated HTTP client")
+    }
+
+    /// Add a verified SPKI fingerprint to the expected set.
+    /// After this call, all new TLS connections (shared and dedicated clients)
+    /// will verify the server cert's SPKI fingerprint is in this set.
+    pub fn add_expected_fingerprint(&self, fingerprint: String) {
+        self.expected_fingerprints
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(fingerprint);
+    }
+
+    /// Returns the number of verified fingerprints currently pinned.
+    pub fn expected_fingerprint_count(&self) -> usize {
+        self.expected_fingerprints
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
     }
 
     /// Build HTTP request headers
@@ -434,7 +466,7 @@ impl InferenceProvider for VLlmProvider {
 
         // Use a dedicated client for this completion so the signature fetch
         // can reuse the same TLS connection (required for L4 load balancing).
-        let dedicated_client = Self::create_dedicated_client();
+        let dedicated_client = self.create_dedicated_client();
         let response = self
             .send_streaming_request(&url, headers, &streaming_params, Some(&dedicated_client))
             .await?;
@@ -473,7 +505,7 @@ impl InferenceProvider for VLlmProvider {
         self.prepare_encryption_headers(&mut headers, &mut non_streaming_params.extra);
 
         // Use a dedicated client for connection pinning (same TLS connection for signature)
-        let dedicated_client = Self::create_dedicated_client();
+        let dedicated_client = self.create_dedicated_client();
         let response = dedicated_client
             .post(&url)
             .headers(headers)

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1,3 +1,4 @@
+use crate::spki_verifier::FingerprintState;
 use crate::{
     models::StreamOptions, spki_verifier, sse_parser::new_sse_parser, ImageEditError,
     ImageGenerationError, RerankError, ScoreError, *,
@@ -5,7 +6,7 @@ use crate::{
 use async_trait::async_trait;
 use reqwest::{header::HeaderValue, Client};
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -79,18 +80,17 @@ pub struct VLlmProvider {
     /// → moves client to `signature_clients[chat_id]` → `get_signature` uses it.
     pending_clients: Arc<std::sync::Mutex<HashMap<String, Client>>>,
     signature_clients: Arc<std::sync::Mutex<HashMap<String, Client>>>,
-    /// Shared set of expected SPKI fingerprints for TLS verification.
-    /// Empty = bootstrap mode (accept any valid cert). Populated after attestation
-    /// verification pins the fingerprint from the attested TDX report.
-    expected_fingerprints: Arc<std::sync::RwLock<HashSet<String>>>,
+    /// TLS fingerprint verification state (Bootstrap → Pinned or Blocked).
+    /// Shared across the main client and all dedicated per-completion clients.
+    fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
 }
 
 impl VLlmProvider {
     /// Create a new vLLM provider with the given configuration
     pub fn new(config: VLlmConfig) -> Self {
-        let expected_fingerprints = Arc::new(std::sync::RwLock::new(HashSet::new()));
+        let fingerprint_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
         let tls_config =
-            spki_verifier::build_rustls_config_with_verifier(expected_fingerprints.clone());
+            spki_verifier::build_rustls_config_with_verifier(fingerprint_state.clone());
 
         // connect_timeout: 5s is generous for local-network backends. A backend behind a
         // firewall-drop (not RST) is the worst case; 5s catches it without penalising
@@ -112,7 +112,7 @@ impl VLlmProvider {
             client,
             pending_clients: Arc::new(std::sync::Mutex::new(HashMap::new())),
             signature_clients: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            expected_fingerprints,
+            fingerprint_state,
         }
     }
 
@@ -122,7 +122,7 @@ impl VLlmProvider {
     /// Shares the same SPKI fingerprint verification as the main client.
     fn create_dedicated_client(&self) -> Client {
         let tls_config =
-            spki_verifier::build_rustls_config_with_verifier(self.expected_fingerprints.clone());
+            spki_verifier::build_rustls_config_with_verifier(self.fingerprint_state.clone());
         Client::builder()
             .use_preconfigured_tls(tls_config)
             .pool_max_idle_per_host(1)
@@ -133,22 +133,30 @@ impl VLlmProvider {
             .expect("Failed to create dedicated HTTP client")
     }
 
-    /// Add a verified SPKI fingerprint to the expected set.
-    /// After this call, all new TLS connections (shared and dedicated clients)
-    /// will verify the server cert's SPKI fingerprint is in this set.
-    pub fn add_expected_fingerprint(&self, fingerprint: String) {
-        self.expected_fingerprints
+    /// Add a verified SPKI fingerprint. Transitions Bootstrap → Pinned,
+    /// or adds to existing Pinned set. Unblocks a Blocked provider.
+    pub fn add_verified_fingerprint(&self, fingerprint: String) {
+        self.fingerprint_state
             .write()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(fingerprint);
+            .add_fingerprint(fingerprint);
+    }
+
+    /// Block all TLS connections (attestation verification failed).
+    /// Only blocks from Bootstrap state — does not override existing Pinned fingerprints.
+    pub fn block_connections(&self) {
+        self.fingerprint_state
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .block();
     }
 
     /// Returns the number of verified fingerprints currently pinned.
-    pub fn expected_fingerprint_count(&self) -> usize {
-        self.expected_fingerprints
+    pub fn pinned_fingerprint_count(&self) -> usize {
+        self.fingerprint_state
             .read()
             .unwrap_or_else(|e| e.into_inner())
-            .len()
+            .pinned_count()
     }
 
     /// Build HTTP request headers

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -55,6 +55,7 @@ aes-gcm = "0.10"
 hmac = "0.12"
 sha2 = "0.10"
 x509-parser = "0.18"
+dcap-qvl = "0.3"
 moka = { version = "0.12.14", features = ["future"] }
 bloomfilter = "3.0.1"
 mockall = { version = "0.14", optional = true }

--- a/crates/services/src/attestation/mod.rs
+++ b/crates/services/src/attestation/mod.rs
@@ -1,6 +1,8 @@
 pub mod models;
+pub mod verification;
 use dstack_sdk::dstack_client;
 pub use models::{AttestationError, ChatSignature, SignatureLookupResult};
+pub use verification::{AttestationVerificationError, AttestationVerifier, VerifiedAttestation};
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/crates/services/src/attestation/mod.rs
+++ b/crates/services/src/attestation/mod.rs
@@ -2,8 +2,8 @@ pub mod models;
 pub mod verification;
 use dstack_sdk::dstack_client;
 pub use models::{AttestationError, ChatSignature, SignatureLookupResult};
-pub use verification::{AttestationVerificationError, AttestationVerifier, VerifiedAttestation};
 use std::sync::Arc;
+pub use verification::{AttestationVerificationError, AttestationVerifier, VerifiedAttestation};
 
 use async_trait::async_trait;
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -37,15 +37,21 @@ struct EventLogData {
     compose_hash: Option<String>,
 }
 
+/// dstack runtime event type constant (0x08000001).
+const DSTACK_RUNTIME_EVENT_TYPE: u32 = 0x08000001;
+
 /// An entry from the TDX event log.
 #[derive(Debug, Clone, serde::Deserialize)]
 struct EventLogEntry {
     /// SHA-384 digest of the event (hex-encoded).
     digest: String,
+    /// Event type (0x08000001 for dstack runtime events).
+    #[serde(default)]
+    event_type: u32,
     /// Event name (e.g., "os-image-hash", "compose-hash", "app-id").
     #[serde(default)]
     event: String,
-    /// Event payload (hex-encoded or plaintext depending on event type).
+    /// Event payload (hex-encoded raw bytes).
     #[serde(default)]
     event_payload: String,
     /// Which RTMR this event extends (0-3).
@@ -353,29 +359,71 @@ impl AttestationVerifier {
         };
 
         // Replay RTMR3: SHA-384 chain of ALL events with imr == 3.
-        // This includes both boot-time events (system-preparing, app-id, compose-hash,
-        // instance-id, boot-mr-done) and runtime events (mr-kms, os-image-hash,
-        // key-provider, storage-fs, system-ready).
+        // For runtime events (event_type == 0x08000001), we first validate that the
+        // digest matches SHA384(event_type_le || ":" || event_name || ":" || payload_bytes).
+        // This prevents an attacker from keeping valid digests while swapping payloads.
+        use sha2::Sha384;
         let mut rtmr3 = [0u8; 48];
+        let mut rtmr3_event_count = 0u32;
         for event in &events {
             if event.imr != 3 {
                 continue;
             }
-            let digest_bytes = hex::decode(&event.digest).map_err(|e| {
-                AttestationVerificationError::InvalidFormat(format!("event digest hex decode: {e}"))
-            })?;
+            rtmr3_event_count += 1;
+
+            // For runtime events, validate digest matches payload
+            let digest_bytes = if event.event_type == DSTACK_RUNTIME_EVENT_TYPE {
+                let payload_bytes = hex::decode(&event.event_payload).map_err(|e| {
+                    AttestationVerificationError::InvalidFormat(format!(
+                        "runtime event '{}' payload hex decode: {e}",
+                        event.event
+                    ))
+                })?;
+                let mut hasher = Sha384::new();
+                sha2::Digest::update(&mut hasher, DSTACK_RUNTIME_EVENT_TYPE.to_ne_bytes());
+                sha2::Digest::update(&mut hasher, b":");
+                sha2::Digest::update(&mut hasher, event.event.as_bytes());
+                sha2::Digest::update(&mut hasher, b":");
+                sha2::Digest::update(&mut hasher, &payload_bytes);
+                let computed: [u8; 48] = sha2::Digest::finalize(hasher).into();
+
+                // If the event has a stored digest, verify it matches
+                if !event.digest.is_empty() {
+                    let stored = hex::decode(&event.digest).map_err(|e| {
+                        AttestationVerificationError::InvalidFormat(format!(
+                            "event '{}' digest hex decode: {e}",
+                            event.event
+                        ))
+                    })?;
+                    if computed[..] != stored[..] {
+                        return Err(AttestationVerificationError::RtmrMismatch(format!(
+                            "runtime event '{}' digest does not match payload: computed={}, stored={}",
+                            event.event,
+                            hex::encode(computed),
+                            hex::encode(&stored)
+                        )));
+                    }
+                }
+                computed.to_vec()
+            } else {
+                // Non-runtime events: use stored digest directly
+                hex::decode(&event.digest).map_err(|e| {
+                    AttestationVerificationError::InvalidFormat(format!(
+                        "event digest hex decode: {e}"
+                    ))
+                })?
+            };
+
             // RTMR extension: RTMR = SHA-384(RTMR || digest)
-            use sha2::Sha384;
             let mut hasher = Sha384::new();
-            hasher.update(rtmr3);
-            hasher.update(&digest_bytes);
-            let result = hasher.finalize();
+            sha2::Digest::update(&mut hasher, rtmr3);
+            sha2::Digest::update(&mut hasher, &digest_bytes);
+            let result = sha2::Digest::finalize(hasher);
             rtmr3.copy_from_slice(&result);
         }
 
-        // Reject if no RTMR3 events found — an empty event log with all-zeros RTMR3
-        // in the quote would silently pass and bypass the image hash allowlist.
-        let has_rtmr3_events = events.iter().any(|e| e.imr == 3);
+        // Reject if no RTMR3 events found
+        let has_rtmr3_events = rtmr3_event_count > 0;
         if !has_rtmr3_events {
             return Err(AttestationVerificationError::RtmrMismatch(
                 "no RTMR3 events in event log — cannot verify runtime measurements".to_string(),

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -492,15 +492,18 @@ fn extract_nvidia_verdict(jwt: &str) -> Result<String, AttestationVerificationEr
         ))
     })?;
 
-    payload
-        .get("x-nvidia-overall-att-result")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .ok_or_else(|| {
-            AttestationVerificationError::GpuVerificationFailed(
-                "x-nvidia-overall-att-result not found in NRAS JWT".to_string(),
-            )
-        })
+    let result = payload.get("x-nvidia-overall-att-result").ok_or_else(|| {
+        AttestationVerificationError::GpuVerificationFailed(
+            "x-nvidia-overall-att-result not found in NRAS JWT".to_string(),
+        )
+    })?;
+
+    // NRAS returns either boolean true/false or string "PASS"/"FAIL"
+    match result {
+        serde_json::Value::Bool(b) => Ok(if *b { "PASS" } else { "FAIL" }.to_string()),
+        serde_json::Value::String(s) => Ok(s.clone()),
+        other => Ok(other.to_string()),
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -1,0 +1,525 @@
+//! Attestation verification for inference provider backends.
+//!
+//! Verifies TDX quotes, report_data bindings (signing address + TLS fingerprint),
+//! image hashes, and GPU evidence from attestation reports returned by inference-proxy.
+
+use sha2::{Digest as Sha2Digest, Sha256};
+use std::collections::HashSet;
+
+const NVIDIA_NRAS_URL: &str = "https://nras.attestation.nvidia.com/v3/attest/gpu";
+
+/// Number of parallel attestation calls per model to discover TLS fingerprints
+/// from multiple backends behind L4 load balancing.
+pub const ATTESTATION_DISCOVERY_PARALLELISM: usize = 10;
+
+/// Result of verifying an attestation report from an inference backend.
+#[derive(Debug, Clone)]
+pub struct VerifiedAttestation {
+    /// The verified SPKI fingerprint of the backend's TLS certificate.
+    pub tls_cert_fingerprint: Option<String>,
+    /// The verified signing address from the attestation.
+    pub signing_address: String,
+    /// TDX TCB status (e.g., "UpToDate", "OutOfDate").
+    pub tcb_status: String,
+    /// Intel advisory IDs.
+    pub advisory_ids: Vec<String>,
+    /// OS image hash extracted from the RTMR3-verified event log.
+    pub os_image_hash: Option<String>,
+    /// Compose hash extracted from the RTMR3-verified event log.
+    pub compose_hash: Option<String>,
+    /// GPU verification verdict (e.g., "PASS"), if GPU evidence was present.
+    pub gpu_verdict: Option<String>,
+}
+
+/// Data extracted from the RTMR3-verified event log.
+struct EventLogData {
+    os_image_hash: Option<String>,
+    compose_hash: Option<String>,
+}
+
+/// An entry from the TDX event log.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct EventLogEntry {
+    /// SHA-384 digest of the event (hex-encoded).
+    digest: String,
+    /// Event name (e.g., "os-image-hash", "compose-hash", "app-id").
+    #[serde(default)]
+    event: String,
+    /// Event payload (hex-encoded or plaintext depending on event type).
+    #[serde(default)]
+    event_payload: String,
+    /// Which RTMR this event extends (0-3).
+    imr: u32,
+}
+
+/// Configuration for attestation verification.
+#[derive(Clone)]
+pub struct AttestationVerifier {
+    /// HTTP client for NVIDIA NRAS calls.
+    http_client: reqwest::Client,
+    /// Set of allowed OS image hashes (from env var). Empty = skip image hash check.
+    allowed_image_hashes: HashSet<String>,
+    /// Optional PCCS URL override for Intel collateral fetching.
+    pccs_url: Option<String>,
+}
+
+impl AttestationVerifier {
+    pub fn new(allowed_image_hashes: HashSet<String>, pccs_url: Option<String>) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to create HTTP client for attestation verification");
+        Self {
+            http_client,
+            allowed_image_hashes,
+            pccs_url,
+        }
+    }
+
+    /// Build an `AttestationVerifier` from environment variables.
+    ///
+    /// - `ALLOWED_IMAGE_HASHES`: comma-separated list of allowed OS image hashes (hex).
+    ///   If unset or empty, image hash verification is skipped.
+    /// - `PCCS_URL`: optional Intel PCCS URL for TDX collateral fetching.
+    pub fn from_env() -> Self {
+        let allowed_image_hashes: HashSet<String> = std::env::var("ALLOWED_IMAGE_HASHES")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if !allowed_image_hashes.is_empty() {
+            tracing::info!(
+                count = allowed_image_hashes.len(),
+                "Loaded allowed image hashes for attestation verification"
+            );
+        }
+
+        let pccs_url = std::env::var("PCCS_URL").ok().filter(|s| !s.is_empty());
+
+        Self::new(allowed_image_hashes, pccs_url)
+    }
+
+    /// Verify an attestation report from an inference backend.
+    ///
+    /// Performs:
+    /// 1. TDX quote verification via dcap-qvl (Intel signature chain)
+    /// 2. Report data binding verification (signing address + TLS fingerprint + nonce)
+    /// 3. OS image hash check against allowlist (if configured)
+    /// 4. GPU evidence verification via NVIDIA NRAS (if present)
+    ///
+    /// The `attestation_report` is the JSON map returned by the backend's
+    /// `/v1/attestation/report` endpoint.
+    pub async fn verify_attestation_report(
+        &self,
+        attestation_report: &serde_json::Map<String, serde_json::Value>,
+        request_nonce: &str,
+    ) -> Result<VerifiedAttestation, AttestationVerificationError> {
+        // 1. Extract and verify TDX quote
+        let intel_quote_hex = attestation_report
+            .get("intel_quote")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AttestationVerificationError::MissingField("intel_quote".to_string())
+            })?;
+
+        let quote_bytes = hex::decode(intel_quote_hex).map_err(|e| {
+            AttestationVerificationError::InvalidFormat(format!("intel_quote hex decode: {e}"))
+        })?;
+
+        let verified_report = dcap_qvl::collateral::get_collateral_and_verify(
+            &quote_bytes,
+            self.pccs_url.as_deref(),
+        )
+        .await
+        .map_err(|e| AttestationVerificationError::TdxVerificationFailed(format!("{e:#}")))?;
+
+        // Check debug mode is disabled
+        let td_report = verified_report.report.as_td10().ok_or_else(|| {
+            AttestationVerificationError::TdxVerificationFailed(
+                "no TD10 report in verified quote".to_string(),
+            )
+        })?;
+
+        let is_debug = td_report.td_attributes[0] & 0x01 != 0;
+        if is_debug {
+            return Err(AttestationVerificationError::TdxVerificationFailed(
+                "TDX debug mode is enabled — rejecting".to_string(),
+            ));
+        }
+
+        let tcb_status = verified_report.status.clone();
+        let advisory_ids = verified_report.advisory_ids.clone();
+
+        // 2. Verify report_data binding
+        let report_data = &td_report.report_data;
+        let signing_address = attestation_report
+            .get("signing_address")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AttestationVerificationError::MissingField("signing_address".to_string())
+            })?;
+
+        let tls_cert_fingerprint = attestation_report
+            .get("tls_cert_fingerprint")
+            .and_then(|v| v.as_str());
+
+        self.verify_report_data(
+            report_data,
+            signing_address,
+            tls_cert_fingerprint,
+            request_nonce,
+            attestation_report
+                .get("signing_algo")
+                .and_then(|v| v.as_str())
+                .unwrap_or("ed25519"),
+        )?;
+
+        // 3. Replay RTMR3 from event log and verify against the TDX quote.
+        //    If successful, extract os_image_hash and compose_hash from the verified log.
+        let event_log_data =
+            self.verify_rtmr3_and_extract(attestation_report, &td_report.rt_mr3)?;
+
+        // 4. Check OS image hash from verified event log against allowlist
+        if let Some(ref hash) = event_log_data.os_image_hash {
+            if !self.allowed_image_hashes.is_empty()
+                && !self.allowed_image_hashes.contains(&hash.to_lowercase())
+            {
+                return Err(AttestationVerificationError::ImageHashMismatch(format!(
+                    "os_image_hash '{}' from RTMR3-verified event log not in allowed list",
+                    hash
+                )));
+            }
+        } else if !self.allowed_image_hashes.is_empty() {
+            return Err(AttestationVerificationError::ImageHashMismatch(
+                "ALLOWED_IMAGE_HASHES configured but no os-image-hash in event log".to_string(),
+            ));
+        }
+
+        // 5. Verify GPU evidence (best-effort — skip if not present)
+        let gpu_verdict = self
+            .verify_gpu_evidence(attestation_report, request_nonce)
+            .await?;
+
+        Ok(VerifiedAttestation {
+            tls_cert_fingerprint: tls_cert_fingerprint.map(|s| s.to_string()),
+            signing_address: signing_address.to_string(),
+            tcb_status,
+            advisory_ids,
+            os_image_hash: event_log_data.os_image_hash,
+            compose_hash: event_log_data.compose_hash,
+            gpu_verdict,
+        })
+    }
+
+    /// Verify that `report_data` correctly binds the signing address, TLS fingerprint, and nonce.
+    ///
+    /// When `tls_cert_fingerprint` is present:
+    ///   `report_data[0:32] = SHA256(signing_address_bytes || fingerprint_bytes)`
+    /// Otherwise:
+    ///   `report_data[0:32] = signing_address_bytes padded to 32`
+    ///
+    /// Always: `report_data[32:64] = nonce_bytes`
+    fn verify_report_data(
+        &self,
+        report_data: &[u8; 64],
+        signing_address: &str,
+        tls_cert_fingerprint: Option<&str>,
+        nonce: &str,
+        _signing_algo: &str,
+    ) -> Result<(), AttestationVerificationError> {
+        // Verify nonce (second 32 bytes)
+        let nonce_bytes =
+            hex::decode(nonce.strip_prefix("0x").unwrap_or(nonce)).map_err(|e| {
+                AttestationVerificationError::InvalidFormat(format!("nonce hex decode: {e}"))
+            })?;
+        if nonce_bytes.len() != 32 {
+            return Err(AttestationVerificationError::ReportDataMismatch(format!(
+                "nonce must be 32 bytes, got {}",
+                nonce_bytes.len()
+            )));
+        }
+        if report_data[32..64] != nonce_bytes[..] {
+            return Err(AttestationVerificationError::ReportDataMismatch(
+                "nonce mismatch in report_data[32:64]".to_string(),
+            ));
+        }
+
+        // Verify first 32 bytes
+        let addr_hex = signing_address
+            .strip_prefix("0x")
+            .unwrap_or(signing_address);
+        let addr_bytes = hex::decode(addr_hex).map_err(|e| {
+            AttestationVerificationError::InvalidFormat(format!(
+                "signing_address hex decode: {e}"
+            ))
+        })?;
+
+        if let Some(fp_hex) = tls_cert_fingerprint {
+            // TLS fingerprint binding: SHA256(signing_address_bytes || fingerprint_bytes)
+            let fp_bytes = hex::decode(fp_hex.strip_prefix("0x").unwrap_or(fp_hex)).map_err(
+                |e| {
+                    AttestationVerificationError::InvalidFormat(format!(
+                        "tls_cert_fingerprint hex decode: {e}"
+                    ))
+                },
+            )?;
+            let mut hasher = Sha256::new();
+            hasher.update(&addr_bytes);
+            hasher.update(&fp_bytes);
+            let expected = hasher.finalize();
+
+            if report_data[..32] != expected[..] {
+                return Err(AttestationVerificationError::ReportDataMismatch(format!(
+                    "report_data[0:32] does not match SHA256(signing_address || tls_fingerprint). \
+                     Expected: {}, got: {}",
+                    hex::encode(expected),
+                    hex::encode(&report_data[..32])
+                )));
+            }
+        } else {
+            // No TLS fingerprint: first 32 bytes = signing_address padded to 32
+            let mut expected = [0u8; 32];
+            let copy_len = addr_bytes.len().min(32);
+            expected[..copy_len].copy_from_slice(&addr_bytes[..copy_len]);
+            if report_data[..32] != expected[..] {
+                return Err(AttestationVerificationError::ReportDataMismatch(format!(
+                    "report_data[0:32] does not match padded signing_address. \
+                     Expected: {}, got: {}",
+                    hex::encode(expected),
+                    hex::encode(&report_data[..32])
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Replay RTMR3 from the event log and verify it matches the TDX quote.
+    ///
+    /// RTMR3 contains runtime measurements: app_id, compose_hash, os-image-hash,
+    /// instance_id, key-provider, etc. By replaying the SHA-384 hash chain from
+    /// the event log and comparing against the quote's `rt_mr3`, we cryptographically
+    /// verify the event log is authentic. Then we extract os_image_hash and compose_hash
+    /// from the verified events.
+    fn verify_rtmr3_and_extract(
+        &self,
+        attestation_report: &serde_json::Map<String, serde_json::Value>,
+        quoted_rtmr3: &[u8; 48],
+    ) -> Result<EventLogData, AttestationVerificationError> {
+        // Parse event log from attestation response
+        let event_log = attestation_report.get("event_log").ok_or_else(|| {
+            AttestationVerificationError::MissingField("event_log".to_string())
+        })?;
+
+        let events: Vec<EventLogEntry> = serde_json::from_value(event_log.clone()).map_err(|e| {
+            AttestationVerificationError::InvalidFormat(format!(
+                "failed to parse event_log: {e}"
+            ))
+        })?;
+
+        // Replay RTMR3: SHA-384 chain of all events with imr == 3
+        // Stops at "boot-mr-done" marker — only pre-boot events are measured into
+        // the dstack-controlled RTMR3 value. Events after boot-mr-done are
+        // extended at runtime (KMS, os-image-hash, key-provider, etc.)
+        let mut rtmr3 = [0u8; 48];
+        for event in &events {
+            if event.imr != 3 {
+                continue;
+            }
+            let digest_bytes = hex::decode(&event.digest).map_err(|e| {
+                AttestationVerificationError::InvalidFormat(format!(
+                    "event digest hex decode: {e}"
+                ))
+            })?;
+            // RTMR extension: RTMR = SHA-384(RTMR || digest)
+            use sha2::Sha384;
+            let mut hasher = Sha384::new();
+            sha2::Digest::update(&mut hasher, rtmr3);
+            sha2::Digest::update(&mut hasher, &digest_bytes);
+            let result = sha2::Digest::finalize(hasher);
+            rtmr3.copy_from_slice(&result);
+        }
+
+        if rtmr3 != *quoted_rtmr3 {
+            return Err(AttestationVerificationError::RtmrMismatch(format!(
+                "RTMR3 replay mismatch: replayed={}, quoted={}",
+                hex::encode(rtmr3),
+                hex::encode(quoted_rtmr3)
+            )));
+        }
+
+        // Event log is verified — extract os-image-hash and compose-hash
+        let mut os_image_hash = None;
+        let mut compose_hash = None;
+        for event in &events {
+            if event.imr != 3 {
+                continue;
+            }
+            match event.event.as_str() {
+                "os-image-hash" => {
+                    os_image_hash = Some(event.event_payload.clone());
+                }
+                "compose-hash" => {
+                    compose_hash = Some(event.event_payload.clone());
+                }
+                _ => {}
+            }
+        }
+
+        Ok(EventLogData {
+            os_image_hash,
+            compose_hash,
+        })
+    }
+
+    /// Verify GPU evidence via NVIDIA NRAS.
+    ///
+    /// Returns `Some(verdict)` if GPU evidence was present and verified,
+    /// `None` if no GPU evidence was included (e.g., gateway without GPU).
+    async fn verify_gpu_evidence(
+        &self,
+        attestation_report: &serde_json::Map<String, serde_json::Value>,
+        request_nonce: &str,
+    ) -> Result<Option<String>, AttestationVerificationError> {
+        let nvidia_payload_str = match attestation_report
+            .get("nvidia_payload")
+            .and_then(|v| v.as_str())
+        {
+            Some(s) if !s.is_empty() => s,
+            _ => return Ok(None), // No GPU evidence — acceptable for non-GPU CVMs
+        };
+
+        let payload: serde_json::Value =
+            serde_json::from_str(nvidia_payload_str).map_err(|e| {
+                AttestationVerificationError::GpuVerificationFailed(format!(
+                    "failed to parse nvidia_payload JSON: {e}"
+                ))
+            })?;
+
+        // Verify nonce matches
+        let payload_nonce = payload
+            .get("nonce")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if payload_nonce.to_lowercase() != request_nonce.to_lowercase() {
+            return Err(AttestationVerificationError::GpuVerificationFailed(
+                format!(
+                    "GPU payload nonce mismatch: expected {}, got {}",
+                    request_nonce, payload_nonce
+                ),
+            ));
+        }
+
+        // Submit to NVIDIA NRAS
+        let response = self
+            .http_client
+            .post(NVIDIA_NRAS_URL)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                AttestationVerificationError::GpuVerificationFailed(format!(
+                    "NVIDIA NRAS request failed: {e}"
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AttestationVerificationError::GpuVerificationFailed(
+                format!("NVIDIA NRAS returned HTTP {status}: {body}"),
+            ));
+        }
+
+        // Response is an array of [category, jwt_token] pairs
+        let body: serde_json::Value = response.json().await.map_err(|e| {
+            AttestationVerificationError::GpuVerificationFailed(format!(
+                "failed to parse NRAS response: {e}"
+            ))
+        })?;
+
+        let jwt_token = body
+            .as_array()
+            .and_then(|arr| arr.first())
+            .and_then(|entry| entry.as_array())
+            .and_then(|pair| pair.get(1))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AttestationVerificationError::GpuVerificationFailed(
+                    "unexpected NRAS response format".to_string(),
+                )
+            })?;
+
+        // Decode JWT payload (second segment, base64url-encoded)
+        let verdict = extract_nvidia_verdict(jwt_token)?;
+
+        if verdict != "PASS" {
+            return Err(AttestationVerificationError::GpuVerificationFailed(
+                format!("NVIDIA attestation verdict: {verdict} (expected PASS)"),
+            ));
+        }
+
+        Ok(Some(verdict))
+    }
+}
+
+/// Extract the `x-nvidia-overall-att-result` from a JWT token's payload.
+fn extract_nvidia_verdict(jwt: &str) -> Result<String, AttestationVerificationError> {
+    let parts: Vec<&str> = jwt.split('.').collect();
+    if parts.len() < 2 {
+        return Err(AttestationVerificationError::GpuVerificationFailed(
+            "invalid JWT format from NRAS".to_string(),
+        ));
+    }
+
+    use base64::Engine;
+    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .map_err(|e| {
+            AttestationVerificationError::GpuVerificationFailed(format!(
+                "failed to decode JWT payload: {e}"
+            ))
+        })?;
+
+    let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).map_err(|e| {
+        AttestationVerificationError::GpuVerificationFailed(format!(
+            "failed to parse JWT payload JSON: {e}"
+        ))
+    })?;
+
+    payload
+        .get("x-nvidia-overall-att-result")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            AttestationVerificationError::GpuVerificationFailed(
+                "x-nvidia-overall-att-result not found in NRAS JWT".to_string(),
+            )
+        })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AttestationVerificationError {
+    #[error("missing field in attestation report: {0}")]
+    MissingField(String),
+
+    #[error("invalid format: {0}")]
+    InvalidFormat(String),
+
+    #[error("TDX quote verification failed: {0}")]
+    TdxVerificationFailed(String),
+
+    #[error("report data binding mismatch: {0}")]
+    ReportDataMismatch(String),
+
+    #[error("RTMR3 replay mismatch: {0}")]
+    RtmrMismatch(String),
+
+    #[error("OS image hash mismatch: {0}")]
+    ImageHashMismatch(String),
+
+    #[error("GPU evidence verification failed: {0}")]
+    GpuVerificationFailed(String),
+}

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -120,20 +120,18 @@ impl AttestationVerifier {
         let intel_quote_hex = attestation_report
             .get("intel_quote")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                AttestationVerificationError::MissingField("intel_quote".to_string())
-            })?;
+            .ok_or_else(|| AttestationVerificationError::MissingField("intel_quote".to_string()))?;
 
         let quote_bytes = hex::decode(intel_quote_hex).map_err(|e| {
             AttestationVerificationError::InvalidFormat(format!("intel_quote hex decode: {e}"))
         })?;
 
-        let verified_report = dcap_qvl::collateral::get_collateral_and_verify(
-            &quote_bytes,
-            self.pccs_url.as_deref(),
-        )
-        .await
-        .map_err(|e| AttestationVerificationError::TdxVerificationFailed(format!("{e:#}")))?;
+        let verified_report =
+            dcap_qvl::collateral::get_collateral_and_verify(&quote_bytes, self.pccs_url.as_deref())
+                .await
+                .map_err(|e| {
+                    AttestationVerificationError::TdxVerificationFailed(format!("{e:#}"))
+                })?;
 
         // Check debug mode is disabled
         let td_report = verified_report.report.as_td10().ok_or_else(|| {
@@ -230,10 +228,9 @@ impl AttestationVerifier {
         _signing_algo: &str,
     ) -> Result<(), AttestationVerificationError> {
         // Verify nonce (second 32 bytes)
-        let nonce_bytes =
-            hex::decode(nonce.strip_prefix("0x").unwrap_or(nonce)).map_err(|e| {
-                AttestationVerificationError::InvalidFormat(format!("nonce hex decode: {e}"))
-            })?;
+        let nonce_bytes = hex::decode(nonce.strip_prefix("0x").unwrap_or(nonce)).map_err(|e| {
+            AttestationVerificationError::InvalidFormat(format!("nonce hex decode: {e}"))
+        })?;
         if nonce_bytes.len() != 32 {
             return Err(AttestationVerificationError::ReportDataMismatch(format!(
                 "nonce must be 32 bytes, got {}",
@@ -251,20 +248,17 @@ impl AttestationVerifier {
             .strip_prefix("0x")
             .unwrap_or(signing_address);
         let addr_bytes = hex::decode(addr_hex).map_err(|e| {
-            AttestationVerificationError::InvalidFormat(format!(
-                "signing_address hex decode: {e}"
-            ))
+            AttestationVerificationError::InvalidFormat(format!("signing_address hex decode: {e}"))
         })?;
 
         if let Some(fp_hex) = tls_cert_fingerprint {
             // TLS fingerprint binding: SHA256(signing_address_bytes || fingerprint_bytes)
-            let fp_bytes = hex::decode(fp_hex.strip_prefix("0x").unwrap_or(fp_hex)).map_err(
-                |e| {
+            let fp_bytes =
+                hex::decode(fp_hex.strip_prefix("0x").unwrap_or(fp_hex)).map_err(|e| {
                     AttestationVerificationError::InvalidFormat(format!(
                         "tls_cert_fingerprint hex decode: {e}"
                     ))
-                },
-            )?;
+                })?;
             let mut hasher = Sha256::new();
             hasher.update(&addr_bytes);
             hasher.update(&fp_bytes);
@@ -309,15 +303,16 @@ impl AttestationVerifier {
         quoted_rtmr3: &[u8; 48],
     ) -> Result<EventLogData, AttestationVerificationError> {
         // Parse event log from attestation response
-        let event_log = attestation_report.get("event_log").ok_or_else(|| {
-            AttestationVerificationError::MissingField("event_log".to_string())
-        })?;
+        let event_log = attestation_report
+            .get("event_log")
+            .ok_or_else(|| AttestationVerificationError::MissingField("event_log".to_string()))?;
 
-        let events: Vec<EventLogEntry> = serde_json::from_value(event_log.clone()).map_err(|e| {
-            AttestationVerificationError::InvalidFormat(format!(
-                "failed to parse event_log: {e}"
-            ))
-        })?;
+        let events: Vec<EventLogEntry> =
+            serde_json::from_value(event_log.clone()).map_err(|e| {
+                AttestationVerificationError::InvalidFormat(format!(
+                    "failed to parse event_log: {e}"
+                ))
+            })?;
 
         // Replay RTMR3: SHA-384 chain of all events with imr == 3
         // Stops at "boot-mr-done" marker — only pre-boot events are measured into
@@ -329,9 +324,7 @@ impl AttestationVerifier {
                 continue;
             }
             let digest_bytes = hex::decode(&event.digest).map_err(|e| {
-                AttestationVerificationError::InvalidFormat(format!(
-                    "event digest hex decode: {e}"
-                ))
+                AttestationVerificationError::InvalidFormat(format!("event digest hex decode: {e}"))
             })?;
             // RTMR extension: RTMR = SHA-384(RTMR || digest)
             use sha2::Sha384;
@@ -391,12 +384,11 @@ impl AttestationVerifier {
             _ => return Ok(None), // No GPU evidence — acceptable for non-GPU CVMs
         };
 
-        let payload: serde_json::Value =
-            serde_json::from_str(nvidia_payload_str).map_err(|e| {
-                AttestationVerificationError::GpuVerificationFailed(format!(
-                    "failed to parse nvidia_payload JSON: {e}"
-                ))
-            })?;
+        let payload: serde_json::Value = serde_json::from_str(nvidia_payload_str).map_err(|e| {
+            AttestationVerificationError::GpuVerificationFailed(format!(
+                "failed to parse nvidia_payload JSON: {e}"
+            ))
+        })?;
 
         // Verify nonce matches
         let payload_nonce = payload

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -122,7 +122,10 @@ impl AttestationVerifier {
             .and_then(|v| v.as_str())
             .ok_or_else(|| AttestationVerificationError::MissingField("intel_quote".to_string()))?;
 
-        let quote_bytes = hex::decode(intel_quote_hex).map_err(|e| {
+        let quote_hex = intel_quote_hex
+            .strip_prefix("0x")
+            .unwrap_or(intel_quote_hex);
+        let quote_bytes = hex::decode(quote_hex).map_err(|e| {
             AttestationVerificationError::InvalidFormat(format!("intel_quote hex decode: {e}"))
         })?;
 

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -61,10 +61,16 @@ pub struct AttestationVerifier {
     allowed_image_hashes: HashSet<String>,
     /// Optional PCCS URL override for Intel collateral fetching.
     pccs_url: Option<String>,
+    /// If true, reject attestations where TCB status is not "UpToDate".
+    require_tcb_up_to_date: bool,
 }
 
 impl AttestationVerifier {
-    pub fn new(allowed_image_hashes: HashSet<String>, pccs_url: Option<String>) -> Self {
+    pub fn new(
+        allowed_image_hashes: HashSet<String>,
+        pccs_url: Option<String>,
+        require_tcb_up_to_date: bool,
+    ) -> Self {
         let http_client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
@@ -73,6 +79,7 @@ impl AttestationVerifier {
             http_client,
             allowed_image_hashes,
             pccs_url,
+            require_tcb_up_to_date,
         }
     }
 
@@ -98,7 +105,11 @@ impl AttestationVerifier {
 
         let pccs_url = std::env::var("PCCS_URL").ok().filter(|s| !s.is_empty());
 
-        Self::new(allowed_image_hashes, pccs_url)
+        let require_tcb_up_to_date = std::env::var("REQUIRE_TCB_UP_TO_DATE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        Self::new(allowed_image_hashes, pccs_url, require_tcb_up_to_date)
     }
 
     /// Verify an attestation report from an inference backend.
@@ -135,6 +146,22 @@ impl AttestationVerifier {
                 .map_err(|e| {
                     AttestationVerificationError::TdxVerificationFailed(format!("{e:#}"))
                 })?;
+
+        // Check TCB status
+        let tcb_status = &verified_report.status;
+        if self.require_tcb_up_to_date && tcb_status != "UpToDate" {
+            return Err(AttestationVerificationError::TdxVerificationFailed(format!(
+                "TCB status is '{tcb_status}' but REQUIRE_TCB_UP_TO_DATE is set (advisory_ids: {:?})",
+                verified_report.advisory_ids
+            )));
+        }
+        if tcb_status != "UpToDate" {
+            tracing::warn!(
+                tcb_status = %tcb_status,
+                advisory_ids = ?verified_report.advisory_ids,
+                "TDX TCB status is not UpToDate — microcode may need updating"
+            );
+        }
 
         // Check debug mode is disabled
         let td_report = verified_report.report.as_td10().ok_or_else(|| {

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -307,17 +307,25 @@ impl AttestationVerifier {
             .get("event_log")
             .ok_or_else(|| AttestationVerificationError::MissingField("event_log".to_string()))?;
 
-        let events: Vec<EventLogEntry> =
+        // Event log may be a JSON array directly or a JSON string containing the array
+        let events: Vec<EventLogEntry> = if let Some(s) = event_log.as_str() {
+            serde_json::from_str(s).map_err(|e| {
+                AttestationVerificationError::InvalidFormat(format!(
+                    "failed to parse event_log string: {e}"
+                ))
+            })?
+        } else {
             serde_json::from_value(event_log.clone()).map_err(|e| {
                 AttestationVerificationError::InvalidFormat(format!(
-                    "failed to parse event_log: {e}"
+                    "failed to parse event_log value: {e}"
                 ))
-            })?;
+            })?
+        };
 
-        // Replay RTMR3: SHA-384 chain of all events with imr == 3
-        // Stops at "boot-mr-done" marker — only pre-boot events are measured into
-        // the dstack-controlled RTMR3 value. Events after boot-mr-done are
-        // extended at runtime (KMS, os-image-hash, key-provider, etc.)
+        // Replay RTMR3: SHA-384 chain of ALL events with imr == 3.
+        // This includes both boot-time events (system-preparing, app-id, compose-hash,
+        // instance-id, boot-mr-done) and runtime events (mr-kms, os-image-hash,
+        // key-provider, storage-fs, system-ready).
         let mut rtmr3 = [0u8; 48];
         for event in &events {
             if event.imr != 3 {
@@ -329,9 +337,9 @@ impl AttestationVerifier {
             // RTMR extension: RTMR = SHA-384(RTMR || digest)
             use sha2::Sha384;
             let mut hasher = Sha384::new();
-            sha2::Digest::update(&mut hasher, rtmr3);
-            sha2::Digest::update(&mut hasher, &digest_bytes);
-            let result = sha2::Digest::finalize(hasher);
+            hasher.update(rtmr3);
+            hasher.update(&digest_bytes);
+            let result = hasher.finalize();
             rtmr3.copy_from_slice(&result);
         }
 

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -346,6 +346,15 @@ impl AttestationVerifier {
             rtmr3.copy_from_slice(&result);
         }
 
+        // Reject if no RTMR3 events found — an empty event log with all-zeros RTMR3
+        // in the quote would silently pass and bypass the image hash allowlist.
+        let has_rtmr3_events = events.iter().any(|e| e.imr == 3);
+        if !has_rtmr3_events {
+            return Err(AttestationVerificationError::RtmrMismatch(
+                "no RTMR3 events in event log — cannot verify runtime measurements".to_string(),
+            ));
+        }
+
         if rtmr3 != *quoted_rtmr3 {
             return Err(AttestationVerificationError::RtmrMismatch(format!(
                 "RTMR3 replay mismatch: replayed={}, quoted={}",

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1431,11 +1431,7 @@ impl InferenceProviderPool {
                             async move {
                                 provider
                                     .get_attestation_report(
-                                        model,
-                                        Some("ed25519".to_string()),
-                                        None,
-                                        None,
-                                        true,
+                                        model, None, None, None, true,
                                     )
                                     .await
                                     .ok()

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1501,11 +1501,19 @@ impl InferenceProviderPool {
                         );
                     }
 
-                    // Step 2: Fetch signing public keys WITH TLS pinning active.
-                    // This ensures signing keys are fetched over verified connections.
+                    // Step 2: Fetch signing public keys over a FRESH provider.
+                    // The bootstrap provider's reqwest pool may have pre-pin connections.
+                    // Creating a new VLlmProvider that shares the same fingerprint_state
+                    // ensures all new TLS connections are verified against pinned fingerprints.
+                    let pinned_provider = Arc::new(VLlmProvider::new_with_fingerprint_state(
+                        VLlmConfig::new(url.clone(), vllm_provider.config().api_key.clone(), None),
+                        vllm_provider.fingerprint_state(),
+                    ));
+                    let pinned_trait = pinned_provider.clone() as Arc<InferenceProviderTrait>;
+
                     let (pub_keys, _, _) =
                         Self::fetch_signing_public_keys_for_both_algorithms(
-                            &serving_provider,
+                            &pinned_trait,
                             &model_name,
                             &url,
                         )
@@ -1513,10 +1521,10 @@ impl InferenceProviderPool {
 
                     let pub_keys: Vec<(String, Arc<InferenceProviderTrait>)> = pub_keys
                         .into_iter()
-                        .map(|(key, _)| (key, serving_provider.clone()))
+                        .map(|(key, _)| (key, pinned_trait.clone()))
                         .collect();
 
-                    (model_name, url, serving_provider, pub_keys, pinned_count)
+                    (model_name, url, pinned_trait as Arc<InferenceProviderTrait>, pub_keys, pinned_count)
                 }
             })
             .collect();

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1443,7 +1443,12 @@ impl InferenceProviderPool {
                         })
                         .collect();
 
-                    let discovery_results = futures::future::join_all(discovery_futures).await;
+                    let discovery_results = tokio::time::timeout(
+                        Duration::from_secs(30),
+                        futures::future::join_all(discovery_futures),
+                    )
+                    .await
+                    .unwrap_or_default();
 
                     // Verify each unique attestation and accumulate fingerprints
                     let mut pinned_count = 0u32;
@@ -1489,10 +1494,16 @@ impl InferenceProviderPool {
                             "TLS SPKI fingerprints pinned from attestation discovery"
                         );
                     } else {
+                        // Fail closed: insert a sentinel so the provider exits bootstrap
+                        // mode and rejects all TLS connections until a verified fingerprint
+                        // is discovered on a future refresh cycle.
+                        vllm_provider.add_expected_fingerprint(
+                            "__attestation_verification_required__".to_string(),
+                        );
                         tracing::warn!(
                             model = %model_name,
                             url = %url,
-                            "No TLS fingerprints pinned — attestation verification failed or unavailable"
+                            "No TLS fingerprints pinned — provider will reject connections until attestation succeeds"
                         );
                     }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1404,7 +1404,7 @@ impl InferenceProviderPool {
                 let api_key = api_key.clone();
                 let verifier = verifier.clone();
                 async move {
-                    // Create provider with empty fingerprint set (bootstrap mode)
+                    // Create provider in bootstrap mode (accepts any valid cert)
                     let vllm_provider = Arc::new(VLlmProvider::new(VLlmConfig::new(
                         url.clone(),
                         api_key,
@@ -1413,28 +1413,29 @@ impl InferenceProviderPool {
                     let serving_provider =
                         vllm_provider.clone() as Arc<InferenceProviderTrait>;
 
-                    let (pub_keys, _, _) =
-                        Self::fetch_signing_public_keys_for_both_algorithms(
-                            &serving_provider,
-                            &model_name,
-                            &url,
-                        )
-                        .await;
-
-                    // Fire N parallel attestation calls to discover TLS fingerprints
-                    // from different backends behind L4 load balancing. Each call may
-                    // hit a different CVM with a different TLS certificate.
+                    // Step 1: Discover and verify TLS fingerprints FIRST.
+                    // Uses N parallel attestation calls to hit multiple backends behind
+                    // L4 load balancing. Each call generates a client-side nonce for
+                    // freshness (prevents replay of old attestation reports).
                     let discovery_futures: Vec<_> = (0..discovery_parallelism)
                         .map(|_| {
                             let provider = serving_provider.clone();
                             let model = model_name.clone();
                             async move {
-                                provider
+                                // Generate client-side nonce for freshness
+                                let nonce_bytes: [u8; 32] = rand::random();
+                                let nonce = hex::encode(nonce_bytes);
+                                let report = provider
                                     .get_attestation_report(
-                                        model, None, None, None, true,
+                                        model,
+                                        None,
+                                        Some(nonce.clone()),
+                                        None,
+                                        true,
                                     )
                                     .await
-                                    .ok()
+                                    .ok()?;
+                                Some((report, nonce))
                             }
                         })
                         .collect();
@@ -1449,7 +1450,7 @@ impl InferenceProviderPool {
                     // Verify each unique attestation and accumulate fingerprints
                     let mut pinned_count = 0u32;
                     let mut seen_fingerprints = std::collections::HashSet::new();
-                    for report in discovery_results.into_iter().flatten() {
+                    for (report, client_nonce) in discovery_results.into_iter().flatten() {
                         let fp = report
                             .get("tls_cert_fingerprint")
                             .and_then(|v| v.as_str())
@@ -1458,14 +1459,14 @@ impl InferenceProviderPool {
                         if fp.is_empty() || !seen_fingerprints.insert(fp.clone()) {
                             continue; // Skip empty or already-verified fingerprints
                         }
-                        let nonce = report
-                            .get("request_nonce")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or_default();
-                        match verifier.verify_attestation_report(&report, nonce).await {
+                        // Verify with the CLIENT-generated nonce (not the backend's)
+                        match verifier
+                            .verify_attestation_report(&report, &client_nonce)
+                            .await
+                        {
                             Ok(verified) => {
                                 if let Some(ref vfp) = verified.tls_cert_fingerprint {
-                                    vllm_provider.add_expected_fingerprint(vfp.clone());
+                                    vllm_provider.add_verified_fingerprint(vfp.clone());
                                     pinned_count += 1;
                                 }
                             }
@@ -1490,18 +1491,25 @@ impl InferenceProviderPool {
                             "TLS SPKI fingerprints pinned from attestation discovery"
                         );
                     } else {
-                        // Fail closed: insert a sentinel so the provider exits bootstrap
-                        // mode and rejects all TLS connections until a verified fingerprint
-                        // is discovered on a future refresh cycle.
-                        vllm_provider.add_expected_fingerprint(
-                            "__attestation_verification_required__".to_string(),
-                        );
+                        // Fail closed: block connections so the provider exits bootstrap
+                        // mode and rejects all TLS until a future refresh succeeds.
+                        vllm_provider.block_connections();
                         tracing::warn!(
                             model = %model_name,
                             url = %url,
                             "No TLS fingerprints pinned — provider will reject connections until attestation succeeds"
                         );
                     }
+
+                    // Step 2: Fetch signing public keys WITH TLS pinning active.
+                    // This ensures signing keys are fetched over verified connections.
+                    let (pub_keys, _, _) =
+                        Self::fetch_signing_public_keys_for_both_algorithms(
+                            &serving_provider,
+                            &model_name,
+                            &url,
+                        )
+                        .await;
 
                     let pub_keys: Vec<(String, Arc<InferenceProviderTrait>)> = pub_keys
                         .into_iter()

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1,3 +1,4 @@
+use crate::attestation::AttestationVerifier;
 use crate::common::encryption_headers;
 use config::ExternalProvidersConfig;
 use inference_providers::{
@@ -71,6 +72,8 @@ pub struct InferenceProviderPool {
     /// across refreshes, the existing provider (and its warm reqwest::Client with
     /// pooled TLS connections) is reused instead of creating a new one.
     inference_url_providers: Arc<RwLock<HashMap<String, Arc<InferenceProviderTrait>>>>,
+    /// Attestation verifier for TDX quote, GPU evidence, and image hash verification.
+    attestation_verifier: Arc<AttestationVerifier>,
 }
 
 impl InferenceProviderPool {
@@ -85,6 +88,7 @@ impl InferenceProviderPool {
             refresh_task_handle: Arc::new(Mutex::new(None)),
             provider_failure_counts: Arc::new(std::sync::RwLock::new(HashMap::new())),
             inference_url_providers: Arc::new(RwLock::new(HashMap::new())),
+            attestation_verifier: Arc::new(AttestationVerifier::from_env()),
         }
     }
 
@@ -173,7 +177,7 @@ impl InferenceProviderPool {
     pub async fn register_provider(&self, model_id: String, provider: Arc<InferenceProviderTrait>) {
         // Fetch signing public keys for both algorithms
         // Use "mock" as URL identifier for logging (since this is typically used for mock providers)
-        let (pub_key_updates, _has_valid_attestation) =
+        let (pub_key_updates, _has_valid_attestation, _attestation_reports) =
             Self::fetch_signing_public_keys_for_both_algorithms(&provider, &model_id, "mock").await;
 
         // Atomic update: update both mappings together under a single lock
@@ -201,7 +205,7 @@ impl InferenceProviderPool {
         for (model_id, provider) in providers {
             // Fetch signing public keys for both algorithms to populate model_pub_key_mapping
             // Use "mock" as URL identifier for logging (since this is typically used for mock providers)
-            let (keys, _has_valid_attestation) =
+            let (keys, _has_valid_attestation, _attestation_reports) =
                 Self::fetch_signing_public_keys_for_both_algorithms(&provider, &model_id, "mock")
                     .await;
             pub_key_updates.extend(keys);
@@ -229,8 +233,8 @@ impl InferenceProviderPool {
     /// Fetch signing public keys for both ECDSA and Ed25519 algorithms
     ///
     /// Attempts to fetch attestation reports for both signing algorithms and returns
-    /// all available signing public keys. This ensures that providers are registered
-    /// for both algorithms if they support them.
+    /// all available signing public keys. Requests `include_tls_fingerprint=true` so
+    /// the attestation binds the TLS certificate SPKI to the TDX report.
     ///
     /// # Arguments
     /// * `provider` - The inference provider to fetch the attestation reports from
@@ -238,16 +242,22 @@ impl InferenceProviderPool {
     /// * `url` - Optional URL for logging purposes (can be empty string if not available)
     ///
     /// # Returns
-    /// * Tuple of (signing_public_keys, has_valid_attestation) where:
+    /// * Tuple of (signing_public_keys, has_valid_attestation, attestation_reports) where:
     ///   - `signing_public_keys`: Vector of (signing_public_key, provider) tuples for all available algorithms
     ///   - `has_valid_attestation`: True if at least one attestation report was successfully fetched
+    ///   - `attestation_reports`: The raw attestation reports for further verification (TDX, GPU, image hash)
     async fn fetch_signing_public_keys_for_both_algorithms(
         provider: &Arc<InferenceProviderTrait>,
         model_name: &str,
         url: &str,
-    ) -> (Vec<(String, Arc<InferenceProviderTrait>)>, bool) {
+    ) -> (
+        Vec<(String, Arc<InferenceProviderTrait>)>,
+        bool,
+        Vec<serde_json::Map<String, serde_json::Value>>,
+    ) {
         let mut pub_key_updates = Vec::new();
         let mut has_valid_attestation = false;
+        let mut attestation_reports = Vec::new();
 
         // Fetch for ECDSA
         if let Some(attestation_report) = Self::fetch_attestation_report_with_retry_for_algo(
@@ -265,6 +275,7 @@ impl InferenceProviderPool {
             {
                 pub_key_updates.push((signing_public_key.to_string(), provider.clone()));
             }
+            attestation_reports.push(attestation_report);
         }
 
         // Fetch for Ed25519
@@ -283,9 +294,10 @@ impl InferenceProviderPool {
             {
                 pub_key_updates.push((signing_public_key.to_string(), provider.clone()));
             }
+            attestation_reports.push(attestation_report);
         }
 
-        (pub_key_updates, has_valid_attestation)
+        (pub_key_updates, has_valid_attestation, attestation_reports)
     }
 
     /// Fetch attestation report with retries for a specific signing algorithm
@@ -318,7 +330,7 @@ impl InferenceProviderPool {
                     signing_algo.map(|s| s.to_string()),
                     None,
                     None,
-                    false,
+                    true,
                 )
                 .await
             {
@@ -1378,33 +1390,118 @@ impl InferenceProviderPool {
             );
         }
 
-        // Phase 1: Create providers for new/changed URLs and probe attestation concurrently.
+        // Phase 1: Create providers for new/changed URLs, probe attestation, and verify.
+        // Makes multiple parallel attestation calls per model to discover TLS fingerprints
+        // from different backends behind L4 load balancing.
+        let verifier = self.attestation_verifier.clone();
+        let discovery_parallelism =
+            crate::attestation::verification::ATTESTATION_DISCOVERY_PARALLELISM;
         let endpoint_futures: Vec<_> = needs_creation
             .iter()
             .map(|(model_name, url)| {
                 let model_name = model_name.clone();
                 let url = url.clone();
                 let api_key = api_key.clone();
+                let verifier = verifier.clone();
                 async move {
-                    let serving_provider = Arc::new(VLlmProvider::new(VLlmConfig::new(
+                    // Create provider with empty fingerprint set (bootstrap mode)
+                    let vllm_provider = Arc::new(VLlmProvider::new(VLlmConfig::new(
                         url.clone(),
                         api_key,
                         None,
-                    ))) as Arc<InferenceProviderTrait>;
+                    )));
+                    let serving_provider =
+                        vllm_provider.clone() as Arc<InferenceProviderTrait>;
 
-                    let (pub_keys, _) = Self::fetch_signing_public_keys_for_both_algorithms(
-                        &serving_provider,
-                        &model_name,
-                        &url,
-                    )
-                    .await;
+                    let (pub_keys, _, _) =
+                        Self::fetch_signing_public_keys_for_both_algorithms(
+                            &serving_provider,
+                            &model_name,
+                            &url,
+                        )
+                        .await;
+
+                    // Fire N parallel attestation calls to discover TLS fingerprints
+                    // from different backends behind L4 load balancing. Each call may
+                    // hit a different CVM with a different TLS certificate.
+                    let discovery_futures: Vec<_> = (0..discovery_parallelism)
+                        .map(|_| {
+                            let provider = serving_provider.clone();
+                            let model = model_name.clone();
+                            async move {
+                                provider
+                                    .get_attestation_report(
+                                        model,
+                                        Some("ed25519".to_string()),
+                                        None,
+                                        None,
+                                        true,
+                                    )
+                                    .await
+                                    .ok()
+                            }
+                        })
+                        .collect();
+
+                    let discovery_results = futures::future::join_all(discovery_futures).await;
+
+                    // Verify each unique attestation and accumulate fingerprints
+                    let mut pinned_count = 0u32;
+                    let mut seen_fingerprints = std::collections::HashSet::new();
+                    for report in discovery_results.into_iter().flatten() {
+                        let fp = report
+                            .get("tls_cert_fingerprint")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        if fp.is_empty() || !seen_fingerprints.insert(fp.clone()) {
+                            continue; // Skip empty or already-verified fingerprints
+                        }
+                        let nonce = report
+                            .get("request_nonce")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default();
+                        match verifier.verify_attestation_report(&report, nonce).await {
+                            Ok(verified) => {
+                                if let Some(ref vfp) = verified.tls_cert_fingerprint {
+                                    vllm_provider.add_expected_fingerprint(vfp.clone());
+                                    pinned_count += 1;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    model = %model_name,
+                                    url = %url,
+                                    fingerprint = %fp,
+                                    error = %e,
+                                    "Attestation verification failed for discovered backend"
+                                );
+                            }
+                        }
+                    }
+
+                    if pinned_count > 0 {
+                        tracing::info!(
+                            model = %model_name,
+                            url = %url,
+                            pinned_fingerprints = pinned_count,
+                            unique_backends = seen_fingerprints.len(),
+                            "TLS SPKI fingerprints pinned from attestation discovery"
+                        );
+                    } else {
+                        tracing::warn!(
+                            model = %model_name,
+                            url = %url,
+                            "No TLS fingerprints pinned — attestation verification failed or unavailable"
+                        );
+                    }
 
                     let pub_keys: Vec<(String, Arc<InferenceProviderTrait>)> = pub_keys
                         .into_iter()
                         .map(|(key, _)| (key, serving_provider.clone()))
                         .collect();
 
-                    (model_name, url, serving_provider, pub_keys)
+                    (model_name, url, serving_provider, pub_keys, pinned_count)
                 }
             })
             .collect();
@@ -1430,11 +1527,12 @@ impl InferenceProviderPool {
         }
 
         // Newly created providers
-        for (model_name, url, provider, pub_keys) in &new_results {
+        for (model_name, url, provider, pub_keys, pinned_count) in &new_results {
             info!(
                 model = %model_name,
                 url = %url,
                 pub_keys = pub_keys.len(),
+                pinned_fingerprints = pinned_count,
                 "Registered inference_url model"
             );
             model_providers

--- a/crates/services/tests/attestation_verification_test.rs
+++ b/crates/services/tests/attestation_verification_test.rs
@@ -64,7 +64,7 @@ async fn test_verify_glm5_attestation() {
     // Verify with the known-good image hash from production
     let allowed: HashSet<String> =
         ["9b69bb1698bacbb6985409a2c272bcb892e09cdcea63d5399c6768b67d3ff677".to_string()].into();
-    let verifier = services::attestation::AttestationVerifier::new(allowed, None);
+    let verifier = services::attestation::AttestationVerifier::new(allowed, None, false);
 
     match verifier.verify_attestation_report(&report, nonce).await {
         Ok(verified) => {
@@ -116,7 +116,7 @@ async fn test_verify_qwen35_attestation() {
         .expect("missing request_nonce");
 
     // No image hash allowlist — skip that check
-    let verifier = services::attestation::AttestationVerifier::new(HashSet::new(), None);
+    let verifier = services::attestation::AttestationVerifier::new(HashSet::new(), None, false);
 
     match verifier.verify_attestation_report(&report, nonce).await {
         Ok(verified) => {
@@ -158,7 +158,7 @@ async fn test_image_hash_rejection() {
 
     // Use a wrong image hash — should reject
     let wrong_hash: HashSet<String> = ["deadbeef00000000".to_string()].into();
-    let verifier = services::attestation::AttestationVerifier::new(wrong_hash, None);
+    let verifier = services::attestation::AttestationVerifier::new(wrong_hash, None, false);
 
     let result = verifier.verify_attestation_report(&report, nonce).await;
     assert!(result.is_err(), "should reject wrong image hash");

--- a/crates/services/tests/attestation_verification_test.rs
+++ b/crates/services/tests/attestation_verification_test.rs
@@ -172,12 +172,12 @@ async fn test_image_hash_rejection() {
 
 #[tokio::test]
 async fn test_spki_fingerprint_verifier() {
-    use inference_providers::spki_verifier;
+    use inference_providers::spki_verifier::{self, FingerprintState};
     use std::sync::{Arc, RwLock};
 
-    // Test bootstrap mode (empty set accepts any cert)
-    let fps = Arc::new(RwLock::new(HashSet::<String>::new()));
-    let config = spki_verifier::build_rustls_config_with_verifier(fps.clone());
+    // Test bootstrap mode (accepts any valid cert)
+    let state = Arc::new(RwLock::new(FingerprintState::Bootstrap));
+    let config = spki_verifier::build_rustls_config_with_verifier(state.clone());
     let client = reqwest::Client::builder()
         .use_preconfigured_tls(config)
         .build()
@@ -204,10 +204,10 @@ async fn test_spki_fingerprint_verifier() {
     }
 
     // Now pin a wrong fingerprint — should reject
-    fps.write()
-        .unwrap()
-        .insert("0000000000000000000000000000000000000000000000000000000000000000".to_string());
-    let config2 = spki_verifier::build_rustls_config_with_verifier(fps.clone());
+    state.write().unwrap().add_fingerprint(
+        "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+    );
+    let config2 = spki_verifier::build_rustls_config_with_verifier(state.clone());
     let client2 = reqwest::Client::builder()
         .use_preconfigured_tls(config2)
         .build()

--- a/crates/services/tests/attestation_verification_test.rs
+++ b/crates/services/tests/attestation_verification_test.rs
@@ -1,0 +1,228 @@
+//! Integration test: verify attestation from real inference backends.
+//!
+//! Run with: cargo test -p services --test attestation_verification_test -- --nocapture
+//!
+//! Requires network access to completions.near.ai backends.
+
+use std::collections::HashSet;
+
+async fn fetch_attestation(
+    url: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("client build: {e}"))?;
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("request: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    resp.json().await.map_err(|e| format!("json parse: {e}"))
+}
+
+#[tokio::test]
+async fn test_verify_glm5_attestation() {
+    let report = fetch_attestation(
+        "https://glm-5.completions.near.ai/v1/attestation/report?signing_algo=ed25519&include_tls_fingerprint=true",
+    )
+    .await;
+
+    let report = match report {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping test — cannot reach GLM-5 backend: {e}");
+            return;
+        }
+    };
+
+    let nonce = report
+        .get("request_nonce")
+        .and_then(|v| v.as_str())
+        .expect("missing request_nonce");
+
+    println!("Fetched attestation report:");
+    println!(
+        "  signing_address: {}",
+        report
+            .get("signing_address")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?")
+    );
+    println!(
+        "  tls_cert_fingerprint: {}",
+        report
+            .get("tls_cert_fingerprint")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?")
+    );
+    println!("  request_nonce: {nonce}");
+
+    // Verify with the known-good image hash from production
+    let allowed: HashSet<String> =
+        ["9b69bb1698bacbb6985409a2c272bcb892e09cdcea63d5399c6768b67d3ff677".to_string()].into();
+    let verifier = services::attestation::AttestationVerifier::new(allowed, None);
+
+    match verifier.verify_attestation_report(&report, nonce).await {
+        Ok(verified) => {
+            println!("\nVerification PASSED:");
+            println!("  tcb_status: {}", verified.tcb_status);
+            println!("  advisory_ids: {:?}", verified.advisory_ids);
+            println!("  os_image_hash: {:?}", verified.os_image_hash);
+            println!("  compose_hash: {:?}", verified.compose_hash);
+            println!(
+                "  tls_cert_fingerprint: {:?}",
+                verified.tls_cert_fingerprint
+            );
+            println!("  gpu_verdict: {:?}", verified.gpu_verdict);
+
+            assert!(
+                verified.tls_cert_fingerprint.is_some(),
+                "should have TLS fingerprint"
+            );
+            assert_eq!(
+                verified.os_image_hash.as_deref(),
+                Some("9b69bb1698bacbb6985409a2c272bcb892e09cdcea63d5399c6768b67d3ff677"),
+                "os_image_hash should match production"
+            );
+        }
+        Err(e) => {
+            panic!("Verification FAILED: {e}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_verify_qwen35_attestation() {
+    let report = fetch_attestation(
+        "https://qwen35-122b.completions.near.ai/v1/attestation/report?signing_algo=ed25519&include_tls_fingerprint=true",
+    )
+    .await;
+
+    let report = match report {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping test — cannot reach Qwen3.5 backend: {e}");
+            return;
+        }
+    };
+
+    let nonce = report
+        .get("request_nonce")
+        .and_then(|v| v.as_str())
+        .expect("missing request_nonce");
+
+    // No image hash allowlist — skip that check
+    let verifier = services::attestation::AttestationVerifier::new(HashSet::new(), None);
+
+    match verifier.verify_attestation_report(&report, nonce).await {
+        Ok(verified) => {
+            println!("\nQwen3.5 Verification PASSED:");
+            println!("  tcb_status: {}", verified.tcb_status);
+            println!("  os_image_hash: {:?}", verified.os_image_hash);
+            println!("  compose_hash: {:?}", verified.compose_hash);
+            println!(
+                "  tls_cert_fingerprint: {:?}",
+                verified.tls_cert_fingerprint
+            );
+            println!("  gpu_verdict: {:?}", verified.gpu_verdict);
+        }
+        Err(e) => {
+            panic!("Qwen3.5 Verification FAILED: {e}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_image_hash_rejection() {
+    let report = fetch_attestation(
+        "https://glm-5.completions.near.ai/v1/attestation/report?signing_algo=ed25519&include_tls_fingerprint=true",
+    )
+    .await;
+
+    let report = match report {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping test — cannot reach GLM-5 backend: {e}");
+            return;
+        }
+    };
+
+    let nonce = report
+        .get("request_nonce")
+        .and_then(|v| v.as_str())
+        .expect("missing request_nonce");
+
+    // Use a wrong image hash — should reject
+    let wrong_hash: HashSet<String> = ["deadbeef00000000".to_string()].into();
+    let verifier = services::attestation::AttestationVerifier::new(wrong_hash, None);
+
+    let result = verifier.verify_attestation_report(&report, nonce).await;
+    assert!(result.is_err(), "should reject wrong image hash");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("not in allowed list"),
+        "error should mention allowlist: {err}"
+    );
+    println!("Image hash rejection test PASSED: {err}");
+}
+
+#[tokio::test]
+async fn test_spki_fingerprint_verifier() {
+    use inference_providers::spki_verifier;
+    use std::sync::{Arc, RwLock};
+
+    // Test bootstrap mode (empty set accepts any cert)
+    let fps = Arc::new(RwLock::new(HashSet::<String>::new()));
+    let config = spki_verifier::build_rustls_config_with_verifier(fps.clone());
+    let client = reqwest::Client::builder()
+        .use_preconfigured_tls(config)
+        .build()
+        .expect("client build");
+
+    let resp = client
+        .get("https://glm-5.completions.near.ai/v1/models")
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await;
+
+    match resp {
+        Ok(r) => println!(
+            "Bootstrap mode: TLS connection succeeded (HTTP {})",
+            r.status()
+        ),
+        Err(e) => {
+            if e.to_string().contains("timed out") {
+                eprintln!("Skipping — timeout reaching backend");
+                return;
+            }
+            panic!("Bootstrap mode should accept any valid cert: {e}");
+        }
+    }
+
+    // Now pin a wrong fingerprint — should reject
+    fps.write()
+        .unwrap()
+        .insert("0000000000000000000000000000000000000000000000000000000000000000".to_string());
+    let config2 = spki_verifier::build_rustls_config_with_verifier(fps.clone());
+    let client2 = reqwest::Client::builder()
+        .use_preconfigured_tls(config2)
+        .build()
+        .expect("client build");
+
+    let resp2 = client2
+        .get("https://glm-5.completions.near.ai/v1/models")
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await;
+
+    assert!(
+        resp2.is_err(),
+        "wrong fingerprint should reject TLS connection"
+    );
+    let err = resp2.unwrap_err().to_string();
+    println!("Wrong fingerprint rejection: {err}");
+}


### PR DESCRIPTION
## Summary

Adds cryptographic verification of inference backend attestation reports and TLS certificate pinning. Previously, cloud-api trusted attestation JSON from backends without verification. Now every backend must prove it runs in a verified TDX enclave with the expected OS image before its TLS certificate is trusted.

## Verification chain (per backend)

| Step | What | How |
|------|------|-----|
| 1. TDX quote | Proves response came from real Intel TDX hardware | `dcap-qvl` verifies Intel signature chain + collateral |
| 2. Debug check | Rejects debug-mode TDX (host can read memory) | Checks `td_attributes` bit 0 |
| 3. Report data binding | Proves TLS fingerprint is bound to the attested enclave | Verifies `report_data[0:32] == SHA256(signing_address \|\| tls_fingerprint)` and `report_data[32:64] == nonce` |
| 4. RTMR3 replay | Proves event log is authentic (not forged) | Replays SHA-384 hash chain from event log entries with `imr == 3`, compares against quote's `rt_mr3` |
| 5. OS image hash | Proves CVM runs expected dstack image | Extracts `os-image-hash` from RTMR3-verified event log, checks against `ALLOWED_IMAGE_HASHES` env var |
| 6. GPU evidence | Proves GPUs are in confidential computing mode | Submits `nvidia_payload` to NVIDIA NRAS API, checks `x-nvidia-overall-att-result` |

## TLS certificate pinning

- Custom `rustls::ServerCertVerifier` (`SpkiFingerprintVerifier`) wraps WebPKI verification and additionally checks the server certificate's SPKI SHA-256 against verified fingerprints
- Rejection happens at the TLS handshake layer — **before any HTTP request data is sent**
- Both the shared `reqwest::Client` and per-completion dedicated clients share the same fingerprint set via `Arc<RwLock<HashSet<String>>>`
- **Fail-closed**: if no attestation can be verified, a sentinel fingerprint exits bootstrap mode and rejects all connections until a future refresh succeeds

## Fingerprint discovery

- **10 parallel** attestation calls per model during provider registration to discover TLS certificates from multiple backends behind L4 load balancing
- Each unique `tls_cert_fingerprint` is independently verified (full chain above) before pinning
- Fingerprints are **cumulative** — only added, never removed. Reused providers across refresh cycles keep all previously verified fingerprints
- Bootstrap mode: empty fingerprint set accepts any valid cert (needed for initial attestation fetch)
- Provider refresh interval changed from 15 minutes to **5 minutes** (discovers new backend certs faster)

## RTMR3 replay (no OS image download)

Instead of using `dstack-verifier` (which downloads OS images to compute expected boot measurements), we replay only RTMR3 from the event log:

1. Parse event log JSON array from attestation response (handles both string and array formats)
2. For each event with `imr == 3`: `RTMR3 = SHA-384(RTMR3 || event.digest)`
3. Compare replayed RTMR3 against the TDX quote's `rt_mr3`
4. If match → event log is authentic → extract `os-image-hash` and `compose-hash`
5. Check `os-image-hash` against allowlist

This is cryptographically sound: the Intel-signed TDX quote contains `rt_mr3`. If our replay matches, every event in the log (including `os-image-hash`) is verified without downloading any OS image artifacts.

## Environment variables

| Variable | Purpose | Default |
|----------|---------|---------|
| `ALLOWED_IMAGE_HASHES` | Comma-separated OS image hash allowlist (hex). Empty = skip check | empty |
| `PCCS_URL` | Intel PCCS URL for TDX collateral fetching | Phala Network PCCS |
| `EXTERNAL_PROVIDER_REFRESH_INTERVAL` | Provider refresh interval in seconds | `300` (was `900`) |

## Integration test results (real production backends)

```
test test_verify_glm5_attestation ... ok        # TDX UpToDate, RTMR3 match, GPU PASS
test test_verify_qwen35_attestation ... ok       # TDX UpToDate, RTMR3 match, GPU PASS
test test_image_hash_rejection ... ok            # Wrong hash rejected after RTMR3 verify
test test_spki_fingerprint_verifier ... ok       # Bootstrap accepts, wrong FP rejects at TLS
```

## Files changed

| File | Change |
|------|--------|
| `crates/inference_providers/src/spki_verifier.rs` | **New** — `SpkiFingerprintVerifier`, SPKI computation, rustls config builder |
| `crates/services/src/attestation/verification.rs` | **New** — `AttestationVerifier` with TDX, RTMR3 replay, image hash, GPU verification |
| `crates/services/tests/attestation_verification_test.rs` | **New** — Integration tests against GLM-5 and Qwen3.5 production backends |
| `crates/inference_providers/src/vllm/mod.rs` | `VLlmProvider` uses custom TLS verifier, fingerprint management methods |
| `crates/services/src/inference_provider_pool/mod.rs` | 10x parallel attestation discovery, verification integration, fail-closed, 30s timeout |
| `crates/config/src/types.rs` | Default refresh interval 900s → 300s |
| `crates/inference_providers/Cargo.toml` | Added `rustls`, `rustls-native-certs`, `x509-parser`, `hex` |
| `crates/services/Cargo.toml` | Added `dcap-qvl` |

## Test plan

- [x] `cargo test --lib --bins` — 193 unit tests pass
- [x] `cargo clippy` — no warnings
- [x] Integration tests pass against GLM-5 and Qwen3.5 production backends
- [x] RTMR3 replay verified against real TDX quotes
- [x] NVIDIA NRAS GPU verification returns PASS
- [x] TLS SPKI pinning: bootstrap accepts, wrong fingerprint rejects
- [x] Image hash allowlist: correct hash passes, wrong hash rejected
- [ ] Deploy to staging with `ALLOWED_IMAGE_HASHES=9b69bb1698bacbb6985409a2c272bcb892e09cdcea63d5399c6768b67d3ff677`
- [ ] Verify logs show "TLS SPKI fingerprints pinned from attestation discovery"
- [ ] Verify inference requests succeed through pinned connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)