### PR TITLE
fix: forward E2EE headers for embeddings, rerank, score, and audio endpoints

### DIFF
--- a/crates/api/src/routes/common.rs
+++ b/crates/api/src/routes/common.rs
@@ -135,6 +135,7 @@ pub struct EncryptionHeaders {
     pub client_pub_key: Option<String>,
     pub model_pub_key: Option<String>,
     pub encryption_version: Option<String>,
+    pub encrypt_all_fields: Option<String>,
 }
 
 /// Validate and extract encryption headers from HTTP request
@@ -168,6 +169,10 @@ pub fn validate_encryption_headers(
         .map(|s| s.to_string());
     let encryption_version = headers
         .get("x-encryption-version")
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
+    let encrypt_all_fields = headers
+        .get("x-encrypt-all-fields")
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
 
@@ -307,6 +312,7 @@ pub fn validate_encryption_headers(
         client_pub_key,
         model_pub_key,
         encryption_version,
+        encrypt_all_fields,
     })
 }
 

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -54,6 +54,12 @@ fn insert_encryption_headers(
             serde_json::Value::String(encryption_version.clone()),
         );
     }
+    if let Some(ref encrypt_all_fields) = encryption_headers.encrypt_all_fields {
+        extra.insert(
+            service_encryption_headers::ENCRYPT_ALL_FIELDS.to_string(),
+            serde_json::Value::String(encrypt_all_fields.clone()),
+        );
+    }
 }
 
 // Custom header for exposing the inference ID as a UUID

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -25,6 +25,37 @@ use uuid::Uuid;
 // Timeout for synchronous usage recording before response is returned
 const USAGE_RECORDING_TIMEOUT_SECS: u64 = 5;
 
+/// Insert validated E2EE headers into a provider `extra` HashMap.
+fn insert_encryption_headers(
+    encryption_headers: &crate::routes::common::EncryptionHeaders,
+    extra: &mut std::collections::HashMap<String, serde_json::Value>,
+) {
+    if let Some(ref signing_algo) = encryption_headers.signing_algo {
+        extra.insert(
+            service_encryption_headers::SIGNING_ALGO.to_string(),
+            serde_json::Value::String(signing_algo.clone()),
+        );
+    }
+    if let Some(ref client_pub_key) = encryption_headers.client_pub_key {
+        extra.insert(
+            service_encryption_headers::CLIENT_PUB_KEY.to_string(),
+            serde_json::Value::String(client_pub_key.clone()),
+        );
+    }
+    if let Some(ref model_pub_key) = encryption_headers.model_pub_key {
+        extra.insert(
+            service_encryption_headers::MODEL_PUB_KEY.to_string(),
+            serde_json::Value::String(model_pub_key.clone()),
+        );
+    }
+    if let Some(ref encryption_version) = encryption_headers.encryption_version {
+        extra.insert(
+            service_encryption_headers::ENCRYPTION_VERSION.to_string(),
+            serde_json::Value::String(encryption_version.clone()),
+        );
+    }
+}
+
 // Custom header for exposing the inference ID as a UUID
 const HEADER_INFERENCE_ID: &str = "Inference-Id";
 
@@ -347,30 +378,7 @@ pub async fn chat_completions(
     };
 
     // Add validated headers to service_request.extra
-    if let Some(ref signing_algo) = encryption_headers.signing_algo {
-        service_request.extra.insert(
-            service_encryption_headers::SIGNING_ALGO.to_string(),
-            serde_json::Value::String(signing_algo.clone()),
-        );
-    }
-    if let Some(ref client_pub_key) = encryption_headers.client_pub_key {
-        service_request.extra.insert(
-            service_encryption_headers::CLIENT_PUB_KEY.to_string(),
-            serde_json::Value::String(client_pub_key.clone()),
-        );
-    }
-    if let Some(ref model_pub_key) = encryption_headers.model_pub_key {
-        service_request.extra.insert(
-            service_encryption_headers::MODEL_PUB_KEY.to_string(),
-            serde_json::Value::String(model_pub_key.clone()),
-        );
-    }
-    if let Some(ref encryption_version) = encryption_headers.encryption_version {
-        service_request.extra.insert(
-            service_encryption_headers::ENCRYPTION_VERSION.to_string(),
-            serde_json::Value::String(encryption_version.clone()),
-        );
-    }
+    insert_encryption_headers(&encryption_headers, &mut service_request.extra);
 
     // Check if streaming is requested
     if request.stream == Some(true) {
@@ -920,32 +928,7 @@ pub async fn image_generations(
 
     // Convert API request to provider params
     let mut extra = std::collections::HashMap::new();
-
-    // Add validated encryption headers to extra
-    if let Some(ref signing_algo) = encryption_headers.signing_algo {
-        extra.insert(
-            service_encryption_headers::SIGNING_ALGO.to_string(),
-            serde_json::Value::String(signing_algo.clone()),
-        );
-    }
-    if let Some(ref client_pub_key) = encryption_headers.client_pub_key {
-        extra.insert(
-            service_encryption_headers::CLIENT_PUB_KEY.to_string(),
-            serde_json::Value::String(client_pub_key.clone()),
-        );
-    }
-    if let Some(ref model_pub_key) = encryption_headers.model_pub_key {
-        extra.insert(
-            service_encryption_headers::MODEL_PUB_KEY.to_string(),
-            serde_json::Value::String(model_pub_key.clone()),
-        );
-    }
-    if let Some(ref encryption_version) = encryption_headers.encryption_version {
-        extra.insert(
-            service_encryption_headers::ENCRYPTION_VERSION.to_string(),
-            serde_json::Value::String(encryption_version.clone()),
-        );
-    }
+    insert_encryption_headers(&encryption_headers, &mut extra);
 
     let params = inference_providers::ImageGenerationParams {
         model: request.model.clone(),
@@ -1107,6 +1090,7 @@ pub async fn audio_transcriptions(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    headers: header::HeaderMap,
     mut multipart: Multipart,
 ) -> axum::response::Response {
     debug!(
@@ -1257,7 +1241,16 @@ pub async fn audio_transcriptions(
     let model_name = request.model.clone();
     let organization_id = api_key.organization.id.0;
 
+    // Extract and validate encryption headers if present
+    let encryption_headers = match crate::routes::common::validate_encryption_headers(&headers) {
+        Ok(headers) => headers,
+        Err(err) => return err.into_response(),
+    };
+
     // Convert API request to provider params
+    let mut extra = std::collections::HashMap::new();
+    insert_encryption_headers(&encryption_headers, &mut extra);
+
     let params = inference_providers::AudioTranscriptionParams {
         model: model_name.clone(),
         file_bytes: request.file_bytes,
@@ -1266,7 +1259,7 @@ pub async fn audio_transcriptions(
         response_format: request.response_format,
         temperature: request.temperature,
         timestamp_granularities: request.timestamp_granularities,
-        extra: std::collections::HashMap::new(),
+        extra,
     };
 
     // Call completion service which handles concurrent request limiting
@@ -1812,6 +1805,7 @@ pub async fn rerank(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(_body_hash): Extension<RequestBodyHash>,
+    headers: header::HeaderMap,
     Json(request): Json<crate::models::RerankRequest>,
 ) -> axum::response::Response {
     debug!(
@@ -1864,12 +1858,21 @@ pub async fn rerank(
     let model_id = model.id;
     let organization_id = api_key.organization.id.0;
 
+    // Extract and validate encryption headers if present
+    let encryption_headers = match crate::routes::common::validate_encryption_headers(&headers) {
+        Ok(headers) => headers,
+        Err(err) => return err.into_response(),
+    };
+
     // Convert API request to provider params
+    let mut extra = std::collections::HashMap::new();
+    insert_encryption_headers(&encryption_headers, &mut extra);
+
     let params = inference_providers::RerankParams {
         model: request.model.clone(),
         query: request.query.clone(),
         documents: request.documents.clone(),
-        extra: std::collections::HashMap::new(),
+        extra,
     };
 
     // Call completion service which handles concurrent request limiting
@@ -2102,6 +2105,7 @@ pub async fn embeddings(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(_body_hash): Extension<RequestBodyHash>,
+    headers: header::HeaderMap,
     body: Bytes,
 ) -> axum::response::Response {
     // Minimal deserialization: extract only the model name for routing
@@ -2161,9 +2165,17 @@ pub async fn embeddings(
     let model_id = model.id;
     let organization_id = api_key.organization.id.0;
 
+    // Extract and validate encryption headers if present
+    let encryption_headers = match crate::routes::common::validate_encryption_headers(&headers) {
+        Ok(headers) => headers,
+        Err(err) => return err.into_response(),
+    };
+    let mut extra = std::collections::HashMap::new();
+    insert_encryption_headers(&encryption_headers, &mut extra);
+
     match app_state
         .completion_service
-        .try_embeddings(organization_id, model_id, &model_name, body)
+        .try_embeddings(organization_id, model_id, &model_name, body, extra)
         .await
     {
         Ok(response_bytes) => {
@@ -2368,6 +2380,7 @@ pub async fn score(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    headers: header::HeaderMap,
     Json(request): Json<crate::models::ScoreRequest>,
 ) -> axum::response::Response {
     debug!(
@@ -2430,11 +2443,22 @@ pub async fn score(
             model_id,
             &request.model,
             body_hash.hash.clone(),
-            inference_providers::ScoreParams {
-                model: request.model.clone(),
-                text_1: request.text_1.clone(),
-                text_2: request.text_2.clone(),
-                extra: std::collections::HashMap::new(),
+            {
+                // Extract and validate encryption headers if present
+                let encryption_headers =
+                    match crate::routes::common::validate_encryption_headers(&headers) {
+                        Ok(headers) => headers,
+                        Err(err) => return err.into_response(),
+                    };
+                let mut extra = std::collections::HashMap::new();
+                insert_encryption_headers(&encryption_headers, &mut extra);
+
+                inference_providers::ScoreParams {
+                    model: request.model.clone(),
+                    text_1: request.text_1.clone(),
+                    text_2: request.text_2.clone(),
+                    extra,
+                }
             },
         )
         .await

--- a/crates/inference_providers/src/external/backend.rs
+++ b/crates/inference_providers/src/external/backend.rs
@@ -177,6 +177,7 @@ pub trait ExternalBackend: Send + Sync {
         &self,
         _config: &BackendConfig,
         _body: bytes::Bytes,
+        _extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, EmbeddingError> {
         Err(EmbeddingError::RequestFailed(format!(
             "Embeddings are not supported by the {} backend.",

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -356,8 +356,12 @@ impl InferenceProvider for ExternalProvider {
             .await
     }
 
-    async fn embeddings_raw(&self, body: bytes::Bytes) -> Result<bytes::Bytes, EmbeddingError> {
-        self.backend.embeddings_raw(&self.config, body).await
+    async fn embeddings_raw(
+        &self,
+        body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, EmbeddingError> {
+        self.backend.embeddings_raw(&self.config, body, extra).await
     }
 }
 

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -215,7 +215,11 @@ pub trait InferenceProvider {
     ///
     /// Accepts the raw JSON request body and returns the raw JSON response bytes.
     /// No deserialization is performed — the cloud API proxies the request as-is.
-    async fn embeddings_raw(&self, body: bytes::Bytes) -> Result<bytes::Bytes, EmbeddingError>;
+    async fn embeddings_raw(
+        &self,
+        body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, EmbeddingError>;
 
     async fn get_signature(
         &self,

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -1053,7 +1053,11 @@ impl crate::InferenceProvider for MockProvider {
         Ok(response)
     }
 
-    async fn embeddings_raw(&self, _body: bytes::Bytes) -> Result<bytes::Bytes, EmbeddingError> {
+    async fn embeddings_raw(
+        &self,
+        _body: bytes::Bytes,
+        _extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, EmbeddingError> {
         let embedding: Vec<f64> = vec![0.0; 384];
         let response_json = serde_json::json!({
             "object": "list",

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -666,7 +666,7 @@ impl InferenceProvider for VLlmProvider {
 
     async fn audio_transcription(
         &self,
-        params: AudioTranscriptionParams,
+        mut params: AudioTranscriptionParams,
         request_hash: String,
     ) -> Result<AudioTranscriptionResponse, AudioTranscriptionError> {
         let url = format!("{}/v1/audio/transcriptions", self.config.base_url);
@@ -705,6 +705,8 @@ impl InferenceProvider for VLlmProvider {
         let mut headers = self
             .build_headers()
             .map_err(|e| AudioTranscriptionError::TranscriptionError(e.to_string()))?;
+        // Forward encryption headers from extra to HTTP headers
+        self.prepare_encryption_headers(&mut headers, &mut params.extra);
         // Remove Content-Type header - reqwest will set it automatically for multipart
         headers.remove("Content-Type");
         headers.insert(
@@ -862,12 +864,13 @@ impl InferenceProvider for VLlmProvider {
     /// Performs a document reranking request
     async fn score(
         &self,
-        params: ScoreParams,
+        mut params: ScoreParams,
         request_hash: String,
     ) -> Result<ScoreResponse, ScoreError> {
         let url = format!("{}/v1/score", self.config.base_url);
 
         let mut headers = self.build_headers().map_err(to_score_error)?;
+        self.prepare_encryption_headers(&mut headers, &mut params.extra);
         headers.insert(
             "X-Request-Hash",
             reqwest::header::HeaderValue::from_str(&request_hash).map_err(to_score_error)?,
@@ -901,10 +904,11 @@ impl InferenceProvider for VLlmProvider {
         Ok(score_response)
     }
 
-    async fn rerank(&self, params: RerankParams) -> Result<RerankResponse, RerankError> {
+    async fn rerank(&self, mut params: RerankParams) -> Result<RerankResponse, RerankError> {
         let url = format!("{}/v1/rerank", self.config.base_url);
 
-        let headers = self.build_headers().map_err(to_rerank_error)?;
+        let mut headers = self.build_headers().map_err(to_rerank_error)?;
+        self.prepare_encryption_headers(&mut headers, &mut params.extra);
 
         let response = self
             .client
@@ -934,10 +938,15 @@ impl InferenceProvider for VLlmProvider {
         Ok(rerank_response)
     }
 
-    async fn embeddings_raw(&self, body: bytes::Bytes) -> Result<bytes::Bytes, EmbeddingError> {
+    async fn embeddings_raw(
+        &self,
+        body: bytes::Bytes,
+        mut extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, EmbeddingError> {
         let url = format!("{}/v1/embeddings", self.config.base_url);
 
-        let headers = self.build_headers().map_err(to_embedding_error)?;
+        let mut headers = self.build_headers().map_err(to_embedding_error)?;
+        self.prepare_encryption_headers(&mut headers, &mut extra);
 
         let response = self
             .client

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -43,6 +43,8 @@ mod encryption_headers {
     pub const MODEL_PUB_KEY: &str = "x_model_pub_key";
     /// Key for encryption version (x-encryption-version header)
     pub const ENCRYPTION_VERSION: &str = "x_encryption_version";
+    /// Key for full field encryption opt-in (x-encrypt-all-fields header)
+    pub const ENCRYPT_ALL_FIELDS: &str = "x_encrypt_all_fields";
 }
 
 /// Configuration for vLLM provider
@@ -238,6 +240,17 @@ impl VLlmProvider {
         {
             if let Ok(value) = HeaderValue::from_str(version) {
                 headers.insert("X-Encryption-Version", value);
+            }
+        }
+
+        // Extract and forward x_encrypt_all_fields as HTTP header, then remove from extra
+        if let Some(val) = extra
+            .remove(encryption_headers::ENCRYPT_ALL_FIELDS)
+            .as_ref()
+            .and_then(|v| v.as_str())
+        {
+            if let Ok(value) = HeaderValue::from_str(val) {
+                headers.insert("X-Encrypt-All-Fields", value);
             }
         }
     }

--- a/crates/services/src/common.rs
+++ b/crates/services/src/common.rs
@@ -20,6 +20,8 @@ pub mod encryption_headers {
     pub const MODEL_PUB_KEY: &str = "x_model_pub_key";
     /// Key for encryption version in params.extra (corresponds to x-encryption-version HTTP header)
     pub const ENCRYPTION_VERSION: &str = "x_encryption_version";
+    /// Key for full field encryption opt-in (corresponds to x-encrypt-all-fields HTTP header)
+    pub const ENCRYPT_ALL_FIELDS: &str = "x_encrypt_all_fields";
 }
 
 pub fn generate_api_key() -> String {

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -1517,6 +1517,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         model_id: Uuid,
         model_name: &str,
         body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, ports::CompletionError> {
         let counter = self
             .try_acquire_concurrent_slot(organization_id, model_id, model_name)
@@ -1524,7 +1525,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         let _guard = ConcurrentSlotGuard::new(counter);
 
         self.inference_provider_pool
-            .embeddings(model_name, body)
+            .embeddings(model_name, body, extra)
             .await
             .map_err(|e| match e {
                 inference_providers::EmbeddingError::RequestFailed(msg) => {

--- a/crates/services/src/completions/ports.rs
+++ b/crates/services/src/completions/ports.rs
@@ -167,6 +167,7 @@ pub trait CompletionServiceTrait: Send + Sync {
         model_id: Uuid,
         model_name: &str,
         body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, CompletionError>;
 
     /// Execute a score request with proper concurrent request limiting.

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1204,6 +1204,7 @@ impl InferenceProviderPool {
         &self,
         model: &str,
         body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, inference_providers::EmbeddingError> {
         tracing::debug!(model = %model, "Starting embeddings request");
 
@@ -1220,7 +1221,7 @@ impl InferenceProviderPool {
         // Try with each provider (with fallback)
         let mut last_error = None;
         for provider in providers {
-            match provider.embeddings_raw(body.clone()).await {
+            match provider.embeddings_raw(body.clone(), extra.clone()).await {
                 Ok(response) => {
                     tracing::info!(model = %model, "Embeddings completed successfully");
                     return Ok(response);


### PR DESCRIPTION
## Summary

- Adds E2EE header extraction and forwarding to the embeddings, rerank, score, and audio transcription endpoints — matching the existing pattern used by chat completions and image generations
- Forwards the new `X-Encrypt-All-Fields` header that controls extended field encryption in the inference-proxy (tool_calls, refusal, logprobs, function_call, tools definitions)
- Threads an `extra: HashMap<String, Value>` parameter through the embeddings raw passthrough chain (trait → pool → service → route) so encryption headers reach the model TEE
- Extracts repeated header insertion logic into `insert_encryption_headers()` helper

Previously, clients sending E2EE headers on these endpoints received no error — the headers were silently ignored and data transited in plaintext. The model TEE (inference-proxy) already supports E2EE for all endpoints; only the gateway was dropping headers.

### Files changed

| File | Change |
|------|--------|
| `crates/api/src/routes/completions.rs` | Add `headers` param + validation to 4 handlers; extract `insert_encryption_headers` helper; forward `X-Encrypt-All-Fields` |
| `crates/api/src/routes/common.rs` | Add `encrypt_all_fields` to `EncryptionHeaders` struct |
| `crates/services/src/common.rs` | Add `ENCRYPT_ALL_FIELDS` constant |
| `crates/inference_providers/src/vllm/mod.rs` | Call `prepare_encryption_headers` in score, rerank, audio, embeddings; forward `X-Encrypt-All-Fields` header |
| `crates/inference_providers/src/lib.rs` | Add `extra` param to `embeddings_raw` trait method |
| `crates/inference_providers/src/external/{mod,backend}.rs` | Update `embeddings_raw` signature |
| `crates/inference_providers/src/mock.rs` | Update `embeddings_raw` signature |
| `crates/services/src/completions/{mod,ports}.rs` | Thread `extra` param to `try_embeddings` |
| `crates/services/src/inference_provider_pool/mod.rs` | Thread `extra` param to `embeddings` |

## Test plan

- [x] `cargo check` passes
- [x] All 193 unit tests pass (`cargo test --lib --bins`)
- [ ] E2E tests with PostgreSQL
- [ ] Live integration test: send E2EE headers on embeddings/rerank/score/audio and verify encrypted responses

Companion PR: nearai/inference-proxy#83 (encrypts tool_calls, refusal, function_call, logprobs fields, gated behind `X-Encrypt-All-Fields` header)