### PR TITLE
Add Resend organization invitation email notifications

### DIFF
--- a/crates/api/src/conversions.rs
+++ b/crates/api/src/conversions.rs
@@ -600,8 +600,10 @@ pub fn services_invitation_result_to_api(
     crate::models::InvitationResult {
         email: result.email,
         success: result.success,
+        email_sent: result.email_sent,
         member: result.member.map(services_member_to_api_member),
         error: result.error,
+        email_error: result.email_error,
     }
 }
 
@@ -625,6 +627,25 @@ pub fn services_invitation_status_to_api(
     }
 }
 
+pub fn services_invitation_email_status_to_api(
+    status: services::organization::InvitationEmailStatus,
+) -> crate::models::InvitationEmailStatus {
+    match status {
+        services::organization::InvitationEmailStatus::NotAttempted => {
+            crate::models::InvitationEmailStatus::NotAttempted
+        }
+        services::organization::InvitationEmailStatus::Sent => {
+            crate::models::InvitationEmailStatus::Sent
+        }
+        services::organization::InvitationEmailStatus::Failed => {
+            crate::models::InvitationEmailStatus::Failed
+        }
+        services::organization::InvitationEmailStatus::Skipped => {
+            crate::models::InvitationEmailStatus::Skipped
+        }
+    }
+}
+
 /// Convert services OrganizationInvitation to API OrganizationInvitationResponse
 pub fn services_invitation_to_api(
     invitation: services::organization::OrganizationInvitation,
@@ -639,6 +660,10 @@ pub fn services_invitation_to_api(
         created_at: invitation.created_at,
         expires_at: invitation.expires_at,
         responded_at: invitation.responded_at,
+        email_status: services_invitation_email_status_to_api(invitation.email_status),
+        email_sent_at: invitation.email_sent_at,
+        email_last_error: invitation.email_last_error,
+        email_message_id: invitation.email_message_id,
     }
 }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -137,13 +137,21 @@ pub fn init_auth_services(database: Arc<Database>, config: &ApiConfig) -> AuthCo
         database.pool().clone(),
     ))
         as Arc<dyn services::organization::ports::OrganizationInvitationRepository>;
+    let email_sender = services::email::sender_from_config(&config.invitation_email)
+        .expect("Failed to initialize invitation email sender");
+    let invitations_url = config.invitation_email.invitations_url();
 
     // Create organization service early (needed by AuthService)
-    let organization_service = Arc::new(services::organization::OrganizationServiceImpl::new(
-        organization_repo.clone() as Arc<dyn services::organization::ports::OrganizationRepository>,
-        user_repository.clone(),
-        invitation_repo,
-    ))
+    let organization_service = Arc::new(
+        services::organization::OrganizationServiceImpl::new_with_email_sender(
+            organization_repo.clone()
+                as Arc<dyn services::organization::ports::OrganizationRepository>,
+            user_repository.clone(),
+            invitation_repo,
+            email_sender,
+            invitations_url,
+        ),
+    )
         as Arc<dyn services::organization::OrganizationServiceTrait + Send + Sync>;
 
     let auth_service: Arc<dyn AuthServiceTrait> = if config.auth.mock {
@@ -1593,6 +1601,7 @@ mod tests {
                 encryption_key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                     .to_string(), // Mock 256-bit hex key
             },
+            invitation_email: config::InvitationEmailConfig::default(),
             otlp: config::OtlpConfig {
                 endpoint: "http://localhost:4317".to_string(),
                 protocol: "grpc".to_string(),
@@ -1691,6 +1700,7 @@ mod tests {
                 encryption_key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                     .to_string(), // Mock 256-bit hex key
             },
+            invitation_email: config::InvitationEmailConfig::default(),
             otlp: config::OtlpConfig {
                 endpoint: "http://localhost:4317".to_string(),
                 protocol: "grpc".to_string(),

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -2152,10 +2152,13 @@ pub struct OrganizationSettingsResponse {
 pub struct InvitationResult {
     pub email: String,
     pub success: bool,
+    pub email_sent: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<OrganizationMemberResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email_error: Option<String>,
 }
 
 /// Response for batch invitation requests
@@ -2472,6 +2475,15 @@ pub enum InvitationStatus {
     Expired,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InvitationEmailStatus {
+    NotAttempted,
+    Sent,
+    Failed,
+    Skipped,
+}
+
 /// Organization invitation response
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct OrganizationInvitationResponse {
@@ -2484,6 +2496,10 @@ pub struct OrganizationInvitationResponse {
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
     pub responded_at: Option<DateTime<Utc>>,
+    pub email_status: InvitationEmailStatus,
+    pub email_sent_at: Option<DateTime<Utc>>,
+    pub email_last_error: Option<String>,
+    pub email_message_id: Option<String>,
 }
 
 /// Organization invitation with organization details

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -191,6 +191,7 @@ use utoipa::{Modify, OpenApi};
             MemberRole,
             // Organization Invitation models
             InvitationStatus,
+            InvitationEmailStatus,
             OrganizationInvitationResponse,
             OrganizationInvitationWithOrgResponse,
             AcceptInvitationResponse,

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -101,6 +101,7 @@ pub fn test_config() -> ApiConfig {
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string()
             }),
         },
+        invitation_email: config::InvitationEmailConfig::default(),
         otlp: config::OtlpConfig {
             endpoint: std::env::var("TELEMETRY_OTLP_ENDPOINT")
                 .unwrap_or_else(|_| "http://localhost:4317".to_string()),

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -428,7 +428,11 @@ impl InvitationEmailConfig {
 
         let from_email = non_empty_env("INVITATION_EMAIL_FROM");
         let reply_to = non_empty_env("INVITATION_EMAIL_REPLY_TO");
-        let resend_api_key = read_optional_secret_env("RESEND_API_KEY_FILE", "RESEND_API_KEY")?;
+        let resend_api_key = if enabled {
+            read_optional_secret_env("RESEND_API_KEY_FILE", "RESEND_API_KEY")?
+        } else {
+            None
+        };
         let frontend_base_url = non_empty_env("CLOUD_UI_BASE_URL");
 
         if enabled {
@@ -630,6 +634,19 @@ mod tests {
         assert!(config.from_email.is_none());
         assert!(config.resend_api_key.is_none());
         assert!(config.invitations_url().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_invitation_email_config_does_not_read_resend_key_file_when_disabled() {
+        clear_invitation_email_env();
+        std::env::set_var("RESEND_API_KEY_FILE", "/missing/resend-api-key");
+
+        let config = InvitationEmailConfig::from_env().unwrap();
+
+        assert!(!config.enabled);
+        assert!(config.resend_api_key.is_none());
+        clear_invitation_email_env();
     }
 
     #[test]

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -10,6 +10,7 @@ pub struct ApiConfig {
     pub auth: AuthConfig,
     pub database: DatabaseConfig,
     pub s3: S3Config,
+    pub invitation_email: InvitationEmailConfig,
     pub otlp: OtlpConfig,
     pub cors: CorsConfig,
     pub external_providers: ExternalProvidersConfig,
@@ -28,6 +29,7 @@ impl ApiConfig {
             auth: AuthConfig::from_env()?,
             database: DatabaseConfig::from_env()?,
             s3: S3Config::from_env()?,
+            invitation_email: InvitationEmailConfig::from_env()?,
             otlp: OtlpConfig::from_env()?,
             cors: CorsConfig::default(),
             external_providers: ExternalProvidersConfig::from_env(),
@@ -407,6 +409,86 @@ impl S3Config {
     }
 }
 
+/// Email notification configuration for organization invitations.
+#[derive(Debug, Clone, Default)]
+pub struct InvitationEmailConfig {
+    pub enabled: bool,
+    pub from_email: Option<String>,
+    pub reply_to: Option<String>,
+    pub resend_api_key: Option<String>,
+    pub frontend_base_url: Option<String>,
+}
+
+impl InvitationEmailConfig {
+    pub fn from_env() -> Result<Self, String> {
+        let enabled = env::var("INVITATION_EMAIL_ENABLED")
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false);
+
+        let from_email = non_empty_env("INVITATION_EMAIL_FROM");
+        let reply_to = non_empty_env("INVITATION_EMAIL_REPLY_TO");
+        let resend_api_key = read_optional_secret_env("RESEND_API_KEY_FILE", "RESEND_API_KEY")?;
+        let frontend_base_url = non_empty_env("CLOUD_UI_BASE_URL");
+
+        if enabled {
+            if from_email.is_none() {
+                return Err(
+                    "INVITATION_EMAIL_FROM must be set when INVITATION_EMAIL_ENABLED=true"
+                        .to_string(),
+                );
+            }
+            if resend_api_key.is_none() {
+                return Err(
+                    "RESEND_API_KEY or RESEND_API_KEY_FILE must be set when INVITATION_EMAIL_ENABLED=true"
+                        .to_string(),
+                );
+            }
+            if frontend_base_url.is_none() {
+                return Err(
+                    "CLOUD_UI_BASE_URL must be set when INVITATION_EMAIL_ENABLED=true".to_string(),
+                );
+            }
+        }
+
+        Ok(Self {
+            enabled,
+            from_email,
+            reply_to,
+            resend_api_key,
+            frontend_base_url,
+        })
+    }
+
+    pub fn invitations_url(&self) -> Option<String> {
+        self.frontend_base_url
+            .as_ref()
+            .map(|base_url| format!("{}/dashboard/invitations", base_url.trim_end_matches('/')))
+    }
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn read_optional_secret_env(file_key: &str, value_key: &str) -> Result<Option<String>, String> {
+    if let Some(path) = non_empty_env(file_key) {
+        let value = std::fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read {file_key}: {e}"))?
+            .trim()
+            .to_string();
+        if value.is_empty() {
+            return Err(format!("{file_key} cannot be empty"));
+        }
+        return Ok(Some(value));
+    }
+
+    Ok(non_empty_env(value_key))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -535,6 +617,107 @@ mod tests {
         assert_eq!(config.exact_matches.len(), 1);
         assert_eq!(config.wildcard_suffixes.len(), 1);
         std::env::remove_var("CORS_ALLOWED_ORIGINS");
+    }
+
+    #[test]
+    #[serial]
+    fn test_invitation_email_config_defaults_disabled() {
+        clear_invitation_email_env();
+
+        let config = InvitationEmailConfig::from_env().unwrap();
+
+        assert!(!config.enabled);
+        assert!(config.from_email.is_none());
+        assert!(config.resend_api_key.is_none());
+        assert!(config.invitations_url().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_invitation_email_config_requires_from_when_enabled() {
+        clear_invitation_email_env();
+        std::env::set_var("INVITATION_EMAIL_ENABLED", "true");
+        std::env::set_var("CLOUD_UI_BASE_URL", "https://cloud.example.com");
+
+        let error = InvitationEmailConfig::from_env().unwrap_err();
+
+        assert!(error.contains("INVITATION_EMAIL_FROM"));
+        clear_invitation_email_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invitation_email_config_requires_resend_api_key_when_enabled() {
+        clear_invitation_email_env();
+        std::env::set_var("INVITATION_EMAIL_ENABLED", "true");
+        std::env::set_var("INVITATION_EMAIL_FROM", "no-reply@example.com");
+        std::env::set_var("CLOUD_UI_BASE_URL", "https://cloud.example.com");
+
+        let error = InvitationEmailConfig::from_env().unwrap_err();
+
+        assert!(error.contains("RESEND_API_KEY"));
+        clear_invitation_email_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invitation_email_config_requires_frontend_url_when_enabled() {
+        clear_invitation_email_env();
+        std::env::set_var("INVITATION_EMAIL_ENABLED", "true");
+        std::env::set_var("INVITATION_EMAIL_FROM", "no-reply@example.com");
+        std::env::set_var("RESEND_API_KEY", "re_test");
+
+        let error = InvitationEmailConfig::from_env().unwrap_err();
+
+        assert!(error.contains("CLOUD_UI_BASE_URL"));
+        clear_invitation_email_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invitation_email_config_builds_inbox_url() {
+        clear_invitation_email_env();
+        std::env::set_var("INVITATION_EMAIL_ENABLED", "true");
+        std::env::set_var("INVITATION_EMAIL_FROM", "no-reply@example.com");
+        std::env::set_var("RESEND_API_KEY", "re_test");
+        std::env::set_var("CLOUD_UI_BASE_URL", "https://cloud.example.com/");
+
+        let config = InvitationEmailConfig::from_env().unwrap();
+
+        assert_eq!(config.resend_api_key.as_deref(), Some("re_test"));
+        assert_eq!(
+            config.invitations_url().as_deref(),
+            Some("https://cloud.example.com/dashboard/invitations")
+        );
+        clear_invitation_email_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invitation_email_config_reads_resend_api_key_file() {
+        clear_invitation_email_env();
+        let path =
+            std::env::temp_dir().join(format!("cloud-api-resend-key-{}", std::process::id()));
+        std::fs::write(&path, " re_file_test \n").unwrap();
+        std::env::set_var("INVITATION_EMAIL_ENABLED", "true");
+        std::env::set_var("INVITATION_EMAIL_FROM", "no-reply@example.com");
+        std::env::set_var("RESEND_API_KEY_FILE", &path);
+        std::env::set_var("CLOUD_UI_BASE_URL", "https://cloud.example.com/");
+
+        let config = InvitationEmailConfig::from_env().unwrap();
+
+        assert_eq!(config.resend_api_key.as_deref(), Some("re_file_test"));
+        clear_invitation_email_env();
+        std::fs::remove_file(path).unwrap();
+    }
+
+    fn clear_invitation_email_env() {
+        std::env::remove_var("INVITATION_EMAIL_ENABLED");
+        std::env::remove_var("INVITATION_EMAIL_FROM");
+        std::env::remove_var("INVITATION_EMAIL_REPLY_TO");
+        std::env::remove_var("RESEND_API_KEY");
+        std::env::remove_var("RESEND_API_KEY_FILE");
+        std::env::remove_var("CLOUD_UI_BASE_URL");
     }
 }
 

--- a/crates/database/src/migrations/sql/V0049__add_invitation_email_delivery.sql
+++ b/crates/database/src/migrations/sql/V0049__add_invitation_email_delivery.sql
@@ -1,0 +1,13 @@
+ALTER TABLE organization_invitations
+    ADD COLUMN email_status VARCHAR(50) NOT NULL DEFAULT 'not_attempted'
+        CHECK (email_status IN ('not_attempted', 'sent', 'failed', 'skipped')),
+    ADD COLUMN email_sent_at TIMESTAMPTZ,
+    ADD COLUMN email_last_error TEXT,
+    ADD COLUMN email_message_id VARCHAR(255);
+
+CREATE INDEX idx_org_invitations_email_status ON organization_invitations(email_status);
+
+COMMENT ON COLUMN organization_invitations.email_status IS 'Email delivery status: not_attempted, sent, failed, or skipped';
+COMMENT ON COLUMN organization_invitations.email_sent_at IS 'Timestamp when invitation email was successfully sent';
+COMMENT ON COLUMN organization_invitations.email_last_error IS 'Sanitized last email delivery error, if delivery failed';
+COMMENT ON COLUMN organization_invitations.email_message_id IS 'Provider message ID returned after successful delivery';

--- a/crates/database/src/models.rs
+++ b/crates/database/src/models.rs
@@ -62,6 +62,10 @@ pub struct OrganizationInvitation {
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
     pub responded_at: Option<DateTime<Utc>>,
+    pub email_status: InvitationEmailStatus,
+    pub email_sent_at: Option<DateTime<Utc>>,
+    pub email_last_error: Option<String>,
+    pub email_message_id: Option<String>,
 }
 
 /// Invitation status
@@ -81,6 +85,27 @@ impl std::fmt::Display for InvitationStatus {
             InvitationStatus::Accepted => write!(f, "accepted"),
             InvitationStatus::Declined => write!(f, "declined"),
             InvitationStatus::Expired => write!(f, "expired"),
+        }
+    }
+}
+
+/// Email delivery status for organization invitations
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum InvitationEmailStatus {
+    NotAttempted,
+    Sent,
+    Failed,
+    Skipped,
+}
+
+impl std::fmt::Display for InvitationEmailStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvitationEmailStatus::NotAttempted => write!(f, "not_attempted"),
+            InvitationEmailStatus::Sent => write!(f, "sent"),
+            InvitationEmailStatus::Failed => write!(f, "failed"),
+            InvitationEmailStatus::Skipped => write!(f, "skipped"),
         }
     }
 }

--- a/crates/database/src/repositories/organization_invitation.rs
+++ b/crates/database/src/repositories/organization_invitation.rs
@@ -1,4 +1,6 @@
-use crate::models::{InvitationStatus, OrganizationInvitation, OrganizationRole};
+use crate::models::{
+    InvitationEmailStatus, InvitationStatus, OrganizationInvitation, OrganizationRole,
+};
 use crate::pool::DbPool;
 use crate::repositories::utils::map_db_error;
 use crate::retry_db;
@@ -7,8 +9,9 @@ use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use services::common::RepositoryError;
 use services::organization::ports::{
-    CreateInvitationRequest, InvitationStatus as ServicesInvitationStatus,
-    OrganizationInvitation as ServicesInvitation, OrganizationInvitationRepository,
+    CreateInvitationRequest, InvitationEmailStatus as ServicesInvitationEmailStatus,
+    InvitationStatus as ServicesInvitationStatus, OrganizationInvitation as ServicesInvitation,
+    OrganizationInvitationRepository,
 };
 use tracing::debug;
 use uuid::Uuid;
@@ -30,12 +33,8 @@ impl PgOrganizationInvitationRepository {
             OrganizationRole::Member => services::organization::MemberRole::Member,
         };
 
-        let status = match db_inv.status {
-            InvitationStatus::Pending => ServicesInvitationStatus::Pending,
-            InvitationStatus::Accepted => ServicesInvitationStatus::Accepted,
-            InvitationStatus::Declined => ServicesInvitationStatus::Declined,
-            InvitationStatus::Expired => ServicesInvitationStatus::Expired,
-        };
+        let status = self.db_to_domain_status(db_inv.status);
+        let email_status = self.db_to_domain_email_status(db_inv.email_status);
 
         Ok(ServicesInvitation {
             id: db_inv.id,
@@ -48,7 +47,53 @@ impl PgOrganizationInvitationRepository {
             created_at: db_inv.created_at,
             expires_at: db_inv.expires_at,
             responded_at: db_inv.responded_at,
+            email_status,
+            email_sent_at: db_inv.email_sent_at,
+            email_last_error: db_inv.email_last_error,
+            email_message_id: db_inv.email_message_id,
         })
+    }
+
+    fn row_to_db_invitation(&self, row: &tokio_postgres::Row) -> Result<OrganizationInvitation> {
+        Ok(OrganizationInvitation {
+            id: row.get("id"),
+            organization_id: row.get("organization_id"),
+            email: row.get("email"),
+            role: serde_json::from_value(serde_json::json!(row.get::<_, String>("role")))?,
+            invited_by_user_id: row.get("invited_by_user_id"),
+            status: serde_json::from_value(serde_json::json!(row.get::<_, String>("status")))?,
+            token: row.get("token"),
+            created_at: row.get("created_at"),
+            expires_at: row.get("expires_at"),
+            responded_at: row.get("responded_at"),
+            email_status: serde_json::from_value(serde_json::json!(
+                row.get::<_, String>("email_status")
+            ))?,
+            email_sent_at: row.get("email_sent_at"),
+            email_last_error: row.get("email_last_error"),
+            email_message_id: row.get("email_message_id"),
+        })
+    }
+
+    fn db_to_domain_status(&self, status: InvitationStatus) -> ServicesInvitationStatus {
+        match status {
+            InvitationStatus::Pending => ServicesInvitationStatus::Pending,
+            InvitationStatus::Accepted => ServicesInvitationStatus::Accepted,
+            InvitationStatus::Declined => ServicesInvitationStatus::Declined,
+            InvitationStatus::Expired => ServicesInvitationStatus::Expired,
+        }
+    }
+
+    fn db_to_domain_email_status(
+        &self,
+        status: InvitationEmailStatus,
+    ) -> ServicesInvitationEmailStatus {
+        match status {
+            InvitationEmailStatus::NotAttempted => ServicesInvitationEmailStatus::NotAttempted,
+            InvitationEmailStatus::Sent => ServicesInvitationEmailStatus::Sent,
+            InvitationEmailStatus::Failed => ServicesInvitationEmailStatus::Failed,
+            InvitationEmailStatus::Skipped => ServicesInvitationEmailStatus::Skipped,
+        }
     }
 
     /// Convert domain role to database role
@@ -128,7 +173,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
                      (organization_id, email, role, invited_by_user_id, token, expires_at)
                      VALUES ($1, $2, $3, $4, $5, $6)
                      RETURNING id, organization_id, email, role, invited_by_user_id, status, token,
-                               created_at, expires_at, responded_at",
+                               created_at, expires_at, responded_at, email_status, email_sent_at,
+                               email_last_error, email_message_id",
                     &[
                         &org_id,
                         &request.email,
@@ -142,18 +188,7 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
                 .map_err(map_db_error)
         })?;
 
-        let db_inv = OrganizationInvitation {
-            id: row.get("id"),
-            organization_id: row.get("organization_id"),
-            email: row.get("email"),
-            role: serde_json::from_value(serde_json::json!(row.get::<_, String>("role")))?,
-            invited_by_user_id: row.get("invited_by_user_id"),
-            status: serde_json::from_value(serde_json::json!(row.get::<_, String>("status")))?,
-            token: row.get("token"),
-            created_at: row.get("created_at"),
-            expires_at: row.get("expires_at"),
-            responded_at: row.get("responded_at"),
-        };
+        let db_inv = self.row_to_db_invitation(&row)?;
 
         self.db_to_domain(db_inv)
     }
@@ -170,7 +205,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
             client
                 .query_opt(
                     "SELECT id, organization_id, email, role, invited_by_user_id, status, token,
-                            created_at, expires_at, responded_at
+                            created_at, expires_at, responded_at, email_status, email_sent_at,
+                            email_last_error, email_message_id
                      FROM organization_invitations
                      WHERE id = $1",
                     &[&id],
@@ -181,20 +217,7 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
 
         match row {
             Some(r) => {
-                let db_inv = OrganizationInvitation {
-                    id: r.get("id"),
-                    organization_id: r.get("organization_id"),
-                    email: r.get("email"),
-                    role: serde_json::from_value(serde_json::json!(r.get::<_, String>("role")))?,
-                    invited_by_user_id: r.get("invited_by_user_id"),
-                    status: serde_json::from_value(
-                        serde_json::json!(r.get::<_, String>("status")),
-                    )?,
-                    token: r.get("token"),
-                    created_at: r.get("created_at"),
-                    expires_at: r.get("expires_at"),
-                    responded_at: r.get("responded_at"),
-                };
+                let db_inv = self.row_to_db_invitation(&r)?;
                 Ok(Some(self.db_to_domain(db_inv)?))
             }
             None => Ok(None),
@@ -213,7 +236,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
             client
                 .query_opt(
                     "SELECT id, organization_id, email, role, invited_by_user_id, status, token,
-                            created_at, expires_at, responded_at
+                            created_at, expires_at, responded_at, email_status, email_sent_at,
+                            email_last_error, email_message_id
                      FROM organization_invitations
                      WHERE token = $1",
                     &[&token],
@@ -224,20 +248,7 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
 
         match row {
             Some(r) => {
-                let db_inv = OrganizationInvitation {
-                    id: r.get("id"),
-                    organization_id: r.get("organization_id"),
-                    email: r.get("email"),
-                    role: serde_json::from_value(serde_json::json!(r.get::<_, String>("role")))?,
-                    invited_by_user_id: r.get("invited_by_user_id"),
-                    status: serde_json::from_value(
-                        serde_json::json!(r.get::<_, String>("status")),
-                    )?,
-                    token: r.get("token"),
-                    created_at: r.get("created_at"),
-                    expires_at: r.get("expires_at"),
-                    responded_at: r.get("responded_at"),
-                };
+                let db_inv = self.row_to_db_invitation(&r)?;
                 Ok(Some(self.db_to_domain(db_inv)?))
             }
             None => Ok(None),
@@ -263,7 +274,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
                 client
                     .query(
                         "SELECT id, organization_id, email, role, invited_by_user_id, status, token,
-                                created_at, expires_at, responded_at
+                            created_at, expires_at, responded_at, email_status, email_sent_at,
+                            email_last_error, email_message_id
                          FROM organization_invitations
                          WHERE organization_id = $1 AND status = $2
                          ORDER BY created_at DESC",
@@ -275,7 +287,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
                 client
                     .query(
                         "SELECT id, organization_id, email, role, invited_by_user_id, status, token,
-                                created_at, expires_at, responded_at
+                            created_at, expires_at, responded_at, email_status, email_sent_at,
+                            email_last_error, email_message_id
                          FROM organization_invitations
                          WHERE organization_id = $1
                          ORDER BY created_at DESC",
@@ -288,18 +301,7 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
 
         let mut invitations = Vec::new();
         for r in rows {
-            let db_inv = OrganizationInvitation {
-                id: r.get("id"),
-                organization_id: r.get("organization_id"),
-                email: r.get("email"),
-                role: serde_json::from_value(serde_json::json!(r.get::<_, String>("role")))?,
-                invited_by_user_id: r.get("invited_by_user_id"),
-                status: serde_json::from_value(serde_json::json!(r.get::<_, String>("status")))?,
-                token: r.get("token"),
-                created_at: r.get("created_at"),
-                expires_at: r.get("expires_at"),
-                responded_at: r.get("responded_at"),
-            };
+            let db_inv = self.row_to_db_invitation(&r)?;
             invitations.push(self.db_to_domain(db_inv)?);
         }
 
@@ -325,7 +327,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
                 client
                     .query(
                         "SELECT id, organization_id, email, role, invited_by_user_id, status, token,
-                                created_at, expires_at, responded_at
+                            created_at, expires_at, responded_at, email_status, email_sent_at,
+                            email_last_error, email_message_id
                          FROM organization_invitations
                          WHERE email = $1 AND status = $2
                          ORDER BY created_at DESC",
@@ -337,7 +340,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
                 client
                     .query(
                         "SELECT id, organization_id, email, role, invited_by_user_id, status, token,
-                                created_at, expires_at, responded_at
+                            created_at, expires_at, responded_at, email_status, email_sent_at,
+                            email_last_error, email_message_id
                          FROM organization_invitations
                          WHERE email = $1
                          ORDER BY created_at DESC",
@@ -350,18 +354,7 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
 
         let mut invitations = Vec::new();
         for r in rows {
-            let db_inv = OrganizationInvitation {
-                id: r.get("id"),
-                organization_id: r.get("organization_id"),
-                email: r.get("email"),
-                role: serde_json::from_value(serde_json::json!(r.get::<_, String>("role")))?,
-                invited_by_user_id: r.get("invited_by_user_id"),
-                status: serde_json::from_value(serde_json::json!(r.get::<_, String>("status")))?,
-                token: r.get("token"),
-                created_at: r.get("created_at"),
-                expires_at: r.get("expires_at"),
-                responded_at: r.get("responded_at"),
-            };
+            let db_inv = self.row_to_db_invitation(&r)?;
             invitations.push(self.db_to_domain(db_inv)?);
         }
 
@@ -389,26 +382,110 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
                      SET status = $1, responded_at = NOW()
                      WHERE id = $2
                      RETURNING id, organization_id, email, role, invited_by_user_id, status, token,
-                               created_at, expires_at, responded_at",
+                               created_at, expires_at, responded_at, email_status, email_sent_at,
+                               email_last_error, email_message_id",
                     &[&db_status.to_string(), &id],
                 )
                 .await
                 .map_err(map_db_error)
         })?;
 
-        let db_inv = OrganizationInvitation {
-            id: row.get("id"),
-            organization_id: row.get("organization_id"),
-            email: row.get("email"),
-            role: serde_json::from_value(serde_json::json!(row.get::<_, String>("role")))?,
-            invited_by_user_id: row.get("invited_by_user_id"),
-            status: serde_json::from_value(serde_json::json!(row.get::<_, String>("status")))?,
-            token: row.get("token"),
-            created_at: row.get("created_at"),
-            expires_at: row.get("expires_at"),
-            responded_at: row.get("responded_at"),
-        };
+        let db_inv = self.row_to_db_invitation(&row)?;
 
+        self.db_to_domain(db_inv)
+    }
+
+    async fn record_email_sent(
+        &self,
+        id: Uuid,
+        message_id: Option<String>,
+    ) -> Result<ServicesInvitation> {
+        let row = retry_db!("record_organization_invitation_email_sent", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_one(
+                    "UPDATE organization_invitations
+                     SET email_status = 'sent',
+                         email_sent_at = NOW(),
+                         email_last_error = NULL,
+                         email_message_id = $2
+                     WHERE id = $1
+                     RETURNING id, organization_id, email, role, invited_by_user_id, status, token,
+                               created_at, expires_at, responded_at, email_status, email_sent_at,
+                               email_last_error, email_message_id",
+                    &[&id, &message_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        let db_inv = self.row_to_db_invitation(&row)?;
+        self.db_to_domain(db_inv)
+    }
+
+    async fn record_email_failed(&self, id: Uuid, error: String) -> Result<ServicesInvitation> {
+        let row = retry_db!("record_organization_invitation_email_failed", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_one(
+                    "UPDATE organization_invitations
+                     SET email_status = 'failed',
+                         email_sent_at = NULL,
+                         email_last_error = $2,
+                         email_message_id = NULL
+                     WHERE id = $1
+                     RETURNING id, organization_id, email, role, invited_by_user_id, status, token,
+                               created_at, expires_at, responded_at, email_status, email_sent_at,
+                               email_last_error, email_message_id",
+                    &[&id, &error],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        let db_inv = self.row_to_db_invitation(&row)?;
+        self.db_to_domain(db_inv)
+    }
+
+    async fn record_email_skipped(&self, id: Uuid) -> Result<ServicesInvitation> {
+        let row = retry_db!("record_organization_invitation_email_skipped", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_one(
+                    "UPDATE organization_invitations
+                     SET email_status = 'skipped',
+                         email_sent_at = NULL,
+                         email_last_error = NULL,
+                         email_message_id = NULL
+                     WHERE id = $1
+                     RETURNING id, organization_id, email, role, invited_by_user_id, status, token,
+                               created_at, expires_at, responded_at, email_status, email_sent_at,
+                               email_last_error, email_message_id",
+                    &[&id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        let db_inv = self.row_to_db_invitation(&row)?;
         self.db_to_domain(db_inv)
     }
 

--- a/crates/services/src/email.rs
+++ b/crates/services/src/email.rs
@@ -1,0 +1,510 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use config::InvitationEmailConfig;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+const RESEND_EMAILS_URL: &str = "https://api.resend.com/emails";
+
+#[derive(Debug, Clone)]
+pub struct InvitationEmail {
+    pub recipient_email: String,
+    pub organization_name: String,
+    pub role: String,
+    pub inviter_name: Option<String>,
+    pub inviter_email: Option<String>,
+    pub expires_at: DateTime<Utc>,
+    pub invitations_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmailDeliveryOutcome {
+    Sent { message_id: Option<String> },
+    Skipped,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
+pub struct EmailError {
+    message: String,
+}
+
+impl EmailError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    pub fn sanitized_message(&self) -> String {
+        sanitize_error(&self.message)
+    }
+}
+
+#[async_trait]
+pub trait EmailSender: Send + Sync {
+    async fn send_invitation(
+        &self,
+        email: &InvitationEmail,
+    ) -> Result<EmailDeliveryOutcome, EmailError>;
+}
+
+pub struct NoopEmailSender;
+
+#[async_trait]
+impl EmailSender for NoopEmailSender {
+    async fn send_invitation(
+        &self,
+        _email: &InvitationEmail,
+    ) -> Result<EmailDeliveryOutcome, EmailError> {
+        Ok(EmailDeliveryOutcome::Skipped)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ResendSendEmailRequest {
+    from: String,
+    to: Vec<String>,
+    subject: String,
+    html: String,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reply_to: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct ResendSendEmailResponse {
+    id: String,
+}
+
+#[async_trait]
+trait ResendTransport: Send + Sync {
+    async fn send_email(
+        &self,
+        api_key: &str,
+        request: ResendSendEmailRequest,
+    ) -> Result<ResendSendEmailResponse, EmailError>;
+}
+
+#[derive(Clone)]
+struct ReqwestResendTransport {
+    client: reqwest::Client,
+    endpoint: String,
+}
+
+impl Default for ReqwestResendTransport {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            endpoint: RESEND_EMAILS_URL.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl ResendTransport for ReqwestResendTransport {
+    async fn send_email(
+        &self,
+        api_key: &str,
+        request: ResendSendEmailRequest,
+    ) -> Result<ResendSendEmailResponse, EmailError> {
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .bearer_auth(api_key)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|err| EmailError::new(format!("Resend send_email request failed: {err}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(EmailError::new(resend_error_message(status, &body)));
+        }
+
+        response
+            .json::<ResendSendEmailResponse>()
+            .await
+            .map_err(|err| EmailError::new(format!("Failed to parse Resend response: {err}")))
+    }
+}
+
+#[derive(Clone)]
+pub struct ResendEmailSender {
+    from_email: String,
+    reply_to: Option<String>,
+    api_key: String,
+    transport: Arc<dyn ResendTransport>,
+}
+
+impl ResendEmailSender {
+    pub fn new(config: &InvitationEmailConfig) -> Result<Self, EmailError> {
+        let from_email = config.from_email.clone().ok_or_else(|| {
+            EmailError::new("INVITATION_EMAIL_FROM is required for Resend invitation email sending")
+        })?;
+        let api_key = config.resend_api_key.clone().ok_or_else(|| {
+            EmailError::new("RESEND_API_KEY is required for Resend invitation email sending")
+        })?;
+
+        Ok(Self::new_with_transport(
+            from_email,
+            config.reply_to.clone(),
+            api_key,
+            Arc::new(ReqwestResendTransport::default()),
+        ))
+    }
+
+    fn new_with_transport(
+        from_email: String,
+        reply_to: Option<String>,
+        api_key: String,
+        transport: Arc<dyn ResendTransport>,
+    ) -> Self {
+        Self {
+            from_email,
+            reply_to,
+            api_key,
+            transport,
+        }
+    }
+}
+
+#[async_trait]
+impl EmailSender for ResendEmailSender {
+    async fn send_invitation(
+        &self,
+        email: &InvitationEmail,
+    ) -> Result<EmailDeliveryOutcome, EmailError> {
+        let rendered = render_invitation_email(email);
+        let request = ResendSendEmailRequest {
+            from: self.from_email.clone(),
+            to: vec![email.recipient_email.clone()],
+            subject: rendered.subject,
+            html: rendered.html_body,
+            text: rendered.text_body,
+            reply_to: self.reply_to.clone(),
+        };
+        let response = self.transport.send_email(&self.api_key, request).await?;
+
+        Ok(EmailDeliveryOutcome::Sent {
+            message_id: Some(response.id),
+        })
+    }
+}
+
+pub fn sender_from_config(
+    config: &InvitationEmailConfig,
+) -> Result<Arc<dyn EmailSender>, EmailError> {
+    if config.enabled {
+        Ok(Arc::new(ResendEmailSender::new(config)?))
+    } else {
+        Ok(Arc::new(NoopEmailSender))
+    }
+}
+
+fn resend_error_message(status: reqwest::StatusCode, body: &str) -> String {
+    let detail = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .or_else(|| value.get("error"))
+                .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        })
+        .or_else(|| {
+            let body = body.trim();
+            if body.is_empty() {
+                None
+            } else {
+                Some(body.to_string())
+            }
+        })
+        .unwrap_or_else(|| "empty response body".to_string());
+
+    format!("Resend send_email failed with status {status}: {detail}")
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderedEmail {
+    pub subject: String,
+    pub html_body: String,
+    pub text_body: String,
+}
+
+pub fn render_invitation_email(email: &InvitationEmail) -> RenderedEmail {
+    let organization_name = email.organization_name.trim();
+    let organization_name = if organization_name.is_empty() {
+        "an organization"
+    } else {
+        organization_name
+    };
+    let role = email.role.trim();
+    let role = if role.is_empty() { "member" } else { role };
+    let inviter = invitation_sender_name(email);
+    let expires_at = email.expires_at.format("%B %-d, %Y at %H:%M UTC");
+    let subject = format!("You’ve been invited to join {organization_name} on NEAR AI Cloud");
+
+    let html_body = format!(
+        r#"<!doctype html>
+<html lang="en">
+  <body style="font-family:Arial,sans-serif;line-height:1.5;color:#111827;">
+    <h1 style="font-size:20px;margin-bottom:16px;">You’ve been invited to NEAR AI Cloud</h1>
+    <p>{inviter} invited you to join <strong>{organization}</strong> as <strong>{role}</strong>.</p>
+    <p>This invitation expires on {expires_at}.</p>
+    <p style="margin:24px 0;">
+      <a href="{url}" style="background:#111827;color:#ffffff;padding:12px 18px;text-decoration:none;border-radius:6px;display:inline-block;">View invitation</a>
+    </p>
+    <p>If the button does not work, open this link:</p>
+    <p><a href="{url}">{url}</a></p>
+  </body>
+</html>"#,
+        inviter = escape_html(&inviter),
+        organization = escape_html(organization_name),
+        role = escape_html(role),
+        expires_at = escape_html(&expires_at.to_string()),
+        url = escape_html(&email.invitations_url),
+    );
+
+    let text_body = format!(
+        "You’ve been invited to NEAR AI Cloud\n\n{inviter} invited you to join {organization_name} as {role}.\n\nThis invitation expires on {expires_at}.\n\nView invitation: {url}\n",
+        url = email.invitations_url,
+    );
+
+    RenderedEmail {
+        subject,
+        html_body,
+        text_body,
+    }
+}
+
+fn invitation_sender_name(email: &InvitationEmail) -> String {
+    if let Some(name) = email
+        .inviter_name
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        return name.to_string();
+    }
+
+    if let Some(email) = email
+        .inviter_email
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        return email.to_string();
+    }
+
+    "A team admin".to_string()
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+pub fn sanitize_error(message: &str) -> String {
+    const MAX_LEN: usize = 1000;
+    let collapsed = message.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if collapsed.chars().count() <= MAX_LEN {
+        return collapsed;
+    }
+
+    let mut truncated = collapsed.chars().take(MAX_LEN).collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::sync::Mutex;
+
+    struct StubResendTransport {
+        outcome: Result<ResendSendEmailResponse, EmailError>,
+        requests: Mutex<Vec<(String, ResendSendEmailRequest)>>,
+    }
+
+    #[async_trait]
+    impl ResendTransport for StubResendTransport {
+        async fn send_email(
+            &self,
+            api_key: &str,
+            request: ResendSendEmailRequest,
+        ) -> Result<ResendSendEmailResponse, EmailError> {
+            self.requests
+                .lock()
+                .unwrap()
+                .push((api_key.to_string(), request));
+            self.outcome.clone()
+        }
+    }
+
+    fn example_invitation_email() -> InvitationEmail {
+        InvitationEmail {
+            recipient_email: "invitee@example.com".to_string(),
+            organization_name: "Example Org".to_string(),
+            role: "admin".to_string(),
+            inviter_name: Some("Alice".to_string()),
+            inviter_email: Some("alice@example.com".to_string()),
+            expires_at: Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap(),
+            invitations_url: "https://cloud.example.com/dashboard/invitations".to_string(),
+        }
+    }
+
+    #[test]
+    fn render_invitation_email_includes_expected_content() {
+        let email = example_invitation_email();
+
+        let rendered = render_invitation_email(&email);
+
+        assert!(rendered.subject.contains("Example Org"));
+        assert!(rendered.html_body.contains("Alice"));
+        assert!(rendered.html_body.contains("Example Org"));
+        assert!(rendered.html_body.contains("admin"));
+        assert!(rendered
+            .html_body
+            .contains("https://cloud.example.com/dashboard/invitations"));
+        assert!(rendered.text_body.contains("May 15, 2026"));
+    }
+
+    #[test]
+    fn render_invitation_email_escapes_html() {
+        let email = InvitationEmail {
+            recipient_email: "invitee@example.com".to_string(),
+            organization_name: "<Org>".to_string(),
+            role: "member".to_string(),
+            inviter_name: Some("Alice & Bob".to_string()),
+            inviter_email: None,
+            expires_at: Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap(),
+            invitations_url: "https://cloud.example.com/dashboard/invitations".to_string(),
+        };
+
+        let rendered = render_invitation_email(&email);
+
+        assert!(rendered.html_body.contains("&lt;Org&gt;"));
+        assert!(rendered.html_body.contains("Alice &amp; Bob"));
+    }
+
+    #[test]
+    fn sanitize_error_removes_newlines_and_truncates() {
+        let message = format!("line one\n{}", "x".repeat(1100));
+
+        let sanitized = sanitize_error(&message);
+
+        assert!(!sanitized.contains('\n'));
+        assert!(sanitized.ends_with('…'));
+    }
+
+    #[tokio::test]
+    async fn resend_sender_builds_payload_and_returns_message_id() {
+        let transport = Arc::new(StubResendTransport {
+            outcome: Ok(ResendSendEmailResponse {
+                id: "email-id".to_string(),
+            }),
+            requests: Mutex::new(Vec::new()),
+        });
+        let sender = ResendEmailSender::new_with_transport(
+            "NEAR AI Cloud <no-reply@near.ai>".to_string(),
+            Some("support@near.ai".to_string()),
+            "re_test".to_string(),
+            transport.clone(),
+        );
+
+        let result = sender
+            .send_invitation(&example_invitation_email())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            EmailDeliveryOutcome::Sent {
+                message_id: Some("email-id".to_string())
+            }
+        );
+        let requests = transport.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let (api_key, request) = &requests[0];
+        assert_eq!(api_key, "re_test");
+        assert_eq!(request.from, "NEAR AI Cloud <no-reply@near.ai>");
+        assert_eq!(request.to, vec!["invitee@example.com"]);
+        assert_eq!(request.reply_to.as_deref(), Some("support@near.ai"));
+        assert!(request.subject.contains("Example Org"));
+        assert!(request.html.contains("View invitation"));
+        assert!(request
+            .text
+            .contains("https://cloud.example.com/dashboard/invitations"));
+    }
+
+    #[tokio::test]
+    async fn resend_sender_propagates_transport_error() {
+        let transport = Arc::new(StubResendTransport {
+            outcome: Err(EmailError::new("Resend failed\nwith details")),
+            requests: Mutex::new(Vec::new()),
+        });
+        let sender = ResendEmailSender::new_with_transport(
+            "NEAR AI Cloud <no-reply@near.ai>".to_string(),
+            None,
+            "re_test".to_string(),
+            transport,
+        );
+
+        let error = sender
+            .send_invitation(&example_invitation_email())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.sanitized_message(), "Resend failed with details");
+    }
+
+    #[test]
+    fn resend_error_message_extracts_json_message() {
+        let message = resend_error_message(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"{"name":"validation_error","message":"domain is not verified"}"#,
+        );
+
+        assert_eq!(
+            message,
+            "Resend send_email failed with status 403 Forbidden: domain is not verified"
+        );
+    }
+
+    #[tokio::test]
+    async fn sender_from_config_uses_noop_when_disabled() {
+        let sender = sender_from_config(&InvitationEmailConfig::default()).unwrap();
+
+        let outcome = sender
+            .send_invitation(&example_invitation_email())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, EmailDeliveryOutcome::Skipped);
+    }
+
+    #[test]
+    fn resend_sender_requires_api_key() {
+        let config = InvitationEmailConfig {
+            enabled: true,
+            from_email: Some("NEAR AI Cloud <no-reply@near.ai>".to_string()),
+            reply_to: None,
+            resend_api_key: None,
+            frontend_base_url: Some("https://cloud.example.com".to_string()),
+        };
+
+        let error = match ResendEmailSender::new(&config) {
+            Ok(_) => panic!("expected missing Resend API key to fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.sanitized_message().contains("RESEND_API_KEY"));
+    }
+}

--- a/crates/services/src/email.rs
+++ b/crates/services/src/email.rs
@@ -2,9 +2,10 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use config::InvitationEmailConfig;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 const RESEND_EMAILS_URL: &str = "https://api.resend.com/emails";
+const RESEND_SEND_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Clone)]
 pub struct InvitationEmail {
@@ -108,14 +109,22 @@ impl ResendTransport for ReqwestResendTransport {
         api_key: &str,
         request: ResendSendEmailRequest,
     ) -> Result<ResendSendEmailResponse, EmailError> {
-        let response = self
-            .client
-            .post(&self.endpoint)
-            .bearer_auth(api_key)
-            .json(&request)
-            .send()
-            .await
-            .map_err(|err| EmailError::new(format!("Resend send_email request failed: {err}")))?;
+        let response = tokio::time::timeout(
+            RESEND_SEND_TIMEOUT,
+            self.client
+                .post(&self.endpoint)
+                .bearer_auth(api_key)
+                .json(&request)
+                .send(),
+        )
+        .await
+        .map_err(|_| {
+            EmailError::new(format!(
+                "Resend send_email timed out after {} seconds",
+                RESEND_SEND_TIMEOUT.as_secs()
+            ))
+        })?
+        .map_err(|err| EmailError::new(format!("Resend send_email request failed: {err}")))?;
 
         let status = response.status();
         if !status.is_success() {

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auto_redact;
 pub mod common;
 pub mod completions;
 pub mod conversations;
+pub mod email;
 pub mod files;
 pub mod id_prefixes;
 pub mod inference_provider_pool;

--- a/crates/services/src/organization/mod.rs
+++ b/crates/services/src/organization/mod.rs
@@ -15,6 +15,12 @@ pub struct OrganizationServiceImpl {
     invitations_url: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct InvitationSenderDetails {
+    name: Option<String>,
+    email: Option<String>,
+}
+
 impl OrganizationServiceImpl {
     pub fn new(
         repository: Arc<dyn OrganizationRepository>,
@@ -709,8 +715,8 @@ impl OrganizationServiceImpl {
     async fn send_invitation_email(
         &self,
         org: &Organization,
-        requester_id: UserId,
         invitation: &ports::OrganizationInvitation,
+        sender_details: &InvitationSenderDetails,
     ) -> (bool, Option<String>) {
         let Some(invitations_url) = self.invitations_url.clone() else {
             match self
@@ -728,26 +734,12 @@ impl OrganizationServiceImpl {
             return (false, None);
         };
 
-        let inviter = self.user_repository.get_by_id(requester_id.clone()).await;
-        let (inviter_name, inviter_email) = match inviter {
-            Ok(Some(user)) => (user.display_name.or(Some(user.username)), Some(user.email)),
-            Ok(None) => (None, None),
-            Err(err) => {
-                tracing::warn!(
-                    invitation_id = %invitation.id,
-                    inviter_id = %requester_id.0,
-                    "Failed to load inviter details for invitation email: {err}"
-                );
-                (None, None)
-            }
-        };
-
         let email = InvitationEmail {
             recipient_email: invitation.email.clone(),
             organization_name: org.name.clone(),
             role: invitation.role.to_string(),
-            inviter_name,
-            inviter_email,
+            inviter_name: sender_details.name.clone(),
+            inviter_email: sender_details.email.clone(),
             expires_at: invitation.expires_at,
             invitations_url,
         };
@@ -802,6 +794,26 @@ impl OrganizationServiceImpl {
         }
     }
 
+    async fn load_invitation_sender_details(
+        &self,
+        requester_id: &UserId,
+    ) -> InvitationSenderDetails {
+        match self.user_repository.get_by_id(requester_id.clone()).await {
+            Ok(Some(user)) => InvitationSenderDetails {
+                name: user.display_name.or(Some(user.username)),
+                email: Some(user.email),
+            },
+            Ok(None) => InvitationSenderDetails::default(),
+            Err(err) => {
+                tracing::warn!(
+                    inviter_id = %requester_id.0,
+                    "Failed to load inviter details for invitation email: {err}"
+                );
+                InvitationSenderDetails::default()
+            }
+        }
+    }
+
     /// Create invitations for users (supports unregistered users, private helper)
     async fn create_invitations_impl(
         &self,
@@ -833,6 +845,11 @@ impl OrganizationServiceImpl {
         let mut results = Vec::new();
         let mut successful = 0;
         let mut failed = 0;
+        let sender_details = if self.invitations_url.is_some() {
+            self.load_invitation_sender_details(&requester_id).await
+        } else {
+            InvitationSenderDetails::default()
+        };
 
         for (email, role) in invitations {
             // Check if user is already a member
@@ -869,7 +886,7 @@ impl OrganizationServiceImpl {
             {
                 Ok(invitation) => {
                     let (email_sent, email_error) = self
-                        .send_invitation_email(&org, requester_id.clone(), &invitation)
+                        .send_invitation_email(&org, &invitation, &sender_details)
                         .await;
                     successful += 1;
                     results.push(ports::InvitationResult {
@@ -1581,6 +1598,7 @@ mod tests {
 
     struct StubUserRepo {
         inviter: User,
+        get_by_id_calls: Mutex<usize>,
     }
 
     #[async_trait]
@@ -1608,6 +1626,7 @@ mod tests {
         }
 
         async fn get_by_id(&self, _: UserId) -> anyhow::Result<Option<User>> {
+            *self.get_by_id_calls.lock().unwrap() += 1;
             Ok(Some(self.inviter.clone()))
         }
 
@@ -1809,6 +1828,7 @@ mod tests {
         OrganizationServiceImpl,
         Arc<StubInvitationRepo>,
         Arc<StubEmailSender>,
+        Arc<StubUserRepo>,
     ) {
         let owner_id = UserId(Uuid::new_v4());
         let org_id = OrganizationId(Uuid::new_v4());
@@ -1843,20 +1863,24 @@ mod tests {
             outcome,
             sent_to: Mutex::new(Vec::new()),
         });
+        let user_repo = Arc::new(StubUserRepo {
+            inviter,
+            get_by_id_calls: Mutex::new(0),
+        });
         let service = OrganizationServiceImpl::new_with_email_sender(
             Arc::new(StubOrgRepo { org }) as Arc<dyn OrganizationRepository>,
-            Arc::new(StubUserRepo { inviter }) as Arc<dyn UserRepository>,
+            user_repo.clone() as Arc<dyn UserRepository>,
             invitation_repo.clone() as Arc<dyn OrganizationInvitationRepository>,
             email_sender.clone() as Arc<dyn EmailSender>,
             invitations_url,
         );
 
-        (service, invitation_repo, email_sender)
+        (service, invitation_repo, email_sender, user_repo)
     }
 
     #[tokio::test]
     async fn create_invitations_records_sent_email_status() {
-        let (service, invitation_repo, email_sender) = make_service(
+        let (service, invitation_repo, email_sender, user_repo) = make_service(
             Ok(EmailDeliveryOutcome::Sent {
                 message_id: Some("resend-email-id".to_string()),
             }),
@@ -1889,11 +1913,48 @@ mod tests {
         let stored = invitation_repo.records.lock().unwrap()[0].clone();
         assert_eq!(stored.email_status, InvitationEmailStatus::Sent);
         assert_eq!(stored.email_message_id.as_deref(), Some("resend-email-id"));
+        assert_eq!(*user_repo.get_by_id_calls.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn create_invitations_loads_inviter_once_for_batch() {
+        let (service, _, email_sender, user_repo) = make_service(
+            Ok(EmailDeliveryOutcome::Sent {
+                message_id: Some("resend-email-id".to_string()),
+            }),
+            Some("https://cloud.example.com/dashboard/invitations".to_string()),
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let response = service
+            .create_invitations(
+                org.id,
+                org.owner_id,
+                vec![
+                    ("one@example.com".to_string(), MemberRole::Admin),
+                    ("two@example.com".to_string(), MemberRole::Member),
+                ],
+                168,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.successful, 2);
+        assert_eq!(
+            email_sender.sent_to.lock().unwrap().as_slice(),
+            &["one@example.com".to_string(), "two@example.com".to_string()]
+        );
+        assert_eq!(*user_repo.get_by_id_calls.lock().unwrap(), 1);
     }
 
     #[tokio::test]
     async fn create_invitations_keeps_invite_when_email_fails() {
-        let (service, invitation_repo, _) = make_service(
+        let (service, invitation_repo, _, _) = make_service(
             Err(EmailError::new("Resend failed\nwith details")),
             Some("https://cloud.example.com/dashboard/invitations".to_string()),
         );
@@ -1931,7 +1992,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_invitations_skips_email_without_invitations_url() {
-        let (service, invitation_repo, email_sender) = make_service(
+        let (service, invitation_repo, email_sender, user_repo) = make_service(
             Ok(EmailDeliveryOutcome::Sent {
                 message_id: Some("resend-email-id".to_string()),
             }),
@@ -1960,5 +2021,6 @@ mod tests {
         assert!(email_sender.sent_to.lock().unwrap().is_empty());
         let stored = invitation_repo.records.lock().unwrap()[0].clone();
         assert_eq!(stored.email_status, InvitationEmailStatus::Skipped);
+        assert_eq!(*user_repo.get_by_id_calls.lock().unwrap(), 0);
     }
 }

--- a/crates/services/src/organization/mod.rs
+++ b/crates/services/src/organization/mod.rs
@@ -1,6 +1,7 @@
 pub mod ports;
 use super::auth::ports::{UserId, UserRepository};
 use super::common::RepositoryError;
+use crate::email::{EmailDeliveryOutcome, EmailSender, InvitationEmail, NoopEmailSender};
 use anyhow::Result;
 use async_trait::async_trait;
 pub use ports::*;
@@ -10,6 +11,8 @@ pub struct OrganizationServiceImpl {
     repository: Arc<dyn OrganizationRepository>,
     user_repository: Arc<dyn UserRepository>,
     invitation_repository: Arc<dyn ports::OrganizationInvitationRepository>,
+    email_sender: Arc<dyn EmailSender>,
+    invitations_url: Option<String>,
 }
 
 impl OrganizationServiceImpl {
@@ -18,10 +21,28 @@ impl OrganizationServiceImpl {
         user_repository: Arc<dyn UserRepository>,
         invitation_repository: Arc<dyn ports::OrganizationInvitationRepository>,
     ) -> Self {
+        Self::new_with_email_sender(
+            repository,
+            user_repository,
+            invitation_repository,
+            Arc::new(NoopEmailSender),
+            None,
+        )
+    }
+
+    pub fn new_with_email_sender(
+        repository: Arc<dyn OrganizationRepository>,
+        user_repository: Arc<dyn UserRepository>,
+        invitation_repository: Arc<dyn ports::OrganizationInvitationRepository>,
+        email_sender: Arc<dyn EmailSender>,
+        invitations_url: Option<String>,
+    ) -> Self {
         Self {
             repository,
             user_repository,
             invitation_repository,
+            email_sender,
+            invitations_url,
         }
     }
 
@@ -502,6 +523,8 @@ impl OrganizationServiceImpl {
                                 success: true,
                                 member: Some(member),
                                 error: None,
+                                email_sent: false,
+                                email_error: None,
                             });
                         }
                         Err(e) => {
@@ -516,6 +539,8 @@ impl OrganizationServiceImpl {
                                 success: false,
                                 member: None,
                                 error: Some(error_msg),
+                                email_sent: false,
+                                email_error: None,
                             });
                         }
                     }
@@ -527,6 +552,8 @@ impl OrganizationServiceImpl {
                         success: false,
                         member: None,
                         error: Some("User not found".to_string()),
+                        email_sent: false,
+                        email_error: None,
                     });
                 }
                 Err(e) => {
@@ -536,6 +563,8 @@ impl OrganizationServiceImpl {
                         success: false,
                         member: None,
                         error: Some(format!("Failed to lookup user: {e}")),
+                        email_sent: false,
+                        email_error: None,
                     });
                 }
             }
@@ -677,6 +706,102 @@ impl OrganizationServiceImpl {
             .map_err(Self::map_repository_error)
     }
 
+    async fn send_invitation_email(
+        &self,
+        org: &Organization,
+        requester_id: UserId,
+        invitation: &ports::OrganizationInvitation,
+    ) -> (bool, Option<String>) {
+        let Some(invitations_url) = self.invitations_url.clone() else {
+            match self
+                .invitation_repository
+                .record_email_skipped(invitation.id)
+                .await
+            {
+                Ok(_) => {}
+                Err(err) => tracing::warn!(
+                    invitation_id = %invitation.id,
+                    organization_id = %invitation.organization_id.0,
+                    "Failed to record skipped invitation email status: {err}"
+                ),
+            }
+            return (false, None);
+        };
+
+        let inviter = self.user_repository.get_by_id(requester_id.clone()).await;
+        let (inviter_name, inviter_email) = match inviter {
+            Ok(Some(user)) => (user.display_name.or(Some(user.username)), Some(user.email)),
+            Ok(None) => (None, None),
+            Err(err) => {
+                tracing::warn!(
+                    invitation_id = %invitation.id,
+                    inviter_id = %requester_id.0,
+                    "Failed to load inviter details for invitation email: {err}"
+                );
+                (None, None)
+            }
+        };
+
+        let email = InvitationEmail {
+            recipient_email: invitation.email.clone(),
+            organization_name: org.name.clone(),
+            role: invitation.role.to_string(),
+            inviter_name,
+            inviter_email,
+            expires_at: invitation.expires_at,
+            invitations_url,
+        };
+
+        match self.email_sender.send_invitation(&email).await {
+            Ok(EmailDeliveryOutcome::Sent { message_id }) => {
+                match self
+                    .invitation_repository
+                    .record_email_sent(invitation.id, message_id)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(err) => tracing::warn!(
+                        invitation_id = %invitation.id,
+                        organization_id = %invitation.organization_id.0,
+                        "Failed to record sent invitation email status: {err}"
+                    ),
+                }
+                (true, None)
+            }
+            Ok(EmailDeliveryOutcome::Skipped) => {
+                match self
+                    .invitation_repository
+                    .record_email_skipped(invitation.id)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(err) => tracing::warn!(
+                        invitation_id = %invitation.id,
+                        organization_id = %invitation.organization_id.0,
+                        "Failed to record skipped invitation email status: {err}"
+                    ),
+                }
+                (false, None)
+            }
+            Err(err) => {
+                let sanitized_error = err.sanitized_message();
+                match self
+                    .invitation_repository
+                    .record_email_failed(invitation.id, sanitized_error.clone())
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(record_err) => tracing::warn!(
+                        invitation_id = %invitation.id,
+                        organization_id = %invitation.organization_id.0,
+                        "Failed to record failed invitation email status: {record_err}"
+                    ),
+                }
+                (false, Some(sanitized_error))
+            }
+        }
+    }
+
     /// Create invitations for users (supports unregistered users, private helper)
     async fn create_invitations_impl(
         &self,
@@ -723,6 +848,8 @@ impl OrganizationServiceImpl {
                         success: false,
                         member: None,
                         error: Some("User is already a member".to_string()),
+                        email_sent: false,
+                        email_error: None,
                     });
                     continue;
                 }
@@ -740,13 +867,18 @@ impl OrganizationServiceImpl {
                 .create(organization_id.0, request, requester_id.0)
                 .await
             {
-                Ok(_invitation) => {
+                Ok(invitation) => {
+                    let (email_sent, email_error) = self
+                        .send_invitation_email(&org, requester_id.clone(), &invitation)
+                        .await;
                     successful += 1;
                     results.push(ports::InvitationResult {
                         email,
                         success: true,
                         member: None,
                         error: None,
+                        email_sent,
+                        email_error,
                     });
                 }
                 Err(e) => {
@@ -756,6 +888,8 @@ impl OrganizationServiceImpl {
                         success: false,
                         member: None,
                         error: Some(format!("Failed to create invitation: {e}")),
+                        email_sent: false,
+                        email_error: None,
                     });
                 }
             }
@@ -1341,5 +1475,490 @@ impl OrganizationServiceTrait for OrganizationServiceImpl {
             .map_err(Self::map_repository_error)?;
 
         Ok(system_prompt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::ports::{User, UserRole};
+    use crate::email::{EmailDeliveryOutcome, EmailError};
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    struct StubOrgRepo {
+        org: Organization,
+    }
+
+    #[async_trait]
+    impl OrganizationRepository for StubOrgRepo {
+        async fn create(
+            &self,
+            _: CreateOrganizationRequest,
+            _: Uuid,
+        ) -> Result<Organization, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn get_by_id(&self, _: Uuid) -> Result<Option<Organization>, RepositoryError> {
+            Ok(Some(self.org.clone()))
+        }
+
+        async fn get_by_name(&self, _: &str) -> Result<Option<Organization>, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn get_member(
+            &self,
+            _: Uuid,
+            _: Uuid,
+        ) -> Result<Option<OrganizationMember>, RepositoryError> {
+            Ok(None)
+        }
+
+        async fn update(
+            &self,
+            _: Uuid,
+            _: UpdateOrganizationRequest,
+        ) -> Result<Organization, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn delete(&self, _: Uuid) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn add_member(
+            &self,
+            _: Uuid,
+            _: AddOrganizationMemberRequest,
+            _: Uuid,
+        ) -> Result<OrganizationMember, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn update_member(
+            &self,
+            _: Uuid,
+            _: Uuid,
+            _: UpdateOrganizationMemberRequest,
+        ) -> Result<OrganizationMember, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn remove_member(&self, _: Uuid, _: Uuid) -> Result<bool, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn list_members_paginated(
+            &self,
+            _: Uuid,
+            _: i64,
+            _: i64,
+        ) -> Result<Vec<OrganizationMember>, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn get_member_count(&self, _: Uuid) -> Result<i64, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn count_organizations_by_user(&self, _: Uuid) -> Result<i64, RepositoryError> {
+            unimplemented!()
+        }
+
+        async fn list_organizations_by_user(
+            &self,
+            _: Uuid,
+            _: i64,
+            _: i64,
+            _: Option<OrganizationOrderBy>,
+            _: Option<OrganizationOrderDirection>,
+        ) -> Result<Vec<Organization>, RepositoryError> {
+            unimplemented!()
+        }
+    }
+
+    struct StubUserRepo {
+        inviter: User,
+    }
+
+    #[async_trait]
+    impl UserRepository for StubUserRepo {
+        async fn create(
+            &self,
+            _: String,
+            _: String,
+            _: Option<String>,
+            _: Option<String>,
+        ) -> anyhow::Result<User> {
+            unimplemented!()
+        }
+
+        async fn create_from_oauth(
+            &self,
+            _: String,
+            _: String,
+            _: Option<String>,
+            _: Option<String>,
+            _: String,
+            _: String,
+        ) -> anyhow::Result<User> {
+            unimplemented!()
+        }
+
+        async fn get_by_id(&self, _: UserId) -> anyhow::Result<Option<User>> {
+            Ok(Some(self.inviter.clone()))
+        }
+
+        async fn get_by_email(&self, _: &str) -> anyhow::Result<Option<User>> {
+            Ok(None)
+        }
+
+        async fn get_by_provider(&self, _: &str, _: &str) -> anyhow::Result<Option<User>> {
+            unimplemented!()
+        }
+
+        async fn update_email(&self, _: UserId, _: String) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+
+        async fn update(
+            &self,
+            _: UserId,
+            _: Option<String>,
+            _: Option<String>,
+        ) -> anyhow::Result<Option<User>> {
+            unimplemented!()
+        }
+
+        async fn update_last_login(&self, _: UserId) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+
+        async fn update_tokens_revoked_at(&self, _: UserId) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+
+        async fn delete(&self, _: UserId) -> anyhow::Result<bool> {
+            unimplemented!()
+        }
+
+        async fn list(&self, _: i64, _: i64) -> anyhow::Result<Vec<User>> {
+            unimplemented!()
+        }
+    }
+
+    struct StubInvitationRepo {
+        records: Mutex<Vec<OrganizationInvitation>>,
+    }
+
+    impl StubInvitationRepo {
+        fn latest(&self, id: Uuid) -> OrganizationInvitation {
+            self.records
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|invitation| invitation.id == id)
+                .unwrap()
+                .clone()
+        }
+
+        fn update_email_status(
+            &self,
+            id: Uuid,
+            email_status: InvitationEmailStatus,
+            email_last_error: Option<String>,
+            email_message_id: Option<String>,
+        ) -> OrganizationInvitation {
+            let mut records = self.records.lock().unwrap();
+            let invitation = records
+                .iter_mut()
+                .find(|invitation| invitation.id == id)
+                .unwrap();
+            invitation.email_status = email_status;
+            invitation.email_sent_at = if invitation.email_status == InvitationEmailStatus::Sent {
+                Some(chrono::Utc::now())
+            } else {
+                None
+            };
+            invitation.email_last_error = email_last_error;
+            invitation.email_message_id = email_message_id;
+            invitation.clone()
+        }
+    }
+
+    #[async_trait]
+    impl OrganizationInvitationRepository for StubInvitationRepo {
+        async fn create(
+            &self,
+            org_id: Uuid,
+            request: CreateInvitationRequest,
+            invited_by: Uuid,
+        ) -> anyhow::Result<OrganizationInvitation> {
+            let invitation = OrganizationInvitation {
+                id: Uuid::new_v4(),
+                organization_id: OrganizationId(org_id),
+                email: request.email,
+                role: request.role,
+                invited_by_user_id: UserId(invited_by),
+                status: InvitationStatus::Pending,
+                token: "token".to_string(),
+                created_at: chrono::Utc::now(),
+                expires_at: chrono::Utc::now() + chrono::Duration::hours(request.expires_in_hours),
+                responded_at: None,
+                email_status: InvitationEmailStatus::NotAttempted,
+                email_sent_at: None,
+                email_last_error: None,
+                email_message_id: None,
+            };
+            self.records.lock().unwrap().push(invitation.clone());
+            Ok(invitation)
+        }
+
+        async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<OrganizationInvitation>> {
+            Ok(Some(self.latest(id)))
+        }
+
+        async fn get_by_token(&self, _: &str) -> anyhow::Result<Option<OrganizationInvitation>> {
+            unimplemented!()
+        }
+
+        async fn list_by_organization(
+            &self,
+            _: Uuid,
+            _: Option<InvitationStatus>,
+        ) -> anyhow::Result<Vec<OrganizationInvitation>> {
+            unimplemented!()
+        }
+
+        async fn list_by_email(
+            &self,
+            _: &str,
+            _: Option<InvitationStatus>,
+        ) -> anyhow::Result<Vec<OrganizationInvitation>> {
+            unimplemented!()
+        }
+
+        async fn update_status(
+            &self,
+            id: Uuid,
+            status: InvitationStatus,
+        ) -> anyhow::Result<OrganizationInvitation> {
+            let mut records = self.records.lock().unwrap();
+            let invitation = records
+                .iter_mut()
+                .find(|invitation| invitation.id == id)
+                .unwrap();
+            invitation.status = status;
+            Ok(invitation.clone())
+        }
+
+        async fn record_email_sent(
+            &self,
+            id: Uuid,
+            message_id: Option<String>,
+        ) -> anyhow::Result<OrganizationInvitation> {
+            Ok(self.update_email_status(id, InvitationEmailStatus::Sent, None, message_id))
+        }
+
+        async fn record_email_failed(
+            &self,
+            id: Uuid,
+            error: String,
+        ) -> anyhow::Result<OrganizationInvitation> {
+            Ok(self.update_email_status(id, InvitationEmailStatus::Failed, Some(error), None))
+        }
+
+        async fn record_email_skipped(&self, id: Uuid) -> anyhow::Result<OrganizationInvitation> {
+            Ok(self.update_email_status(id, InvitationEmailStatus::Skipped, None, None))
+        }
+
+        async fn delete(&self, _: Uuid) -> anyhow::Result<bool> {
+            unimplemented!()
+        }
+
+        async fn mark_expired(&self) -> anyhow::Result<usize> {
+            unimplemented!()
+        }
+    }
+
+    struct StubEmailSender {
+        outcome: Result<EmailDeliveryOutcome, EmailError>,
+        sent_to: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl EmailSender for StubEmailSender {
+        async fn send_invitation(
+            &self,
+            email: &InvitationEmail,
+        ) -> Result<EmailDeliveryOutcome, EmailError> {
+            self.sent_to
+                .lock()
+                .unwrap()
+                .push(email.recipient_email.clone());
+            self.outcome.clone()
+        }
+    }
+
+    fn make_service(
+        outcome: Result<EmailDeliveryOutcome, EmailError>,
+        invitations_url: Option<String>,
+    ) -> (
+        OrganizationServiceImpl,
+        Arc<StubInvitationRepo>,
+        Arc<StubEmailSender>,
+    ) {
+        let owner_id = UserId(Uuid::new_v4());
+        let org_id = OrganizationId(Uuid::new_v4());
+        let org = Organization {
+            id: org_id,
+            name: "Example Org".to_string(),
+            description: None,
+            owner_id: owner_id.clone(),
+            settings: serde_json::json!({}),
+            is_active: true,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let inviter = User {
+            id: owner_id,
+            email: "owner@example.com".to_string(),
+            username: "owner".to_string(),
+            display_name: Some("Owner".to_string()),
+            avatar_url: None,
+            auth_provider: "test".to_string(),
+            role: UserRole::User,
+            is_active: true,
+            last_login: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            tokens_revoked_at: None,
+        };
+        let invitation_repo = Arc::new(StubInvitationRepo {
+            records: Mutex::new(Vec::new()),
+        });
+        let email_sender = Arc::new(StubEmailSender {
+            outcome,
+            sent_to: Mutex::new(Vec::new()),
+        });
+        let service = OrganizationServiceImpl::new_with_email_sender(
+            Arc::new(StubOrgRepo { org }) as Arc<dyn OrganizationRepository>,
+            Arc::new(StubUserRepo { inviter }) as Arc<dyn UserRepository>,
+            invitation_repo.clone() as Arc<dyn OrganizationInvitationRepository>,
+            email_sender.clone() as Arc<dyn EmailSender>,
+            invitations_url,
+        );
+
+        (service, invitation_repo, email_sender)
+    }
+
+    #[tokio::test]
+    async fn create_invitations_records_sent_email_status() {
+        let (service, invitation_repo, email_sender) = make_service(
+            Ok(EmailDeliveryOutcome::Sent {
+                message_id: Some("resend-email-id".to_string()),
+            }),
+            Some("https://cloud.example.com/dashboard/invitations".to_string()),
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let response = service
+            .create_invitations(
+                org.id,
+                org.owner_id,
+                vec![("invitee@example.com".to_string(), MemberRole::Admin)],
+                168,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.successful, 1);
+        assert!(response.results[0].email_sent);
+        assert_eq!(response.results[0].email_error, None);
+        assert_eq!(
+            email_sender.sent_to.lock().unwrap().as_slice(),
+            &["invitee@example.com".to_string()]
+        );
+        let stored = invitation_repo.records.lock().unwrap()[0].clone();
+        assert_eq!(stored.email_status, InvitationEmailStatus::Sent);
+        assert_eq!(stored.email_message_id.as_deref(), Some("resend-email-id"));
+    }
+
+    #[tokio::test]
+    async fn create_invitations_keeps_invite_when_email_fails() {
+        let (service, invitation_repo, _) = make_service(
+            Err(EmailError::new("Resend failed\nwith details")),
+            Some("https://cloud.example.com/dashboard/invitations".to_string()),
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let response = service
+            .create_invitations(
+                org.id,
+                org.owner_id,
+                vec![("invitee@example.com".to_string(), MemberRole::Member)],
+                168,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.successful, 1);
+        assert!(response.results[0].success);
+        assert!(!response.results[0].email_sent);
+        assert_eq!(
+            response.results[0].email_error.as_deref(),
+            Some("Resend failed with details")
+        );
+        let stored = invitation_repo.records.lock().unwrap()[0].clone();
+        assert_eq!(stored.email_status, InvitationEmailStatus::Failed);
+        assert_eq!(
+            stored.email_last_error.as_deref(),
+            Some("Resend failed with details")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_invitations_skips_email_without_invitations_url() {
+        let (service, invitation_repo, email_sender) = make_service(
+            Ok(EmailDeliveryOutcome::Sent {
+                message_id: Some("resend-email-id".to_string()),
+            }),
+            None,
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let response = service
+            .create_invitations(
+                org.id,
+                org.owner_id,
+                vec![("invitee@example.com".to_string(), MemberRole::Member)],
+                168,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.successful, 1);
+        assert!(!response.results[0].email_sent);
+        assert!(response.results[0].email_error.is_none());
+        assert!(email_sender.sent_to.lock().unwrap().is_empty());
+        let stored = invitation_repo.records.lock().unwrap()[0].clone();
+        assert_eq!(stored.email_status, InvitationEmailStatus::Skipped);
     }
 }

--- a/crates/services/src/organization/ports.rs
+++ b/crates/services/src/organization/ports.rs
@@ -72,6 +72,16 @@ impl MemberRole {
     }
 }
 
+impl std::fmt::Display for MemberRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemberRole::Owner => write!(f, "owner"),
+            MemberRole::Admin => write!(f, "admin"),
+            MemberRole::Member => write!(f, "member"),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum OrganizationError {
     #[error("Organization not found")]
@@ -138,6 +148,8 @@ pub struct InvitationResult {
     pub success: bool,
     pub member: Option<OrganizationMember>,
     pub error: Option<String>,
+    pub email_sent: bool,
+    pub email_error: Option<String>,
 }
 
 /// Batch invitation response
@@ -159,6 +171,16 @@ pub enum InvitationStatus {
     Expired,
 }
 
+/// Invitation email delivery status
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum InvitationEmailStatus {
+    NotAttempted,
+    Sent,
+    Failed,
+    Skipped,
+}
+
 /// Organization invitation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrganizationInvitation {
@@ -172,6 +194,10 @@ pub struct OrganizationInvitation {
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
     pub responded_at: Option<DateTime<Utc>>,
+    pub email_status: InvitationEmailStatus,
+    pub email_sent_at: Option<DateTime<Utc>>,
+    pub email_last_error: Option<String>,
+    pub email_message_id: Option<String>,
 }
 
 /// Create invitation request
@@ -295,6 +321,19 @@ pub trait OrganizationInvitationRepository: Send + Sync {
         id: Uuid,
         status: InvitationStatus,
     ) -> Result<OrganizationInvitation>;
+
+    /// Record a successful invitation email delivery
+    async fn record_email_sent(
+        &self,
+        id: Uuid,
+        message_id: Option<String>,
+    ) -> Result<OrganizationInvitation>;
+
+    /// Record a failed invitation email delivery
+    async fn record_email_failed(&self, id: Uuid, error: String) -> Result<OrganizationInvitation>;
+
+    /// Record a skipped invitation email delivery
+    async fn record_email_skipped(&self, id: Uuid) -> Result<OrganizationInvitation>;
 
     /// Delete invitation
     async fn delete(&self, id: Uuid) -> Result<bool>;

--- a/env.example
+++ b/env.example
@@ -130,6 +130,26 @@ S3_ENCRYPTION_KEY=your-hex-encoded-256-bit-encryption-key
 # S3_ENCRYPTION_KEY_FILE=/path/to/encryption-key-file
 
 # =============================================================================
+# Organization Invitation Email Notifications (Resend)
+# =============================================================================
+# Enable email delivery for organization invitations
+INVITATION_EMAIL_ENABLED=false
+
+# Verified Resend sender address used as the From address when enabled.
+# The sender domain must be verified in Resend before production delivery.
+# INVITATION_EMAIL_FROM="NEAR AI Cloud <no-reply@near.ai>"
+
+# Optional reply-to address
+# INVITATION_EMAIL_REPLY_TO=support@example.com
+
+# Resend API key. Prefer RESEND_API_KEY_FILE for deployed secrets.
+# RESEND_API_KEY=re_xxxxxxxxx
+# RESEND_API_KEY_FILE=/path/to/resend-api-key
+
+# Public frontend base URL used for invitation email links
+# CLOUD_UI_BASE_URL=https://cloud.near.ai
+
+# =============================================================================
 # Optional: Configuration Loading Mode
 # =============================================================================
 # Uncomment to explicitly use environment variables instead of config.yaml


### PR DESCRIPTION
## Summary
- send organization invitation emails through Resend when invitations are created
- persist invitation email delivery status, Resend email id, send timestamp, and sanitized errors
- expose email delivery fields in invitation API responses and document Resend env config

## Review follow-up
- added a 15s Resend send timeout so invitation requests do not hang indefinitely on email delivery
- hoisted inviter lookup out of the per-invitation loop so batch invites do one inviter query instead of N
- kept the email CTA pointed at the existing Cloud UI invitations inbox because `nearai-cloud-ui` does not currently expose a token landing page; linking to `/v1/invitations/{token}` would send users to API JSON rather than a usable UI

## Deployment notes
- set `INVITATION_EMAIL_ENABLED=true`, `INVITATION_EMAIL_FROM`, `RESEND_API_KEY_FILE` or `RESEND_API_KEY`, and `CLOUD_UI_BASE_URL`
- Resend rejected `NEAR AI Cloud <no-reply@near.ai>` in dev because the `near.ai` domain is not verified in that Resend account yet
- live smoke delivery to Pierre succeeded with Resend's test sender; email id `50b86c6f-1276-4b29-a977-b0f27594e3aa`

## Validation
- `cargo test -p services email --lib`
- `cargo test -p services create_invitations --lib`
- `cargo test -p config invitation_email`
- `cargo check -p services -p database -p api`
- `cargo test -p api --lib`
- `cargo test -p database --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## Follow-up issues
- Admin API oversight/resend: https://github.com/nearai/cloud-api/issues/578
- Admin UI oversight/resend: https://github.com/nearai/nearai-cloud-admin-ui/issues/34
