### PR TITLE
feat: add /v1/privacy/classify endpoint

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -19,7 +19,7 @@ use crate::{
         billing::{get_billing_costs, BillingRouteState},
         completions::{
             audio_transcriptions, chat_completions, embeddings, image_edits, image_generations,
-            models, rerank, score,
+            models, privacy_classify, rerank, score,
         },
         conversations,
         health::health_check,
@@ -978,6 +978,7 @@ pub fn build_completion_routes(
         .route("/rerank", post(rerank))
         .route("/embeddings", post(embeddings))
         .route("/score", post(score))
+        .route("/privacy/classify", post(privacy_classify))
         .layer(DefaultBodyLimit::max(AUDIO_TRANSCRIPTION_MAX_BODY_SIZE))
         .with_state(app_state.clone())
         .layer(from_fn_with_state(

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -649,6 +649,7 @@ pub async fn init_inference_providers_with_mocks(
         "Qwen/Qwen-Image-2512".to_string(),
         "Qwen/Qwen3-Reranker-0.6B".to_string(),
         "Qwen/Qwen3-Embedding-0.6B".to_string(),
+        "openai/privacy-filter".to_string(),
     ];
 
     let providers: Vec<(

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -55,6 +55,10 @@ use utoipa::OpenApi;
 // Audio transcription file size limit (25 MB for OpenAI Whisper API compatibility)
 const AUDIO_TRANSCRIPTION_MAX_BODY_SIZE: usize = 25 * 1024 * 1024; // 25 MB
 
+// Privacy classify input is text only, model context is small (e.g. 512 tokens).
+// Cap at 256 KB so the route doesn't inherit the 25 MB audio-transcription limit.
+const PRIVACY_CLASSIFY_MAX_BODY_SIZE: usize = 256 * 1024; // 256 KB
+
 /// Service initialization components
 #[derive(Clone)]
 pub struct AuthComponents {
@@ -979,7 +983,12 @@ pub fn build_completion_routes(
         .route("/rerank", post(rerank))
         .route("/embeddings", post(embeddings))
         .route("/score", post(score))
-        .route("/privacy/classify", post(privacy_classify))
+        // Override the router-level audio limit (25 MB) for privacy/classify: this is a
+        // text-only endpoint, so a 256 KB cap is more appropriate.
+        .route(
+            "/privacy/classify",
+            post(privacy_classify).layer(DefaultBodyLimit::max(PRIVACY_CLASSIFY_MAX_BODY_SIZE)),
+        )
         .layer(DefaultBodyLimit::max(AUDIO_TRANSCRIPTION_MAX_BODY_SIZE))
         .with_state(app_state.clone())
         .layer(from_fn_with_state(

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -23,6 +23,7 @@ use utoipa::{Modify, OpenApi};
         (name = "Audio", description = "Audio transcription endpoints"),
         (name = "Rerank", description = "Document reranking endpoints"),
         (name = "Score", description = "Text similarity scoring endpoints"),
+        (name = "Privacy", description = "Privacy classification (PII span detection) endpoints"),
         (name = "Models", description = "Public model catalog and information"),
         (name = "Conversations", description = "Conversation management"),
         (name = "Responses", description = "Response handling and streaming"),
@@ -48,6 +49,7 @@ use utoipa::{Modify, OpenApi};
         crate::routes::completions::image_edits,
         crate::routes::completions::rerank,
         crate::routes::completions::score,
+        crate::routes::completions::privacy_classify,
         // crate::routes::completions::completions,
         crate::routes::completions::models,
         // Model endpoints (public model catalog)

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -2362,6 +2362,314 @@ pub async fn embeddings(
     }
 }
 
+/// Privacy classification endpoint (passthrough)
+///
+/// Proxies privacy classification requests to a token-classification model
+/// (e.g. `openai/privacy-filter`) that returns PII spans with categories and scores.
+/// Only the `model` field is read from the request for routing; the rest is forwarded as-is.
+///
+/// These documentation-only types approximate the request and response bodies
+/// for OpenAPI schema generation. The runtime handler still accepts a raw
+/// `Bytes` body and forwards it transparently to the provider.
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+struct PrivacyClassifyRequestDoc {
+    /// ID of the model to use for privacy classification.
+    model: String,
+    /// Text or list of texts to classify. Either a string or array of strings.
+    #[serde(default)]
+    input: serde_json::Value,
+    /// Optional minimum confidence score for returned spans (0.0–1.0).
+    #[serde(default)]
+    threshold: Option<f64>,
+}
+
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+struct PrivacyClassifyResponseDoc {
+    /// Model identifier that produced the classification.
+    #[serde(default)]
+    model: String,
+    /// Per-input classification results; each entry contains `spans` and per-input `usage`.
+    #[serde(default)]
+    data: serde_json::Value,
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/privacy/classify",
+    tag = "Privacy",
+    request_body = PrivacyClassifyRequestDoc,
+    responses(
+        (status = 200, description = "Privacy classification completed successfully", body = PrivacyClassifyResponseDoc),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 404, description = "Model not found", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+        (status = 500, description = "Server error", body = ErrorResponse)
+    ),
+    security(
+        ("api_key" = [])
+    )
+)]
+pub async fn privacy_classify(
+    State(app_state): State<AppState>,
+    Extension(api_key): Extension<AuthenticatedApiKey>,
+    Extension(_body_hash): Extension<RequestBodyHash>,
+    headers: header::HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    // Minimal deserialization: extract only the model name for routing
+    #[derive(serde::Deserialize)]
+    struct ModelExtract {
+        model: String,
+    }
+
+    let model_name = match serde_json::from_slice::<ModelExtract>(&body) {
+        Ok(extract) => extract.model,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                ResponseJson(ErrorResponse::new(
+                    format!("Invalid request body: {e}"),
+                    "invalid_request_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    debug!(
+        "Privacy classify request: model={}, org={}, workspace={}",
+        model_name, api_key.organization.id, api_key.workspace.id.0
+    );
+
+    let model = match app_state
+        .models_service
+        .get_model_by_name(&model_name)
+        .await
+    {
+        Ok(model) => model,
+        Err(services::models::ModelsError::NotFound(_)) => {
+            return (
+                StatusCode::NOT_FOUND,
+                ResponseJson(ErrorResponse::new(
+                    format!("Model '{}' not found", model_name),
+                    "not_found_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to resolve model for privacy classify");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to resolve model".to_string(),
+                    "server_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+    let model_id = model.id;
+    let organization_id = api_key.organization.id.0;
+
+    let encryption_headers = match crate::routes::common::validate_encryption_headers(&headers) {
+        Ok(headers) => headers,
+        Err(err) => return err.into_response(),
+    };
+    let mut extra = std::collections::HashMap::new();
+    insert_encryption_headers(&encryption_headers, &mut extra);
+
+    match app_state
+        .completion_service
+        .try_privacy_classify(organization_id, model_id, &model_name, body, extra)
+        .await
+    {
+        Ok(response_bytes) => {
+            // Privacy filter response shape:
+            //   { "model": "...", "data": [{ "index": i, "spans": [...], "usage": { "input_tokens": N } }, ...] }
+            // Sum per-item input_tokens for billing.
+            #[derive(serde::Deserialize)]
+            struct UsageExtract {
+                #[serde(default)]
+                data: Vec<DataEntry>,
+            }
+            #[derive(serde::Deserialize)]
+            struct DataEntry {
+                #[serde(default)]
+                usage: Option<UsageFields>,
+            }
+            #[derive(serde::Deserialize)]
+            struct UsageFields {
+                input_tokens: Option<i32>,
+            }
+
+            let mut token_count = serde_json::from_slice::<UsageExtract>(&response_bytes)
+                .ok()
+                .map(|u| {
+                    u.data
+                        .into_iter()
+                        .filter_map(|d| d.usage.and_then(|x| x.input_tokens))
+                        .sum::<i32>()
+                })
+                .unwrap_or(0);
+
+            const MAX_REASONABLE_TOKENS: i32 = 1_000_000;
+            let mut token_anomaly_detected = false;
+
+            if token_count > MAX_REASONABLE_TOKENS {
+                tracing::error!(
+                    token_count = token_count,
+                    max_expected = MAX_REASONABLE_TOKENS,
+                    model = %model_name,
+                    organization_id = %organization_id,
+                    "Provider returned unreasonable token count for privacy classify - capping"
+                );
+                token_anomaly_detected = true;
+                let model_tag = format!("model:{}", model_name);
+                let reason_tag = format!(
+                    "reason:{}",
+                    services::metrics::consts::REASON_TOKEN_OVERFLOW
+                );
+                let anomaly_tags = [model_tag.as_str(), reason_tag.as_str()];
+                app_state.metrics_service.record_count(
+                    services::metrics::consts::METRIC_PROVIDER_TOKEN_ANOMALIES,
+                    1,
+                    &anomaly_tags,
+                );
+                token_count = MAX_REASONABLE_TOKENS;
+            }
+
+            if token_count == 0 {
+                tracing::warn!(
+                    model = %model_name,
+                    organization_id = %organization_id,
+                    "Provider returned zero tokens for privacy classify"
+                );
+                token_anomaly_detected = true;
+                let model_tag = format!("model:{}", model_name);
+                let reason_tag =
+                    format!("reason:{}", services::metrics::consts::REASON_MISSING_USAGE);
+                let zero_tokens_tags = [model_tag.as_str(), reason_tag.as_str()];
+                app_state.metrics_service.record_count(
+                    services::metrics::consts::METRIC_PROVIDER_ZERO_TOKENS,
+                    1,
+                    &zero_tokens_tags,
+                );
+            }
+
+            if token_anomaly_detected {
+                tracing::info!(
+                    model = %model_name,
+                    organization_id = %organization_id,
+                    final_token_count = token_count,
+                    "Token count anomaly: Provider data quality issue detected. Recommendation: Check provider logs and configuration."
+                );
+            }
+
+            let workspace_id = api_key.workspace.id.0;
+            let api_key_id = match Uuid::parse_str(&api_key.api_key.id.0) {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::error!(error = %e, "Invalid API key ID for usage tracking");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        ResponseJson(ErrorResponse::new(
+                            "Failed to record usage".to_string(),
+                            "server_error".to_string(),
+                        )),
+                    )
+                        .into_response();
+                }
+            };
+
+            let inference_id = uuid::Uuid::new_v4();
+            let usage_request = services::usage::RecordUsageServiceRequest {
+                organization_id,
+                workspace_id,
+                api_key_id,
+                model_id,
+                input_tokens: token_count,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                inference_type: services::usage::ports::InferenceType::PrivacyClassify,
+                ttft_ms: None,
+                avg_itl_ms: None,
+                inference_id: Some(inference_id),
+                provider_request_id: None,
+                stop_reason: Some(services::usage::StopReason::Completed),
+                response_id: None,
+                image_count: None,
+            };
+
+            if let Err(e) = app_state.usage_service.record_usage(usage_request).await {
+                tracing::error!(error = %e, "Failed to record privacy classify usage");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ResponseJson(ErrorResponse::new(
+                        "Failed to record usage - please retry".to_string(),
+                        "server_error".to_string(),
+                    )),
+                )
+                    .into_response();
+            }
+
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(response_bytes))
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
+        Err(e) => {
+            let (status_code, error_type, message) = match e {
+                services::completions::ports::CompletionError::RateLimitExceeded(msg) => {
+                    tracing::warn!("Concurrent request limit exceeded for privacy classify");
+                    (StatusCode::TOO_MANY_REQUESTS, "rate_limit_error", msg)
+                }
+                services::completions::ports::CompletionError::ProviderError {
+                    status_code,
+                    ..
+                } => {
+                    tracing::error!("Privacy classify provider error");
+                    let http_status = StatusCode::from_u16(status_code)
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    (
+                        http_status,
+                        "server_error",
+                        "Privacy classify request failed. Please try again later.".to_string(),
+                    )
+                }
+                services::completions::ports::CompletionError::InvalidModel(msg) => {
+                    tracing::warn!("Privacy classify model not found");
+                    (StatusCode::NOT_FOUND, "not_found_error", msg)
+                }
+                services::completions::ports::CompletionError::ServiceOverloaded(_) => {
+                    tracing::warn!("Privacy classify service overloaded");
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "service_overloaded",
+                        "The service is temporarily overloaded. Please retry with exponential backoff.".to_string(),
+                    )
+                }
+                _ => {
+                    tracing::error!("Unexpected privacy classify error");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Privacy classify request failed".to_string(),
+                    )
+                }
+            };
+
+            (
+                status_code,
+                ResponseJson(ErrorResponse::new(message, error_type.to_string())),
+            )
+                .into_response()
+        }
+    }
+}
+
 /// Text similarity scoring endpoint
 ///
 /// Scores the similarity between two texts using a scoring/ranking model.

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -2504,15 +2504,21 @@ pub async fn privacy_classify(
                 input_tokens: Option<i32>,
             }
 
-            let mut token_count = serde_json::from_slice::<UsageExtract>(&response_bytes)
+            // Sum into i64 with saturating arithmetic and clamp to i32. The provider
+            // controls both the number of data entries and per-entry input_tokens, so a
+            // naive `sum::<i32>()` could wrap silently in release builds before the
+            // MAX_REASONABLE_TOKENS check, recording negative usage.
+            let token_sum_i64: i64 = serde_json::from_slice::<UsageExtract>(&response_bytes)
                 .ok()
                 .map(|u| {
                     u.data
                         .into_iter()
                         .filter_map(|d| d.usage.and_then(|x| x.input_tokens))
-                        .sum::<i32>()
+                        .filter(|t| *t >= 0)
+                        .fold(0i64, |acc, t| acc.saturating_add(t as i64))
                 })
                 .unwrap_or(0);
+            let mut token_count = token_sum_i64.clamp(0, i32::MAX as i64) as i32;
 
             const MAX_REASONABLE_TOKENS: i32 = 1_000_000;
             let mut token_anomaly_detected = false;

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -36,6 +36,7 @@ mod near_auth;
 mod oauth_frontend_callback;
 mod org_system_prompt;
 mod pagination_validation;
+mod privacy_classify;
 mod provider_errors;
 mod repositories;
 mod rerank;

--- a/crates/api/tests/e2e_all/privacy_classify.rs
+++ b/crates/api/tests/e2e_all/privacy_classify.rs
@@ -1,0 +1,216 @@
+//! E2E tests for /v1/privacy/classify passthrough endpoint
+//!
+//! Exercises the route end-to-end against the MockProvider, which returns a
+//! structurally-valid privacy-filter response with usage.input_tokens=10.
+
+use crate::common::*;
+use api::models::{BatchUpdateModelApiRequest, ErrorResponse};
+
+async fn setup_privacy_filter_model(server: &axum_test::TestServer) -> String {
+    let mut batch = BatchUpdateModelApiRequest::new();
+    batch.insert(
+        "openai/privacy-filter".to_string(),
+        serde_json::from_value(serde_json::json!({
+            "inputCostPerToken": {
+                "amount": 1000000,
+                "currency": "USD"
+            },
+            "outputCostPerToken": {
+                "amount": 0,
+                "currency": "USD"
+            },
+            "costPerImage": {
+                "amount": 0,
+                "currency": "USD"
+            },
+            "modelDisplayName": "Privacy Filter",
+            "modelDescription": "PII span detection (token classification)",
+            "contextLength": 512,
+            "verifiable": false,
+            "isActive": true
+        }))
+        .unwrap(),
+    );
+    let updated = admin_batch_upsert_models(server, batch, get_session_id()).await;
+    assert_eq!(updated.len(), 1, "Should have updated 1 model");
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    "openai/privacy-filter".to_string()
+}
+
+#[tokio::test]
+async fn test_privacy_classify_basic() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/classify")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": "My SSN is 123-45-6789",
+            "threshold": 0.5
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        200,
+        "Privacy classify should succeed"
+    );
+
+    let body: serde_json::Value = response.json();
+    assert!(
+        body.get("model").is_some(),
+        "Response should have model field"
+    );
+    let data = body["data"].as_array().expect("data should be array");
+    assert!(!data.is_empty(), "Should have at least one entry");
+    assert!(
+        data[0].get("spans").is_some(),
+        "Each entry should have spans field"
+    );
+    assert!(
+        data[0]["usage"]["input_tokens"].as_i64().unwrap() >= 0,
+        "Entry should have non-negative input_tokens"
+    );
+}
+
+#[tokio::test]
+async fn test_privacy_classify_array_input() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/classify")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": ["alice@example.com", "+1-555-123-4567"]
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+}
+
+#[tokio::test]
+async fn test_privacy_classify_model_not_found() {
+    let server = setup_test_server().await;
+
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/classify")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "NonExistent/Model",
+            "input": "Hello"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 404);
+    let error: ErrorResponse = response.json();
+    assert!(
+        error.error.message.contains("not found"),
+        "Error message should mention model not found"
+    );
+}
+
+#[tokio::test]
+async fn test_privacy_classify_missing_api_key() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+
+    let response = server
+        .post("/v1/privacy/classify")
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": "Hello"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 401);
+}
+
+#[tokio::test]
+async fn test_privacy_classify_invalid_request() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/classify")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "input": "Hello"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+}
+
+#[tokio::test]
+async fn test_privacy_classify_costs_deducted() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 100_000_000_000i64).await;
+    let org_id = org.id.clone();
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let initial_balance_response = server
+        .get(format!("/v1/organizations/{}/usage/balance", org_id).as_str())
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(initial_balance_response.status_code(), 200);
+    let initial_balance = serde_json::from_str::<api::routes::usage::OrganizationBalanceResponse>(
+        &initial_balance_response.text(),
+    )
+    .expect("Failed to parse initial balance");
+    let initial_spent = initial_balance.total_spent;
+
+    let response = server
+        .post("/v1/privacy/classify")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": "My SSN is 123-45-6789"
+        }))
+        .await;
+    assert_eq!(response.status_code(), 200);
+
+    let final_balance_response = server
+        .get(format!("/v1/organizations/{}/usage/balance", org_id).as_str())
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(final_balance_response.status_code(), 200);
+    let final_balance = serde_json::from_str::<api::routes::usage::OrganizationBalanceResponse>(
+        &final_balance_response.text(),
+    )
+    .expect("Failed to parse final balance");
+
+    // Mock returns usage.input_tokens=10, price is 1_000_000 USD-9-decimals per token.
+    // Expected spend delta = 10 * 1_000_000 = 10_000_000.
+    let delta = final_balance.total_spent - initial_spent;
+    assert_eq!(
+        delta, 10_000_000,
+        "Privacy classify should bill 10 tokens × 1_000_000 = 10_000_000",
+    );
+}

--- a/crates/api/tests/e2e_all/privacy_classify.rs
+++ b/crates/api/tests/e2e_all/privacy_classify.rs
@@ -164,6 +164,34 @@ async fn test_privacy_classify_invalid_request() {
 }
 
 #[tokio::test]
+async fn test_privacy_classify_body_size_limit() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    // ~300 KB payload, above the 256 KB per-route cap.
+    let oversized_input = "x".repeat(300 * 1024);
+
+    let response = server
+        .post("/v1/privacy/classify")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": oversized_input,
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        413,
+        "Should reject body larger than 256 KB cap"
+    );
+}
+
+#[tokio::test]
 async fn test_privacy_classify_costs_deducted() {
     let server = setup_test_server().await;
 

--- a/crates/inference_providers/src/external/backend.rs
+++ b/crates/inference_providers/src/external/backend.rs
@@ -8,8 +8,8 @@ use crate::{
     AudioTranscriptionError, AudioTranscriptionParams, AudioTranscriptionResponse,
     ChatCompletionParams, ChatCompletionResponseWithBytes, CompletionError, EmbeddingError,
     ImageEditError, ImageEditParams, ImageEditResponseWithBytes, ImageGenerationError,
-    ImageGenerationParams, ImageGenerationResponseWithBytes, RerankError, RerankParams,
-    RerankResponse, ScoreError, ScoreParams, ScoreResponse, StreamingResult,
+    ImageGenerationParams, ImageGenerationResponseWithBytes, PrivacyClassifyError, RerankError,
+    RerankParams, RerankResponse, ScoreError, ScoreParams, ScoreResponse, StreamingResult,
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -181,6 +181,22 @@ pub trait ExternalBackend: Send + Sync {
     ) -> Result<bytes::Bytes, EmbeddingError> {
         Err(EmbeddingError::RequestFailed(format!(
             "Embeddings are not supported by the {} backend.",
+            self.backend_type()
+        )))
+    }
+
+    /// Performs a privacy classification request as a raw passthrough.
+    ///
+    /// Default implementation returns an error indicating privacy classification
+    /// is not supported by external providers.
+    async fn privacy_classify_raw(
+        &self,
+        _config: &BackendConfig,
+        _body: bytes::Bytes,
+        _extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, PrivacyClassifyError> {
+        Err(PrivacyClassifyError::RequestFailed(format!(
+            "Privacy classification is not supported by the {} backend.",
             self.backend_type()
         )))
     }

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -34,8 +34,8 @@ use crate::{
     ChatSignature, CompletionError, CompletionParams, EmbeddingError, ImageEditError,
     ImageEditParams, ImageEditResponseWithBytes, ImageGenerationError, ImageGenerationParams,
     ImageGenerationResponseWithBytes, InferenceProvider, ListModelsError, ModelsResponse,
-    RerankError, RerankParams, RerankResponse, ScoreError, ScoreParams, ScoreResponse,
-    StreamingResult,
+    PrivacyClassifyError, RerankError, RerankParams, RerankResponse, ScoreError, ScoreParams,
+    ScoreResponse, StreamingResult,
 };
 use async_trait::async_trait;
 use backend::{BackendConfig, ExternalBackend};
@@ -362,6 +362,16 @@ impl InferenceProvider for ExternalProvider {
         extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, EmbeddingError> {
         self.backend.embeddings_raw(&self.config, body, extra).await
+    }
+
+    async fn privacy_classify_raw(
+        &self,
+        body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, PrivacyClassifyError> {
+        self.backend
+            .privacy_classify_raw(&self.config, body, extra)
+            .await
     }
 }
 

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -81,10 +81,10 @@ pub use models::{
     CompletionError, CompletionParams, EmbeddingError, FinishReason, FunctionChoice,
     FunctionDefinition, ImageData, ImageEditError, ImageEditParams, ImageEditResponse,
     ImageEditResponseWithBytes, ImageGenerationError, ImageGenerationParams,
-    ImageGenerationResponse, ImageGenerationResponseWithBytes, MessageRole, ModelInfo, RerankError,
-    RerankParams, RerankResponse, RerankResult, RerankUsage, ScoreError, ScoreParams,
-    ScoreResponse, ScoreResult, ScoreUsage, StreamChunk, StreamOptions, TokenUsage, ToolChoice,
-    ToolDefinition, TranscriptionSegment, TranscriptionWord,
+    ImageGenerationResponse, ImageGenerationResponseWithBytes, MessageRole, ModelInfo,
+    PrivacyClassifyError, RerankError, RerankParams, RerankResponse, RerankResult, RerankUsage,
+    ScoreError, ScoreParams, ScoreResponse, ScoreResult, ScoreUsage, StreamChunk, StreamOptions,
+    TokenUsage, ToolChoice, ToolDefinition, TranscriptionSegment, TranscriptionWord,
 };
 pub use sse_parser::{new_sse_parser, BufferedSSEParser, SSEEvent, SSEEventParser, SSEParser};
 pub use vllm::{VLlmConfig, VLlmProvider};
@@ -236,6 +236,17 @@ pub trait InferenceProvider {
         body: bytes::Bytes,
         extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, EmbeddingError>;
+
+    /// Performs a privacy classification request as a raw passthrough.
+    ///
+    /// Accepts the raw JSON request body and returns the raw JSON response bytes.
+    /// No deserialization is performed — the cloud API proxies the request as-is to
+    /// the backend's `/v1/privacy/classify` endpoint.
+    async fn privacy_classify_raw(
+        &self,
+        body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, PrivacyClassifyError>;
 
     async fn get_signature(
         &self,

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -1090,11 +1090,16 @@ impl crate::InferenceProvider for MockProvider {
 
     async fn privacy_classify_raw(
         &self,
-        _body: bytes::Bytes,
+        body: bytes::Bytes,
         _extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, PrivacyClassifyError> {
+        // Echo the requested model so round-trip assertions in tests are meaningful.
+        let model = serde_json::from_slice::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v.get("model").and_then(|m| m.as_str()).map(str::to_string))
+            .unwrap_or_else(|| "mock-privacy-filter".to_string());
         let response_json = serde_json::json!({
-            "model": "mock-privacy-filter",
+            "model": model,
             "data": [{
                 "index": 0,
                 "spans": [],

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -11,9 +11,9 @@ use crate::{
     CompletionParams, EmbeddingError, FinishReason, FunctionCallDelta, ImageData, ImageEditError,
     ImageEditParams, ImageEditResponseWithBytes, ImageGenerationError, ImageGenerationParams,
     ImageGenerationResponse, ImageGenerationResponseWithBytes, ListModelsError, MessageRole,
-    ModelInfo, ModelsResponse, RerankError, RerankParams, RerankResponse, RerankResult,
-    RerankUsage, SSEEvent, ScoreError, ScoreParams, ScoreResponse, ScoreResult, ScoreUsage,
-    StreamChunk, StreamingResult, TokenUsage, ToolCallDelta, TranscriptionSegment,
+    ModelInfo, ModelsResponse, PrivacyClassifyError, RerankError, RerankParams, RerankResponse,
+    RerankResult, RerankUsage, SSEEvent, ScoreError, ScoreParams, ScoreResponse, ScoreResult,
+    ScoreUsage, StreamChunk, StreamingResult, TokenUsage, ToolCallDelta, TranscriptionSegment,
     TranscriptionWord,
 };
 use async_trait::async_trait;
@@ -1085,6 +1085,24 @@ impl crate::InferenceProvider for MockProvider {
         });
         let bytes = serde_json::to_vec(&response_json)
             .map_err(|e| EmbeddingError::RequestFailed(e.to_string()))?;
+        Ok(bytes::Bytes::from(bytes))
+    }
+
+    async fn privacy_classify_raw(
+        &self,
+        _body: bytes::Bytes,
+        _extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, PrivacyClassifyError> {
+        let response_json = serde_json::json!({
+            "model": "mock-privacy-filter",
+            "data": [{
+                "index": 0,
+                "spans": [],
+                "usage": {"input_tokens": 10}
+            }]
+        });
+        let bytes = serde_json::to_vec(&response_json)
+            .map_err(|e| PrivacyClassifyError::RequestFailed(e.to_string()))?;
         Ok(bytes::Bytes::from(bytes))
     }
 

--- a/crates/inference_providers/src/models.rs
+++ b/crates/inference_providers/src/models.rs
@@ -1256,3 +1256,12 @@ pub enum EmbeddingError {
     #[error("HTTP {status_code}: {message}")]
     HttpError { status_code: u16, message: String },
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrivacyClassifyError {
+    #[error("Privacy classify request failed: {0}")]
+    RequestFailed(String),
+
+    #[error("HTTP {status_code}: {message}")]
+    HttpError { status_code: u16, message: String },
+}

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -3,7 +3,7 @@ mod prefix_router;
 use crate::spki_verifier::{FingerprintState, SharedTlsRoots};
 use crate::{
     models::StreamOptions, sse_parser::new_sse_parser, ImageEditError, ImageGenerationError,
-    RerankError, ScoreError, *,
+    PrivacyClassifyError, RerankError, ScoreError, *,
 };
 use async_trait::async_trait;
 use prefix_router::PrefixRouter;
@@ -32,6 +32,11 @@ fn to_score_error<E: std::fmt::Display>(e: E) -> ScoreError {
 /// Convert any displayable error to EmbeddingError::RequestFailed
 fn to_embedding_error<E: std::fmt::Display>(e: E) -> EmbeddingError {
     EmbeddingError::RequestFailed(e.to_string())
+}
+
+/// Convert any displayable error to PrivacyClassifyError::RequestFailed
+fn to_privacy_classify_error<E: std::fmt::Display>(e: E) -> PrivacyClassifyError {
+    PrivacyClassifyError::RequestFailed(e.to_string())
 }
 
 /// Encryption header keys used in params.extra for passing encryption information
@@ -1453,6 +1458,43 @@ impl InferenceProvider for VLlmProvider {
         }
 
         let raw_bytes = response.bytes().await.map_err(to_embedding_error)?;
+        Ok(raw_bytes)
+    }
+
+    async fn privacy_classify_raw(
+        &self,
+        body: bytes::Bytes,
+        mut extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, PrivacyClassifyError> {
+        let url = format!("{}/v1/privacy/classify", self.config.base_url);
+
+        let mut headers = self.build_headers().map_err(to_privacy_classify_error)?;
+        self.prepare_encryption_headers(&mut headers, &mut extra);
+
+        let response = self
+            .client
+            .post(&url)
+            .headers(headers)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .timeout(self.config.completion_timeout())
+            .send()
+            .await
+            .map_err(to_privacy_classify_error)?;
+
+        if !response.status().is_success() {
+            let status_code = response.status().as_u16();
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(PrivacyClassifyError::HttpError {
+                status_code,
+                message,
+            });
+        }
+
+        let raw_bytes = response.bytes().await.map_err(to_privacy_classify_error)?;
         Ok(raw_bytes)
     }
 }

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -1578,6 +1578,54 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
             })
     }
 
+    async fn try_privacy_classify(
+        &self,
+        organization_id: Uuid,
+        model_id: Uuid,
+        model_name: &str,
+        body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, ports::CompletionError> {
+        let counter = self
+            .try_acquire_concurrent_slot(organization_id, model_id, model_name)
+            .await?;
+        let _guard = ConcurrentSlotGuard::new(counter);
+
+        self.inference_provider_pool
+            .privacy_classify(model_name, body, extra)
+            .await
+            .map_err(|e| match e {
+                inference_providers::PrivacyClassifyError::RequestFailed(msg) => {
+                    ports::CompletionError::ProviderError {
+                        status_code: 502,
+                        message: msg,
+                    }
+                }
+                inference_providers::PrivacyClassifyError::HttpError {
+                    status_code,
+                    message,
+                } => match status_code {
+                    401 | 403 => ports::CompletionError::ProviderError {
+                        status_code: 500,
+                        message: "The model is currently unavailable. Please try again later."
+                            .to_string(),
+                    },
+                    429 => ports::CompletionError::RateLimitExceeded(
+                        "Rate limit exceeded by upstream provider. Please retry with exponential backoff.".to_string(),
+                    ),
+                    503 => ports::CompletionError::ServiceOverloaded(message),
+                    500..=599 => ports::CompletionError::ProviderError {
+                        status_code: 502,
+                        message,
+                    },
+                    other => ports::CompletionError::ProviderError {
+                        status_code: other,
+                        message,
+                    },
+                },
+            })
+    }
+
     async fn try_score(
         &self,
         organization_id: Uuid,

--- a/crates/services/src/completions/ports.rs
+++ b/crates/services/src/completions/ports.rs
@@ -170,6 +170,16 @@ pub trait CompletionServiceTrait: Send + Sync {
         extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, CompletionError>;
 
+    /// Execute a privacy classification request as a raw passthrough with concurrent request limiting.
+    async fn try_privacy_classify(
+        &self,
+        organization_id: Uuid,
+        model_id: Uuid,
+        model_name: &str,
+        body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, CompletionError>;
+
     /// Execute a score request with proper concurrent request limiting.
     ///
     /// Each organization has a per-model concurrent request limit (default: 64).

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1793,6 +1793,49 @@ impl InferenceProviderPool {
         ))
     }
 
+    pub async fn privacy_classify(
+        &self,
+        model: &str,
+        body: bytes::Bytes,
+        extra: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<bytes::Bytes, inference_providers::PrivacyClassifyError> {
+        tracing::debug!(model = %model, "Starting privacy classify request");
+
+        let providers = match self.get_providers_with_fallback(model, None).await {
+            Some(p) => p,
+            None => {
+                return Err(inference_providers::PrivacyClassifyError::RequestFailed(
+                    format!("Model '{}' not found in provider pool", model),
+                ));
+            }
+        };
+
+        let mut last_error = None;
+        for provider in providers {
+            match provider
+                .privacy_classify_raw(body.clone(), extra.clone())
+                .await
+            {
+                Ok(response) => {
+                    tracing::info!(model = %model, "Privacy classify completed successfully");
+                    return Ok(response);
+                }
+                Err(e) => {
+                    tracing::warn!(model = %model, error = %e, "Privacy classify failed with provider, trying next");
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        let error_msg = last_error
+            .map(|e| Self::sanitize_error_message(&e.to_string()))
+            .unwrap_or_else(|| "No providers available for privacy classify".to_string());
+
+        Err(inference_providers::PrivacyClassifyError::RequestFailed(
+            error_msg,
+        ))
+    }
+
     pub async fn score(
         &self,
         params: inference_providers::ScoreParams,

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -193,7 +193,9 @@ impl UsageServiceTrait for UsageServiceImpl {
                     })?;
                 (duration_cost, 0, duration_cost)
             }
-            ports::InferenceType::Rerank | ports::InferenceType::Embedding => {
+            ports::InferenceType::Rerank
+            | ports::InferenceType::Embedding
+            | ports::InferenceType::PrivacyClassify => {
                 // For rerank/embedding: use input tokens as the billing unit.
                 // Cache pricing is intentionally NOT applied, even if
                 // cache_read_cost_per_token is configured on the model.

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -196,7 +196,7 @@ impl UsageServiceTrait for UsageServiceImpl {
             ports::InferenceType::Rerank
             | ports::InferenceType::Embedding
             | ports::InferenceType::PrivacyClassify => {
-                // For rerank/embedding: use input tokens as the billing unit.
+                // For rerank/embedding/privacy_classify: use input tokens as the billing unit.
                 // Cache pricing is intentionally NOT applied, even if
                 // cache_read_cost_per_token is configured on the model.
                 // Use checked arithmetic to prevent integer overflow in billing-critical path

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -23,6 +23,8 @@ pub enum InferenceType {
     Score,
     /// Text embeddings
     Embedding,
+    /// Privacy classification (PII span detection)
+    PrivacyClassify,
 }
 
 impl InferenceType {
@@ -37,6 +39,7 @@ impl InferenceType {
             InferenceType::Rerank => "rerank",
             InferenceType::Score => "score",
             InferenceType::Embedding => "embedding",
+            InferenceType::PrivacyClassify => "privacy_classify",
         }
     }
 }
@@ -60,6 +63,7 @@ impl std::str::FromStr for InferenceType {
             "rerank" => Ok(InferenceType::Rerank),
             "score" => Ok(InferenceType::Score),
             "embedding" => Ok(InferenceType::Embedding),
+            "privacy_classify" => Ok(InferenceType::PrivacyClassify),
             _ => Err(format!("Unknown inference type: {}", s)),
         }
     }


### PR DESCRIPTION
## Summary

- Adds `POST /v1/privacy/classify` as a raw passthrough to a backend token-classification model (e.g. `openai/privacy-filter`)
- Follows the existing `embeddings_raw` pattern: only the `model` field is deserialized for routing; the request body and response bytes are forwarded unchanged
- Wires the new `privacy_classify_raw` trait method through `InferenceProvider` (vLLM impl + external/mock stubs), the inference provider pool, and `CompletionServiceTrait` with concurrent-slot guarding
- Adds `InferenceType::PrivacyClassify` for usage tracking, billed as `input_tokens × input_cost_per_token` (summed from `data[*].usage.input_tokens` in the provider response) — same semantics as embedding/rerank
- Registers the route on the text-inference router (in front of usage/auth/rate-limit middleware) and adds the path to the OpenAPI spec

Unblocks nearai/infra#86. The `/v1/redact` endpoint (nearai/infra#87) is a separate concern and will land in a follow-up PR.

The privacy-filter model itself is already deployed at port 8007 on gpu04 and registered at `privacy-filter.completions.near.ai` (see `cvm-conf/small-models.yaml`). The model still needs to be added to the cloud-api models DB via `POST /v1/admin/models` before this endpoint can be exercised end-to-end against the live backend.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --lib --bins -p inference_providers -p services -p api` (224 + 60 unit tests pass; `test_openapi_spec_generation` covers the new path)
- [ ] After merge: admin-upsert `openai/privacy-filter` into cloud-api DB with `input_modalities=["text"]`, `output_modalities=["text"]`, `provider_type=vllm`, `inference_url=https://privacy-filter.completions.near.ai`, then `curl -X POST $CLOUD_API/v1/privacy/classify -H 'Authorization: Bearer sk-...' -d '{"model":"openai/privacy-filter","input":"my SSN is 123-45-6789","threshold":0.5}'`
- [ ] E2E test against staging