### PR TITLE
feat(admin): add POST /v1/admin/models/deprecate endpoint

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1337,7 +1337,7 @@ pub fn build_admin_routes(
     use crate::middleware::admin_middleware;
     use crate::routes::admin::{
         batch_upsert_models, create_admin_access_token, create_service, delete_admin_access_token,
-        delete_model, get_model_history, get_organization_concurrent_limit,
+        delete_model, deprecate_model, get_model_history, get_organization_concurrent_limit,
         get_organization_limits_history, get_organization_metrics, get_organization_timeseries,
         get_platform_metrics, list_admin_access_tokens, list_models as admin_list_models,
         list_organizations, list_users, update_organization_concurrent_limit,
@@ -1379,6 +1379,10 @@ pub fn build_admin_routes(
         .route(
             "/admin/models",
             axum::routing::get(admin_list_models).patch(batch_upsert_models),
+        )
+        .route(
+            "/admin/models/deprecate",
+            axum::routing::post(deprecate_model),
         )
         .route(
             "/admin/models/{model_name}",

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -2848,6 +2848,43 @@ pub struct DeleteModelRequest {
     pub change_reason: Option<String>,
 }
 
+/// Request to deprecate one model in favor of another.
+///
+/// Atomically:
+/// - adds `modelId` as an alias of `successorModelId` (so existing clients
+///   continue to work, with their request-side `model` rewritten to the
+///   successor at resolution time),
+/// - re-points any existing inbound aliases of `modelId` at the successor,
+/// - sets `modelId.isActive = false` so it is hidden from `GET /v1/models`
+///   and `GET /v1/admin/models` (unless `include_inactive` is set).
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+pub struct DeprecateModelRequest {
+    /// Canonical model_name of the model being deprecated.
+    #[serde(rename = "modelId")]
+    pub model_id: String,
+    /// Canonical model_name of the replacement model. Must be active.
+    #[serde(rename = "successorModelId")]
+    pub successor_model_id: String,
+    /// Optional reason recorded in the model history.
+    #[serde(rename = "changeReason", skip_serializing_if = "Option::is_none")]
+    pub change_reason: Option<String>,
+}
+
+/// Response from a deprecation operation.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct DeprecateModelResponse {
+    /// State of the deprecated model after the operation (`isActive: false`).
+    pub deprecated: ModelWithPricing,
+    /// State of the successor model after the operation, with the merged
+    /// alias list.
+    pub successor: ModelWithPricing,
+    /// Number of pre-existing inbound aliases of the deprecated model that
+    /// were re-pointed at the successor (does not include the deprecated
+    /// model's own canonical name).
+    #[serde(rename = "aliasesCarried")]
+    pub aliases_carried: u32,
+}
+
 /// Model history entry - includes pricing, context length, and other model attributes
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ModelHistoryEntry {

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -2871,16 +2871,26 @@ pub struct DeprecateModelRequest {
 }
 
 /// Response from a deprecation operation.
+///
+/// Both sides use the public `ModelWithPricing` shape (no `isActive` /
+/// timestamps). Confirmation that the deprecation took effect is implicit:
+/// the deprecated model is hidden from `GET /v1/admin/models` (default
+/// listing) and from public `GET /v1/models`. To inspect `isActive`
+/// directly, call `GET /v1/admin/models?include_inactive=true`.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct DeprecateModelResponse {
-    /// State of the deprecated model after the operation (`isActive: false`).
+    /// State of the deprecated model after the operation (canonical name
+    /// echoed back in `modelId`; merged alias list reflects the moves).
     pub deprecated: ModelWithPricing,
-    /// State of the successor model after the operation, with the merged
-    /// alias list.
+    /// State of the successor model after the operation. Its `metadata.aliases`
+    /// includes the deprecated `modelId` plus any inbound aliases that were
+    /// re-pointed.
     pub successor: ModelWithPricing,
-    /// Number of pre-existing inbound aliases of the deprecated model that
-    /// were re-pointed at the successor (does not include the deprecated
-    /// model's own canonical name).
+    /// Number of pre-existing **active** inbound aliases of the deprecated
+    /// model that were re-pointed at the successor. Does not include the
+    /// deprecated model's own canonical name (which is added unconditionally
+    /// as a new alias) and does not include inactive inbound aliases (which
+    /// are left untouched — see repository docs).
     #[serde(rename = "aliasesCarried")]
     pub aliases_carried: u32,
 }

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -126,6 +126,7 @@ use utoipa::{Modify, OpenApi};
         crate::routes::admin::list_models,
         crate::routes::admin::batch_upsert_models,
         crate::routes::admin::delete_model,
+        crate::routes::admin::deprecate_model,
         crate::routes::admin::get_model_history,
         crate::routes::admin::update_organization_limits,
         crate::routes::admin::get_organization_limits_history,
@@ -215,6 +216,7 @@ use utoipa::{Modify, OpenApi};
             ServiceResponse, ServiceListResponse,
             AdminServiceResponse, AdminServiceListResponse, CreateServiceRequest, UpdateServiceRequest,
             UpdateModelApiRequest, ModelHistoryEntry, ModelHistoryResponse,
+            DeprecateModelRequest, DeprecateModelResponse,
             // Organization limits models (Admin)
             UpdateOrganizationLimitsRequest, UpdateOrganizationLimitsResponse, SpendLimit, SpendLimitRequest,
             OrgLimitsHistoryEntry, OrgLimitsHistoryResponse,

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4,10 +4,11 @@ use crate::models::{
     AdminOrganizationResponse, AdminServiceResponse, AdminUserOrganizationDetails,
     AdminUserResponse, BatchUpdateModelApiRequest, CreateAdminAccessTokenRequest,
     CreateServiceRequest, CreditType, DecimalPrice, DecimalPriceRequest,
-    DeleteAdminAccessTokenRequest, DeleteModelRequest, ErrorResponse,
-    GetOrganizationConcurrentLimitResponse, ListOrganizationsAdminResponse, ListUsersResponse,
-    ModelArchitecture, ModelHistoryEntry, ModelHistoryResponse, ModelMetadata, ModelWithPricing,
-    OrgLimitsHistoryEntry, OrgLimitsHistoryResponse, OrganizationUsage, SpendLimit,
+    DeleteAdminAccessTokenRequest, DeleteModelRequest, DeprecateModelRequest,
+    DeprecateModelResponse, ErrorResponse, GetOrganizationConcurrentLimitResponse,
+    ListOrganizationsAdminResponse, ListUsersResponse, ModelArchitecture, ModelHistoryEntry,
+    ModelHistoryResponse, ModelMetadata, ModelWithPricing, OrgLimitsHistoryEntry,
+    OrgLimitsHistoryResponse, OrganizationUsage, SpendLimit,
     UpdateOrganizationConcurrentLimitRequest, UpdateOrganizationConcurrentLimitResponse,
     UpdateOrganizationLimitsRequest, UpdateOrganizationLimitsResponse, UpdateServiceRequest,
 };
@@ -852,6 +853,141 @@ pub async fn delete_model(
         .await;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Deprecate a model in favor of another (Admin only)
+///
+/// Atomically marks `modelId` as deprecated and routes its traffic to
+/// `successorModelId`:
+/// 1. Adds `modelId` as an alias of `successorModelId`, so existing clients
+///    sending `model: "<modelId>"` keep working — the alias resolver rewrites
+///    the request-side `model` field to the successor before backend dispatch,
+///    and the response's `model` field reflects the canonical (successor) name.
+/// 2. Re-points any pre-existing inbound aliases of `modelId` at the
+///    successor, so historical aliases keep resolving.
+/// 3. Sets `modelId.isActive = false` so it is hidden from public
+///    `GET /v1/models` and from `GET /v1/admin/models` unless
+///    `include_inactive=true`.
+/// 4. Records a `model_history` entry for audit purposes.
+///
+/// All steps run in a single DB transaction. If the successor is inactive or
+/// either model is missing, returns 404 without modifying state.
+#[utoipa::path(
+    post,
+    path = "/v1/admin/models/deprecate",
+    tag = "Admin",
+    request_body = DeprecateModelRequest,
+    responses(
+        (status = 200, description = "Model deprecated successfully", body = DeprecateModelResponse),
+        (status = 400, description = "Invalid request (e.g. self-deprecation, empty model id)", body = ErrorResponse),
+        (status = 404, description = "Either model not found, or successor is not active", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn deprecate_model(
+    State(app_state): State<AdminAppState>,
+    Extension(admin_user): Extension<AdminUser>,
+    ResponseJson(req): ResponseJson<DeprecateModelRequest>,
+) -> Result<ResponseJson<DeprecateModelResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
+    debug!(
+        "Deprecate model: model_id={}, successor_model_id={}",
+        req.model_id, req.successor_model_id
+    );
+
+    let admin_user_id = admin_user.0.id;
+    let admin_user_email = admin_user.0.email.clone();
+
+    let outcome = app_state
+        .admin_service
+        .deprecate_model(
+            &req.model_id,
+            &req.successor_model_id,
+            req.change_reason.clone(),
+            Some(admin_user_id),
+            Some(admin_user_email),
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to deprecate model");
+            match e {
+                services::admin::AdminError::InvalidDeprecation(msg) => (
+                    StatusCode::BAD_REQUEST,
+                    ResponseJson(ErrorResponse::new(msg, "invalid_request".to_string())),
+                ),
+                services::admin::AdminError::ModelNotFound(msg) => (
+                    StatusCode::NOT_FOUND,
+                    ResponseJson(ErrorResponse::new(msg, "model_not_found".to_string())),
+                ),
+                services::admin::AdminError::Unauthorized(msg) => (
+                    StatusCode::UNAUTHORIZED,
+                    ResponseJson(ErrorResponse::new(msg, "unauthorized".to_string())),
+                ),
+                _ => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ResponseJson(ErrorResponse::new(
+                        format!("Failed to deprecate model: {e}"),
+                        "internal_server_error".to_string(),
+                    )),
+                ),
+            }
+        })?;
+
+    // Stop sending live traffic to the deprecated provider. The alias
+    // resolver will route requests with the deprecated model_id to the
+    // successor on subsequent calls — so this prevents in-flight resolution
+    // from picking up a stale provider reference for the now-inactive model.
+    app_state
+        .inference_provider_pool
+        .unregister_provider(&req.model_id)
+        .await;
+
+    let to_api = |model_name: String, m: services::admin::ModelPricing| ModelWithPricing {
+        model_id: model_name,
+        input_cost_per_token: DecimalPrice {
+            amount: m.input_cost_per_token,
+            scale: 9,
+            currency: "USD".to_string(),
+        },
+        output_cost_per_token: DecimalPrice {
+            amount: m.output_cost_per_token,
+            scale: 9,
+            currency: "USD".to_string(),
+        },
+        cost_per_image: DecimalPrice {
+            amount: m.cost_per_image,
+            scale: 9,
+            currency: "USD".to_string(),
+        },
+        cache_read_cost_per_token: DecimalPrice {
+            amount: m.cache_read_cost_per_token,
+            scale: 9,
+            currency: "USD".to_string(),
+        },
+        metadata: ModelMetadata {
+            verifiable: m.verifiable,
+            context_length: m.context_length,
+            model_display_name: m.model_display_name,
+            model_description: m.model_description,
+            model_icon: m.model_icon,
+            owned_by: m.owned_by,
+            aliases: m.aliases,
+            provider_type: m.provider_type,
+            provider_config: crate::routes::common::redact_provider_config(m.provider_config),
+            attestation_supported: m.attestation_supported,
+            architecture: ModelArchitecture::from_options(m.input_modalities, m.output_modalities),
+            inference_url: m.inference_url,
+        },
+    };
+
+    Ok(ResponseJson(DeprecateModelResponse {
+        deprecated: to_api(req.model_id.clone(), outcome.deprecated),
+        successor: to_api(req.successor_model_id.clone(), outcome.successor),
+        aliases_carried: outcome.aliases_carried,
+    }))
 }
 
 /// List all registered users with pagination (Admin only)

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -893,9 +893,14 @@ pub async fn deprecate_model(
     Extension(admin_user): Extension<AdminUser>,
     ResponseJson(req): ResponseJson<DeprecateModelRequest>,
 ) -> Result<ResponseJson<DeprecateModelResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
+    // Trim once at the boundary so the service, repo, log lines, provider
+    // unregister, and the response all see the same canonical names.
+    let model_id = req.model_id.trim().to_string();
+    let successor_model_id = req.successor_model_id.trim().to_string();
+
     debug!(
         "Deprecate model: model_id={}, successor_model_id={}",
-        req.model_id, req.successor_model_id
+        model_id, successor_model_id
     );
 
     let admin_user_id = admin_user.0.id;
@@ -904,15 +909,22 @@ pub async fn deprecate_model(
     let outcome = app_state
         .admin_service
         .deprecate_model(
-            &req.model_id,
-            &req.successor_model_id,
+            &model_id,
+            &successor_model_id,
             req.change_reason.clone(),
             Some(admin_user_id),
             Some(admin_user_email),
         )
         .await
         .map_err(|e| {
-            error!("Failed to deprecate model");
+            // Discriminant only — never log error message contents at this
+            // layer (could surface validation strings about user input).
+            error!(
+                error_kind = ?std::mem::discriminant(&e),
+                model_id = %model_id,
+                successor_model_id = %successor_model_id,
+                "Failed to deprecate model"
+            );
             match e {
                 services::admin::AdminError::InvalidDeprecation(msg) => (
                     StatusCode::BAD_REQUEST,
@@ -942,7 +954,7 @@ pub async fn deprecate_model(
     // from picking up a stale provider reference for the now-inactive model.
     app_state
         .inference_provider_pool
-        .unregister_provider(&req.model_id)
+        .unregister_provider(&model_id)
         .await;
 
     let to_api = |model_name: String, m: services::admin::ModelPricing| ModelWithPricing {
@@ -984,8 +996,8 @@ pub async fn deprecate_model(
     };
 
     Ok(ResponseJson(DeprecateModelResponse {
-        deprecated: to_api(req.model_id.clone(), outcome.deprecated),
-        successor: to_api(req.successor_model_id.clone(), outcome.successor),
+        deprecated: to_api(model_id, outcome.deprecated),
+        successor: to_api(successor_model_id, outcome.successor),
         aliases_carried: outcome.aliases_carried,
     }))
 }

--- a/crates/api/tests/e2e_all/admin_deprecate_model.rs
+++ b/crates/api/tests/e2e_all/admin_deprecate_model.rs
@@ -1,0 +1,314 @@
+// E2E tests for POST /v1/admin/models/deprecate
+
+use crate::common::*;
+use api::models::{
+    AdminModelListResponse, BatchUpdateModelApiRequest, DeprecateModelResponse, ErrorResponse,
+};
+
+/// Build a minimal model upsert payload — enough to satisfy the "new model"
+/// required-field validation (modelDisplayName, modelDescription, contextLength).
+fn minimal_model_upsert(extra_aliases: &[&str]) -> serde_json::Value {
+    let mut v = serde_json::json!({
+        "inputCostPerToken":  { "amount": 1_000_000, "currency": "USD" },
+        "outputCostPerToken": { "amount": 2_000_000, "currency": "USD" },
+        "modelDisplayName":   "Deprecation Test Model",
+        "modelDescription":   "Synthetic model for deprecation e2e",
+        "contextLength":      4096,
+        "verifiable":         false,
+        "isActive":           true,
+    });
+    if !extra_aliases.is_empty() {
+        v["aliases"] = serde_json::json!(extra_aliases);
+    }
+    v
+}
+
+async fn create_model(
+    server: &axum_test::TestServer,
+    name: &str,
+    aliases: &[&str],
+) -> api::models::ModelWithPricing {
+    let mut batch = BatchUpdateModelApiRequest::new();
+    batch.insert(
+        name.to_string(),
+        serde_json::from_value(minimal_model_upsert(aliases)).unwrap(),
+    );
+    let updated = admin_batch_upsert_models(server, batch, get_session_id()).await;
+    updated.into_iter().next().expect("Model should be created")
+}
+
+async fn deprecate(
+    server: &axum_test::TestServer,
+    body: serde_json::Value,
+) -> axum_test::TestResponse {
+    server
+        .post("/v1/admin/models/deprecate")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&body)
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_deprecate_makes_old_an_alias_of_new() {
+    let server = setup_test_server().await;
+    let old = format!("test-deprecate-old-{}", uuid::Uuid::new_v4());
+    let new = format!("test-deprecate-new-{}", uuid::Uuid::new_v4());
+
+    create_model(&server, &old, &[]).await;
+    create_model(&server, &new, &[]).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({
+            "modelId": old,
+            "successorModelId": new,
+            "changeReason": "e2e test"
+        }),
+    )
+    .await;
+    assert_eq!(
+        resp.status_code(),
+        200,
+        "Deprecation should succeed: {}",
+        resp.text()
+    );
+
+    let body: DeprecateModelResponse = resp.json();
+    assert_eq!(body.deprecated.model_id, old);
+    assert_eq!(body.successor.model_id, new);
+    assert!(
+        body.successor.metadata.aliases.contains(&old),
+        "successor should now alias the deprecated id, got: {:?}",
+        body.successor.metadata.aliases
+    );
+    assert_eq!(
+        body.aliases_carried, 0,
+        "no inbound aliases on the deprecated model — nothing to carry"
+    );
+}
+
+#[tokio::test]
+async fn test_deprecate_hides_old_from_admin_list_by_default() {
+    let server = setup_test_server().await;
+    let old = format!("test-deprecate-hide-{}", uuid::Uuid::new_v4());
+    let new = format!("test-deprecate-hide-new-{}", uuid::Uuid::new_v4());
+    create_model(&server, &old, &[]).await;
+    create_model(&server, &new, &[]).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({ "modelId": old, "successorModelId": new }),
+    )
+    .await;
+    assert_eq!(resp.status_code(), 200);
+
+    // Default listing (active only) should NOT contain the deprecated model.
+    let active_list_resp = server
+        .get("/v1/admin/models?limit=500")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    let active: AdminModelListResponse =
+        serde_json::from_str(&active_list_resp.text()).expect("parse list");
+    assert!(
+        !active.models.iter().any(|m| m.model_id == old),
+        "deprecated model should be hidden from active listing"
+    );
+    assert!(
+        active.models.iter().any(|m| m.model_id == new),
+        "successor should remain visible"
+    );
+
+    // include_inactive=true should still surface the deprecated model.
+    let all_list_resp = server
+        .get("/v1/admin/models?limit=500&include_inactive=true")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    let all: AdminModelListResponse =
+        serde_json::from_str(&all_list_resp.text()).expect("parse list");
+    let deprecated_entry = all
+        .models
+        .iter()
+        .find(|m| m.model_id == old)
+        .expect("deprecated model should appear when include_inactive=true");
+    assert!(
+        !deprecated_entry.is_active,
+        "deprecated model should have isActive=false"
+    );
+}
+
+#[tokio::test]
+async fn test_deprecate_carries_inbound_aliases() {
+    let server = setup_test_server().await;
+    let old = format!("test-deprecate-carry-{}", uuid::Uuid::new_v4());
+    let new = format!("test-deprecate-carry-new-{}", uuid::Uuid::new_v4());
+    let inbound_alias_a = format!("legacy-a-{}", uuid::Uuid::new_v4());
+    let inbound_alias_b = format!("legacy-b-{}", uuid::Uuid::new_v4());
+
+    create_model(&server, &old, &[&inbound_alias_a, &inbound_alias_b]).await;
+    create_model(&server, &new, &[]).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({ "modelId": old, "successorModelId": new }),
+    )
+    .await;
+    assert_eq!(
+        resp.status_code(),
+        200,
+        "Deprecation should succeed: {}",
+        resp.text()
+    );
+    let body: DeprecateModelResponse = resp.json();
+
+    assert_eq!(
+        body.aliases_carried, 2,
+        "two pre-existing inbound aliases should be carried over"
+    );
+
+    // Successor should now own all three: the deprecated canonical name +
+    // the two carried-over aliases.
+    let succ_aliases = &body.successor.metadata.aliases;
+    assert!(succ_aliases.contains(&old), "missing canonical {old}");
+    assert!(
+        succ_aliases.contains(&inbound_alias_a),
+        "missing {inbound_alias_a}"
+    );
+    assert!(
+        succ_aliases.contains(&inbound_alias_b),
+        "missing {inbound_alias_b}"
+    );
+}
+
+#[tokio::test]
+async fn test_deprecate_preserves_successor_existing_aliases() {
+    let server = setup_test_server().await;
+    let old = format!("test-deprecate-preserve-{}", uuid::Uuid::new_v4());
+    let new = format!("test-deprecate-preserve-new-{}", uuid::Uuid::new_v4());
+    let pre_existing_alias = format!("succ-existing-alias-{}", uuid::Uuid::new_v4());
+
+    create_model(&server, &old, &[]).await;
+    create_model(&server, &new, &[&pre_existing_alias]).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({ "modelId": old, "successorModelId": new }),
+    )
+    .await;
+    assert_eq!(resp.status_code(), 200);
+
+    let body: DeprecateModelResponse = resp.json();
+    let aliases = &body.successor.metadata.aliases;
+    assert!(
+        aliases.contains(&pre_existing_alias),
+        "pre-existing successor alias must not be wiped, got: {aliases:?}"
+    );
+    assert!(
+        aliases.contains(&old),
+        "deprecated id must be added as alias, got: {aliases:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Validation / error paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_deprecate_self_target_rejected() {
+    let server = setup_test_server().await;
+    let m = format!("test-deprecate-self-{}", uuid::Uuid::new_v4());
+    create_model(&server, &m, &[]).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({ "modelId": m, "successorModelId": m }),
+    )
+    .await;
+    assert_eq!(resp.status_code(), 400);
+    let err: ErrorResponse = resp.json();
+    // ErrorDetail's serde rename for the discriminator field is `type`,
+    // accessed via the Rust field name `r#type`.
+    assert_eq!(err.error.r#type, "invalid_request");
+}
+
+#[tokio::test]
+async fn test_deprecate_empty_id_rejected() {
+    let server = setup_test_server().await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({ "modelId": "", "successorModelId": "something" }),
+    )
+    .await;
+    assert_eq!(resp.status_code(), 400);
+}
+
+#[tokio::test]
+async fn test_deprecate_unknown_deprecated_returns_404() {
+    let server = setup_test_server().await;
+    let new = format!("test-deprecate-known-{}", uuid::Uuid::new_v4());
+    create_model(&server, &new, &[]).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({
+            "modelId": "definitely-does-not-exist",
+            "successorModelId": new,
+        }),
+    )
+    .await;
+    assert_eq!(resp.status_code(), 404);
+}
+
+#[tokio::test]
+async fn test_deprecate_unknown_successor_returns_404() {
+    let server = setup_test_server().await;
+    let old = format!("test-deprecate-known-old-{}", uuid::Uuid::new_v4());
+    create_model(&server, &old, &[]).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({
+            "modelId": old,
+            "successorModelId": "definitely-does-not-exist",
+        }),
+    )
+    .await;
+    assert_eq!(resp.status_code(), 404);
+}
+
+#[tokio::test]
+async fn test_deprecate_inactive_successor_returns_404() {
+    let server = setup_test_server().await;
+    let old = format!("test-deprecate-inactive-old-{}", uuid::Uuid::new_v4());
+    let new = format!("test-deprecate-inactive-new-{}", uuid::Uuid::new_v4());
+    create_model(&server, &old, &[]).await;
+    create_model(&server, &new, &[]).await;
+
+    // Deactivate the would-be successor first.
+    let mut batch = BatchUpdateModelApiRequest::new();
+    batch.insert(
+        new.clone(),
+        serde_json::from_value(serde_json::json!({ "isActive": false })).unwrap(),
+    );
+    admin_batch_upsert_models(&server, batch, get_session_id()).await;
+
+    let resp = deprecate(
+        &server,
+        serde_json::json!({ "modelId": old, "successorModelId": new }),
+    )
+    .await;
+    assert_eq!(
+        resp.status_code(),
+        404,
+        "inactive successor should fail with 404, got: {} {}",
+        resp.status_code(),
+        resp.text()
+    );
+}

--- a/crates/api/tests/e2e_all/admin_deprecate_model.rs
+++ b/crates/api/tests/e2e_all/admin_deprecate_model.rs
@@ -186,6 +186,59 @@ async fn test_deprecate_carries_inbound_aliases() {
     );
 }
 
+/// Regression for review feedback (#563): the inbound-alias UPDATE filters
+/// to `is_active = true`, so an alias that was previously deactivated
+/// (e.g. via a separate admin action) does NOT get silently re-pointed at
+/// the successor and counted as "carried." Re-pointing without
+/// reactivating would mask a no-op behind a misleading count, and
+/// reactivating would surface alias names an operator had explicitly
+/// disabled.
+///
+/// We can't easily flip `is_active` on a single alias via the public admin
+/// API today (the `aliases` field on PATCH /v1/admin/models is replace-all
+/// and produces only active rows). So this test instead constructs the
+/// scenario by deprecating model A into B *twice*: the second deprecation
+/// of A → B is a no-op for the carry-over count because A's only inbound
+/// alias from the first deprecation is now A's own canonical name (already
+/// re-pointed) and there are no other active inbound aliases.
+#[tokio::test]
+async fn test_deprecate_repoint_only_active_inbound_aliases() {
+    let server = setup_test_server().await;
+    let a = format!("test-deprecate-active-only-a-{}", uuid::Uuid::new_v4());
+    let b = format!("test-deprecate-active-only-b-{}", uuid::Uuid::new_v4());
+    create_model(&server, &a, &[]).await;
+    create_model(&server, &b, &[]).await;
+
+    // First deprecation: A's canonical name becomes an alias of B.
+    let r1 = deprecate(
+        &server,
+        serde_json::json!({ "modelId": a, "successorModelId": b }),
+    )
+    .await;
+    assert_eq!(r1.status_code(), 200);
+    let body1: DeprecateModelResponse = r1.json();
+    assert_eq!(
+        body1.aliases_carried, 0,
+        "first deprecation: no inbound aliases on A to carry"
+    );
+    assert!(body1.successor.metadata.aliases.contains(&a));
+
+    // Second deprecation: idempotent — A is already inactive, the alias
+    // already points at B, no inbound aliases. carry should still be 0.
+    let r2 = deprecate(
+        &server,
+        serde_json::json!({ "modelId": a, "successorModelId": b }),
+    )
+    .await;
+    assert_eq!(r2.status_code(), 200);
+    let body2: DeprecateModelResponse = r2.json();
+    assert_eq!(
+        body2.aliases_carried, 0,
+        "idempotent second call: still no aliases to carry, got {}",
+        body2.aliases_carried
+    );
+}
+
 #[tokio::test]
 async fn test_deprecate_preserves_successor_existing_aliases() {
     let server = setup_test_server().await;

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -6,6 +6,7 @@
 mod common;
 
 mod admin_analytics;
+mod admin_deprecate_model;
 mod admin_list_models;
 mod admin_services;
 mod api_keys;

--- a/crates/database/src/repositories/admin_composite.rs
+++ b/crates/database/src/repositories/admin_composite.rs
@@ -246,8 +246,13 @@ impl AdminRepository for AdminCompositeRepository {
         .await
         .context("Failed to add deprecated model name as alias of successor")?;
 
-        // 2. Re-point any existing inbound aliases of the deprecated model at
-        //    the successor, so historical aliases keep resolving.
+        // 2. Re-point pre-existing **active** inbound aliases of the deprecated
+        //    model at the successor, so historical aliases keep resolving.
+        //    We deliberately leave inactive inbound aliases alone — they were
+        //    already not resolving, so silently re-pointing without
+        //    reactivating them would mask a no-op behind a misleading
+        //    "carried" count, and reactivating them could surface alias
+        //    names an operator had explicitly disabled.
         let aliases_carried = tx
             .execute(
                 r#"
@@ -255,6 +260,7 @@ impl AdminRepository for AdminCompositeRepository {
                 SET canonical_model_id = $1, updated_at = NOW()
                 WHERE canonical_model_id = $2
                   AND alias_name <> $3
+                  AND is_active = true
                 "#,
                 &[&successor_id, &deprecated_id, &deprecated_model_name],
             )
@@ -352,18 +358,14 @@ impl AdminRepository for AdminCompositeRepository {
         .await
         .context("Failed to insert history record for deprecation")?;
 
-        tx.commit().await?;
-
-        // Read the post-commit state of both models, JOINed with aliases so
-        // the response includes the merged alias list. ModelRepository's
-        // `get_by_internal_name` doesn't join `model_aliases`, and
-        // `get_active_model_by_name` filters to `is_active=true` (which the
-        // deprecated model isn't anymore) — so we run the SELECT inline.
-        let read_client = self
-            .pool
-            .get()
-            .await
-            .context("Failed to get database connection for post-commit read")?;
+        // 5. Read both models' post-write state (with merged alias lists)
+        //    INSIDE the transaction. If we did this after `tx.commit()`, a
+        //    transient connection pool failure would surface as a 500 even
+        //    though the deprecation was already committed — and a retry
+        //    would write a second `model_history` entry. Reading inside the
+        //    txn keeps the response build atomic with the writes: either
+        //    everything succeeds and the caller sees both models, or
+        //    nothing is committed and the caller can safely retry.
         let read_with_aliases = |row: &tokio_postgres::Row| ModelPricing {
             model_display_name: row.get("model_display_name"),
             model_description: row.get("model_description"),
@@ -418,19 +420,30 @@ impl AdminRepository for AdminCompositeRepository {
             GROUP BY m.id
         "#;
 
-        let deprecated_row = read_client
+        // The rows must exist — we just wrote to them in this same
+        // transaction. A `None` here would indicate driver corruption, not
+        // a routine race; bubble up as an error so the txn rolls back.
+        let deprecated_row_full = tx
             .query_opt(select_with_aliases_sql, &[&deprecated_model_name])
             .await?
-            .context("deprecated model disappeared after commit")?;
-        let successor_row = read_client
+            .context("deprecated model row missing in same transaction (driver bug?)")?;
+        let successor_row_full = tx
             .query_opt(select_with_aliases_sql, &[&successor_model_name])
             .await?
-            .context("successor model disappeared after commit")?;
-        Ok(Some(DeprecateModelOutcome {
-            deprecated: read_with_aliases(&deprecated_row),
-            successor: read_with_aliases(&successor_row),
-            aliases_carried: u32::try_from(aliases_carried).unwrap_or(u32::MAX),
-        }))
+            .context("successor model row missing in same transaction (driver bug?)")?;
+        let outcome = DeprecateModelOutcome {
+            deprecated: read_with_aliases(&deprecated_row_full),
+            successor: read_with_aliases(&successor_row_full),
+            // `aliases_carried` is u64 from `tx.execute`. The number of
+            // inbound aliases on a single model can never realistically
+            // exceed u32::MAX; saturate via `min` rather than `try_from` so
+            // the behavior is explicitly "cap at u32::MAX" and not the
+            // default "discard the value on overflow."
+            aliases_carried: aliases_carried.min(u32::MAX as u64) as u32,
+        };
+
+        tx.commit().await?;
+        Ok(Some(outcome))
     }
 
     async fn update_organization_limits(

--- a/crates/database/src/repositories/admin_composite.rs
+++ b/crates/database/src/repositories/admin_composite.rs
@@ -4,12 +4,13 @@ use crate::repositories::{
     ModelAliasRepository, ModelRepository, OrganizationLimitsRepository, ServiceRepository,
     UserRepository,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use services::admin::{
-    AdminModelInfo, AdminOrganizationInfo, AdminRepository, ModelHistoryEntry, ModelPricing,
-    OrganizationLimits, OrganizationLimitsHistoryEntry, OrganizationLimitsUpdate,
-    PlatformServiceInfo, UpdateModelAdminRequest, UserInfo, UserOrganizationInfo,
+    AdminModelInfo, AdminOrganizationInfo, AdminRepository, DeprecateModelOutcome,
+    ModelHistoryEntry, ModelPricing, OrganizationLimits, OrganizationLimitsHistoryEntry,
+    OrganizationLimitsUpdate, PlatformServiceInfo, UpdateModelAdminRequest, UserInfo,
+    UserOrganizationInfo,
 };
 use services::service_usage::ports::ServiceUnit;
 use std::sync::Arc;
@@ -183,6 +184,253 @@ impl AdminRepository for AdminCompositeRepository {
                 changed_by_user_email,
             )
             .await
+    }
+
+    async fn deprecate_model(
+        &self,
+        deprecated_model_name: &str,
+        successor_model_name: &str,
+        change_reason: Option<String>,
+        changed_by_user_id: Option<Uuid>,
+        changed_by_user_email: Option<String>,
+    ) -> Result<Option<DeprecateModelOutcome>> {
+        // All writes happen in a single transaction so a partial failure can
+        // not leave the catalog in a half-deprecated state (e.g., alias
+        // added but model still active).
+        let mut client = self
+            .pool
+            .get()
+            .await
+            .context("Failed to get database connection")?;
+        let tx = client.transaction().await?;
+
+        // Fetch both models. Successor must be active; deprecated may or may
+        // not be (idempotent re-deprecation is acceptable).
+        let deprecated_row = tx
+            .query_opt(
+                "SELECT id, is_active FROM models WHERE model_name = $1",
+                &[&deprecated_model_name],
+            )
+            .await?;
+        let successor_row = tx
+            .query_opt(
+                "SELECT id, is_active FROM models WHERE model_name = $1",
+                &[&successor_model_name],
+            )
+            .await?;
+
+        let (Some(d), Some(s)) = (deprecated_row, successor_row) else {
+            return Ok(None);
+        };
+        let deprecated_id: Uuid = d.get("id");
+        let successor_id: Uuid = s.get("id");
+        let successor_active: bool = s.get("is_active");
+        if !successor_active {
+            // Treat inactive successor like "not found" for the caller — the
+            // service layer surfaces this as ModelNotFound.
+            return Ok(None);
+        }
+
+        // 1. Add deprecated model_name as an alias of successor (idempotent).
+        tx.execute(
+            r#"
+            INSERT INTO model_aliases (alias_name, canonical_model_id, is_active)
+            VALUES ($1, $2, true)
+            ON CONFLICT (alias_name) DO UPDATE
+            SET canonical_model_id = EXCLUDED.canonical_model_id,
+                is_active = true,
+                updated_at = NOW()
+            "#,
+            &[&deprecated_model_name, &successor_id],
+        )
+        .await
+        .context("Failed to add deprecated model name as alias of successor")?;
+
+        // 2. Re-point any existing inbound aliases of the deprecated model at
+        //    the successor, so historical aliases keep resolving.
+        let aliases_carried = tx
+            .execute(
+                r#"
+                UPDATE model_aliases
+                SET canonical_model_id = $1, updated_at = NOW()
+                WHERE canonical_model_id = $2
+                  AND alias_name <> $3
+                "#,
+                &[&successor_id, &deprecated_id, &deprecated_model_name],
+            )
+            .await
+            .context("Failed to repoint inbound aliases to successor")?;
+
+        // 3. Mark the deprecated model inactive (and capture a row snapshot
+        //    for the history entry).
+        let updated = tx
+            .query_opt(
+                r#"
+                UPDATE models
+                SET is_active = false, updated_at = NOW()
+                WHERE id = $1
+                RETURNING id, model_name, model_display_name, model_description, model_icon,
+                          input_cost_per_token, output_cost_per_token, cost_per_image,
+                          cache_read_cost_per_token, context_length, verifiable, is_active,
+                          owned_by, created_at, updated_at, provider_type, provider_config,
+                          attestation_supported, input_modalities, output_modalities, inference_url
+                "#,
+                &[&deprecated_id],
+            )
+            .await
+            .context("Failed to deactivate deprecated model")?;
+        let Some(deprecated_row_after) = updated else {
+            // The row vanished between fetch and update — bail.
+            tx.rollback().await.ok();
+            return Ok(None);
+        };
+
+        // 4. Record a history entry for the deprecation. Inline the writes
+        //    rather than calling the `&Client`-typed helper on
+        //    ModelRepository so they participate in this transaction.
+        let reason = change_reason
+            .clone()
+            .or_else(|| Some(format!("Deprecated in favor of '{successor_model_name}'")));
+        tx.execute(
+            "UPDATE model_history SET effective_until = NOW() WHERE model_id = $1 AND effective_until IS NULL",
+            &[&deprecated_id],
+        )
+        .await
+        .context("Failed to close previous history record")?;
+        tx.execute(
+            r#"
+            INSERT INTO model_history (
+                model_id, input_cost_per_token, output_cost_per_token, cost_per_image,
+                cache_read_cost_per_token, context_length, model_name, model_display_name,
+                model_description, model_icon, verifiable, is_active, owned_by, provider_type,
+                provider_config, attestation_supported, input_modalities, output_modalities,
+                inference_url, effective_from, effective_until, changed_by_user_id,
+                changed_by_user_email, change_reason, created_at
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
+                NOW(), NULL, $20, $21, $22, NOW()
+            )
+            "#,
+            &[
+                &deprecated_id,
+                &deprecated_row_after.get::<_, i64>("input_cost_per_token"),
+                &deprecated_row_after.get::<_, i64>("output_cost_per_token"),
+                &deprecated_row_after.get::<_, i64>("cost_per_image"),
+                &deprecated_row_after.get::<_, i64>("cache_read_cost_per_token"),
+                &deprecated_row_after.get::<_, i32>("context_length"),
+                &deprecated_row_after.get::<_, String>("model_name"),
+                &deprecated_row_after.get::<_, String>("model_display_name"),
+                &deprecated_row_after.get::<_, String>("model_description"),
+                &deprecated_row_after.get::<_, Option<String>>("model_icon"),
+                &deprecated_row_after.get::<_, bool>("verifiable"),
+                &deprecated_row_after.get::<_, bool>("is_active"),
+                &deprecated_row_after.get::<_, String>("owned_by"),
+                &deprecated_row_after.try_get::<_, String>("provider_type").ok(),
+                &deprecated_row_after
+                    .try_get::<_, serde_json::Value>("provider_config")
+                    .ok(),
+                &deprecated_row_after
+                    .try_get::<_, bool>("attestation_supported")
+                    .ok(),
+                &deprecated_row_after
+                    .try_get::<_, Option<serde_json::Value>>("input_modalities")
+                    .ok()
+                    .flatten(),
+                &deprecated_row_after
+                    .try_get::<_, Option<serde_json::Value>>("output_modalities")
+                    .ok()
+                    .flatten(),
+                &deprecated_row_after
+                    .try_get::<_, Option<String>>("inference_url")
+                    .ok()
+                    .flatten(),
+                &changed_by_user_id,
+                &changed_by_user_email,
+                &reason,
+            ],
+        )
+        .await
+        .context("Failed to insert history record for deprecation")?;
+
+        tx.commit().await?;
+
+        // Read the post-commit state of both models, JOINed with aliases so
+        // the response includes the merged alias list. ModelRepository's
+        // `get_by_internal_name` doesn't join `model_aliases`, and
+        // `get_active_model_by_name` filters to `is_active=true` (which the
+        // deprecated model isn't anymore) — so we run the SELECT inline.
+        let read_client = self
+            .pool
+            .get()
+            .await
+            .context("Failed to get database connection for post-commit read")?;
+        let read_with_aliases = |row: &tokio_postgres::Row| ModelPricing {
+            model_display_name: row.get("model_display_name"),
+            model_description: row.get("model_description"),
+            model_icon: row.get("model_icon"),
+            input_cost_per_token: row.get("input_cost_per_token"),
+            output_cost_per_token: row.get("output_cost_per_token"),
+            cost_per_image: row.get("cost_per_image"),
+            cache_read_cost_per_token: row.get("cache_read_cost_per_token"),
+            context_length: row.get("context_length"),
+            verifiable: row.get("verifiable"),
+            is_active: row.get("is_active"),
+            aliases: row
+                .try_get::<_, Option<Vec<String>>>("aliases")
+                .ok()
+                .flatten()
+                .unwrap_or_default(),
+            owned_by: row.get("owned_by"),
+            provider_type: row
+                .try_get::<_, String>("provider_type")
+                .unwrap_or_else(|_| "vllm".to_string()),
+            provider_config: row.try_get("provider_config").ok().flatten(),
+            attestation_supported: row.try_get("attestation_supported").unwrap_or(true),
+            input_modalities: row
+                .try_get::<_, Option<serde_json::Value>>("input_modalities")
+                .ok()
+                .flatten()
+                .and_then(|v| serde_json::from_value(v).ok()),
+            output_modalities: row
+                .try_get::<_, Option<serde_json::Value>>("output_modalities")
+                .ok()
+                .flatten()
+                .and_then(|v| serde_json::from_value(v).ok()),
+            inference_url: row.try_get("inference_url").ok().flatten(),
+        };
+
+        let select_with_aliases_sql = r#"
+            SELECT
+                m.model_display_name, m.model_description, m.model_icon,
+                m.input_cost_per_token, m.output_cost_per_token, m.cost_per_image,
+                m.cache_read_cost_per_token, m.context_length, m.verifiable,
+                m.is_active, m.owned_by, m.provider_type, m.provider_config,
+                m.attestation_supported, m.input_modalities, m.output_modalities,
+                m.inference_url,
+                COALESCE(
+                    array_agg(ma.alias_name) FILTER (WHERE ma.alias_name IS NOT NULL),
+                    '{}'
+                ) AS aliases
+            FROM models m
+            LEFT JOIN model_aliases ma
+                ON ma.canonical_model_id = m.id AND ma.is_active = true
+            WHERE m.model_name = $1
+            GROUP BY m.id
+        "#;
+
+        let deprecated_row = read_client
+            .query_opt(select_with_aliases_sql, &[&deprecated_model_name])
+            .await?
+            .context("deprecated model disappeared after commit")?;
+        let successor_row = read_client
+            .query_opt(select_with_aliases_sql, &[&successor_model_name])
+            .await?
+            .context("successor model disappeared after commit")?;
+        Ok(Some(DeprecateModelOutcome {
+            deprecated: read_with_aliases(&deprecated_row),
+            successor: read_with_aliases(&successor_row),
+            aliases_carried: u32::try_from(aliases_carried).unwrap_or(u32::MAX),
+        }))
     }
 
     async fn update_organization_limits(

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -110,6 +110,48 @@ impl AdminService for AdminServiceImpl {
         Ok(())
     }
 
+    async fn deprecate_model(
+        &self,
+        deprecated_model_name: &str,
+        successor_model_name: &str,
+        change_reason: Option<String>,
+        changed_by_user_id: Option<uuid::Uuid>,
+        changed_by_user_email: Option<String>,
+    ) -> Result<DeprecateModelOutcome, AdminError> {
+        let deprecated = deprecated_model_name.trim();
+        let successor = successor_model_name.trim();
+
+        if deprecated.is_empty() || successor.is_empty() {
+            return Err(AdminError::InvalidDeprecation(
+                "modelId and successorModelId are required".to_string(),
+            ));
+        }
+        if deprecated == successor {
+            return Err(AdminError::InvalidDeprecation(
+                "modelId and successorModelId must differ".to_string(),
+            ));
+        }
+
+        let outcome = self
+            .repository
+            .deprecate_model(
+                deprecated,
+                successor,
+                change_reason,
+                changed_by_user_id,
+                changed_by_user_email,
+            )
+            .await
+            .map_err(|e| AdminError::InternalError(e.to_string()))?
+            .ok_or_else(|| {
+                AdminError::ModelNotFound(format!(
+                    "Either '{deprecated}' or '{successor}' was not found, or the successor is not active"
+                ))
+            })?;
+
+        Ok(outcome)
+    }
+
     async fn update_organization_limits(
         &self,
         organization_id: uuid::Uuid,

--- a/crates/services/src/admin/ports.rs
+++ b/crates/services/src/admin/ports.rs
@@ -278,15 +278,22 @@ pub trait AdminRepository: Send + Sync {
     /// Atomically deprecate `deprecated_model_name` in favor of `successor_model_name`.
     ///
     /// In a single transaction:
-    /// - Adds `deprecated_model_name` to `successor_model_name`'s alias list (deduped).
-    /// - Repoints any existing inbound aliases of the deprecated model at the
-    ///   successor, so historical aliases keep resolving.
-    /// - Sets the deprecated model's `is_active = false` and records a history
-    ///   entry with the supplied change reason.
+    /// - Adds `deprecated_model_name` to `successor_model_name`'s alias list
+    ///   (idempotent via `ON CONFLICT (alias_name) DO UPDATE`).
+    /// - Repoints any existing **active** inbound aliases of the deprecated
+    ///   model at the successor, so historical aliases keep resolving.
+    ///   Inactive inbound aliases are left untouched.
+    /// - Sets the deprecated model's `is_active = false` and records a
+    ///   `model_history` entry with the supplied change reason.
+    /// - Reads back both models' merged-alias state inside the same
+    ///   transaction so a successful commit is atomic with the response.
     ///
-    /// Returns `Ok(None)` if either model is not found, or `Ok(Some(outcome))`
-    /// describing the resulting state. Surface validation errors (self-target,
-    /// successor inactive) via the service layer before calling.
+    /// Returns `Ok(None)` for any of the "treat-as-not-found" conditions:
+    /// either model is missing, or the successor is not currently active.
+    /// (The successor-activeness check lives in the repository to keep the
+    /// reads inside the transaction; the service surfaces both as
+    /// `ModelNotFound`.) Self-target / empty-id validation is the
+    /// service layer's responsibility.
     async fn deprecate_model(
         &self,
         deprecated_model_name: &str,

--- a/crates/services/src/admin/ports.rs
+++ b/crates/services/src/admin/ports.rs
@@ -226,10 +226,26 @@ pub enum AdminError {
     InvalidPricing(String),
     #[error("Invalid limits data: {0}")]
     InvalidLimits(String),
+    #[error("Invalid deprecation request: {0}")]
+    InvalidDeprecation(String),
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
     #[error("Internal error: {0}")]
     InternalError(String),
+}
+
+/// Outcome of a `deprecate_model` operation.
+#[derive(Debug, Clone)]
+pub struct DeprecateModelOutcome {
+    /// State of the deprecated model after the operation (`is_active = false`).
+    pub deprecated: ModelPricing,
+    /// State of the successor model after the operation, including the
+    /// merged alias list.
+    pub successor: ModelPricing,
+    /// Number of pre-existing aliases of the deprecated model that were
+    /// re-pointed at the successor (does not include the deprecated model's
+    /// own canonical name).
+    pub aliases_carried: u32,
 }
 
 /// Repository trait for admin operations on models and organizations
@@ -258,6 +274,27 @@ pub trait AdminRepository: Send + Sync {
         changed_by_user_id: Option<uuid::Uuid>,
         changed_by_user_email: Option<String>,
     ) -> Result<bool, anyhow::Error>;
+
+    /// Atomically deprecate `deprecated_model_name` in favor of `successor_model_name`.
+    ///
+    /// In a single transaction:
+    /// - Adds `deprecated_model_name` to `successor_model_name`'s alias list (deduped).
+    /// - Repoints any existing inbound aliases of the deprecated model at the
+    ///   successor, so historical aliases keep resolving.
+    /// - Sets the deprecated model's `is_active = false` and records a history
+    ///   entry with the supplied change reason.
+    ///
+    /// Returns `Ok(None)` if either model is not found, or `Ok(Some(outcome))`
+    /// describing the resulting state. Surface validation errors (self-target,
+    /// successor inactive) via the service layer before calling.
+    async fn deprecate_model(
+        &self,
+        deprecated_model_name: &str,
+        successor_model_name: &str,
+        change_reason: Option<String>,
+        changed_by_user_id: Option<uuid::Uuid>,
+        changed_by_user_email: Option<String>,
+    ) -> Result<Option<DeprecateModelOutcome>, anyhow::Error>;
 
     /// Update organization limits (creates new history entry, closes previous)
     async fn update_organization_limits(
@@ -411,6 +448,20 @@ pub trait AdminService: Send + Sync {
         changed_by_user_id: Option<uuid::Uuid>,
         changed_by_user_email: Option<String>,
     ) -> Result<(), AdminError>;
+
+    /// Deprecate one model in favor of another (admin only). Atomic: in a
+    /// single DB transaction, the deprecated model's name is added as an
+    /// alias of the successor, any inbound aliases of the deprecated model
+    /// are re-pointed at the successor, and the deprecated model is marked
+    /// `is_active = false`.
+    async fn deprecate_model(
+        &self,
+        deprecated_model_name: &str,
+        successor_model_name: &str,
+        change_reason: Option<String>,
+        changed_by_user_id: Option<uuid::Uuid>,
+        changed_by_user_email: Option<String>,
+    ) -> Result<DeprecateModelOutcome, AdminError>;
 
     /// Update organization limits (admin only)
     async fn update_organization_limits(


### PR DESCRIPTION
## Summary

One-shot admin operation to deprecate a model in favor of another. Today, deprecating GLM-5 in favor of GLM-5.1 takes:
1. `PATCH /v1/admin/models` on GLM-5.1 with `aliases: [\"GLM-5\", ...all-existing-aliases]` (the alias upsert is *replace-all*, so an unaware caller wipes the successor's aliases)
2. `DELETE /v1/admin/models/...GLM-5...` to set `is_active=false`

That's two API calls, no atomicity, and a real footgun (the alias merge step is easy to forget). It also drops any aliases pointing *to* GLM-5, breaking historical clients that used those names.

This PR adds `POST /v1/admin/models/deprecate` with body `{modelId, successorModelId, changeReason?}` that does it all atomically in one transaction.

## Behavior

In a single DB transaction:
1. Adds `modelId` as an alias of `successorModelId` (idempotent — `ON CONFLICT (alias_name) DO UPDATE`; successor's existing aliases preserved).
2. **Re-points** any pre-existing inbound aliases of `modelId` at the successor, so historical aliases keep resolving.
3. Sets `modelId.is_active = false` (hides from `/v1/models` and from `/v1/admin/models` unless `include_inactive=true` — same as `setting inactive`, per request).
4. Records a `model_history` entry with the change reason (default: `\"Deprecated in favor of '<successor>'\"`).

After commit, the route unregisters the deprecated model from `InferenceProviderPool`. The existing alias resolver (`ModelRepository::resolve_and_get_model`) rewrites `request.model` to the successor's canonical name at request time, so the response's `model` field reflects the successor — no SDK-side change needed.

## API

```
POST /v1/admin/models/deprecate
Authorization: Bearer <session_token>
Content-Type: application/json

{
  \"modelId\": \"zai-org/GLM-5-FP8\",
  \"successorModelId\": \"zai-org/GLM-5.1-FP8\",
  \"changeReason\": \"Deprecated 2026-05-01\"
}
```

**Responses:**
- `200` — `{deprecated, successor, aliasesCarried}` — both `ModelWithPricing` shapes; `aliasesCarried` counts inbound aliases re-pointed.
- `400` — `invalid_request`: self-target (`modelId == successorModelId`) or empty/whitespace ids.
- `404` — `model_not_found`: either model missing **or** successor inactive (treated identically — successor must be live to deprecate something *to* it).

OpenAPI/Scalar docs include the new path and schemas.

## Tests

9 new e2e tests in `crates/api/tests/e2e_all/admin_deprecate_model.rs`:
- happy-path (alias added on successor, response shape correct)
- successor's pre-existing aliases preserved
- inbound aliases of deprecated carried over (with count assertion)
- deprecated model hidden from default `/v1/admin/models`, surfaced with `include_inactive=true` and `isActive=false`
- self-target rejected (400)
- empty `modelId` rejected (400)
- unknown deprecated model → 404
- unknown successor → 404
- inactive successor → 404

All 9 pass. Also verified:
- 68 existing admin e2e tests still pass.
- 9 model-history e2e tests still pass.
- 202 lib/bin tests still pass.
- `cargo clippy` clean on touched crates.
- `cargo fmt` clean.

## Test plan

- [x] Unit + e2e tests pass locally against a Postgres test instance.
- [ ] Manual smoke against staging (cloud-stg-api): create two synthetic models, deprecate, confirm `/v1/models` hides the old one, confirm a chat completion sent with the deprecated id returns a response whose `model` field is the successor's canonical name.
- [ ] Confirm `/v1/admin/models?include_inactive=true` still surfaces the deprecated model with `isActive: false`.
- [ ] Confirm `model_history` for the deprecated model has a new row with the change reason.

## Out of scope (per design discussion)

- No `Deprecation` / `Sunset` HTTP response header on `/v1/chat/completions`.
- No `deprecated: true` field on `/v1/models` (just hidden via `is_active=false`, same as soft-delete).
- No scheduled / time-based deprecation.