### PR TITLE
fix: re-fetch signing keys for reused providers missing pubkey mappings

### DIFF
--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1540,7 +1540,61 @@ impl InferenceProviderPool {
         let mut pub_key_updates: Vec<(String, Arc<InferenceProviderTrait>)> = Vec::new();
         let mut new_url_cache: HashMap<String, Arc<InferenceProviderTrait>> = HashMap::new();
 
-        // Reused providers (URL unchanged — keep warm TLS connections)
+        // Reused providers (URL unchanged — keep warm TLS connections).
+        // Check if any reused provider is missing pubkey mappings and re-fetch if so.
+        // This can happen when the initial pubkey fetch failed (e.g., transient network
+        // error during startup) — since reused providers skip pubkey discovery, the keys
+        // would be permanently lost without this recovery path.
+        {
+            let mappings = self.provider_mappings.read().await;
+            let mut needs_pubkey_refetch: Vec<(String, String, Arc<InferenceProviderTrait>)> =
+                Vec::new();
+            for (model_name, url, provider) in &reused {
+                let ptr = Arc::as_ptr(provider) as *const () as usize;
+                let has_pubkey = mappings.pubkey_to_providers.values().any(|providers| {
+                    providers
+                        .iter()
+                        .any(|p| Arc::as_ptr(p) as *const () as usize == ptr)
+                });
+                if !has_pubkey {
+                    needs_pubkey_refetch.push((model_name.clone(), url.clone(), provider.clone()));
+                }
+            }
+            drop(mappings);
+
+            if !needs_pubkey_refetch.is_empty() {
+                warn!(
+                    count = needs_pubkey_refetch.len(),
+                    models = ?needs_pubkey_refetch.iter().map(|(m, _, _)| m.as_str()).collect::<Vec<_>>(),
+                    "Reused providers missing pubkey mappings — re-fetching signing keys"
+                );
+                for (model_name, url, provider) in &needs_pubkey_refetch {
+                    let (keys, _, _) = Self::fetch_signing_public_keys_for_both_algorithms(
+                        provider, model_name, url,
+                    )
+                    .await;
+                    let keys: Vec<(String, Arc<InferenceProviderTrait>)> = keys
+                        .into_iter()
+                        .map(|(k, _)| (k, provider.clone()))
+                        .collect();
+                    if keys.is_empty() {
+                        warn!(
+                            model = %model_name,
+                            url = %url,
+                            "Failed to re-fetch signing keys for reused provider"
+                        );
+                    } else {
+                        info!(
+                            model = %model_name,
+                            pub_keys = keys.len(),
+                            "Re-fetched signing keys for reused provider"
+                        );
+                        pub_key_updates.extend(keys);
+                    }
+                }
+            }
+        }
+
         for (model_name, url, provider) in &reused {
             model_providers
                 .entry(model_name.clone())

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -2288,6 +2288,79 @@ mod tests {
         }
     }
 
+    /// Verify that the self-healing recovery path re-fetches pubkeys for reused
+    /// providers that are missing from pubkey_to_providers.
+    ///
+    /// Regression test: if the initial pubkey fetch failed during provider creation
+    /// (transient network error), the provider was cached in inference_url_providers
+    /// but had no pubkey mappings. Subsequent refreshes reused the provider and never
+    /// retried the pubkey fetch, leaving E2EE permanently broken for that model.
+    #[tokio::test]
+    async fn test_reused_provider_missing_pubkeys_are_refetched() {
+        use inference_providers::mock::MockProvider;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model_id = "test-model".to_string();
+
+        // Register a provider with known pubkeys
+        let mock_provider = Arc::new(MockProvider::new());
+        pool.register_provider(model_id.clone(), mock_provider.clone())
+            .await;
+
+        let ecdsa_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+        // Verify pubkeys exist after registration
+        {
+            let mappings = pool.provider_mappings.read().await;
+            assert!(
+                mappings.pubkey_to_providers.contains_key(ecdsa_key),
+                "ECDSA key should exist after registration"
+            );
+        }
+
+        // Simulate the bug: clear pubkey mappings (as if initial fetch failed)
+        {
+            let mut mappings = pool.provider_mappings.write().await;
+            mappings.pubkey_to_providers.clear();
+        }
+
+        // Seed the URL cache so the provider is "reused" on next load
+        let url = "https://test.completions.near.ai".to_string();
+        {
+            let mut cache = pool.inference_url_providers.write().await;
+            cache.insert(
+                url.clone(),
+                mock_provider.clone() as Arc<InferenceProviderTrait>,
+            );
+        }
+
+        // Call load_inference_url_models — the provider should be reused and
+        // the self-healing path should detect missing pubkeys and re-fetch them.
+        pool.load_inference_url_models(vec![(model_id.clone(), url)])
+            .await;
+
+        // Verify pubkeys were recovered
+        {
+            let mappings = pool.provider_mappings.read().await;
+            assert!(
+                mappings.pubkey_to_providers.contains_key(ecdsa_key),
+                "ECDSA key should be RECOVERED after refresh via self-healing path"
+            );
+        }
+
+        // Verify E2EE routing works
+        let result: Result<((), _), _> = pool
+            .retry_with_fallback(&model_id, "test_op", Some(ecdsa_key), |_provider| async {
+                Ok(())
+            })
+            .await;
+        assert!(
+            result.is_ok(),
+            "E2EE routing should work after pubkey recovery, got: {:?}",
+            result.err()
+        );
+    }
+
     /// Test that E2EE routing via pubkey works end-to-end after register_provider.
     /// This exercises: register_provider → fetch attestation → store pubkey → route by pubkey.
     #[tokio::test]

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1547,20 +1547,25 @@ impl InferenceProviderPool {
         // would be permanently lost without this recovery path.
         {
             let mappings = self.provider_mappings.read().await;
-            let mut needs_pubkey_refetch: Vec<(String, String, Arc<InferenceProviderTrait>)> =
-                Vec::new();
+            // Build a set of all provider pointers currently in pubkey mappings (O(N+M)
+            // instead of scanning all values per reused provider).
+            let mut known_ptrs: std::collections::HashSet<usize> = mappings
+                .pubkey_to_providers
+                .values()
+                .flatten()
+                .map(|p| Arc::as_ptr(p) as *const () as usize)
+                .collect();
+            drop(mappings);
+
+            let mut needs_pubkey_refetch = Vec::new();
             for (model_name, url, provider) in &reused {
                 let ptr = Arc::as_ptr(provider) as *const () as usize;
-                let has_pubkey = mappings.pubkey_to_providers.values().any(|providers| {
-                    providers
-                        .iter()
-                        .any(|p| Arc::as_ptr(p) as *const () as usize == ptr)
-                });
-                if !has_pubkey {
+                // insert() returns true only if the pointer was NOT already present,
+                // which also deduplicates when multiple models share a provider.
+                if known_ptrs.insert(ptr) {
                     needs_pubkey_refetch.push((model_name.clone(), url.clone(), provider.clone()));
                 }
             }
-            drop(mappings);
 
             if !needs_pubkey_refetch.is_empty() {
                 warn!(
@@ -1573,10 +1578,6 @@ impl InferenceProviderPool {
                         provider, model_name, url,
                     )
                     .await;
-                    let keys: Vec<(String, Arc<InferenceProviderTrait>)> = keys
-                        .into_iter()
-                        .map(|(k, _)| (k, provider.clone()))
-                        .collect();
                     if keys.is_empty() {
                         warn!(
                             model = %model_name,


### PR DESCRIPTION
## Summary

- On each provider refresh cycle, check if any reused provider (URL unchanged) is missing from `pubkey_to_providers`. If so, re-fetch its signing keys via the attestation endpoint.
- This is a self-healing recovery path: if the initial pubkey fetch fails during startup (transient network error, backend unreachable), subsequent refresh cycles will retry instead of leaving the keys permanently lost.

## Root cause

Confirmed via Datadog logs on `cpu02-cloud-api-prod`:

- **Two `cloud-api` containers** running simultaneously (container IDs `6f5bdef9...` and `45b9e685...`)
- Container A: **18 pubkeys** (all models, including GLM-5 ECDSA `59e5d3f7...`)
- Container B: **16 pubkeys** (missing GLM-5 ECDSA + Ed25519 keys)
- Requests hitting Container B with a GLM-5 pubkey → `Arc::ptr_eq` intersection is empty → **HTTP 421** "The encryption key is no longer valid"
- 10 real 421 errors found between 02:47–03:09 UTC today, all from container `5805230f...` on cpu02-prod, all for `zai-org/GLM-5-FP8` ECDSA

The bug: `load_inference_url_models` only fetches signing keys for **newly created** providers. When a provider is reused (URL unchanged in `inference_url_providers` cache), its existing pubkey mappings are preserved — but if they were never successfully fetched in the first place, they stay permanently missing.

## Test plan

- [x] `cargo test --lib --bins` — 193 tests pass
- [x] `cargo clippy` — no warnings
- [ ] Deploy to staging, verify `pubkey_to_providers state after update` logs show recovery for any missing keys
- [ ] Monitor Datadog for `"Reused providers missing pubkey mappings"` WARN log to confirm the recovery path fires
- [ ] Verify no more 421 errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)