### PR TITLE
Stagger inter-model cumulative discovery to prevent GPU evidence worker saturation

### DIFF
--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -25,6 +25,19 @@ pub const ATTESTATION_DISCOVERY_PARALLELISM: usize = 5;
 /// steady-state refresh load stays low.
 pub const CUMULATIVE_DISCOVERY_CALLS: usize = 2;
 
+/// Inter-model stagger for cumulative discovery on each refresh cycle (milliseconds).
+///
+/// When the provider pool refreshes, it runs cumulative attestation discovery
+/// for every reused model. Without staggering, all models fire their first
+/// discovery call at t=0, creating a burst that saturates the GPU evidence
+/// worker on dense hosts (e.g. gpu04 runs 8+ model instances).
+///
+/// With this stagger, model i starts its discovery after `i * MODEL_DISCOVERY_STAGGER_MS`
+/// delay. At 2 s/model the burst is spread across tens of seconds rather than
+/// a single wall-clock instant, while still completing well within the 5-minute
+/// refresh interval even for large pools.
+pub const MODEL_DISCOVERY_STAGGER_MS: u64 = 2_000;
+
 /// Result of verifying an attestation report from an inference backend.
 #[derive(Debug, Clone)]
 pub struct VerifiedAttestation {

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -36,6 +36,11 @@ pub const CUMULATIVE_DISCOVERY_CALLS: usize = 2;
 /// delay. At 2 s/model the burst is spread across tens of seconds rather than
 /// a single wall-clock instant, while still completing well within the 5-minute
 /// refresh interval even for large pools.
+///
+/// Note: the cumulative discovery loop runs inside `buffer_unordered(10)`, so
+/// tasks at index >= 10 begin their sleep only after a concurrency slot opens.
+/// Their effective wall-clock delay is therefore ≥ i × STAGGER_MS, making the
+/// spread more conservative (not less) for pools larger than 10 models.
 pub const MODEL_DISCOVERY_STAGGER_MS: u64 = 2_000;
 
 /// Result of verifying an attestation report from an inference backend.

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -2219,8 +2219,22 @@ impl InferenceProviderPool {
                         let api_key = api_key.clone();
                         let verifier = verifier.clone();
                         let tls_roots = tls_roots.clone();
+                        // Stagger index: model i waits i × MODEL_DISCOVERY_STAGGER_MS before
+                        // firing its first discovery call. This spreads the per-refresh burst
+                        // across time instead of hitting all backends simultaneously, preventing
+                        // GPU evidence worker saturation on dense hosts (e.g. multiple models
+                        // on the same inference host).
+                        let stagger_idx = discovery_tasks.len();
+                        let model_stagger_ms =
+                            crate::attestation::verification::MODEL_DISCOVERY_STAGGER_MS;
                         discovery_tasks.push(
                             async move {
+                                if stagger_idx > 0 {
+                                    tokio::time::sleep(Duration::from_millis(
+                                        model_stagger_ms * stagger_idx as u64,
+                                    ))
+                                    .await;
+                                }
                                 let outcome = Self::discover_model(
                                     &url,
                                     &api_key,

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -2231,7 +2231,7 @@ impl InferenceProviderPool {
                             async move {
                                 if stagger_idx > 0 {
                                     tokio::time::sleep(Duration::from_millis(
-                                        model_stagger_ms * stagger_idx as u64,
+                                        model_stagger_ms.saturating_mul(stagger_idx as u64),
                                     ))
                                     .await;
                                 }


### PR DESCRIPTION
## Summary

- Adds `MODEL_DISCOVERY_STAGGER_MS = 2000` constant to `attestation/verification.rs`
- On each 5-minute provider refresh, model `i` now sleeps `i × 2 s` before starting cumulative attestation discovery, spreading the burst across ~2×N seconds instead of firing all models simultaneously
- Stagger applies **only to the cumulative-discovery path** (reused providers on periodic refresh) — initial discovery at startup is unaffected

## Root Cause

On each refresh cycle, `buffer_unordered(10)` ran cumulative discovery for all reused models concurrently. All models hit the same inference host (e.g. gpu04) at t=0, creating a burst of `N × CUMULATIVE_DISCOVERY_CALLS` simultaneous attestation requests. The GPU evidence worker on the backend exhausted its queue and logged:

```
GPU evidence worker timed out after 60s, restarting and retrying
```

Clients waiting for `/v1/attestation/report` received HTTP 499 (nginx client-closed) after hitting their 30 s timeout, confirmed across two separate staging test runs:

| Run | Model | Error |
|-----|-------|-------|
| Loop 1 | `Qwen3-30B` ECDSA | ReadTimeout 30 s → nginx 499 @ 16:51:35 UTC |
| Loop 2 | `gpt-oss-120b` Ed25519 | ReadTimeout 30 s → nginx 499 @ 17:09:08 UTC |

Both failures occurred ~3–4 min into continuous load testing, coinciding with the 5-minute refresh burst.

## Test plan

- [x] `cargo build --lib` clean
- [x] `cargo test --lib --bins` — 222 passed
- [ ] Deploy to staging and rerun the repeat attestation test loop — should now run >50 iterations without a timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)