### PR TITLE
Add user-facing usage metrics and timeseries endpoints

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -702,6 +702,14 @@ pub fn build_app_with_config(
     domain_services: DomainServices,
     config: Arc<ApiConfig>,
 ) -> Router {
+    // Create analytics service (shared between user and admin routes)
+    let analytics_repository = Arc::new(database::repositories::PgAnalyticsRepository::new(
+        database.pool().clone(),
+    ));
+    let analytics_service = Arc::new(services::admin::AnalyticsService::new(
+        analytics_repository as Arc<dyn services::admin::AnalyticsRepository>,
+    ));
+
     // Create app state for completions and management routes
     let app_state = AppState {
         organization_service: domain_services.organization_service.clone(),
@@ -717,6 +725,7 @@ pub fn build_app_with_config(
         files_service: domain_services.files_service.clone(),
         inference_provider_pool: domain_services.inference_provider_pool.clone(),
         metrics_service: domain_services.metrics_service.clone(),
+        analytics_service: analytics_service.clone(),
         config: config.clone(),
     };
 
@@ -805,6 +814,7 @@ pub fn build_app_with_config(
         &auth_components.auth_state_middleware,
         config.clone(),
         app_state.inference_provider_pool.clone(),
+        analytics_service,
     );
 
     let invitation_routes =
@@ -1333,6 +1343,7 @@ pub fn build_admin_routes(
     auth_state_middleware: &AuthState,
     config: Arc<ApiConfig>,
     inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
+    analytics_service: Arc<services::admin::AnalyticsService>,
 ) -> Router {
     use crate::middleware::admin_middleware;
     use crate::routes::admin::{
@@ -1343,10 +1354,8 @@ pub fn build_admin_routes(
         list_organizations, list_users, update_organization_concurrent_limit,
         update_organization_limits, update_service, AdminAppState,
     };
-    use database::repositories::{
-        AdminAccessTokenRepository, AdminCompositeRepository, PgAnalyticsRepository,
-    };
-    use services::admin::{AdminServiceImpl, AnalyticsService};
+    use database::repositories::{AdminAccessTokenRepository, AdminCompositeRepository};
+    use services::admin::AdminServiceImpl;
 
     // Create composite admin repository (handles models, organization limits, and users)
     let admin_repository = Arc::new(AdminCompositeRepository::new(database.pool().clone()));
@@ -1354,12 +1363,6 @@ pub fn build_admin_routes(
     // Create admin access token repository
     let admin_access_token_repository =
         Arc::new(AdminAccessTokenRepository::new(database.pool().clone()));
-
-    // Create analytics repository and service
-    let analytics_repository = Arc::new(PgAnalyticsRepository::new(database.pool().clone()));
-    let analytics_service = Arc::new(AnalyticsService::new(
-        analytics_repository as Arc<dyn services::admin::AnalyticsRepository>,
-    ));
 
     // Create admin service with composite repository
     let admin_service = Arc::new(AdminServiceImpl::new(

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -118,6 +118,8 @@ use utoipa::{Modify, OpenApi};
         crate::routes::usage::get_organization_usage_history,
         crate::routes::usage::get_api_key_usage_history,
         crate::routes::usage::record_usage,
+        crate::routes::usage::get_user_organization_metrics,
+        crate::routes::usage::get_user_organization_timeseries,
         // Gateway endpoints (model gateway integration)
         crate::routes::gateway::check_api_key,
         // Billing endpoints (HuggingFace integration)
@@ -234,6 +236,12 @@ use utoipa::{Modify, OpenApi};
             crate::routes::usage::ServiceUsageHistoryResponse,
             crate::routes::usage::ServiceUsageEntryResponse,
             crate::routes::usage::RecordUsageResponse,
+            crate::routes::usage::UserOrganizationMetrics,
+            crate::routes::usage::UserMetricsSummary,
+            crate::routes::usage::UserModelMetrics,
+            crate::routes::usage::UserWorkspaceMetrics,
+            crate::routes::usage::UserTimeSeriesMetrics,
+            crate::routes::usage::UserTimeSeriesPoint,
             // Gateway models
             crate::routes::gateway::CheckApiKeyResponse,
             // Billing models (HuggingFace integration)

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -29,6 +29,7 @@ pub struct AppState {
     pub files_service: Arc<dyn FileServiceTrait + Send + Sync>,
     pub inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
     pub metrics_service: Arc<dyn services::metrics::MetricsServiceTrait>,
+    pub analytics_service: Arc<services::admin::AnalyticsService>,
     pub config: Arc<config::ApiConfig>,
 }
 
@@ -115,6 +116,14 @@ pub fn build_management_router(app_state: AppState, auth_state: AuthState) -> Ro
         .route(
             "/{id}/service-usage/history",
             get(crate::routes::usage::get_service_usage_history),
+        )
+        .route(
+            "/{id}/usage/metrics",
+            get(crate::routes::usage::get_user_organization_metrics),
+        )
+        .route(
+            "/{id}/usage/timeseries",
+            get(crate::routes::usage::get_user_organization_timeseries),
         );
 
     // User routes (require access token authentication)

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -9,6 +9,7 @@ use axum::{
     response::Json as ResponseJson,
     Extension, Json,
 };
+use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -838,4 +839,332 @@ pub async fn record_usage(
     };
 
     Ok(ResponseJson(response))
+}
+
+// ============= User-facing analytics endpoints =============
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserMetricsSummary {
+    pub total_requests: i64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    pub total_cache_read_tokens: i64,
+    pub total_cost_usd: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserModelMetrics {
+    pub model_name: String,
+    pub requests: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cost_usd: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserWorkspaceMetrics {
+    pub workspace_id: String,
+    pub workspace_name: String,
+    pub requests: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cost_usd: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserOrganizationMetrics {
+    pub organization_id: String,
+    pub period_start: String,
+    pub period_end: String,
+    pub summary: UserMetricsSummary,
+    pub by_model: Vec<UserModelMetrics>,
+    pub by_workspace: Vec<UserWorkspaceMetrics>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserTimeSeriesPoint {
+    pub date: String,
+    pub requests: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cost_usd: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserTimeSeriesMetrics {
+    pub organization_id: String,
+    pub period_start: String,
+    pub period_end: String,
+    pub granularity: String,
+    pub data: Vec<UserTimeSeriesPoint>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MetricsQuery {
+    pub start: Option<String>,
+    pub end: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TimeSeriesQuery {
+    pub start: Option<String>,
+    pub end: Option<String>,
+    pub granularity: Option<String>,
+}
+
+fn parse_datetime_or_default(
+    value: &Option<String>,
+    default: chrono::DateTime<Utc>,
+) -> Result<chrono::DateTime<Utc>, (StatusCode, ResponseJson<ErrorResponse>)> {
+    match value {
+        Some(s) => chrono::DateTime::parse_from_rfc3339(s)
+            .map(|dt| dt.with_timezone(&Utc))
+            .map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    ResponseJson(ErrorResponse::new(
+                        "Invalid date format. Use ISO 8601 (e.g. 2024-01-01T00:00:00Z)."
+                            .to_string(),
+                        "invalid_date".to_string(),
+                    )),
+                )
+            }),
+        None => Ok(default),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/usage/metrics",
+    tag = "Usage",
+    params(
+        ("org_id" = String, Path, description = "Organization ID"),
+        ("start" = Option<String>, Query, description = "Start date (ISO 8601, default: 30 days ago)"),
+        ("end" = Option<String>, Query, description = "End date (ISO 8601, default: now)")
+    ),
+    responses(
+        (status = 200, description = "Organization usage metrics", body = UserOrganizationMetrics),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn get_user_organization_metrics(
+    State(app_state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(org_id): Path<String>,
+    Query(query): Query<MetricsQuery>,
+) -> Result<ResponseJson<UserOrganizationMetrics>, (StatusCode, ResponseJson<ErrorResponse>)> {
+    let organization_id = Uuid::parse_str(&org_id).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "Invalid organization ID".to_string(),
+                "invalid_id".to_string(),
+            )),
+        )
+    })?;
+
+    let user_id = crate::conversions::authenticated_user_to_user_id(user);
+    let is_member = app_state
+        .organization_service
+        .is_member(
+            services::organization::OrganizationId(organization_id),
+            user_id,
+        )
+        .await
+        .map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to verify organization access".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    if !is_member {
+        return Err((
+            StatusCode::FORBIDDEN,
+            ResponseJson(ErrorResponse::new(
+                "You are not authorized to access this organization's metrics.".to_string(),
+                "forbidden".to_string(),
+            )),
+        ));
+    }
+
+    let now = Utc::now();
+    let start = parse_datetime_or_default(&query.start, now - Duration::days(30))?;
+    let end = parse_datetime_or_default(&query.end, now)?;
+
+    let metrics = app_state
+        .analytics_service
+        .get_organization_metrics(organization_id, start, end)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get organization metrics: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to retrieve organization metrics".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    Ok(ResponseJson(UserOrganizationMetrics {
+        organization_id: metrics.organization_id.to_string(),
+        period_start: metrics.period_start.to_rfc3339(),
+        period_end: metrics.period_end.to_rfc3339(),
+        summary: UserMetricsSummary {
+            total_requests: metrics.summary.total_requests,
+            total_input_tokens: metrics.summary.total_input_tokens,
+            total_output_tokens: metrics.summary.total_output_tokens,
+            total_cache_read_tokens: metrics.summary.total_cache_read_tokens,
+            total_cost_usd: metrics.summary.total_cost_usd,
+        },
+        by_model: metrics
+            .by_model
+            .into_iter()
+            .map(|m| UserModelMetrics {
+                model_name: m.model_name,
+                requests: m.requests,
+                input_tokens: m.input_tokens,
+                output_tokens: m.output_tokens,
+                cache_read_tokens: m.cache_read_tokens,
+                cost_usd: m.cost_usd,
+            })
+            .collect(),
+        by_workspace: metrics
+            .by_workspace
+            .into_iter()
+            .map(|w| UserWorkspaceMetrics {
+                workspace_id: w.workspace_id.to_string(),
+                workspace_name: w.workspace_name,
+                requests: w.requests,
+                input_tokens: w.input_tokens,
+                output_tokens: w.output_tokens,
+                cost_usd: w.cost_usd,
+            })
+            .collect(),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/usage/timeseries",
+    tag = "Usage",
+    params(
+        ("org_id" = String, Path, description = "Organization ID"),
+        ("start" = Option<String>, Query, description = "Start date (ISO 8601, default: 30 days ago)"),
+        ("end" = Option<String>, Query, description = "End date (ISO 8601, default: now)"),
+        ("granularity" = Option<String>, Query, description = "Time bucket size: hour, day, week (default: day)")
+    ),
+    responses(
+        (status = 200, description = "Organization usage timeseries", body = UserTimeSeriesMetrics),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn get_user_organization_timeseries(
+    State(app_state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(org_id): Path<String>,
+    Query(query): Query<TimeSeriesQuery>,
+) -> Result<ResponseJson<UserTimeSeriesMetrics>, (StatusCode, ResponseJson<ErrorResponse>)> {
+    let organization_id = Uuid::parse_str(&org_id).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "Invalid organization ID".to_string(),
+                "invalid_id".to_string(),
+            )),
+        )
+    })?;
+
+    let user_id = crate::conversions::authenticated_user_to_user_id(user);
+    let is_member = app_state
+        .organization_service
+        .is_member(
+            services::organization::OrganizationId(organization_id),
+            user_id,
+        )
+        .await
+        .map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to verify organization access".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    if !is_member {
+        return Err((
+            StatusCode::FORBIDDEN,
+            ResponseJson(ErrorResponse::new(
+                "You are not authorized to access this organization's metrics.".to_string(),
+                "forbidden".to_string(),
+            )),
+        ));
+    }
+
+    let granularity = query.granularity.as_deref().unwrap_or("day");
+    if !["hour", "day", "week"].contains(&granularity) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "Invalid granularity. Must be one of: hour, day, week.".to_string(),
+                "invalid_granularity".to_string(),
+            )),
+        ));
+    }
+
+    let now = Utc::now();
+    let start = parse_datetime_or_default(&query.start, now - Duration::days(30))?;
+    let end = parse_datetime_or_default(&query.end, now)?;
+
+    let timeseries = app_state
+        .analytics_service
+        .get_organization_timeseries(organization_id, start, end, granularity)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get organization timeseries: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to retrieve organization timeseries".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    Ok(ResponseJson(UserTimeSeriesMetrics {
+        organization_id: timeseries.organization_id.to_string(),
+        period_start: timeseries.period_start.to_rfc3339(),
+        period_end: timeseries.period_end.to_rfc3339(),
+        granularity: timeseries.granularity,
+        data: timeseries
+            .data
+            .into_iter()
+            .map(|p| UserTimeSeriesPoint {
+                date: p.date,
+                requests: p.requests,
+                input_tokens: p.input_tokens,
+                output_tokens: p.output_tokens,
+                cache_read_tokens: p.cache_read_tokens,
+                cost_usd: p.cost_usd,
+            })
+            .collect(),
+    }))
 }

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -869,6 +869,7 @@ pub struct UserWorkspaceMetrics {
     pub requests: i64,
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub cache_read_tokens: i64,
     pub cost_usd: f64,
 }
 
@@ -999,8 +1000,8 @@ pub async fn get_user_organization_metrics(
     }
 
     let now = Utc::now();
-    let start = parse_datetime_or_default(&query.start, now - Duration::days(30))?;
     let end = parse_datetime_or_default(&query.end, now)?;
+    let start = parse_datetime_or_default(&query.start, end - Duration::days(30))?;
 
     let metrics = app_state
         .analytics_service
@@ -1049,6 +1050,7 @@ pub async fn get_user_organization_metrics(
                 requests: w.requests,
                 input_tokens: w.input_tokens,
                 output_tokens: w.output_tokens,
+                cache_read_tokens: w.cache_read_tokens,
                 cost_usd: w.cost_usd,
             })
             .collect(),
@@ -1131,8 +1133,8 @@ pub async fn get_user_organization_timeseries(
     }
 
     let now = Utc::now();
-    let start = parse_datetime_or_default(&query.start, now - Duration::days(30))?;
     let end = parse_datetime_or_default(&query.end, now)?;
+    let start = parse_datetime_or_default(&query.start, end - Duration::days(30))?;
 
     let timeseries = app_state
         .analytics_service

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -1004,6 +1004,16 @@ pub async fn get_user_organization_metrics(
     let end = parse_datetime_or_default(&query.end, now)?;
     let start = parse_datetime_or_default(&query.start, end - Duration::days(30))?;
 
+    if start >= end {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "start must be before end".to_string(),
+                "invalid_date_range".to_string(),
+            )),
+        ));
+    }
+
     let metrics = app_state
         .analytics_service
         .get_organization_metrics(organization_id, start, end)
@@ -1137,6 +1147,16 @@ pub async fn get_user_organization_timeseries(
     let now = Utc::now();
     let end = parse_datetime_or_default(&query.end, now)?;
     let start = parse_datetime_or_default(&query.start, end - Duration::days(30))?;
+
+    if start >= end {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "start must be before end".to_string(),
+                "invalid_date_range".to_string(),
+            )),
+        ));
+    }
 
     let timeseries = app_state
         .analytics_service

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -980,6 +980,7 @@ pub async fn get_user_organization_metrics(
         )
         .await
         .map_err(|_| {
+            tracing::error!("Failed to check organization membership");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ResponseJson(ErrorResponse::new(
@@ -1102,6 +1103,7 @@ pub async fn get_user_organization_timeseries(
         )
         .await
         .map_err(|_| {
+            tracing::error!("Failed to check organization membership");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ResponseJson(ErrorResponse::new(

--- a/crates/database/src/repositories/analytics.rs
+++ b/crates/database/src/repositories/analytics.rs
@@ -54,10 +54,11 @@ impl AnalyticsRepository for PgAnalyticsRepository {
         let summary_row = client
             .query_one(
                 r#"
-                SELECT 
+                SELECT
                     COUNT(*)::bigint as requests,
                     COALESCE(SUM(input_tokens), 0)::bigint as input_tokens,
                     COALESCE(SUM(output_tokens), 0)::bigint as output_tokens,
+                    COALESCE(SUM(cache_read_tokens), 0)::bigint as cache_read_tokens,
                     COALESCE(SUM(total_cost), 0)::bigint as cost_nano,
                     COUNT(DISTINCT api_key_id)::bigint as unique_api_keys
                 FROM organization_usage_log
@@ -74,8 +75,9 @@ impl AnalyticsRepository for PgAnalyticsRepository {
             total_requests: summary_row.get::<_, i64>(0),
             total_input_tokens: summary_row.get::<_, i64>(1),
             total_output_tokens: summary_row.get::<_, i64>(2),
-            total_cost_usd: nano_to_usd(summary_row.get::<_, i64>(3)),
-            unique_api_keys: summary_row.get::<_, i64>(4),
+            total_cache_read_tokens: summary_row.get::<_, i64>(3),
+            total_cost_usd: nano_to_usd(summary_row.get::<_, i64>(4)),
+            unique_api_keys: summary_row.get::<_, i64>(5),
         };
 
         // Get metrics by workspace
@@ -152,9 +154,12 @@ impl AnalyticsRepository for PgAnalyticsRepository {
         let model_rows = client
             .query(
                 r#"
-                SELECT 
+                SELECT
                     ul.model_name,
                     COUNT(*)::bigint as requests,
+                    COALESCE(SUM(ul.input_tokens), 0)::bigint as input_tokens,
+                    COALESCE(SUM(ul.output_tokens), 0)::bigint as output_tokens,
+                    COALESCE(SUM(ul.cache_read_tokens), 0)::bigint as cache_read_tokens,
                     COALESCE(SUM(ul.total_cost), 0)::bigint as cost_nano,
                     AVG(ul.ttft_ms)::double precision as avg_ttft_ms,
                     PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ul.ttft_ms)::double precision as p95_ttft_ms,
@@ -177,11 +182,14 @@ impl AnalyticsRepository for PgAnalyticsRepository {
             .map(|row| ModelMetrics {
                 model_name: row.get(0),
                 requests: row.get(1),
-                avg_ttft_ms: row.get::<_, Option<f64>>(3),
-                p95_ttft_ms: row.get::<_, Option<f64>>(4),
-                avg_itl_ms: row.get::<_, Option<f64>>(5),
-                p95_itl_ms: row.get::<_, Option<f64>>(6),
-                cost_usd: nano_to_usd(row.get::<_, i64>(2)),
+                input_tokens: row.get(2),
+                output_tokens: row.get(3),
+                cache_read_tokens: row.get(4),
+                cost_usd: nano_to_usd(row.get::<_, i64>(5)),
+                avg_ttft_ms: row.get::<_, Option<f64>>(6),
+                p95_ttft_ms: row.get::<_, Option<f64>>(7),
+                avg_itl_ms: row.get::<_, Option<f64>>(8),
+                p95_itl_ms: row.get::<_, Option<f64>>(9),
             })
             .collect();
 
@@ -343,11 +351,12 @@ impl AnalyticsRepository for PgAnalyticsRepository {
         // Get time series data
         let query = format!(
             r#"
-            SELECT 
+            SELECT
                 DATE_TRUNC('{date_trunc}', created_at)::text as date,
                 COUNT(*)::bigint as requests,
                 COALESCE(SUM(input_tokens), 0)::bigint as input_tokens,
                 COALESCE(SUM(output_tokens), 0)::bigint as output_tokens,
+                COALESCE(SUM(cache_read_tokens), 0)::bigint as cache_read_tokens,
                 COALESCE(SUM(total_cost), 0)::bigint as cost_nano
             FROM organization_usage_log
             WHERE organization_id = $1
@@ -370,7 +379,8 @@ impl AnalyticsRepository for PgAnalyticsRepository {
                 requests: row.get(1),
                 input_tokens: row.get(2),
                 output_tokens: row.get(3),
-                cost_usd: nano_to_usd(row.get::<_, i64>(4)),
+                cache_read_tokens: row.get(4),
+                cost_usd: nano_to_usd(row.get::<_, i64>(5)),
             })
             .collect();
 

--- a/crates/database/src/repositories/analytics.rs
+++ b/crates/database/src/repositories/analytics.rs
@@ -84,12 +84,13 @@ impl AnalyticsRepository for PgAnalyticsRepository {
         let workspace_rows = client
             .query(
                 r#"
-                SELECT 
+                SELECT
                     w.id as workspace_id,
                     w.name as workspace_name,
                     COUNT(ul.id)::bigint as requests,
                     COALESCE(SUM(ul.input_tokens), 0)::bigint as input_tokens,
                     COALESCE(SUM(ul.output_tokens), 0)::bigint as output_tokens,
+                    COALESCE(SUM(ul.cache_read_tokens), 0)::bigint as cache_read_tokens,
                     COALESCE(SUM(ul.total_cost), 0)::bigint as cost_nano
                 FROM workspaces w
                 LEFT JOIN organization_usage_log ul ON ul.workspace_id = w.id 
@@ -112,7 +113,8 @@ impl AnalyticsRepository for PgAnalyticsRepository {
                 requests: row.get(2),
                 input_tokens: row.get(3),
                 output_tokens: row.get(4),
-                cost_usd: nano_to_usd(row.get::<_, i64>(5)),
+                cache_read_tokens: row.get(5),
+                cost_usd: nano_to_usd(row.get::<_, i64>(6)),
             })
             .collect();
 

--- a/crates/services/src/admin/analytics.rs
+++ b/crates/services/src/admin/analytics.rs
@@ -17,6 +17,7 @@ pub struct MetricsSummary {
     pub total_requests: i64,
     pub total_input_tokens: i64,
     pub total_output_tokens: i64,
+    pub total_cache_read_tokens: i64,
     /// Total cost in USD (converted from nano-dollars)
     pub total_cost_usd: f64,
     /// Number of unique API keys used in the period
@@ -50,6 +51,9 @@ pub struct ApiKeyMetrics {
 pub struct ModelMetrics {
     pub model_name: String,
     pub requests: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
     /// Average time to first token in milliseconds
     pub avg_ttft_ms: Option<f64>,
     /// 95th percentile time to first token in milliseconds
@@ -112,6 +116,7 @@ pub struct TimeSeriesPoint {
     pub requests: i64,
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub cache_read_tokens: i64,
     pub cost_usd: f64,
 }
 

--- a/crates/services/src/admin/analytics.rs
+++ b/crates/services/src/admin/analytics.rs
@@ -32,6 +32,7 @@ pub struct WorkspaceMetrics {
     pub requests: i64,
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub cache_read_tokens: i64,
     /// Cost in USD
     pub cost_usd: f64,
 }


### PR DESCRIPTION
## Summary
- **Two new user-facing endpoints** reusing existing admin analytics infrastructure:
  - `GET /v1/organizations/{id}/usage/metrics?start=&end=` — aggregated summary + model/workspace breakdown
  - `GET /v1/organizations/{id}/usage/timeseries?start=&end=&granularity=` — time-bucketed data for charts (hour/day/week)
- **Added cache_read_tokens** to all analytics SQL queries (summary, model breakdown, timeseries) — benefits both admin and user endpoints
- **Shared AnalyticsService** between user and admin routes (constructed once, passed to both)
- User endpoints strip admin-only fields (API key breakdown, latency percentiles)
- Auth: session token + org membership check (same as existing usage endpoints)

## Changes
- `crates/services/src/admin/analytics.rs` — added cache_read_tokens fields to MetricsSummary, ModelMetrics, TimeSeriesPoint
- `crates/database/src/repositories/analytics.rs` — updated SQL queries to aggregate cache_read_tokens
- `crates/api/src/routes/usage.rs` — new user-facing structs and handlers
- `crates/api/src/routes/api.rs` — AppState + route registration
- `crates/api/src/lib.rs` — shared AnalyticsService construction
- `crates/api/src/openapi.rs` — API docs

## Test plan
- [ ] `cargo test --lib --bins` passes (210 tests)
- [ ] `cargo clippy` clean
- [ ] Hit `/v1/organizations/{id}/usage/metrics` as org member — verify aggregated data
- [ ] Hit `/v1/organizations/{id}/usage/timeseries?granularity=day` — verify time buckets
- [ ] Verify admin endpoints still work with new cache_read_tokens fields
- [ ] Verify non-member gets 403