### PR TITLE
chore: ignore hickory-proto CVEs RUSTSEC-2026-0119 and RUSTSEC-2026-0118

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -41,15 +41,16 @@ ignore = [
 
     # hickory-proto 0.25.2 CPU exhaustion via crafted DNS response.
     # Transitive dep: reqwest 0.12 -> hickory-resolver 0.25 -> hickory-proto 0.25.2.
-    # Cannot upgrade: reqwest 0.12 pins hickory to ^0.25; no 0.25.x patch exists
-    # (hickory team released 0.26.x instead of backporting). We only resolve
-    # admin-configured endpoints (no user-controlled hostnames), so exploitation
-    # requires DNS infrastructure compromise.
+    # Cannot upgrade: the fix landed in hickory-net 0.26.1 (the affected code was
+    # moved to a new crate in 0.26.0; no hickory-proto patch version exists).
+    # reqwest 0.12 would need to adopt hickory-net 0.26.x before we can upgrade.
+    # We only resolve admin-configured endpoints (no user-controlled hostnames),
+    # so exploitation requires DNS infrastructure compromise.
     # https://rustsec.org/advisories/RUSTSEC-2026-0119
     "RUSTSEC-2026-0119",
 
     # hickory-proto 0.25.2 NSEC3 CPU exhaustion (DNSSEC only).
-    # Same transitive dep chain as above; same upgrade blocker.
+    # Same transitive dep chain as above; same upgrade blocker (fix in hickory-net 0.26.1).
     # Not exploitable: DNSSEC validation is not enabled in our reqwest/hickory config.
     # https://rustsec.org/advisories/RUSTSEC-2026-0118
     "RUSTSEC-2026-0118",

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -38,6 +38,21 @@ ignore = [
     # Same transitive dep chain as above.
     # https://rustsec.org/advisories/RUSTSEC-2026-0104
     "RUSTSEC-2026-0104",
+
+    # hickory-proto 0.25.2 CPU exhaustion via crafted DNS response.
+    # Transitive dep: reqwest 0.12 -> hickory-resolver 0.25 -> hickory-proto 0.25.2.
+    # Cannot upgrade: reqwest 0.12 pins hickory to ^0.25; no 0.25.x patch exists
+    # (hickory team released 0.26.x instead of backporting). We only resolve
+    # admin-configured endpoints (no user-controlled hostnames), so exploitation
+    # requires DNS infrastructure compromise.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0119
+    "RUSTSEC-2026-0119",
+
+    # hickory-proto 0.25.2 NSEC3 CPU exhaustion (DNSSEC only).
+    # Same transitive dep chain as above; same upgrade blocker.
+    # Not exploitable: DNSSEC validation is not enabled in our reqwest/hickory config.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0118
+    "RUSTSEC-2026-0118",
 ]
 
 # Treat unmaintained crates as warnings (not errors)

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -41,16 +41,16 @@ ignore = [
 
     # hickory-proto 0.25.2 CPU exhaustion via crafted DNS response.
     # Transitive dep: reqwest 0.12 -> hickory-resolver 0.25 -> hickory-proto 0.25.2.
-    # Cannot upgrade: the fix landed in hickory-net 0.26.1 (the affected code was
-    # moved to a new crate in 0.26.0; no hickory-proto patch version exists).
-    # reqwest 0.12 would need to adopt hickory-net 0.26.x before we can upgrade.
+    # Cannot upgrade: fix is in hickory-proto >= 0.26.1, but reqwest 0.12 pins
+    # hickory to ^0.25 and no 0.25.x backport exists. reqwest must adopt 0.26.x first.
     # We only resolve admin-configured endpoints (no user-controlled hostnames),
     # so exploitation requires DNS infrastructure compromise.
     # https://rustsec.org/advisories/RUSTSEC-2026-0119
     "RUSTSEC-2026-0119",
 
     # hickory-proto 0.25.2 NSEC3 CPU exhaustion (DNSSEC only).
-    # Same transitive dep chain as above; same upgrade blocker (fix in hickory-net 0.26.1).
+    # Same transitive dep chain as above. Fix moved to hickory-net 0.26.1 (code
+    # restructured into new crate in 0.26.0; no 0.25.x backport exists).
     # Not exploitable: DNSSEC validation is not enabled in our reqwest/hickory config.
     # https://rustsec.org/advisories/RUSTSEC-2026-0118
     "RUSTSEC-2026-0118",


### PR DESCRIPTION
## Summary

- Two new hickory-proto CVEs published 2026-05-01 are breaking the `security_audit` CI job on unrelated PRs
- Adds both to the `.cargo/audit.toml` ignore list with full justification
- No code changes

## Why ignore rather than upgrade?

**No upgrade path exists today:**
- The CVE fixes landed in hickory 0.26.x — the hickory team did not backport to 0.25.x
- reqwest 0.12 pins hickory-resolver to ^0.25; cargo update cannot pull in 0.26.x
- No reqwest release exists yet that uses hickory 0.26.x

**Neither CVE is exploitable in practice:**
- RUSTSEC-2026-0119 (CPU exhaustion via crafted DNS): requires DNS MITM. We only resolve admin-configured endpoints, no user-controlled hostnames.
- RUSTSEC-2026-0118 (NSEC3 CPU exhaustion, DNSSEC only): DNSSEC is not enabled in our reqwest/hickory config.

**Revisit when:** reqwest publishes a version bumping hickory to ^0.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)