### PR TITLE
Inline backend verification: zero fingerprint-mismatch failures

### DIFF
--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -53,6 +53,8 @@
 //! }
 //! ```
 
+use reqwest::Client;
+
 pub mod chunk_builder;
 pub mod external;
 pub mod mock;
@@ -94,6 +96,19 @@ pub use external::{
     AnthropicBackend, ExternalProvider, ExternalProviderConfig, GeminiBackend,
     OpenAiCompatibleBackend, ProviderConfig,
 };
+
+/// Creates a verified `reqwest::Client` with an H2 connection to a specific backend.
+///
+/// Used by `VLlmProvider` for inline backend verification: when a bucket needs a new
+/// client, the verifier connects to model-proxy, fetches the backend's attestation
+/// report, verifies it (TDX quote, GPU evidence, image hash), pins the TLS fingerprint,
+/// and returns the client with its established connection.
+#[async_trait::async_trait]
+pub trait BackendVerifier: Send + Sync {
+    /// Connect to `base_url`, verify the backend's attestation, and return a client
+    /// whose H2 connection is pinned to that verified backend.
+    async fn create_verified_client(&self, base_url: &str) -> Result<Client, String>;
+}
 
 /// Try to extract a human-readable error message from a JSON error response body.
 ///

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -247,12 +247,28 @@ impl VLlmProvider {
         for _attempt in 0..=Self::INLINE_VERIFY_RETRIES {
             match verifier.create_verified_client(&self.config.base_url).await {
                 Ok(client) => {
-                    *self.bucket_clients[bucket_id]
+                    // Double-check: another concurrent request may have filled
+                    // this bucket while we were verifying. Use its client if so
+                    // (avoids wasting the connection it established).
+                    let mut guard = self.bucket_clients[bucket_id]
                         .lock()
-                        .unwrap_or_else(|e| e.into_inner()) = Some(client.clone());
+                        .unwrap_or_else(|e| e.into_inner());
+                    if let Some(ref existing) = *guard {
+                        return Ok(existing.clone());
+                    }
+                    *guard = Some(client.clone());
                     return Ok(client);
                 }
                 Err(e) => {
+                    // Another request may have filled the bucket while we failed.
+                    let guard = self.bucket_clients[bucket_id]
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    if let Some(ref existing) = *guard {
+                        return Ok(existing.clone());
+                    }
+                    drop(guard);
+
                     tracing::warn!(
                         bucket = bucket_id,
                         error = %e,
@@ -270,9 +286,9 @@ impl VLlmProvider {
         )))
     }
 
-    /// Clear a bucket's client (e.g., after a connection error) so it will be
-    /// re-verified on next use.
-    #[allow(dead_code)]
+    /// Clear a bucket's client so it will be re-verified on next use.
+    /// Called on connection errors — prevents a stale client (whose H2
+    /// connection dropped) from persisting in Bootstrap mode on reconnect.
     fn clear_bucket(&self, bucket_id: usize) {
         *self.bucket_clients[bucket_id]
             .lock()
@@ -634,9 +650,27 @@ impl InferenceProvider for VLlmProvider {
         // pins the client.
         let bucket_id = self.prefix_router.route(&streaming_params.messages);
         let bucket_client = self.get_or_verify_bucket_client(bucket_id).await?;
-        let response = self
-            .send_streaming_request(&url, headers, &streaming_params, Some(&bucket_client))
-            .await?;
+        let response = match self
+            .send_streaming_request(
+                &url,
+                headers.clone(),
+                &streaming_params,
+                Some(&bucket_client),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(CompletionError::CompletionError(ref msg))
+                if msg.contains("connection") || msg.contains("connect") =>
+            {
+                // Connection dropped — clear bucket so next request re-verifies.
+                self.clear_bucket(bucket_id);
+                let fresh = self.get_or_verify_bucket_client(bucket_id).await?;
+                self.send_streaming_request(&url, headers, &streaming_params, Some(&fresh))
+                    .await?
+            }
+            Err(e) => return Err(e),
+        };
 
         // Store the bucket ID for signature fetching.
         self.pending_buckets
@@ -673,14 +707,27 @@ impl InferenceProvider for VLlmProvider {
         let bucket_client = self.get_or_verify_bucket_client(bucket_id).await?;
         let timeout = Duration::from_secs(self.config.timeout_seconds as u64);
 
-        let response = bucket_client
-            .post(&url)
-            .headers(headers)
-            .json(&non_streaming_params)
-            .timeout(timeout)
-            .send()
-            .await
-            .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
+        let send = |client: &Client, hdrs: reqwest::header::HeaderMap| {
+            client
+                .post(&url)
+                .headers(hdrs)
+                .json(&non_streaming_params)
+                .timeout(timeout)
+                .send()
+        };
+
+        let response = match send(&bucket_client, headers.clone()).await {
+            Ok(r) => r,
+            Err(e) if e.is_connect() || e.to_string().contains("connection") => {
+                // Connection dropped — clear bucket, re-verify, retry once.
+                self.clear_bucket(bucket_id);
+                let fresh = self.get_or_verify_bucket_client(bucket_id).await?;
+                send(&fresh, headers)
+                    .await
+                    .map_err(|e| CompletionError::CompletionError(e.to_string()))?
+            }
+            Err(e) => return Err(CompletionError::CompletionError(e.to_string())),
+        };
 
         if !response.status().is_success() {
             let status = response.status();
@@ -1368,7 +1415,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lazy_buckets_start_empty_without_verifier() {
+    fn test_legacy_provider_eagerly_creates_buckets() {
         // Without a verifier, buckets are eagerly pre-created (legacy path)
         let provider = create_test_provider();
         let guard = provider.bucket_clients[0]

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -76,11 +76,10 @@ pub struct VLlmProvider {
     config: VLlmConfig,
     /// General-purpose client for non-completion requests (attestation, models, etc.)
     client: Client,
-    /// Persistent clients indexed by prefix bucket ID. Each maintains a single
-    /// connection pinned to a specific backend via L4 TLS passthrough. Requests
-    /// with the same prompt prefix route to the same bucket → same backend →
-    /// prefix cache hit.
-    bucket_clients: Vec<Client>,
+    /// Lazily-filled bucket clients indexed by prefix bucket ID. Each slot starts
+    /// empty and is filled on first use via inline backend verification. Once filled,
+    /// the client maintains a persistent H2 connection to a specific verified backend.
+    bucket_clients: Vec<std::sync::Mutex<Option<Client>>>,
     /// Prefix router: message-level trie mapping conversation prefixes to bucket IDs.
     prefix_router: Arc<PrefixRouter>,
     /// Maps request_hash → bucket_id during streaming (before chat_id is known).
@@ -90,23 +89,47 @@ pub struct VLlmProvider {
     /// TLS fingerprint verification state (Bootstrap → Pinned or Blocked).
     /// Shared across the main client and all bucket clients.
     fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
+    /// Creates verified clients for lazy bucket initialization.
+    /// When a bucket needs a client, the verifier connects to a backend,
+    /// verifies its attestation, pins the fingerprint, and returns the client.
+    backend_verifier: Option<Arc<dyn crate::BackendVerifier>>,
 }
 
 impl VLlmProvider {
-    /// Create a new vLLM provider with the given configuration
+    /// Create a new vLLM provider with the given configuration.
+    /// Without a `BackendVerifier`, bucket clients are pre-created eagerly
+    /// (legacy behavior for tests and non-TEE environments).
     pub fn new(config: VLlmConfig) -> Self {
         let fingerprint_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
         Self::new_with_fingerprint_state(config, fingerprint_state)
     }
 
     /// Create a new vLLM provider sharing an existing fingerprint state.
-    /// Used to create a fresh connection pool after TLS pinning is established,
-    /// ensuring all new connections go through the SPKI verifier.
+    /// Without a `BackendVerifier`, bucket clients are pre-created eagerly.
     pub fn new_with_fingerprint_state(
         config: VLlmConfig,
         fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
     ) -> Self {
-        // Load root certs once, share across all clients (~150KB instead of N×150KB)
+        Self::build(config, fingerprint_state, None)
+    }
+
+    /// Create a new vLLM provider with inline backend verification.
+    /// Bucket clients are created lazily: on first use, the verifier connects to
+    /// a backend, verifies attestation, pins the fingerprint, and returns a client
+    /// whose H2 connection is pinned to that verified backend.
+    pub fn new_with_verifier(
+        config: VLlmConfig,
+        fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
+        verifier: Arc<dyn crate::BackendVerifier>,
+    ) -> Self {
+        Self::build(config, fingerprint_state, Some(verifier))
+    }
+
+    fn build(
+        config: VLlmConfig,
+        fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
+        backend_verifier: Option<Arc<dyn crate::BackendVerifier>>,
+    ) -> Self {
         let tls_roots = SharedTlsRoots::load();
 
         // General-purpose client for non-completion requests
@@ -118,31 +141,31 @@ impl VLlmProvider {
             .build()
             .expect("Failed to create HTTP client");
 
-        // Prefix router determines which bucket to use for each completion
         let prefix_router = Arc::new(PrefixRouter::new());
         let num_buckets = prefix_router.num_buckets();
 
-        // Create persistent bucket clients — each maintains one connection
-        // pinned to a specific backend via L4 TLS passthrough.
-        //
-        // Relies on HTTP/2 multiplexing: concurrent requests on the same bucket
-        // share one TLS connection → guaranteed same backend. CVM nginx (port 8444)
-        // negotiates h2 via ALPN. With HTTP/1.1 fallback, concurrent requests may
-        // open additional connections to different backends — signature fetches
-        // handle this with a retry fallback (see get_signature).
-        let bucket_clients: Vec<Client> = (0..num_buckets)
-            .map(|_| {
-                Client::builder()
-                    .use_preconfigured_tls(tls_roots.build_config(fingerprint_state.clone()))
-                    .pool_max_idle_per_host(1)
-                    .http2_adaptive_window(true)
-                    .connect_timeout(Duration::from_secs(5))
-                    .pool_idle_timeout(Duration::from_secs(300))
-                    .read_timeout(Duration::from_secs(300))
-                    .build()
-                    .expect("Failed to create bucket HTTP client")
-            })
-            .collect();
+        // Bucket clients: lazily filled when a verifier is available (each bucket
+        // gets a verified client on first use), or eagerly pre-created (legacy).
+        let bucket_clients: Vec<std::sync::Mutex<Option<Client>>> = if backend_verifier.is_some() {
+            (0..num_buckets)
+                .map(|_| std::sync::Mutex::new(None))
+                .collect()
+        } else {
+            (0..num_buckets)
+                .map(|_| {
+                    let c = Client::builder()
+                        .use_preconfigured_tls(tls_roots.build_config(fingerprint_state.clone()))
+                        .pool_max_idle_per_host(1)
+                        .http2_adaptive_window(true)
+                        .connect_timeout(Duration::from_secs(5))
+                        .pool_idle_timeout(Duration::from_secs(300))
+                        .read_timeout(Duration::from_secs(300))
+                        .build()
+                        .expect("Failed to create bucket HTTP client");
+                    std::sync::Mutex::new(Some(c))
+                })
+                .collect()
+        };
 
         Self {
             config,
@@ -152,6 +175,7 @@ impl VLlmProvider {
             pending_buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
             signature_buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
             fingerprint_state,
+            backend_verifier,
         }
     }
 
@@ -191,11 +215,68 @@ impl VLlmProvider {
             .pinned_count()
     }
 
-    /// Check if an error message indicates a TLS SPKI fingerprint mismatch.
-    /// Matches the error strings produced by `SpkiFingerprintVerifier` in `spki_verifier.rs`.
-    fn is_tls_fingerprint_error_msg(msg: &str) -> bool {
-        msg.contains("does not match any attested fingerprint")
-            || msg.contains("TLS connections blocked")
+    /// Maximum inline-verification retries when creating a verified bucket client.
+    const INLINE_VERIFY_RETRIES: usize = 2;
+
+    /// Get the client for a bucket, creating and verifying it inline if needed.
+    /// On first use, connects to a backend via L4, fetches its attestation report,
+    /// verifies it, pins the fingerprint, and caches the client.
+    async fn get_or_verify_bucket_client(
+        &self,
+        bucket_id: usize,
+    ) -> Result<Client, CompletionError> {
+        // Fast path: bucket already has a verified client.
+        // reqwest::Client::clone is an Arc refcount bump — hold the lock briefly.
+        {
+            let guard = self.bucket_clients[bucket_id]
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if let Some(ref client) = *guard {
+                return Ok(client.clone());
+            }
+        }
+
+        // Slow path: inline verification.
+        let verifier = self.backend_verifier.as_ref().ok_or_else(|| {
+            CompletionError::CompletionError(
+                "No backend verifier configured for lazy bucket creation".to_string(),
+            )
+        })?;
+
+        let mut last_err = None;
+        for _attempt in 0..=Self::INLINE_VERIFY_RETRIES {
+            match verifier.create_verified_client(&self.config.base_url).await {
+                Ok(client) => {
+                    *self.bucket_clients[bucket_id]
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner()) = Some(client.clone());
+                    return Ok(client);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        bucket = bucket_id,
+                        error = %e,
+                        "Inline backend verification failed, retrying"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        Err(CompletionError::CompletionError(format!(
+            "Failed to create verified client after {} attempts: {}",
+            Self::INLINE_VERIFY_RETRIES + 1,
+            last_err.unwrap_or_default()
+        )))
+    }
+
+    /// Clear a bucket's client (e.g., after a connection error) so it will be
+    /// re-verified on next use.
+    #[allow(dead_code)]
+    fn clear_bucket(&self, bucket_id: usize) {
+        *self.bucket_clients[bucket_id]
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
     }
 
     /// Build HTTP request headers
@@ -272,10 +353,6 @@ impl VLlmProvider {
         }
     }
 
-    /// Maximum retries with alternate bucket clients when TLS fingerprint
-    /// verification fails because L4 routed to an undiscovered backend.
-    const TLS_FINGERPRINT_RETRIES: usize = 2;
-
     /// Send a streaming HTTP POST request with TTFB timeout protection.
     ///
     /// Uses `tokio::time::timeout` only around `.send()` so the timeout applies to TTFB only
@@ -349,17 +426,19 @@ impl InferenceProvider for VLlmProvider {
             .unwrap_or_else(|e| e.into_inner())
             .get(chat_id)
             .copied();
-        let primary_client = match bucket_id {
-            Some(id) => &self.bucket_clients[id],
-            None => &self.client,
-        };
+        let bucket_client = bucket_id.and_then(|id| {
+            self.bucket_clients[id]
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        });
 
         let timeout = Duration::from_secs(self.config.timeout_seconds as u64);
-        let clients_to_try: Vec<&Client> = if bucket_id.is_some() {
-            vec![primary_client, &self.client]
-        } else {
-            vec![primary_client]
-        };
+        let mut clients_to_try: Vec<&Client> = Vec::new();
+        if let Some(ref bc) = bucket_client {
+            clients_to_try.push(bc);
+        }
+        clients_to_try.push(&self.client);
 
         let mut last_error = None;
         for client in clients_to_try {
@@ -549,59 +628,24 @@ impl InferenceProvider for VLlmProvider {
         self.prepare_encryption_headers(&mut headers, &mut streaming_params.extra);
 
         // Route to a bucket client based on prompt prefix.
-        // The bucket client maintains a persistent TLS connection pinned to a
-        // specific backend via L4 passthrough → prefix cache hits.
-        //
-        // On TLS fingerprint mismatch (L4 routed to an undiscovered backend),
-        // try alternate bucket clients which likely have warm connections to
-        // different (attested) backends.
+        // The bucket client maintains a persistent H2 connection to a verified backend
+        // via L4 passthrough → prefix cache hits. Buckets are lazily filled: on first
+        // use, inline verification connects to a backend, verifies attestation, and
+        // pins the client.
         let bucket_id = self.prefix_router.route(&streaming_params.messages);
-        let num_buckets = self.bucket_clients.len();
-        let mut last_err = None;
+        let bucket_client = self.get_or_verify_bucket_client(bucket_id).await?;
+        let response = self
+            .send_streaming_request(&url, headers, &streaming_params, Some(&bucket_client))
+            .await?;
 
-        for attempt in 0..=Self::TLS_FINGERPRINT_RETRIES {
-            let effective_bucket = (bucket_id + attempt) % num_buckets;
-            let bucket_client = &self.bucket_clients[effective_bucket];
+        // Store the bucket ID for signature fetching.
+        self.pending_buckets
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(request_hash, bucket_id);
 
-            match self
-                .send_streaming_request(
-                    &url,
-                    headers.clone(),
-                    &streaming_params,
-                    Some(bucket_client),
-                )
-                .await
-            {
-                Ok(response) => {
-                    // Store the effective bucket ID for signature fetching.
-                    self.pending_buckets
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .insert(request_hash, effective_bucket);
-
-                    let sse_stream = new_sse_parser(response.bytes_stream(), true);
-                    return Ok(Box::pin(sse_stream));
-                }
-                Err(CompletionError::CompletionError(ref msg))
-                    if Self::is_tls_fingerprint_error_msg(msg) =>
-                {
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        bucket = effective_bucket,
-                        "TLS fingerprint mismatch, trying alternate bucket"
-                    );
-                    last_err = Some(CompletionError::CompletionError(msg.clone()));
-                    continue;
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        Err(last_err.unwrap_or_else(|| {
-            CompletionError::CompletionError(
-                "TLS fingerprint verification failed after retries".to_string(),
-            )
-        }))
+        let sse_stream = new_sse_parser(response.bytes_stream(), true);
+        Ok(Box::pin(sse_stream))
     }
 
     /// Performs a chat completion request
@@ -624,52 +668,19 @@ impl InferenceProvider for VLlmProvider {
         // Prepare encryption headers
         self.prepare_encryption_headers(&mut headers, &mut non_streaming_params.extra);
 
-        // Route to a bucket client based on prompt prefix (same as streaming path).
-        // On TLS fingerprint mismatch, try alternate bucket clients.
+        // Route to a verified bucket client based on prompt prefix.
         let bucket_id = self.prefix_router.route(&non_streaming_params.messages);
-        let num_buckets = self.bucket_clients.len();
+        let bucket_client = self.get_or_verify_bucket_client(bucket_id).await?;
         let timeout = Duration::from_secs(self.config.timeout_seconds as u64);
 
-        let (response, effective_bucket) = {
-            let mut last_err = None;
-            let mut result = None;
-            for attempt in 0..=Self::TLS_FINGERPRINT_RETRIES {
-                let eb = (bucket_id + attempt) % num_buckets;
-                match self.bucket_clients[eb]
-                    .post(&url)
-                    .headers(headers.clone())
-                    .json(&non_streaming_params)
-                    .timeout(timeout)
-                    .send()
-                    .await
-                {
-                    Ok(resp) => {
-                        result = Some((resp, eb));
-                        break;
-                    }
-                    Err(e) if Self::is_tls_fingerprint_error_msg(&e.to_string()) => {
-                        tracing::warn!(
-                            attempt = attempt + 1,
-                            bucket = eb,
-                            "TLS fingerprint mismatch, trying alternate bucket"
-                        );
-                        last_err = Some(e);
-                        continue;
-                    }
-                    Err(e) => return Err(CompletionError::CompletionError(e.to_string())),
-                }
-            }
-            match result {
-                Some(r) => r,
-                None => {
-                    return Err(CompletionError::CompletionError(
-                        last_err
-                            .map(|e| e.to_string())
-                            .unwrap_or_else(|| "TLS fingerprint verification failed".to_string()),
-                    ));
-                }
-            }
-        };
+        let response = bucket_client
+            .post(&url)
+            .headers(headers)
+            .json(&non_streaming_params)
+            .timeout(timeout)
+            .send()
+            .await
+            .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -704,7 +715,7 @@ impl InferenceProvider for VLlmProvider {
         self.signature_buckets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(chat_id, effective_bucket);
+            .insert(chat_id, bucket_id);
 
         Ok(ChatCompletionResponseWithBytes {
             response: chat_completion_response,
@@ -1348,50 +1359,102 @@ mod tests {
     }
 
     #[test]
-    fn test_is_tls_fingerprint_error_msg_detects_mismatch() {
-        // The exact error string from SpkiFingerprintVerifier (spki_verifier.rs:140-142)
-        // as wrapped by reqwest.
-        let msg = "error sending request for url (https://glm-5.completions.near.ai/v1/chat/completions): \
-            error trying to connect: invalid peer certificate: \
-            TLS certificate SPKI fingerprint abc123def456 does not match any attested fingerprint";
-        assert!(VLlmProvider::is_tls_fingerprint_error_msg(msg));
-    }
-
-    #[test]
-    fn test_is_tls_fingerprint_error_msg_detects_blocked() {
-        // The exact error string from SpkiFingerprintVerifier (spki_verifier.rs:128-130)
-        let msg = "error trying to connect: invalid peer certificate: \
-            TLS connections blocked: attestation verification failed";
-        assert!(VLlmProvider::is_tls_fingerprint_error_msg(msg));
-    }
-
-    #[test]
-    fn test_is_tls_fingerprint_error_msg_ignores_other_errors() {
-        // Connection errors should not trigger fingerprint retry
-        assert!(!VLlmProvider::is_tls_fingerprint_error_msg(
-            "error sending request: connection refused"
-        ));
-        assert!(!VLlmProvider::is_tls_fingerprint_error_msg(
-            "error sending request: timed out"
-        ));
-        assert!(!VLlmProvider::is_tls_fingerprint_error_msg(
-            "error trying to connect: dns error: failed to lookup address"
-        ));
-        // Partial matches should not trigger
-        assert!(!VLlmProvider::is_tls_fingerprint_error_msg(
-            "TLS certificate expired"
-        ));
-        assert!(!VLlmProvider::is_tls_fingerprint_error_msg(
-            "SPKI fingerprint computed"
-        ));
-    }
-
-    #[test]
     fn test_bucket_count_matches_prefix_router() {
         let provider = create_test_provider();
         assert_eq!(
             provider.bucket_clients.len(),
             provider.prefix_router.num_buckets()
         );
+    }
+
+    #[test]
+    fn test_lazy_buckets_start_empty_without_verifier() {
+        // Without a verifier, buckets are eagerly pre-created (legacy path)
+        let provider = create_test_provider();
+        let guard = provider.bucket_clients[0]
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert!(guard.is_some(), "Legacy provider should pre-create buckets");
+    }
+
+    #[test]
+    fn test_lazy_buckets_start_empty_with_verifier() {
+        use std::sync::Arc;
+        struct NoopVerifier;
+        #[async_trait::async_trait]
+        impl crate::BackendVerifier for NoopVerifier {
+            async fn create_verified_client(
+                &self,
+                _base_url: &str,
+            ) -> Result<reqwest::Client, String> {
+                Ok(reqwest::Client::new())
+            }
+        }
+
+        let provider = VLlmProvider::new_with_verifier(
+            VLlmConfig {
+                base_url: "http://localhost".to_string(),
+                api_key: None,
+                timeout_seconds: 30,
+            },
+            Arc::new(std::sync::RwLock::new(
+                crate::spki_verifier::FingerprintState::Bootstrap,
+            )),
+            Arc::new(NoopVerifier),
+        );
+        let guard = provider.bucket_clients[0]
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert!(
+            guard.is_none(),
+            "Verifier-backed provider should start with empty buckets"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_or_verify_fills_bucket() {
+        use std::sync::Arc;
+        struct NoopVerifier;
+        #[async_trait::async_trait]
+        impl crate::BackendVerifier for NoopVerifier {
+            async fn create_verified_client(
+                &self,
+                _base_url: &str,
+            ) -> Result<reqwest::Client, String> {
+                Ok(reqwest::Client::new())
+            }
+        }
+
+        let provider = VLlmProvider::new_with_verifier(
+            VLlmConfig {
+                base_url: "http://localhost".to_string(),
+                api_key: None,
+                timeout_seconds: 30,
+            },
+            Arc::new(std::sync::RwLock::new(
+                crate::spki_verifier::FingerprintState::Bootstrap,
+            )),
+            Arc::new(NoopVerifier),
+        );
+
+        // Bucket starts empty
+        assert!(provider.bucket_clients[0].lock().unwrap().is_none());
+
+        // get_or_verify fills it
+        let result = provider.get_or_verify_bucket_client(0).await;
+        assert!(result.is_ok());
+        assert!(provider.bucket_clients[0].lock().unwrap().is_some());
+
+        // Second call returns cached client (fast path)
+        let result2 = provider.get_or_verify_bucket_client(0).await;
+        assert!(result2.is_ok());
+    }
+
+    #[test]
+    fn test_clear_bucket() {
+        let provider = create_test_provider();
+        assert!(provider.bucket_clients[0].lock().unwrap().is_some());
+        provider.clear_bucket(0);
+        assert!(provider.bucket_clients[0].lock().unwrap().is_none());
     }
 }

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -286,9 +286,28 @@ impl VLlmProvider {
         )))
     }
 
+    /// Check if a CompletionError indicates a connection/transport failure
+    /// (as opposed to an HTTP-level error from the backend).
+    fn is_connection_error(err: &CompletionError) -> bool {
+        match err {
+            CompletionError::CompletionError(msg) => {
+                // reqwest connection errors contain these keywords.
+                // After send_streaming_request converts reqwest::Error to String,
+                // this is the only way to detect transport failures.
+                msg.contains("error sending request")
+                    || msg.contains("connection closed")
+                    || msg.contains("connection reset")
+                    || msg.contains("broken pipe")
+                    || msg.contains("does not match any attested fingerprint")
+                    || msg.contains("TLS connections blocked")
+            }
+            _ => false,
+        }
+    }
+
     /// Clear a bucket's client so it will be re-verified on next use.
     /// Called on connection errors — prevents a stale client (whose H2
-    /// connection dropped) from persisting in Bootstrap mode on reconnect.
+    /// connection dropped) from being reused with an unverified reconnection.
     fn clear_bucket(&self, bucket_id: usize) {
         *self.bucket_clients[bucket_id]
             .lock()
@@ -660,10 +679,9 @@ impl InferenceProvider for VLlmProvider {
             .await
         {
             Ok(r) => r,
-            Err(CompletionError::CompletionError(ref msg))
-                if msg.contains("connection") || msg.contains("connect") =>
-            {
-                // Connection dropped — clear bucket so next request re-verifies.
+            Err(ref e) if Self::is_connection_error(e) => {
+                // Connection dropped or fingerprint mismatch on reconnect —
+                // clear bucket and re-verify with a fresh attestation.
                 self.clear_bucket(bucket_id);
                 let fresh = self.get_or_verify_bucket_client(bucket_id).await?;
                 self.send_streaming_request(&url, headers, &streaming_params, Some(&fresh))
@@ -718,8 +736,14 @@ impl InferenceProvider for VLlmProvider {
 
         let response = match send(&bucket_client, headers.clone()).await {
             Ok(r) => r,
-            Err(e) if e.is_connect() || e.to_string().contains("connection") => {
-                // Connection dropped — clear bucket, re-verify, retry once.
+            Err(e)
+                if e.is_connect()
+                    || e.to_string()
+                        .contains("does not match any attested fingerprint")
+                    || e.to_string().contains("error sending request") =>
+            {
+                // Connection dropped or fingerprint mismatch on reconnect —
+                // clear bucket and re-verify with a fresh attestation.
                 self.clear_bucket(bucket_id);
                 let fresh = self.get_or_verify_bucket_client(bucket_id).await?;
                 send(&fresh, headers)

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -113,6 +113,89 @@ pub struct InferenceProviderPool {
     attestation_verifier: Arc<AttestationVerifier>,
 }
 
+/// Backend verifier that creates verified reqwest clients by connecting to a backend,
+/// fetching its attestation report, and verifying the TDX quote + GPU evidence.
+/// Used by `VLlmProvider` for lazy bucket client creation.
+struct PoolBackendVerifier {
+    api_key: Option<String>,
+    tls_roots: SharedTlsRoots,
+    attestation_verifier: Arc<AttestationVerifier>,
+    /// Shared fingerprint state — newly discovered fingerprints are pinned here
+    /// so other providers and discovery cycles benefit.
+    fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
+}
+
+#[async_trait::async_trait]
+impl inference_providers::BackendVerifier for PoolBackendVerifier {
+    async fn create_verified_client(&self, base_url: &str) -> Result<reqwest::Client, String> {
+        // 1. Build a client with isolated Bootstrap state (accepts any WebPKI cert).
+        let bootstrap_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
+        let client = reqwest::Client::builder()
+            .use_preconfigured_tls(self.tls_roots.build_config(bootstrap_state))
+            .pool_max_idle_per_host(1)
+            .http2_adaptive_window(true)
+            .connect_timeout(Duration::from_secs(5))
+            .pool_idle_timeout(Duration::from_secs(300))
+            .read_timeout(Duration::from_secs(300))
+            .build()
+            .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+
+        // 2. Fetch attestation report — this establishes the H2 connection to some backend.
+        let nonce = uuid::Uuid::new_v4().to_string();
+        let url = format!(
+            "{base_url}/v1/attestation/report?include_tls_fingerprint=true&nonce={nonce}&signing_algo=ecdsa"
+        );
+        let mut request = client.get(&url);
+        if let Some(ref key) = self.api_key {
+            request = request.header("Authorization", format!("Bearer {key}"));
+        }
+        let response = tokio::time::timeout(Duration::from_secs(10), request.send())
+            .await
+            .map_err(|_| "Attestation request timed out".to_string())?
+            .map_err(|e| format!("Attestation request failed: {e}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown".to_string());
+            return Err(format!("Attestation HTTP {status}: {body}"));
+        }
+
+        let report: serde_json::Map<String, serde_json::Value> = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse attestation response: {e}"))?;
+
+        // 3. Verify the attestation report (TDX quote, GPU evidence, image hash).
+        let verified = self
+            .attestation_verifier
+            .verify_attestation_report(&report, &nonce)
+            .await
+            .map_err(|e| format!("Attestation verification failed: {e}"))?;
+
+        // 4. Pin the verified TLS fingerprint in the shared state.
+        if let Some(ref fp) = verified.tls_cert_fingerprint {
+            let mut state = self
+                .fingerprint_state
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            let before = state.pinned_count();
+            state.add_fingerprint(fp.clone());
+            if state.pinned_count() > before {
+                info!(
+                    fingerprint = %fp,
+                    "Inline verification pinned new TLS fingerprint"
+                );
+            }
+        }
+
+        // 5. Return the client — its H2 connection is pinned to the verified backend.
+        Ok(client)
+    }
+}
+
 impl InferenceProviderPool {
     /// Create a new pool with optional API key for backend authentication
     pub fn new(api_key: Option<String>, external_configs: ExternalProvidersConfig) -> Self {
@@ -1737,14 +1820,21 @@ impl InferenceProviderPool {
                     )
                     .await;
 
-                    // Serving provider shares the same fingerprint_state — its
-                    // reqwest clients will verify future TLS handshakes against
-                    // whatever has been pinned so far (and pick up new pins as
-                    // cumulative discovery expands the set).
+                    // Serving provider with inline backend verification.
+                    // Bucket clients are created lazily: on first use, the verifier
+                    // connects to a backend, verifies attestation, and pins the
+                    // fingerprint. This eliminates failures from undiscovered backends.
+                    let backend_verifier = Arc::new(PoolBackendVerifier {
+                        api_key: api_key.clone(),
+                        tls_roots: tls_roots.clone(),
+                        attestation_verifier: verifier.clone(),
+                        fingerprint_state: state.clone(),
+                    });
                     let serving_provider =
-                        Arc::new(VLlmProvider::new_with_fingerprint_state(
+                        Arc::new(VLlmProvider::new_with_verifier(
                             VLlmConfig::new(url.clone(), api_key.clone(), None),
                             state.clone(),
+                            backend_verifier,
                         ));
 
                     if outcome.total_pinned == 0 {

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -118,6 +118,7 @@ pub struct InferenceProviderPool {
 /// Used by `VLlmProvider` for lazy bucket client creation.
 struct PoolBackendVerifier {
     api_key: Option<String>,
+    model_name: String,
     tls_roots: SharedTlsRoots,
     attestation_verifier: Arc<AttestationVerifier>,
     /// Shared fingerprint state — newly discovered fingerprints are pinned here
@@ -128,10 +129,11 @@ struct PoolBackendVerifier {
 #[async_trait::async_trait]
 impl inference_providers::BackendVerifier for PoolBackendVerifier {
     async fn create_verified_client(&self, base_url: &str) -> Result<reqwest::Client, String> {
-        // 1. Build a client with isolated Bootstrap state (accepts any WebPKI cert).
-        let bootstrap_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
+        // 1. Build a client with isolated Bootstrap state (accepts any WebPKI cert
+        //    for the initial connection to discover the backend's fingerprint).
+        let client_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
         let client = reqwest::Client::builder()
-            .use_preconfigured_tls(self.tls_roots.build_config(bootstrap_state))
+            .use_preconfigured_tls(self.tls_roots.build_config(client_state.clone()))
             .pool_max_idle_per_host(1)
             .http2_adaptive_window(true)
             .connect_timeout(Duration::from_secs(5))
@@ -140,11 +142,20 @@ impl inference_providers::BackendVerifier for PoolBackendVerifier {
             .build()
             .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 
-        // 2. Fetch attestation report — this establishes the H2 connection to some backend.
-        let nonce = uuid::Uuid::new_v4().to_string();
-        let url = format!(
-            "{base_url}/v1/attestation/report?include_tls_fingerprint=true&nonce={nonce}&signing_algo=ecdsa"
-        );
+        // 2. Fetch attestation report — this establishes the H2 connection.
+        //    Nonce must be 32-byte hex (same format as discover_model).
+        let nonce_bytes: [u8; 32] = rand::random();
+        let nonce = hex::encode(nonce_bytes);
+
+        let qs = serde_urlencoded::to_string([
+            ("model", self.model_name.as_str()),
+            ("signing_algo", "ecdsa"),
+            ("nonce", &nonce),
+            ("include_tls_fingerprint", "true"),
+        ])
+        .map_err(|e| format!("Failed to build query string: {e}"))?;
+
+        let url = format!("{base_url}/v1/attestation/report?{qs}");
         let mut request = client.get(&url);
         if let Some(ref key) = self.api_key {
             request = request.header("Authorization", format!("Bearer {key}"));
@@ -175,23 +186,38 @@ impl inference_providers::BackendVerifier for PoolBackendVerifier {
             .await
             .map_err(|e| format!("Attestation verification failed: {e}"))?;
 
-        // 4. Pin the verified TLS fingerprint in the shared state.
+        // 4. Pin the verified fingerprint in BOTH the shared state (so other
+        //    providers benefit) AND the client's own state (so reconnections
+        //    to a different backend are rejected — forces re-verification).
         if let Some(ref fp) = verified.tls_cert_fingerprint {
-            let mut state = self
-                .fingerprint_state
-                .write()
-                .unwrap_or_else(|e| e.into_inner());
-            let before = state.pinned_count();
-            state.add_fingerprint(fp.clone());
-            if state.pinned_count() > before {
-                info!(
-                    fingerprint = %fp,
-                    "Inline verification pinned new TLS fingerprint"
-                );
+            // Shared state
+            {
+                let mut shared = self
+                    .fingerprint_state
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner());
+                let before = shared.pinned_count();
+                shared.add_fingerprint(fp.clone());
+                if shared.pinned_count() > before {
+                    info!(
+                        fingerprint = %fp,
+                        "Inline verification pinned new TLS fingerprint"
+                    );
+                }
             }
+            // Client's own state: Bootstrap → Pinned({fp}).
+            // If the H2 connection drops and reqwest silently reconnects,
+            // the new handshake must match this specific fingerprint.
+            // A reconnection to a different backend will fail, triggering
+            // clear_bucket → re-verification.
+            client_state
+                .write()
+                .unwrap_or_else(|e| e.into_inner())
+                .add_fingerprint(fp.clone());
         }
 
-        // 5. Return the client — its H2 connection is pinned to the verified backend.
+        // 5. Return the client — its H2 connection is to the verified backend,
+        //    and its TLS verifier only accepts that backend on reconnection.
         Ok(client)
     }
 }
@@ -1826,6 +1852,7 @@ impl InferenceProviderPool {
                     // fingerprint. This eliminates failures from undiscovered backends.
                     let backend_verifier = Arc::new(PoolBackendVerifier {
                         api_key: api_key.clone(),
+                        model_name: model_name.clone(),
                         tls_roots: tls_roots.clone(),
                         attestation_verifier: verifier.clone(),
                         fingerprint_state: state.clone(),


### PR DESCRIPTION
## Summary

Replaces pre-created bucket clients (which randomly connect to backends through L4, failing on undiscovered fingerprints) with **lazily-filled buckets that verify each backend via attestation before serving requests**.

**Problem**: On every deploy, initial discovery (5 calls) only covers ~23% of backends for models with 4 backends behind L4. Requests routed to undiscovered backends fail. The alternate-bucket retry from #551 reduced but didn't eliminate failures (~1.3% remaining).

**Root cause**: Discovery and connection routing are completely decoupled — discovery finds random backends, bucket clients connect to random backends, there's no guarantee they align.

**Fix**: When a bucket needs a client, connect to a backend, fetch its attestation report, verify it (TDX + GPU + image hash), pin the fingerprint, then serve the request on that verified connection.

### Request flow (new)

```
Request → bucket[N] empty?
  YES → inline_verify():
        1. Create Bootstrap client → L4 routes to some backend
        2. GET /v1/attestation/report → verify TDX quote, GPU, image hash
        3. Pin fingerprint → cache client in bucket[N]
        4. Serve request (+4s first time only)
  NO  → use cached client → serve request (instant, H2 reuse)
```

### Architecture

- `BackendVerifier` trait in `inference_providers` crate (cross-crate boundary)
- `PoolBackendVerifier` implementation in `services` crate (has `AttestationVerifier`)
- `VLlmProvider::new_with_verifier()` for production (lazy buckets)
- `VLlmProvider::new()` preserved for tests (eager pre-creation)

### What this eliminates

- Zero fingerprint-mismatch failures (every bucket verified before use)
- No grace periods needed
- No alternate-bucket retry needed (removed from #551)
- Security maintained: full attestation verification before serving

## Test plan

- [x] All 196 unit tests pass
- [x] `cargo clippy` clean
- [ ] Deploy to staging — verify zero 502s during and after deploy
- [ ] Check logs for "Inline verification pinned new TLS fingerprint" on first requests
- [ ] After warmup: all buckets cached, no more verification overhead