### PR TITLE
feat: prefix-aware routing for inference cache optimization

### DIFF
--- a/crates/inference_providers/src/spki_verifier.rs
+++ b/crates/inference_providers/src/spki_verifier.rs
@@ -168,41 +168,63 @@ impl ServerCertVerifier for SpkiFingerprintVerifier {
     }
 }
 
+/// Shared TLS infrastructure (root certs + crypto provider) for building
+/// multiple `ClientConfig`s without duplicating the ~150KB root cert store.
+#[derive(Clone)]
+pub struct SharedTlsRoots {
+    root_store: Arc<rustls::RootCertStore>,
+    provider: Arc<rustls::crypto::CryptoProvider>,
+}
+
+impl SharedTlsRoots {
+    /// Load native root certificates once. Reuse via `.clone()` for multiple clients.
+    pub fn load() -> Self {
+        let mut root_store = rustls::RootCertStore::empty();
+        let native = rustls_native_certs::load_native_certs();
+        for err in &native.errors {
+            tracing::warn!("error loading native root cert: {err}");
+        }
+        for cert in native.certs {
+            root_store.add(cert).ok();
+        }
+        Self {
+            root_store: Arc::new(root_store),
+            provider: Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
+        }
+    }
+
+    /// Build a `rustls::ClientConfig` with SPKI fingerprint verification.
+    pub fn build_config(&self, state: Arc<RwLock<FingerprintState>>) -> rustls::ClientConfig {
+        let default_verifier = rustls::client::WebPkiServerVerifier::builder_with_provider(
+            self.root_store.clone(),
+            self.provider.clone(),
+        )
+        .build()
+        .expect("failed to build WebPKI verifier");
+
+        let verifier = SpkiFingerprintVerifier::new(default_verifier, state);
+
+        let mut config = rustls::ClientConfig::builder_with_provider(self.provider.clone())
+            .with_safe_default_protocol_versions()
+            .expect("failed to set protocol versions")
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(verifier))
+            .with_no_client_auth();
+
+        config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        config
+    }
+}
+
 /// Build a `rustls::ClientConfig` using native root certificates and a custom
 /// `SpkiFingerprintVerifier` that pins to the given fingerprint state.
+///
+/// Convenience wrapper — loads root certs each call. For creating many clients,
+/// use `SharedTlsRoots::load()` once and call `.build_config()` per client.
 pub fn build_rustls_config_with_verifier(
     state: Arc<RwLock<FingerprintState>>,
 ) -> rustls::ClientConfig {
-    let mut root_store = rustls::RootCertStore::empty();
-    let native = rustls_native_certs::load_native_certs();
-    for err in &native.errors {
-        tracing::warn!("error loading native root cert: {err}");
-    }
-    for cert in native.certs {
-        root_store.add(cert).ok();
-    }
-
-    let provider = rustls::crypto::aws_lc_rs::default_provider();
-
-    let default_verifier = rustls::client::WebPkiServerVerifier::builder_with_provider(
-        Arc::new(root_store),
-        Arc::new(provider.clone()),
-    )
-    .build()
-    .expect("failed to build WebPKI verifier");
-
-    let verifier = SpkiFingerprintVerifier::new(default_verifier, state);
-
-    let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
-        .with_safe_default_protocol_versions()
-        .expect("failed to set protocol versions")
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(verifier))
-        .with_no_client_auth();
-
-    // reqwest negotiates ALPN; without this, HTTP/2 and HTTP/1.1 won't work
-    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-    config
+    SharedTlsRoots::load().build_config(state)
 }
 
 #[cfg(test)]

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1,9 +1,12 @@
+mod prefix_router;
+
 use crate::spki_verifier::FingerprintState;
 use crate::{
     models::StreamOptions, spki_verifier, sse_parser::new_sse_parser, ImageEditError,
     ImageGenerationError, RerankError, ScoreError, *,
 };
 use async_trait::async_trait;
+use prefix_router::PrefixRouter;
 use reqwest::{header::HeaderValue, Client};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -71,19 +74,21 @@ impl VLlmConfig {
 /// Supports both chat completions and text completions with streaming.
 pub struct VLlmProvider {
     config: VLlmConfig,
+    /// General-purpose client for non-completion requests (attestation, models, etc.)
     client: Client,
-    /// Dedicated per-completion clients for connection-pinned signature fetching.
-    /// With L4 TLS passthrough load balancing, each TLS connection is pinned to a
-    /// specific backend. Signature fetches must reuse the same connection that served
-    /// the completion, otherwise they hit a different backend and get 404.
-    ///
-    /// Flow: completion creates a dedicated Client → stored in `pending_clients[request_hash]`
-    /// → pool peeks chat_id from stream → calls `pin_chat_connection(request_hash, chat_id)`
-    /// → moves client to `signature_clients[chat_id]` → `get_signature` uses it.
-    pending_clients: Arc<std::sync::Mutex<HashMap<String, Client>>>,
-    signature_clients: Arc<std::sync::Mutex<HashMap<String, Client>>>,
+    /// Persistent clients indexed by prefix bucket ID. Each maintains a single
+    /// connection pinned to a specific backend via L4 TLS passthrough. Requests
+    /// with the same prompt prefix route to the same bucket → same backend →
+    /// prefix cache hit.
+    bucket_clients: Vec<Client>,
+    /// Prefix router: message-level trie mapping conversation prefixes to bucket IDs.
+    prefix_router: Arc<PrefixRouter>,
+    /// Maps request_hash → bucket_id during streaming (before chat_id is known).
+    pending_buckets: Arc<std::sync::Mutex<HashMap<String, usize>>>,
+    /// Maps chat_id → bucket_id for signature fetching on the correct backend.
+    signature_buckets: Arc<std::sync::Mutex<HashMap<String, usize>>>,
     /// TLS fingerprint verification state (Bootstrap → Pinned or Blocked).
-    /// Shared across the main client and all dedicated per-completion clients.
+    /// Shared across the main client and all bucket clients.
     fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
 }
 
@@ -101,29 +106,47 @@ impl VLlmProvider {
         config: VLlmConfig,
         fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
     ) -> Self {
+        // General-purpose client for non-completion requests
         let tls_config =
             spki_verifier::build_rustls_config_with_verifier(fingerprint_state.clone());
-
-        // connect_timeout: 5s is generous for local-network backends. A backend behind a
-        // firewall-drop (not RST) is the worst case; 5s catches it without penalising
-        // fallback latency. Connection-refused is instant regardless.
-        // read_timeout guards against stalled backends: if no bytes arrive for this
-        // duration, the connection is dropped. Must be generous (300s) because under
-        // heavy load vLLM can stall between chunks during decode when KV cache is under
-        // pressure, causing premature stream termination and lost usage stats.
         let client = Client::builder()
             .use_preconfigured_tls(tls_config)
-            .connect_timeout(std::time::Duration::from_secs(5))
-            .pool_idle_timeout(std::time::Duration::from_secs(90))
-            .read_timeout(std::time::Duration::from_secs(300))
+            .connect_timeout(Duration::from_secs(5))
+            .pool_idle_timeout(Duration::from_secs(90))
+            .read_timeout(Duration::from_secs(300))
             .build()
             .expect("Failed to create HTTP client");
+
+        // Prefix router determines which bucket to use for each completion
+        let prefix_router = Arc::new(PrefixRouter::new());
+        let num_buckets = prefix_router.num_buckets();
+
+        // Create persistent bucket clients — each maintains one connection
+        // pinned to a specific backend via L4 TLS passthrough.
+        // pool_max_idle_per_host(1) keeps exactly one connection alive.
+        // With HTTP/2, concurrent requests multiplex on the same connection.
+        let bucket_clients: Vec<Client> = (0..num_buckets)
+            .map(|_| {
+                let tls_config =
+                    spki_verifier::build_rustls_config_with_verifier(fingerprint_state.clone());
+                Client::builder()
+                    .use_preconfigured_tls(tls_config)
+                    .pool_max_idle_per_host(1)
+                    .connect_timeout(Duration::from_secs(5))
+                    .pool_idle_timeout(Duration::from_secs(300))
+                    .read_timeout(Duration::from_secs(300))
+                    .build()
+                    .expect("Failed to create bucket HTTP client")
+            })
+            .collect();
 
         Self {
             config,
             client,
-            pending_clients: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            signature_clients: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            bucket_clients,
+            prefix_router,
+            pending_buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            signature_buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
             fingerprint_state,
         }
     }
@@ -136,23 +159,6 @@ impl VLlmProvider {
     /// Get a reference to the shared fingerprint state.
     pub fn fingerprint_state(&self) -> Arc<std::sync::RwLock<FingerprintState>> {
         self.fingerprint_state.clone()
-    }
-
-    /// Create a dedicated reqwest::Client for a single completion.
-    /// This client has its own connection pool, ensuring the TLS connection
-    /// used for the completion is reused for subsequent signature fetches.
-    /// Shares the same SPKI fingerprint verification as the main client.
-    fn create_dedicated_client(&self) -> Client {
-        let tls_config =
-            spki_verifier::build_rustls_config_with_verifier(self.fingerprint_state.clone());
-        Client::builder()
-            .use_preconfigured_tls(tls_config)
-            .pool_max_idle_per_host(1)
-            .connect_timeout(std::time::Duration::from_secs(5))
-            .pool_idle_timeout(std::time::Duration::from_secs(90))
-            .read_timeout(std::time::Duration::from_secs(300))
-            .build()
-            .expect("Failed to create dedicated HTTP client")
     }
 
     /// Add a verified SPKI fingerprint. Transitions Bootstrap → Pinned,
@@ -317,18 +323,19 @@ impl InferenceProvider for VLlmProvider {
             .build_headers()
             .map_err(CompletionError::CompletionError)?;
 
-        // Use the dedicated client for this chat_id if available.
+        // Use the bucket client for this chat_id if available.
         // This ensures the signature fetch goes over the same TLS connection
         // that served the completion (critical for L4 load-balanced backends).
-        // Clone rather than remove — get_signature is called once per algo
-        // (ecdsa + ed25519). Cleanup happens via unpin_chat_connection.
-        let dedicated_client = self
-            .signature_clients
+        let bucket_id = self
+            .signature_buckets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .get(chat_id)
-            .cloned();
-        let client = dedicated_client.as_ref().unwrap_or(&self.client);
+            .copied();
+        let client = match bucket_id {
+            Some(id) => &self.bucket_clients[id],
+            None => &self.client,
+        };
 
         let response = client
             .get(&url)
@@ -357,21 +364,21 @@ impl InferenceProvider for VLlmProvider {
     }
 
     fn pin_chat_connection(&self, request_hash: &str, chat_id: &str) {
-        if let Some(client) = self
-            .pending_clients
+        if let Some(bucket_id) = self
+            .pending_buckets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(request_hash)
         {
-            self.signature_clients
+            self.signature_buckets
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
-                .insert(chat_id.to_string(), client);
+                .insert(chat_id.to_string(), bucket_id);
         }
     }
 
     fn unpin_chat_connection(&self, chat_id: &str) {
-        self.signature_clients
+        self.signature_buckets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(chat_id);
@@ -505,20 +512,22 @@ impl InferenceProvider for VLlmProvider {
         // Prepare encryption headers
         self.prepare_encryption_headers(&mut headers, &mut streaming_params.extra);
 
-        // Use a dedicated client for this completion so the signature fetch
-        // can reuse the same TLS connection (required for L4 load balancing).
-        let dedicated_client = self.create_dedicated_client();
+        // Route to a bucket client based on prompt prefix.
+        // The bucket client maintains a persistent TLS connection pinned to a
+        // specific backend via L4 passthrough → prefix cache hits.
+        let bucket_id = self.prefix_router.route(&streaming_params.messages);
+        let bucket_client = &self.bucket_clients[bucket_id];
         let response = self
-            .send_streaming_request(&url, headers, &streaming_params, Some(&dedicated_client))
+            .send_streaming_request(&url, headers, &streaming_params, Some(bucket_client))
             .await?;
 
-        // Store the dedicated client keyed by request_hash.
+        // Store the bucket ID keyed by request_hash.
         // The pool will call pin_chat_connection() after peeking the chat_id
-        // to move it to signature_clients[chat_id].
-        self.pending_clients
+        // to move it to signature_buckets[chat_id].
+        self.pending_buckets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(request_hash, dedicated_client);
+            .insert(request_hash, bucket_id);
 
         // Use the SSE parser to handle the stream properly
         let sse_stream = new_sse_parser(response.bytes_stream(), true);
@@ -545,9 +554,10 @@ impl InferenceProvider for VLlmProvider {
         // Prepare encryption headers
         self.prepare_encryption_headers(&mut headers, &mut non_streaming_params.extra);
 
-        // Use a dedicated client for connection pinning (same TLS connection for signature)
-        let dedicated_client = self.create_dedicated_client();
-        let response = dedicated_client
+        // Route to a bucket client based on prompt prefix (same as streaming path)
+        let bucket_id = self.prefix_router.route(&non_streaming_params.messages);
+        let bucket_client = &self.bucket_clients[bucket_id];
+        let response = bucket_client
             .post(&url)
             .headers(headers)
             .json(&non_streaming_params)
@@ -583,13 +593,13 @@ impl InferenceProvider for VLlmProvider {
             CompletionError::CompletionError(format!("Failed to parse response: {e}"))
         })?;
 
-        // Store the dedicated client for signature fetching.
+        // Store the bucket ID for signature fetching.
         // For non-streaming, we know the chat_id immediately.
         let chat_id = chat_completion_response.id.clone();
-        self.signature_clients
+        self.signature_buckets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(chat_id, dedicated_client);
+            .insert(chat_id, bucket_id);
 
         Ok(ChatCompletionResponseWithBytes {
             response: chat_completion_response,

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -124,13 +124,18 @@ impl VLlmProvider {
 
         // Create persistent bucket clients — each maintains one connection
         // pinned to a specific backend via L4 TLS passthrough.
-        // pool_max_idle_per_host(1) keeps exactly one connection alive.
-        // With HTTP/2, concurrent requests multiplex on the same connection.
+        //
+        // Relies on HTTP/2 multiplexing: concurrent requests on the same bucket
+        // share one TLS connection → guaranteed same backend. CVM nginx (port 8444)
+        // negotiates h2 via ALPN. With HTTP/1.1 fallback, concurrent requests may
+        // open additional connections to different backends — signature fetches
+        // handle this with a retry fallback (see get_signature).
         let bucket_clients: Vec<Client> = (0..num_buckets)
             .map(|_| {
                 Client::builder()
                     .use_preconfigured_tls(tls_roots.build_config(fingerprint_state.clone()))
                     .pool_max_idle_per_host(1)
+                    .http2_adaptive_window(true)
                     .connect_timeout(Duration::from_secs(5))
                     .pool_idle_timeout(Duration::from_secs(300))
                     .read_timeout(Duration::from_secs(300))
@@ -322,44 +327,65 @@ impl InferenceProvider for VLlmProvider {
             .build_headers()
             .map_err(CompletionError::CompletionError)?;
 
-        // Use the bucket client for this chat_id if available.
-        // This ensures the signature fetch goes over the same TLS connection
-        // that served the completion (critical for L4 load-balanced backends).
+        // Use the bucket client for this chat_id to hit the same backend.
+        // With HTTP/2 (ALPN-negotiated), all requests multiplex on one connection.
+        // Under HTTP/1.1 fallback with concurrency, the bucket client may have
+        // opened a second connection to a different backend — if we get 404,
+        // retry once on the general-purpose client as a fallback.
         let bucket_id = self
             .signature_buckets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .get(chat_id)
             .copied();
-        let client = match bucket_id {
+        let primary_client = match bucket_id {
             Some(id) => &self.bucket_clients[id],
             None => &self.client,
         };
 
-        let response = client
-            .get(&url)
-            .headers(headers)
-            .timeout(Duration::from_secs(self.config.timeout_seconds as u64))
-            .send()
-            .await
-            .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
+        let timeout = Duration::from_secs(self.config.timeout_seconds as u64);
+        let clients_to_try: Vec<&Client> = if bucket_id.is_some() {
+            vec![primary_client, &self.client]
+        } else {
+            vec![primary_client]
+        };
 
-        if !response.status().is_success() {
+        let mut last_error = None;
+        for client in clients_to_try {
+            let response = client
+                .get(&url)
+                .headers(headers.clone())
+                .timeout(timeout)
+                .send()
+                .await
+                .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
+
+            if response.status().is_success() {
+                let signature = response
+                    .json()
+                    .await
+                    .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
+                return Ok(signature);
+            }
+
             let status = response.status().as_u16();
             let error_text = response
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("Failed to read error response body: {e}"));
-            return Err(CompletionError::CompletionError(format!(
+            last_error = Some(format!(
                 "Signature fetch failed (HTTP {status}): {error_text}"
-            )));
+            ));
+
+            // Only retry on 404 (wrong backend) — other errors are definitive
+            if status != 404 {
+                break;
+            }
         }
 
-        let signature = response
-            .json()
-            .await
-            .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
-        Ok(signature)
+        Err(CompletionError::CompletionError(
+            last_error.unwrap_or_else(|| "Signature fetch failed".to_string()),
+        ))
     }
 
     fn pin_chat_connection(&self, request_hash: &str, chat_id: &str) {

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -2,8 +2,8 @@ mod prefix_router;
 
 use crate::spki_verifier::{FingerprintState, SharedTlsRoots};
 use crate::{
-    models::StreamOptions, spki_verifier, sse_parser::new_sse_parser, ImageEditError,
-    ImageGenerationError, RerankError, ScoreError, *,
+    models::StreamOptions, sse_parser::new_sse_parser, ImageEditError, ImageGenerationError,
+    RerankError, ScoreError, *,
 };
 use async_trait::async_trait;
 use prefix_router::PrefixRouter;

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1,6 +1,6 @@
 mod prefix_router;
 
-use crate::spki_verifier::FingerprintState;
+use crate::spki_verifier::{FingerprintState, SharedTlsRoots};
 use crate::{
     models::StreamOptions, spki_verifier, sse_parser::new_sse_parser, ImageEditError,
     ImageGenerationError, RerankError, ScoreError, *,
@@ -106,11 +106,12 @@ impl VLlmProvider {
         config: VLlmConfig,
         fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
     ) -> Self {
+        // Load root certs once, share across all clients (~150KB instead of N×150KB)
+        let tls_roots = SharedTlsRoots::load();
+
         // General-purpose client for non-completion requests
-        let tls_config =
-            spki_verifier::build_rustls_config_with_verifier(fingerprint_state.clone());
         let client = Client::builder()
-            .use_preconfigured_tls(tls_config)
+            .use_preconfigured_tls(tls_roots.build_config(fingerprint_state.clone()))
             .connect_timeout(Duration::from_secs(5))
             .pool_idle_timeout(Duration::from_secs(90))
             .read_timeout(Duration::from_secs(300))
@@ -127,10 +128,8 @@ impl VLlmProvider {
         // With HTTP/2, concurrent requests multiplex on the same connection.
         let bucket_clients: Vec<Client> = (0..num_buckets)
             .map(|_| {
-                let tls_config =
-                    spki_verifier::build_rustls_config_with_verifier(fingerprint_state.clone());
                 Client::builder()
-                    .use_preconfigured_tls(tls_config)
+                    .use_preconfigured_tls(tls_roots.build_config(fingerprint_state.clone()))
                     .pool_max_idle_per_host(1)
                     .connect_timeout(Duration::from_secs(5))
                     .pool_idle_timeout(Duration::from_secs(300))

--- a/crates/inference_providers/src/vllm/prefix_router.rs
+++ b/crates/inference_providers/src/vllm/prefix_router.rs
@@ -19,6 +19,7 @@ fn num_buckets() -> usize {
         .and_then(|s| s.parse().ok())
         .filter(|&n| n > 0)
         .unwrap_or(64)
+        .min(1024) // Cap to prevent excessive memory from misconfiguration
 }
 
 /// Maximum number of messages to consider for routing.
@@ -26,6 +27,7 @@ fn max_trie_depth() -> usize {
     std::env::var("PREFIX_MAX_MESSAGES")
         .ok()
         .and_then(|s| s.parse().ok())
+        .filter(|&n| n > 0)
         .unwrap_or(8)
 }
 
@@ -51,7 +53,10 @@ pub struct PrefixRouter {
 
 impl PrefixRouter {
     pub fn new() -> Self {
-        let num_buckets = num_buckets();
+        Self::with_config(num_buckets(), max_trie_depth())
+    }
+
+    fn with_config(num_buckets: usize, max_depth: usize) -> Self {
         Self {
             trie: RwLock::new(TrieNode {
                 children: HashMap::new(),
@@ -59,7 +64,7 @@ impl PrefixRouter {
             }),
             next_bucket: AtomicUsize::new(1),
             num_buckets,
-            max_depth: max_trie_depth(),
+            max_depth,
         }
     }
 
@@ -74,28 +79,35 @@ impl PrefixRouter {
             return 0;
         }
 
-        // Fast path: read-only lookup
-        {
-            let trie = self.trie.read().unwrap_or_else(|e| e.into_inner());
-            if let Some(bucket) = Self::lookup_readonly(&trie, &hashes) {
-                return bucket;
-            }
+        // Fast path: read-only lookup. Since deeper nodes inherit parent buckets,
+        // this always returns a valid bucket even for partially-unseen prefixes.
+        // Only take write lock when the first message (system prompt) is brand new.
+        let trie = self.trie.read().unwrap_or_else(|e| e.into_inner());
+        let first_msg_exists = trie.children.contains_key(&hashes[0]);
+        let bucket = Self::lookup_readonly(&trie, &hashes);
+        drop(trie);
+
+        if first_msg_exists {
+            return bucket;
         }
 
-        // Slow path: insert new nodes
+        // Slow path: first message unseen — need to assign a new bucket
         let mut trie = self.trie.write().unwrap_or_else(|e| e.into_inner());
         self.lookup_or_insert(&mut trie, &hashes)
     }
 
-    fn lookup_readonly(node: &TrieNode, hashes: &[u64]) -> Option<usize> {
+    /// Read-only lookup. Returns the deepest matching node's bucket.
+    /// Since deeper nodes inherit the parent's bucket, we can return early
+    /// when we hit an unseen message — the parent's bucket is correct.
+    fn lookup_readonly(node: &TrieNode, hashes: &[u64]) -> usize {
         let mut current = node;
         for h in hashes {
             match current.children.get(h) {
                 Some(child) => current = child,
-                None => return None,
+                None => break, // Unseen message — parent's bucket is inherited
             }
         }
-        Some(current.bucket)
+        current.bucket
     }
 
     /// Only root's direct children get fresh buckets. All deeper nodes inherit
@@ -176,9 +188,13 @@ mod tests {
         }
     }
 
+    fn router() -> PrefixRouter {
+        PrefixRouter::with_config(64, 8)
+    }
+
     #[test]
     fn test_same_system_prompt_same_bucket() {
-        let router = PrefixRouter::new();
+        let router = router();
         let msgs1 = vec![
             msg(MessageRole::System, "You are a helpful assistant."),
             msg(MessageRole::User, "What is 2+2?"),
@@ -194,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_identical_conversations_same_bucket() {
-        let router = PrefixRouter::new();
+        let router = router();
         let msgs = vec![
             msg(MessageRole::System, "You are helpful."),
             msg(MessageRole::User, "Hi"),
@@ -204,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_different_system_prompts_different_buckets() {
-        let router = PrefixRouter::new();
+        let router = router();
         let msgs1 = vec![msg(MessageRole::System, "You are a Python expert.")];
         let msgs2 = vec![msg(MessageRole::System, "You are a Rust expert.")];
         assert_ne!(router.route(&msgs1), router.route(&msgs2));
@@ -212,13 +228,13 @@ mod tests {
 
     #[test]
     fn test_empty_messages() {
-        let router = PrefixRouter::new();
+        let router = router();
         assert_eq!(router.route(&[]), 0);
     }
 
     #[test]
     fn test_bucket_range() {
-        let router = PrefixRouter::new();
+        let router = router();
         for i in 0..100 {
             let msgs = vec![msg(MessageRole::User, &format!("message {i}"))];
             assert!(router.route(&msgs) < router.num_buckets());

--- a/crates/inference_providers/src/vllm/prefix_router.rs
+++ b/crates/inference_providers/src/vllm/prefix_router.rs
@@ -1,0 +1,227 @@
+//! Prefix-aware routing for inference cache hit optimization.
+//!
+//! Maintains a trie where each level corresponds to a message in the conversation.
+//! Requests sharing the same system prompt route to the same bucket regardless of
+//! subsequent user messages. Each bucket maps to a persistent TLS connection pinned
+//! to a specific backend via L4 passthrough.
+
+use crate::models::ChatMessage;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::RwLock;
+
+/// Number of prefix routing buckets (persistent connections per provider).
+fn num_buckets() -> usize {
+    std::env::var("NUM_PREFIX_BUCKETS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(64)
+}
+
+/// Maximum number of messages to consider for routing.
+fn max_trie_depth() -> usize {
+    std::env::var("PREFIX_MAX_MESSAGES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8)
+}
+
+struct TrieNode {
+    children: HashMap<u64, Box<TrieNode>>,
+    /// Bucket ID. Only root's direct children get fresh buckets (one per unique
+    /// first message, typically the system prompt). All deeper nodes inherit
+    /// their parent's bucket, keeping conversations with the same prefix on
+    /// the same backend.
+    bucket: usize,
+}
+
+/// Routes requests to buckets based on conversation prefix similarity.
+///
+/// Each trie level represents one message (role + content hash).
+/// Requests sharing the same system prompt → same bucket → same backend → cache hit.
+pub struct PrefixRouter {
+    trie: RwLock<TrieNode>,
+    next_bucket: AtomicUsize,
+    num_buckets: usize,
+    max_depth: usize,
+}
+
+impl PrefixRouter {
+    pub fn new() -> Self {
+        let num_buckets = num_buckets();
+        Self {
+            trie: RwLock::new(TrieNode {
+                children: HashMap::new(),
+                bucket: 0,
+            }),
+            next_bucket: AtomicUsize::new(1),
+            num_buckets,
+            max_depth: max_trie_depth(),
+        }
+    }
+
+    pub fn num_buckets(&self) -> usize {
+        self.num_buckets
+    }
+
+    /// Route a request to a bucket based on its conversation prefix.
+    pub fn route(&self, messages: &[ChatMessage]) -> usize {
+        let hashes = hash_messages(messages, self.max_depth);
+        if hashes.is_empty() {
+            return 0;
+        }
+
+        // Fast path: read-only lookup
+        {
+            let trie = self.trie.read().unwrap_or_else(|e| e.into_inner());
+            if let Some(bucket) = Self::lookup_readonly(&trie, &hashes) {
+                return bucket;
+            }
+        }
+
+        // Slow path: insert new nodes
+        let mut trie = self.trie.write().unwrap_or_else(|e| e.into_inner());
+        self.lookup_or_insert(&mut trie, &hashes)
+    }
+
+    fn lookup_readonly(node: &TrieNode, hashes: &[u64]) -> Option<usize> {
+        let mut current = node;
+        for h in hashes {
+            match current.children.get(h) {
+                Some(child) => current = child,
+                None => return None,
+            }
+        }
+        Some(current.bucket)
+    }
+
+    /// Only root's direct children get fresh buckets. All deeper nodes inherit
+    /// their parent's bucket.
+    fn lookup_or_insert(&self, root: &mut TrieNode, hashes: &[u64]) -> usize {
+        let mut node = root;
+        let mut is_root = true;
+
+        for h in hashes {
+            let parent_bucket = node.bucket;
+
+            if !node.children.contains_key(h) {
+                let bucket = if is_root {
+                    self.next_bucket.fetch_add(1, Ordering::Relaxed) % self.num_buckets
+                } else {
+                    parent_bucket
+                };
+                node.children.insert(
+                    *h,
+                    Box::new(TrieNode {
+                        children: HashMap::new(),
+                        bucket,
+                    }),
+                );
+            }
+
+            node = node.children.get_mut(h).unwrap();
+            is_root = false;
+        }
+        node.bucket
+    }
+}
+
+/// Hash each message to produce trie edge keys.
+fn hash_messages(messages: &[ChatMessage], max_depth: usize) -> Vec<u64> {
+    let limit = messages.len().min(max_depth);
+    let mut hashes = Vec::with_capacity(limit);
+
+    for msg in &messages[..limit] {
+        let mut hasher = DefaultHasher::new();
+        let role_tag: u8 = match msg.role {
+            crate::models::MessageRole::System => 0,
+            crate::models::MessageRole::User => 1,
+            crate::models::MessageRole::Assistant => 2,
+            crate::models::MessageRole::Tool => 3,
+        };
+        role_tag.hash(&mut hasher);
+        if let Some(ref content) = msg.content {
+            match content {
+                serde_json::Value::String(s) => s.hash(&mut hasher),
+                serde_json::Value::Array(parts) => {
+                    for part in parts {
+                        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                            text.hash(&mut hasher);
+                        }
+                    }
+                }
+                other => other.to_string().hash(&mut hasher),
+            }
+        }
+        hashes.push(hasher.finish());
+    }
+    hashes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::MessageRole;
+
+    fn msg(role: MessageRole, content: &str) -> ChatMessage {
+        ChatMessage {
+            role,
+            content: Some(serde_json::Value::String(content.to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }
+    }
+
+    #[test]
+    fn test_same_system_prompt_same_bucket() {
+        let router = PrefixRouter::new();
+        let msgs1 = vec![
+            msg(MessageRole::System, "You are a helpful assistant."),
+            msg(MessageRole::User, "What is 2+2?"),
+        ];
+        let msgs2 = vec![
+            msg(MessageRole::System, "You are a helpful assistant."),
+            msg(MessageRole::User, "What is the meaning of life?"),
+        ];
+        let b1 = router.route(&msgs1);
+        let b2 = router.route(&msgs2);
+        assert_eq!(b1, b2, "Same system prompt → same bucket");
+    }
+
+    #[test]
+    fn test_identical_conversations_same_bucket() {
+        let router = PrefixRouter::new();
+        let msgs = vec![
+            msg(MessageRole::System, "You are helpful."),
+            msg(MessageRole::User, "Hi"),
+        ];
+        assert_eq!(router.route(&msgs), router.route(&msgs));
+    }
+
+    #[test]
+    fn test_different_system_prompts_different_buckets() {
+        let router = PrefixRouter::new();
+        let msgs1 = vec![msg(MessageRole::System, "You are a Python expert.")];
+        let msgs2 = vec![msg(MessageRole::System, "You are a Rust expert.")];
+        assert_ne!(router.route(&msgs1), router.route(&msgs2));
+    }
+
+    #[test]
+    fn test_empty_messages() {
+        let router = PrefixRouter::new();
+        assert_eq!(router.route(&[]), 0);
+    }
+
+    #[test]
+    fn test_bucket_range() {
+        let router = PrefixRouter::new();
+        for i in 0..100 {
+            let msgs = vec![msg(MessageRole::User, &format!("message {i}"))];
+            assert!(router.route(&msgs) < router.num_buckets());
+        }
+    }
+}

--- a/scripts/eval_prefix_cache.py
+++ b/scripts/eval_prefix_cache.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Evaluate prefix cache hit rate across inference backends.
+
+Sends batches of requests with shared system prompts to measure how well
+prefix caching works with the current routing. Run before and after
+prefix-aware routing to compare.
+
+Usage:
+    # Against staging (default)
+    python3 scripts/eval_prefix_cache.py
+
+    # Against production
+    API_URL=https://cloud-api.near.ai API_KEY=sk-... python3 scripts/eval_prefix_cache.py
+
+    # Custom model
+    MODEL=glm-4-0520 python3 scripts/eval_prefix_cache.py
+"""
+
+import json
+import os
+import time
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections import defaultdict
+
+try:
+    import requests
+except ImportError:
+    print("pip install requests")
+    sys.exit(1)
+
+API_URL = os.environ.get("API_URL", "https://cloud-stg-api.near.ai")
+API_KEY = os.environ.get("API_KEY", "")
+MODEL = os.environ.get("MODEL", "qwen3.5-122b-a10b")
+NUM_REQUESTS = int(os.environ.get("NUM_REQUESTS", "20"))
+CONCURRENCY = int(os.environ.get("CONCURRENCY", "4"))
+MAX_TOKENS = int(os.environ.get("MAX_TOKENS", "32"))
+
+HEADERS = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json",
+}
+
+# A long system prompt that should be cached across requests
+SYSTEM_PROMPT = """You are a helpful AI assistant specialized in software engineering.
+You provide concise, accurate answers about programming, system design, and debugging.
+When asked about code, you explain the reasoning behind your suggestions.
+You follow best practices for security, performance, and maintainability.
+You are familiar with Rust, Python, TypeScript, and infrastructure tooling.
+When uncertain, you say so rather than guessing.
+You format code examples with proper syntax highlighting.
+You consider edge cases and error handling in your suggestions.
+""" * 5  # Repeat to make it longer (~2000 chars) for better prefix cache testing
+
+# Different user prompts — all share the same system prompt prefix
+USER_PROMPTS = [
+    "What is the difference between a mutex and a semaphore?",
+    "Explain the CAP theorem in one paragraph.",
+    "How does TCP congestion control work?",
+    "What is the purpose of the Linux OOM killer?",
+    "Describe the difference between stack and heap allocation.",
+    "What is a consistent hash ring?",
+    "How does TLS 1.3 differ from TLS 1.2?",
+    "What is copy-on-write in operating systems?",
+    "Explain the difference between threads and coroutines.",
+    "What is the purpose of an L4 vs L7 load balancer?",
+]
+
+
+def send_completion(prompt_idx: int, request_num: int) -> dict:
+    """Send a chat completion request and return timing + metadata."""
+    user_prompt = USER_PROMPTS[prompt_idx % len(USER_PROMPTS)]
+    body = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        "max_tokens": MAX_TOKENS,
+        "stream": False,
+    }
+
+    t0 = time.monotonic()
+    try:
+        resp = requests.post(
+            f"{API_URL}/v1/chat/completions",
+            headers=HEADERS,
+            json=body,
+            timeout=60,
+        )
+        elapsed = time.monotonic() - t0
+
+        if resp.status_code != 200:
+            return {
+                "request_num": request_num,
+                "prompt_idx": prompt_idx,
+                "status": resp.status_code,
+                "error": resp.text[:200],
+                "elapsed": elapsed,
+            }
+
+        data = resp.json()
+        usage = data.get("usage", {})
+        prompt_details = usage.get("prompt_tokens_details") or {}
+        chat_id = data.get("id", "")
+
+        return {
+            "request_num": request_num,
+            "prompt_idx": prompt_idx,
+            "chat_id": chat_id,
+            "status": 200,
+            "elapsed": elapsed,
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "cached_tokens": prompt_details.get("cached_tokens", 0),
+            "ttft": elapsed,  # approximation for non-streaming
+        }
+    except Exception as e:
+        return {
+            "request_num": request_num,
+            "prompt_idx": prompt_idx,
+            "status": 0,
+            "error": str(e),
+            "elapsed": time.monotonic() - t0,
+        }
+
+
+def fetch_signature_backend(chat_id: str) -> str | None:
+    """Fetch signature for a chat_id — the signing_address identifies the backend."""
+    try:
+        resp = requests.get(
+            f"{API_URL}/v1/signature/{chat_id}?signing_algo=ed25519",
+            headers=HEADERS,
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return resp.json().get("signing_address", "")
+    except Exception:
+        pass
+    return None
+
+
+def discover_backends() -> dict:
+    """Discover backends by making parallel attestation calls."""
+    backends = {}
+    # Use the inference URL directly if accessible, otherwise use cloud-api attestation
+    try:
+        resp = requests.get(
+            f"{API_URL}/v1/attestation/report?model={MODEL}&signing_algo=ed25519&include_tls_fingerprint=true",
+            headers=HEADERS,
+            timeout=15,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            for att in data.get("model_attestations", []):
+                addr = att.get("signing_address", "")
+                fp = att.get("tls_cert_fingerprint", "")
+                if addr:
+                    backends[addr[:16]] = fp[:16] if fp else "no-fp"
+    except Exception:
+        pass
+    return backends
+
+
+def main():
+    print(f"=== Prefix Cache Evaluation ===")
+    print(f"API: {API_URL}")
+    print(f"Model: {MODEL}")
+    print(f"Requests: {NUM_REQUESTS} (concurrency={CONCURRENCY})")
+    print(f"System prompt: {len(SYSTEM_PROMPT)} chars")
+    print(f"Max tokens: {MAX_TOKENS}")
+    print()
+
+    # Phase 1: Discover backends
+    print("Discovering backends...")
+    backends = discover_backends()
+    if backends:
+        print(f"  Found {len(backends)} backend(s):")
+        for addr, fp in backends.items():
+            print(f"    signing_addr={addr}...  tls_fp={fp}...")
+    else:
+        print("  Could not discover backends via attestation")
+    print()
+
+    # Phase 2: Warmup — send a few requests to prime the prefix cache
+    print("Warmup: sending 2 requests to prime prefix cache...")
+    for i in range(2):
+        result = send_completion(0, -1)
+        status = result.get("status", 0)
+        cached = result.get("cached_tokens", 0)
+        print(f"  warmup-{i+1}: status={status} cached_tokens={cached} elapsed={result['elapsed']:.2f}s")
+    print()
+
+    # Phase 3: Measure — send requests with shared system prompt
+    print(f"Sending {NUM_REQUESTS} requests (shared system prompt, varied user prompts)...")
+    results = []
+    with ThreadPoolExecutor(max_workers=CONCURRENCY) as executor:
+        futures = {}
+        for i in range(NUM_REQUESTS):
+            prompt_idx = i % len(USER_PROMPTS)
+            f = executor.submit(send_completion, prompt_idx, i)
+            futures[f] = i
+
+        for f in as_completed(futures):
+            result = f.result()
+            results.append(result)
+            i = result["request_num"]
+            cached = result.get("cached_tokens", 0)
+            prompt = result.get("prompt_tokens", 0)
+            status = result.get("status", 0)
+            elapsed = result.get("elapsed", 0)
+            pct = f"{cached/prompt*100:.0f}%" if prompt > 0 else "n/a"
+            err = f" error={result.get('error', '')[:60]}" if status != 200 else ""
+            print(f"  req-{i:02d}: status={status} prompt={prompt} cached={cached} ({pct}) elapsed={elapsed:.2f}s{err}")
+
+    print()
+
+    # Phase 4: Analyze results
+    successful = [r for r in results if r.get("status") == 200]
+    failed = [r for r in results if r.get("status") != 200]
+
+    if not successful:
+        print("All requests failed!")
+        return
+
+    total_prompt = sum(r.get("prompt_tokens", 0) for r in successful)
+    total_cached = sum(r.get("cached_tokens", 0) for r in successful)
+    avg_elapsed = sum(r["elapsed"] for r in successful) / len(successful)
+    cache_rate = total_cached / total_prompt * 100 if total_prompt > 0 else 0
+
+    print(f"=== Results ===")
+    print(f"Successful: {len(successful)}/{NUM_REQUESTS}")
+    print(f"Failed: {len(failed)}/{NUM_REQUESTS}")
+    print(f"Total prompt tokens: {total_prompt}")
+    print(f"Total cached tokens: {total_cached}")
+    print(f"Cache hit rate: {cache_rate:.1f}%")
+    print(f"Avg latency: {avg_elapsed:.2f}s")
+    print()
+
+    # Phase 5: Check backend distribution via signatures
+    print("Checking backend distribution via signatures...")
+    backend_counts = defaultdict(int)
+    for r in successful:
+        chat_id = r.get("chat_id", "")
+        if not chat_id:
+            continue
+        addr = fetch_signature_backend(chat_id)
+        if addr:
+            key = addr[:16]
+            backend_counts[key] += 1
+            time.sleep(0.1)  # gentle rate limit
+
+    if backend_counts:
+        print(f"  Requests distributed across {len(backend_counts)} backend(s):")
+        for addr, count in sorted(backend_counts.items(), key=lambda x: -x[1]):
+            pct = count / sum(backend_counts.values()) * 100
+            print(f"    {addr}...: {count} requests ({pct:.0f}%)")
+    else:
+        print("  Could not determine backend distribution")
+
+    print()
+    print(f"=== Summary ===")
+    print(f"Cache hit rate: {cache_rate:.1f}% (higher is better)")
+    print(f"Backend spread: {len(backend_counts)} backends (lower = better for cache)")
+    if cache_rate < 10:
+        print("→ Low cache rate — prefix routing should help significantly")
+    elif cache_rate < 50:
+        print("→ Moderate cache rate — prefix routing can improve this")
+    else:
+        print("→ Good cache rate — prefix routing may have diminishing returns")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_prefix_cache.py
+++ b/scripts/eval_prefix_cache.py
@@ -16,7 +16,6 @@ Usage:
     MODEL=glm-4-0520 python3 scripts/eval_prefix_cache.py
 """
 
-import json
 import os
 import time
 import sys

--- a/scripts/test_prefix_routing.py
+++ b/scripts/test_prefix_routing.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Integration test for prefix-aware routing and signature fetch.
+
+Verifies:
+1. Requests with the same system prompt hit the same backend (same signing_address)
+2. Requests with different system prompts may hit different backends
+3. Signature fetch succeeds for all completions (proves bucket client pinning works)
+4. Streaming and non-streaming paths both work
+
+Usage:
+    API_KEY=sk-... python3 scripts/test_prefix_routing.py
+    API_KEY=sk-... API_URL=https://cloud-api.near.ai MODEL=zai-org/GLM-5-FP8 python3 scripts/test_prefix_routing.py
+"""
+
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+try:
+    import requests
+except ImportError:
+    print("pip install requests")
+    sys.exit(1)
+
+API_URL = os.environ.get("API_URL", "https://cloud-stg-api.near.ai")
+API_KEY = os.environ.get("API_KEY", "")
+MODEL = os.environ.get("MODEL", "qwen3.5-122b-a10b")
+
+if not API_KEY:
+    print("ERROR: API_KEY env var required")
+    sys.exit(1)
+
+HEADERS = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json",
+}
+
+SYSTEM_A = "You are an expert mathematician. Always show your work step by step." * 10
+SYSTEM_B = "You are a creative fiction writer. Use vivid imagery and metaphors." * 10
+
+
+def completion_and_signature(system_prompt, user_msg, stream=False):
+    """Send a completion, then fetch its signature. Returns (chat_id, signing_address, stream)."""
+    body = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_msg},
+        ],
+        "max_tokens": 16,
+        "stream": stream,
+    }
+
+    t0 = time.monotonic()
+
+    if stream:
+        resp = requests.post(
+            f"{API_URL}/v1/chat/completions",
+            headers=HEADERS,
+            json=body,
+            stream=True,
+            timeout=60,
+        )
+        if resp.status_code != 200:
+            return {"error": f"HTTP {resp.status_code}: {resp.text[:200]}"}
+
+        chat_id = None
+        for line in resp.iter_lines():
+            line = line.decode("utf-8", errors="replace")
+            if line.startswith("data: ") and line != "data: [DONE]":
+                import json
+                try:
+                    chunk = json.loads(line[6:])
+                    if "id" in chunk:
+                        chat_id = chunk["id"]
+                except Exception:
+                    pass
+        resp.close()
+    else:
+        resp = requests.post(
+            f"{API_URL}/v1/chat/completions",
+            headers=HEADERS,
+            json=body,
+            timeout=60,
+        )
+        if resp.status_code != 200:
+            return {"error": f"HTTP {resp.status_code}: {resp.text[:200]}"}
+        chat_id = resp.json().get("id")
+
+    elapsed = time.monotonic() - t0
+
+    if not chat_id:
+        return {"error": "no chat_id in response"}
+
+    # Fetch signature — this is the critical test: it must hit the same backend
+    time.sleep(0.5)  # Brief delay for async signature storage
+    sig_resp = requests.get(
+        f"{API_URL}/v1/signature/{chat_id}?signing_algo=ed25519",
+        headers=HEADERS,
+        timeout=15,
+    )
+
+    if sig_resp.status_code == 200:
+        sig = sig_resp.json()
+        return {
+            "chat_id": chat_id,
+            "signing_address": sig.get("signing_address", ""),
+            "signature_ok": True,
+            "stream": stream,
+            "elapsed": elapsed,
+        }
+    else:
+        return {
+            "chat_id": chat_id,
+            "signing_address": "",
+            "signature_ok": False,
+            "signature_status": sig_resp.status_code,
+            "stream": stream,
+            "elapsed": elapsed,
+        }
+
+
+def run_test():
+    passed = 0
+    failed = 0
+
+    def check(name, condition, detail=""):
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"  PASS: {name}")
+        else:
+            failed += 1
+            print(f"  FAIL: {name} — {detail}")
+
+    print(f"=== Prefix Routing Integration Test ===")
+    print(f"API: {API_URL}")
+    print(f"Model: {MODEL}")
+    print()
+
+    # --- Test 1: Same system prompt → same backend ---
+    print("Test 1: Same system prompt → same backend (non-streaming)")
+    results_a = []
+    for i in range(4):
+        r = completion_and_signature(SYSTEM_A, f"What is {i+1}+{i+1}?", stream=False)
+        if "error" in r:
+            print(f"  ERROR: {r['error']}")
+            continue
+        results_a.append(r)
+        addr = r["signing_address"][:16]
+        print(f"  req-{i}: chat_id={r['chat_id'][:12]}... addr={addr}... sig_ok={r['signature_ok']}")
+
+    if len(results_a) >= 2:
+        addrs_a = set(r["signing_address"] for r in results_a)
+        check(
+            "all requests hit same backend",
+            len(addrs_a) == 1,
+            f"got {len(addrs_a)} distinct backends: {[a[:16] for a in addrs_a]}",
+        )
+        check(
+            "all signatures fetched successfully",
+            all(r["signature_ok"] for r in results_a),
+            f"failures: {[r['chat_id'][:12] for r in results_a if not r['signature_ok']]}",
+        )
+    else:
+        print("  SKIP: not enough successful requests")
+    print()
+
+    # --- Test 2: Same system prompt → same backend (streaming) ---
+    print("Test 2: Same system prompt → same backend (streaming)")
+    results_a_stream = []
+    for i in range(4):
+        r = completion_and_signature(SYSTEM_A, f"What is {i+10}*{i+2}?", stream=True)
+        if "error" in r:
+            print(f"  ERROR: {r['error']}")
+            continue
+        results_a_stream.append(r)
+        addr = r["signing_address"][:16]
+        print(f"  req-{i}: chat_id={r['chat_id'][:12]}... addr={addr}... sig_ok={r['signature_ok']}")
+
+    if len(results_a_stream) >= 2:
+        addrs_as = set(r["signing_address"] for r in results_a_stream)
+        check(
+            "streaming: all requests hit same backend",
+            len(addrs_as) == 1,
+            f"got {len(addrs_as)} distinct backends",
+        )
+        check(
+            "streaming: all signatures fetched",
+            all(r["signature_ok"] for r in results_a_stream),
+        )
+    print()
+
+    # --- Test 3: Different system prompt → may hit different backend ---
+    print("Test 3: Different system prompt (may hit different backend)")
+    results_b = []
+    for i in range(3):
+        r = completion_and_signature(SYSTEM_B, f"Write about topic {i}", stream=False)
+        if "error" in r:
+            print(f"  ERROR: {r['error']}")
+            continue
+        results_b.append(r)
+        addr = r["signing_address"][:16]
+        print(f"  req-{i}: addr={addr}... sig_ok={r['signature_ok']}")
+
+    if results_b:
+        check(
+            "all signatures fetched for prompt B",
+            all(r["signature_ok"] for r in results_b),
+        )
+    if results_a and results_b:
+        addrs_all_a = set(r["signing_address"] for r in results_a)
+        addrs_all_b = set(r["signing_address"] for r in results_b)
+        # Note: with model-proxy L4 and limited backends, they may still hit the same one
+        if addrs_all_a != addrs_all_b:
+            print("  INFO: different system prompts hit different backends (good)")
+        else:
+            print("  INFO: same backend for both prompts (possible with few backends)")
+    print()
+
+    # --- Test 4: Concurrent requests with same prefix ---
+    print("Test 4: Concurrent requests with same system prompt")
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {
+            executor.submit(
+                completion_and_signature, SYSTEM_A, f"Concurrent question {i}", False
+            ): i
+            for i in range(4)
+        }
+        results_conc = []
+        for f in as_completed(futures):
+            r = f.result()
+            if "error" not in r:
+                results_conc.append(r)
+                addr = r["signing_address"][:16]
+                i = futures[f]
+                print(f"  req-{i}: addr={addr}... sig_ok={r['signature_ok']}")
+            else:
+                print(f"  req-{futures[f]}: ERROR {r['error'][:80]}")
+
+    if len(results_conc) >= 2:
+        addrs_conc = set(r["signing_address"] for r in results_conc)
+        check(
+            "concurrent: all hit same backend",
+            len(addrs_conc) == 1,
+            f"got {len(addrs_conc)} distinct backends",
+        )
+        check(
+            "concurrent: all signatures fetched",
+            all(r["signature_ok"] for r in results_conc),
+        )
+    print()
+
+    # --- Summary ---
+    total = passed + failed
+    print(f"=== Results: {passed}/{total} passed, {failed}/{total} failed ===")
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
## Summary

Routes requests with similar prompt prefixes to the same inference backend, maximizing vLLM/SGLang prefix cache hits. Built on top of #529 (merged).

**Problem**: cloud-api creates a new `reqwest::Client` per chat completion. With L4 TLS passthrough (model-proxy), each new client opens a fresh TLS connection routed to a random backend CVM. Requests sharing the same system prompt scatter across backends, missing the prefix cache entirely.

**Solution**: Replace per-completion dedicated clients with a pool of persistent "bucket" clients. A message-level trie maps conversation prefixes to buckets. Same system prompt → same bucket → same TLS connection → same backend → prefix cache hit.

## How it works

### 1. Message-level trie (`prefix_router.rs`)

Each trie level = one message (hash of `role_tag + content`). On each request:
1. Hash the first N messages (up to `PREFIX_MAX_MESSAGES`, default 8)
2. Traverse the trie following existing edges (read lock, fast path)
3. If the first message (system prompt) is new, take write lock and assign a fresh bucket

**Bucket inheritance**: only root's direct children get fresh buckets. All deeper nodes inherit the parent's bucket. This means requests sharing a system prompt but with different user messages all route to the same bucket:

```
Root (bucket 0)
├── hash("system: You are a Python expert") → bucket 3
│   ├── hash("user: What is a list?") → bucket 3 (inherited)
│   └── hash("user: Explain decorators") → bucket 3 (inherited)
├── hash("system: You are a Rust expert") → bucket 5
│   └── hash("user: What is ownership?") → bucket 5 (inherited)
```

**Read-lock fast path**: since deeper nodes inherit parent buckets, `lookup_readonly` returns the correct bucket even for partially-unseen message sequences. Write lock is only needed when a brand new system prompt appears.

### 2. Bucket clients (`VLlmProvider`)

- `NUM_PREFIX_BUCKETS` (default 64, max 1024) persistent `reqwest::Client` instances
- Each: `pool_max_idle_per_host(1)` — one persistent TLS connection per bucket
- HTTP/2 multiplexing: concurrent same-prefix requests share one connection → guaranteed same backend
- `SharedTlsRoots`: root cert store (~150KB) loaded once and shared via `Arc` across all bucket clients + the general-purpose client. Without sharing, 64 buckets would duplicate ~10MB of root certs.

### 3. Signature pinning

Replaces per-completion dedicated client pattern:

| | Before | After |
|--|--------|-------|
| Completion | `create_dedicated_client()` → new Client | `bucket_clients[prefix_router.route(messages)]` |
| Pending | `pending_clients[request_hash] = Client` | `pending_buckets[request_hash] = bucket_id` |
| Pin | move Client to `signature_clients[chat_id]` | move bucket_id to `signature_buckets[chat_id]` |
| Signature fetch | `signature_clients[chat_id].get(...)` | `bucket_clients[signature_buckets[chat_id]].get(...)` |
| Cleanup | drop Client | remove mapping (bucket client persists) |

## Baseline measurements (staging)

| Model | Cache hit rate | Backend spread | Notes |
|-------|---------------|----------------|-------|
| GLM-5-FP8 | 55% (lucky) / 0% (scattered) | 1 | SGLang 64-token cache page, 90% of tokens cached when same backend |
| Qwen3.5-122B | 0% | 1 | vLLM 2096-token block, prompt too short; needs `--enable-prefix-caching` |

With prefix routing, GLM-5 should consistently hit 90%+ cache rate regardless of concurrent client count, since requests with the same system prompt always hit the same backend.

## Files changed

| File | Change |
|------|--------|
| `crates/inference_providers/src/vllm/prefix_router.rs` | **New** — `PrefixRouter` trie, message hashing, bucket assignment |
| `crates/inference_providers/src/vllm/mod.rs` | Replace `pending_clients`/`signature_clients` with bucket routing, use `SharedTlsRoots` |
| `crates/inference_providers/src/spki_verifier.rs` | Add `SharedTlsRoots` for sharing root cert store across clients |
| `scripts/eval_prefix_cache.py` | **New** — evaluation script for measuring prefix cache hit rates |

## Environment variables

| Variable | Default | Max | Purpose |
|----------|---------|-----|---------|
| `NUM_PREFIX_BUCKETS` | 64 | 1024 | Persistent connections per provider |
| `PREFIX_MAX_MESSAGES` | 8 | — | Trie depth (messages considered for routing) |

## Test plan

- [x] `cargo test --lib --bins` — 193 tests pass (includes prefix router unit tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] CI: Lint ✅ Test Suite ✅ security_audit ✅
- [ ] Deploy to staging, run `API_KEY=... scripts/eval_prefix_cache.py` on GLM-5
- [ ] Compare cache hit rate vs baseline
- [ ] Verify signature fetch works (same backend via bucket client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)