### PR TITLE
fix: resolve Google SSO failure after email change on same account

### DIFF
--- a/crates/database/src/repositories/user.rs
+++ b/crates/database/src/repositories/user.rs
@@ -47,13 +47,6 @@ impl UserRepository {
                 auth_provider, provider_user_id
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8, $9)
-            ON CONFLICT (email) DO UPDATE SET
-                username = EXCLUDED.username,
-                display_name = EXCLUDED.display_name,
-                avatar_url = EXCLUDED.avatar_url,
-                updated_at = EXCLUDED.updated_at,
-                auth_provider = EXCLUDED.auth_provider,
-                provider_user_id = EXCLUDED.provider_user_id
             RETURNING *
             "#,
                     &[

--- a/crates/database/src/repositories/user.rs
+++ b/crates/database/src/repositories/user.rs
@@ -532,6 +532,37 @@ impl services::auth::UserRepository for UserRepository {
         Ok(maybe_user.map(db_user_to_service_user))
     }
 
+    async fn get_by_provider(
+        &self,
+        auth_provider: &str,
+        provider_user_id: &str,
+    ) -> anyhow::Result<Option<services::auth::User>> {
+        let maybe_user = self
+            .get_by_provider(auth_provider, provider_user_id)
+            .await?;
+        Ok(maybe_user.map(db_user_to_service_user))
+    }
+
+    async fn update_email(&self, id: services::auth::UserId, email: String) -> anyhow::Result<()> {
+        retry_db!("update_user_email", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .execute(
+                    "UPDATE users SET email = $2, updated_at = NOW() WHERE id = $1",
+                    &[&id.0, &email],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+        Ok(())
+    }
+
     async fn update(
         &self,
         id: services::auth::UserId,

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -233,15 +233,14 @@ impl AuthServiceTrait for AuthService {
 
     async fn get_or_create_oauth_user(&self, oauth_info: OAuthUserInfo) -> Result<User, AuthError> {
         use crate::organization::OrganizationId;
-        // Check if user already exists
+        // Look up by provider identity — the stable, unique identifier from the OAuth provider
         let existing_user = self
             .user_repository
-            .get_by_email(&oauth_info.email)
+            .get_by_provider(&oauth_info.provider, &oauth_info.provider_user_id)
             .await
             .map_err(|e| AuthError::InternalError(format!("Failed to check existing user: {e}")))?;
 
         if let Some(user) = existing_user {
-            // Update last login
             self.user_repository
                 .update_last_login(user.id.clone())
                 .await
@@ -249,7 +248,15 @@ impl AuthServiceTrait for AuthService {
                     AuthError::InternalError(format!("Failed to update last login: {e}"))
                 })?;
 
-            // Update user info if changed
+            if user.email != oauth_info.email {
+                self.user_repository
+                    .update_email(user.id.clone(), oauth_info.email)
+                    .await
+                    .map_err(|e| {
+                        AuthError::InternalError(format!("Failed to update user email: {e}"))
+                    })?;
+            }
+
             if user.display_name != oauth_info.display_name
                 || user.avatar_url != oauth_info.avatar_url
             {
@@ -541,5 +548,644 @@ impl AuthService {
             .cleanup_expired()
             .await
             .map_err(|e| AuthError::InternalError(format!("Failed to cleanup sessions: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::RepositoryError;
+    use crate::organization::{
+        AddOrganizationMemberRequest, BatchInvitationResponse, CreateOrganizationRequest,
+        InvitationStatus, MemberRole, Organization, OrganizationError, OrganizationId,
+        OrganizationInvitation, OrganizationMember, OrganizationMemberWithUser,
+        OrganizationOrderBy, OrganizationOrderDirection, OrganizationRepository,
+        OrganizationServiceTrait, UpdateOrganizationMemberRequest, UpdateOrganizationRequest,
+    };
+    use crate::workspace::{
+        ApiKey, ApiKeyId, ApiKeyRepository, CreateApiKeyRequest, Workspace, WorkspaceId,
+        WorkspaceOrderBy, WorkspaceOrderDirection, WorkspaceRepository,
+    };
+    use bloomfilter::Bloom;
+    use chrono::Utc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Mutex;
+    use tokio::sync::RwLock;
+    use uuid::Uuid;
+
+    fn make_user(email: &str, provider: &str) -> User {
+        User {
+            id: UserId(Uuid::new_v4()),
+            email: email.to_string(),
+            username: email.split('@').next().unwrap().to_string(),
+            display_name: Some("Test User".to_string()),
+            avatar_url: None,
+            auth_provider: provider.to_string(),
+            role: UserRole::User,
+            is_active: true,
+            last_login: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            tokens_revoked_at: None,
+        }
+    }
+
+    struct MockUserRepo {
+        user: Mutex<Option<User>>,
+        email_updated: Mutex<Option<String>>,
+        last_login_updated: Mutex<bool>,
+        profile_updated: Mutex<bool>,
+    }
+
+    impl MockUserRepo {
+        fn with_user(user: User) -> Self {
+            Self {
+                user: Mutex::new(Some(user)),
+                email_updated: Mutex::new(None),
+                last_login_updated: Mutex::new(false),
+                profile_updated: Mutex::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl UserRepository for MockUserRepo {
+        async fn create(
+            &self,
+            _: String,
+            _: String,
+            _: Option<String>,
+            _: Option<String>,
+        ) -> anyhow::Result<User> {
+            unimplemented!()
+        }
+        async fn create_from_oauth(
+            &self,
+            _: String,
+            _: String,
+            _: Option<String>,
+            _: Option<String>,
+            _: String,
+            _: String,
+        ) -> anyhow::Result<User> {
+            unimplemented!()
+        }
+        async fn get_by_id(&self, _: UserId) -> anyhow::Result<Option<User>> {
+            unimplemented!()
+        }
+        async fn get_by_email(&self, _: &str) -> anyhow::Result<Option<User>> {
+            unimplemented!()
+        }
+        async fn get_by_provider(
+            &self,
+            auth_provider: &str,
+            _provider_user_id: &str,
+        ) -> anyhow::Result<Option<User>> {
+            let user = self.user.lock().unwrap();
+            Ok(user
+                .as_ref()
+                .filter(|u| u.auth_provider == auth_provider)
+                .cloned())
+        }
+        async fn update(
+            &self,
+            _: UserId,
+            _: Option<String>,
+            _: Option<String>,
+        ) -> anyhow::Result<Option<User>> {
+            *self.profile_updated.lock().unwrap() = true;
+            Ok(self.user.lock().unwrap().clone())
+        }
+        async fn update_email(&self, _: UserId, email: String) -> anyhow::Result<()> {
+            *self.email_updated.lock().unwrap() = Some(email);
+            Ok(())
+        }
+        async fn update_last_login(&self, _: UserId) -> anyhow::Result<()> {
+            *self.last_login_updated.lock().unwrap() = true;
+            Ok(())
+        }
+        async fn update_tokens_revoked_at(&self, _: UserId) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn delete(&self, _: UserId) -> anyhow::Result<bool> {
+            unimplemented!()
+        }
+        async fn list(&self, _: i64, _: i64) -> anyhow::Result<Vec<User>> {
+            unimplemented!()
+        }
+    }
+
+    // Stubs for traits required to construct AuthService but not called in returning-user tests.
+    struct StubSessionRepo;
+    #[async_trait]
+    impl SessionRepository for StubSessionRepo {
+        async fn create(
+            &self,
+            _: UserId,
+            _: Option<String>,
+            _: String,
+            _: i64,
+        ) -> anyhow::Result<(Session, String)> {
+            unimplemented!()
+        }
+        async fn validate(&self, _: SessionToken, _: &str) -> anyhow::Result<Option<Session>> {
+            unimplemented!()
+        }
+        async fn get_by_id(&self, _: SessionId) -> anyhow::Result<Option<Session>> {
+            unimplemented!()
+        }
+        async fn list_by_user(&self, _: UserId) -> anyhow::Result<Vec<Session>> {
+            unimplemented!()
+        }
+        async fn extend(&self, _: SessionId, _: i64) -> anyhow::Result<bool> {
+            unimplemented!()
+        }
+        async fn rotate(&self, _: SessionId, _: &str, _: i64) -> anyhow::Result<(Session, String)> {
+            unimplemented!()
+        }
+        async fn revoke(&self, _: SessionId) -> anyhow::Result<bool> {
+            unimplemented!()
+        }
+        async fn revoke_all_for_user(&self, _: UserId) -> anyhow::Result<usize> {
+            unimplemented!()
+        }
+        async fn cleanup_expired(&self) -> anyhow::Result<usize> {
+            unimplemented!()
+        }
+    }
+
+    struct StubApiKeyRepo;
+    #[async_trait]
+    impl ApiKeyRepository for StubApiKeyRepo {
+        async fn validate(&self, _: String) -> Result<Option<ApiKey>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn create(&self, _: CreateApiKeyRequest) -> Result<ApiKey, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_by_id(&self, _: ApiKeyId) -> Result<Option<ApiKey>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn list_by_workspace_paginated(
+            &self,
+            _: WorkspaceId,
+            _: i64,
+            _: i64,
+        ) -> Result<Vec<ApiKey>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn delete(&self, _: ApiKeyId) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+        async fn update_last_used(&self, _: ApiKeyId) -> Result<(), RepositoryError> {
+            unimplemented!()
+        }
+        async fn update_spend_limit(
+            &self,
+            _: ApiKeyId,
+            _: Option<i64>,
+        ) -> Result<ApiKey, RepositoryError> {
+            unimplemented!()
+        }
+        async fn update(
+            &self,
+            _: ApiKeyId,
+            _: Option<String>,
+            _: Option<Option<chrono::DateTime<Utc>>>,
+            _: Option<Option<i64>>,
+            _: Option<bool>,
+        ) -> Result<ApiKey, RepositoryError> {
+            unimplemented!()
+        }
+        async fn count_by_workspace(&self, _: WorkspaceId) -> Result<i64, RepositoryError> {
+            unimplemented!()
+        }
+        async fn check_name_duplication(
+            &self,
+            _: WorkspaceId,
+            _: &str,
+        ) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+        async fn revoke(&self, _: ApiKeyId) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_all_active_key_hashes(&self) -> Result<Vec<String>, RepositoryError> {
+            Ok(vec![])
+        }
+        async fn get_active_key_hashes_created_after(
+            &self,
+            _: chrono::DateTime<Utc>,
+        ) -> Result<Vec<String>, RepositoryError> {
+            Ok(vec![])
+        }
+    }
+
+    struct StubOrgRepo;
+    #[async_trait]
+    impl OrganizationRepository for StubOrgRepo {
+        async fn create(
+            &self,
+            _: CreateOrganizationRequest,
+            _: Uuid,
+        ) -> Result<Organization, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_by_id(&self, _: Uuid) -> Result<Option<Organization>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_by_name(&self, _: &str) -> Result<Option<Organization>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_member(
+            &self,
+            _: Uuid,
+            _: Uuid,
+        ) -> Result<Option<OrganizationMember>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn update(
+            &self,
+            _: Uuid,
+            _: UpdateOrganizationRequest,
+        ) -> Result<Organization, RepositoryError> {
+            unimplemented!()
+        }
+        async fn delete(&self, _: Uuid) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+        async fn add_member(
+            &self,
+            _: Uuid,
+            _: AddOrganizationMemberRequest,
+            _: Uuid,
+        ) -> Result<OrganizationMember, RepositoryError> {
+            unimplemented!()
+        }
+        async fn update_member(
+            &self,
+            _: Uuid,
+            _: Uuid,
+            _: UpdateOrganizationMemberRequest,
+        ) -> Result<OrganizationMember, RepositoryError> {
+            unimplemented!()
+        }
+        async fn remove_member(&self, _: Uuid, _: Uuid) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+        async fn list_members_paginated(
+            &self,
+            _: Uuid,
+            _: i64,
+            _: i64,
+        ) -> Result<Vec<OrganizationMember>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_member_count(&self, _: Uuid) -> Result<i64, RepositoryError> {
+            unimplemented!()
+        }
+        async fn count_organizations_by_user(&self, _: Uuid) -> Result<i64, RepositoryError> {
+            unimplemented!()
+        }
+        async fn list_organizations_by_user(
+            &self,
+            _: Uuid,
+            _: i64,
+            _: i64,
+            _: Option<OrganizationOrderBy>,
+            _: Option<OrganizationOrderDirection>,
+        ) -> Result<Vec<Organization>, RepositoryError> {
+            unimplemented!()
+        }
+    }
+
+    struct StubWorkspaceRepo;
+    #[async_trait]
+    impl WorkspaceRepository for StubWorkspaceRepo {
+        async fn get_by_id(&self, _: WorkspaceId) -> Result<Option<Workspace>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_by_name(
+            &self,
+            _: Uuid,
+            _: &str,
+        ) -> Result<Option<Workspace>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn get_workspace_with_organization(
+            &self,
+            _: WorkspaceId,
+        ) -> Result<Option<(Workspace, Organization)>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn list_by_organization(
+            &self,
+            _: OrganizationId,
+        ) -> Result<Vec<Workspace>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn list_by_organization_paginated(
+            &self,
+            _: OrganizationId,
+            _: i64,
+            _: i64,
+            _: Option<WorkspaceOrderBy>,
+            _: Option<WorkspaceOrderDirection>,
+        ) -> Result<Vec<Workspace>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn create(
+            &self,
+            _: String,
+            _: Option<String>,
+            _: OrganizationId,
+            _: UserId,
+        ) -> Result<Workspace, RepositoryError> {
+            unimplemented!()
+        }
+        async fn update(
+            &self,
+            _: WorkspaceId,
+            _: Option<String>,
+            _: Option<String>,
+            _: Option<serde_json::Value>,
+        ) -> Result<Option<Workspace>, RepositoryError> {
+            unimplemented!()
+        }
+        async fn delete(&self, _: WorkspaceId) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+        async fn count_by_organization(&self, _: OrganizationId) -> Result<i64, RepositoryError> {
+            unimplemented!()
+        }
+    }
+
+    struct StubOrgService;
+    #[async_trait]
+    impl OrganizationServiceTrait for StubOrgService {
+        async fn create_organization(
+            &self,
+            _: String,
+            _: Option<String>,
+            _: UserId,
+        ) -> Result<Organization, OrganizationError> {
+            unimplemented!()
+        }
+        async fn get_organization(
+            &self,
+            _: OrganizationId,
+        ) -> Result<Organization, OrganizationError> {
+            unimplemented!()
+        }
+        async fn update_organization(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: Option<String>,
+            _: Option<String>,
+            _: Option<i32>,
+            _: Option<serde_json::Value>,
+        ) -> Result<Organization, OrganizationError> {
+            unimplemented!()
+        }
+        async fn delete_organization(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+        ) -> Result<bool, OrganizationError> {
+            unimplemented!()
+        }
+        async fn list_organizations_for_user(
+            &self,
+            _: UserId,
+            _: i64,
+            _: i64,
+            _: Option<OrganizationOrderBy>,
+            _: Option<OrganizationOrderDirection>,
+        ) -> Result<Vec<Organization>, OrganizationError> {
+            unimplemented!()
+        }
+        async fn count_organizations_for_user(&self, _: UserId) -> Result<i64, OrganizationError> {
+            unimplemented!()
+        }
+        async fn add_member(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: UserId,
+            _: MemberRole,
+        ) -> Result<OrganizationMember, OrganizationError> {
+            unimplemented!()
+        }
+        async fn remove_member(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: UserId,
+        ) -> Result<bool, OrganizationError> {
+            unimplemented!()
+        }
+        async fn update_member_role(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: UserId,
+            _: MemberRole,
+        ) -> Result<OrganizationMember, OrganizationError> {
+            unimplemented!()
+        }
+        async fn is_member(&self, _: OrganizationId, _: UserId) -> Result<bool, OrganizationError> {
+            unimplemented!()
+        }
+        async fn get_user_role(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+        ) -> Result<Option<MemberRole>, OrganizationError> {
+            unimplemented!()
+        }
+        async fn get_member_count(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+        ) -> Result<i64, OrganizationError> {
+            unimplemented!()
+        }
+        async fn get_organization_by_name(
+            &self,
+            _: &str,
+        ) -> Result<Option<Organization>, OrganizationError> {
+            unimplemented!()
+        }
+        async fn get_members_with_users_paginated(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: i64,
+            _: i64,
+        ) -> Result<Vec<OrganizationMemberWithUser>, OrganizationError> {
+            unimplemented!()
+        }
+        async fn invite_members_by_email(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: Vec<(String, MemberRole)>,
+        ) -> Result<BatchInvitationResponse, OrganizationError> {
+            unimplemented!()
+        }
+        async fn add_member_validated(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: UserId,
+            _: MemberRole,
+        ) -> Result<OrganizationMember, OrganizationError> {
+            unimplemented!()
+        }
+        async fn update_member_role_validated(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: UserId,
+            _: MemberRole,
+        ) -> Result<OrganizationMember, OrganizationError> {
+            unimplemented!()
+        }
+        async fn remove_member_validated(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: UserId,
+        ) -> Result<bool, OrganizationError> {
+            unimplemented!()
+        }
+        async fn create_invitations(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: Vec<(String, MemberRole)>,
+            _: i64,
+        ) -> Result<BatchInvitationResponse, OrganizationError> {
+            unimplemented!()
+        }
+        async fn list_user_invitations(
+            &self,
+            _: &str,
+        ) -> Result<Vec<OrganizationInvitation>, OrganizationError> {
+            unimplemented!()
+        }
+        async fn get_invitation_by_token(
+            &self,
+            _: &str,
+        ) -> Result<OrganizationInvitation, OrganizationError> {
+            unimplemented!()
+        }
+        async fn accept_invitation_by_token(
+            &self,
+            _: &str,
+            _: UserId,
+            _: &str,
+        ) -> Result<OrganizationMember, OrganizationError> {
+            unimplemented!()
+        }
+        async fn accept_invitation(
+            &self,
+            _: Uuid,
+            _: UserId,
+            _: &str,
+        ) -> Result<OrganizationMember, OrganizationError> {
+            unimplemented!()
+        }
+        async fn decline_invitation(&self, _: Uuid, _: &str) -> Result<(), OrganizationError> {
+            unimplemented!()
+        }
+        async fn list_organization_invitations(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: Option<InvitationStatus>,
+        ) -> Result<Vec<OrganizationInvitation>, OrganizationError> {
+            unimplemented!()
+        }
+        async fn get_system_prompt(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+        ) -> Result<Option<String>, OrganizationError> {
+            unimplemented!()
+        }
+        async fn update_system_prompt(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: Option<String>,
+        ) -> Result<Option<String>, OrganizationError> {
+            unimplemented!()
+        }
+    }
+
+    fn build_auth_service(user_repo: Arc<MockUserRepo>) -> AuthService {
+        let bloom = Bloom::new_for_fp_rate(100, 0.01).expect("bloom filter creation failed");
+        AuthService {
+            user_repository: user_repo,
+            session_repository: Arc::new(StubSessionRepo),
+            api_key_repository: Arc::new(StubApiKeyRepo),
+            organization_repository: Arc::new(StubOrgRepo),
+            workspace_repository: Arc::new(StubWorkspaceRepo),
+            organization_service: Arc::new(StubOrgService),
+            api_key_cache: moka::future::Cache::builder().build(),
+            api_key_bloom_filter: Arc::new(RwLock::new(bloom)),
+            bloom_filter_ready: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_returning_user_matched_by_provider_identity() {
+        let existing = make_user("alice@example.com", "google");
+        let repo = Arc::new(MockUserRepo::with_user(existing.clone()));
+        let service = build_auth_service(repo.clone());
+
+        let result = service
+            .get_or_create_oauth_user(OAuthUserInfo {
+                provider: "google".to_string(),
+                provider_user_id: "google-sub-123".to_string(),
+                email: "alice@example.com".to_string(),
+                username: "alice".to_string(),
+                display_name: Some("Test User".to_string()),
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, existing.id);
+        assert!(*repo.last_login_updated.lock().unwrap());
+        assert!(repo.email_updated.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_returning_user_email_changed_updates_email() {
+        let existing = make_user("old@example.com", "google");
+        let repo = Arc::new(MockUserRepo::with_user(existing.clone()));
+        let service = build_auth_service(repo.clone());
+
+        let result = service
+            .get_or_create_oauth_user(OAuthUserInfo {
+                provider: "google".to_string(),
+                provider_user_id: "google-sub-456".to_string(),
+                email: "new@example.com".to_string(),
+                username: "new".to_string(),
+                display_name: Some("Test User".to_string()),
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, existing.id);
+        assert!(*repo.last_login_updated.lock().unwrap());
+        assert_eq!(
+            *repo.email_updated.lock().unwrap(),
+            Some("new@example.com".to_string())
+        );
     }
 }

--- a/crates/services/src/auth/ports.rs
+++ b/crates/services/src/auth/ports.rs
@@ -169,6 +169,14 @@ pub trait UserRepository: Send + Sync {
 
     async fn get_by_email(&self, email: &str) -> anyhow::Result<Option<User>>;
 
+    async fn get_by_provider(
+        &self,
+        auth_provider: &str,
+        provider_user_id: &str,
+    ) -> anyhow::Result<Option<User>>;
+
+    async fn update_email(&self, id: UserId, email: String) -> anyhow::Result<()>;
+
     async fn update(
         &self,
         id: UserId,


### PR DESCRIPTION
## Summary
- **Fixes** #547 — Google SSO fails with "Cannot add this resource as it already exists" when a user changes their primary email on the same Google account
- Changed `get_or_create_oauth_user` to identify returning users by `(auth_provider, provider_user_id)` instead of email — the stable identity from the OAuth provider
- If the provider returns a changed email, it is updated on the existing user record
- Email is no longer used for returning-user matching, which also prevents silent account merging across different providers (e.g., GitHub user won't be silently merged with a Google user sharing the same email)
- Added `get_by_provider` and `update_email` to the `UserRepository` trait and database implementation
- Added unit tests for the provider-identity lookup and email-update paths

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -D warnings` passes
- [x] 224 unit tests pass (`cargo test --lib --bins`)
- [x] 441 e2e tests pass (`cargo test --test e2e_all`); 1 pre-existing flaky failure (`rerank::test_rerank_costs_deducted_correctly`) unrelated to this change
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)