### PR TITLE
fix: per-call timeout + stagger for attestation discovery

### DIFF
--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -10,7 +10,11 @@ const NVIDIA_NRAS_URL: &str = "https://nras.attestation.nvidia.com/v3/attest/gpu
 
 /// Number of parallel attestation calls per model to discover TLS fingerprints
 /// from multiple backends behind L4 load balancing.
-pub const ATTESTATION_DISCOVERY_PARALLELISM: usize = 10;
+///
+/// Each cloud-api instance runs its own discovery, so the effective load on a
+/// model is `PARALLELISM * cloud-api instance count` per refresh cycle. Keep
+/// this modest to avoid piling attestation work on inference backends.
+pub const ATTESTATION_DISCOVERY_PARALLELISM: usize = 5;
 
 /// Result of verifying an attestation report from an inference backend.
 #[derive(Debug, Clone)]

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1418,29 +1418,48 @@ impl InferenceProviderPool {
                     // Uses N parallel attestation calls to hit multiple backends behind
                     // L4 load balancing. Each call generates a client-side nonce for
                     // freshness (prevents replay of old attestation reports).
+                    // Stagger launches ~200ms apart to spread load and encourage
+                    // fresh TCP connections to different L4 backends. Each individual
+                    // call is bounded by a 10s hard timeout so a single slow/hanging
+                    // backend can't starve the whole discovery batch — previously,
+                    // `join_all` under a 30s outer timeout would discard all successful
+                    // results when even one call hung, blocking the provider entirely.
+                    const PER_CALL_TIMEOUT: Duration = Duration::from_secs(10);
+                    const STAGGER_MS: u64 = 200;
                     let discovery_futures: Vec<_> = (0..discovery_parallelism)
-                        .map(|_| {
+                        .map(|i| {
                             let provider = serving_provider.clone();
                             let model = model_name.clone();
                             async move {
+                                if i > 0 {
+                                    tokio::time::sleep(Duration::from_millis(
+                                        STAGGER_MS * i as u64,
+                                    ))
+                                    .await;
+                                }
                                 // Generate client-side nonce for freshness
                                 let nonce_bytes: [u8; 32] = rand::random();
                                 let nonce = hex::encode(nonce_bytes);
-                                let report = provider
-                                    .get_attestation_report(
+                                let report = tokio::time::timeout(
+                                    PER_CALL_TIMEOUT,
+                                    provider.get_attestation_report(
                                         model,
                                         None,
                                         Some(nonce.clone()),
                                         None,
                                         true,
-                                    )
-                                    .await
-                                    .ok()?;
+                                    ),
+                                )
+                                .await
+                                .ok()?
+                                .ok()?;
                                 Some((report, nonce))
                             }
                         })
                         .collect();
 
+                    // Outer cap is a safety net; per-call timeouts + stagger bound the
+                    // normal worst case (~STAGGER_MS * (N-1) + PER_CALL_TIMEOUT).
                     let discovery_results = tokio::time::timeout(
                         Duration::from_secs(30),
                         futures::future::join_all(discovery_futures),


### PR DESCRIPTION
## Summary

Observed in prod: GLM-5-FP8 and Qwen3.5-122B-A10B repeatedly dropped from cloud-api's provider pool on both cpu01 and cpu02. Clients hit *"Model not found in provider pool"* and E2EE requests failed with *"No provider found for model public key"* even though the model's real signing key was current and the backends were healthy (direct curl from the host returned 200 in ~100ms).

Root cause is a race in the attestation discovery path, **not** the eviction logic from #537.

### The bug

`crates/services/src/inference_provider_pool/mod.rs`:

```rust
let discovery_results = tokio::time::timeout(
    Duration::from_secs(30),
    futures::future::join_all(discovery_futures),  // waits for ALL 10
)
.await
.unwrap_or_default();  // Elapsed → empty Vec
```

`join_all` only resolves when **every** future completes. Each individual attestation call inherits the vLLM provider's 90s request timeout. If even **one** of the 10 parallel calls hangs past 30s, the outer timeout fires first, `unwrap_or_default()` returns an empty `Vec`, and **all of the successful results are thrown away**. `pinned_count` then falls to 0, `block_connections()` fires, and the provider is permanently blocked.

### Reproduction

10 parallel bootstrap-style calls to `glm-5.completions.near.ai` from cpu01 just now:

```
req1: 200 in 0.47s    req4: 200 in 0.49s    req7: 200 in 0.48s    req10: 200 in 1.22s
req2: 200 in 0.48s    req5: 200 in 0.81s    req9: 200 in 0.84s    req6: 200 in 15.42s
req3: 200 in 0.30s                                                req8: timeout 30s+
```

9 fast successes, 1 slow straggler → cloud-api discards all 9.

GLM-5.1 (single backend on gpu11) doesn't trip this because it has no backend variance. #537's eviction path re-ran discovery each refresh but every retry hit the same race, which is why the redeploy didn't fix anything.

### The fix

- Bound each individual attestation call with a 10s per-call timeout so a slow straggler fails on its own instead of dragging the batch down.
- Stagger launches 200ms apart to spread load on the model's attestation endpoint and encourage fresh TCP connections to different L4 backends.
- Keep the 30s outer cap as a safety net.

Worst-case discovery time becomes `200ms × 9 + 10s ≈ 11.8s`, well within the outer cap.

## Test plan

- [x] `cargo build -p services` — clean
- [x] `cargo test -p services --lib inference_provider_pool` — 25 passed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p services --lib` — clean
- [ ] After merge + staging deploy: confirm GLM-5-FP8 and Qwen3.5-122B-A10B appear in `pubkey_to_providers` in Datadog (`pubkey_mapping_count` should return to ~20) and no recurring `Reused providers missing pubkey mappings` warnings.
- [ ] After prod deploy: confirm no `Model not found in provider pool` and no `No provider found for model public key` for those two models over a 30-minute window.