### PR TITLE
feat: x-auto-redact for chat completions

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -10,6 +10,7 @@ use axum::{
     response::{IntoResponse, Json as ResponseJson, Response},
 };
 use futures::stream::StreamExt;
+use services::auto_redact::{self, AutoRedactError, RedactionMap, StreamUnredact};
 use services::common::encryption_headers as service_encryption_headers;
 use services::completions::{
     hash_inference_id_to_uuid,
@@ -285,6 +286,124 @@ fn convert_chat_request_to_service(
     }
 }
 
+/// Decide whether to enable auto-redact based on the request, mutate the
+/// service request to scrub the body field, and (if enabled) run the PII
+/// detector + rewrite messages in place. Returns the placeholder map for
+/// downstream un-redact; an empty map is also returned when auto-redact is
+/// off.
+async fn maybe_redact(
+    headers: &header::HeaderMap,
+    service_request: &mut ServiceCompletionRequest,
+    pool: &services::inference_provider_pool::InferenceProviderPool,
+) -> Result<(bool, RedactionMap), AutoRedactError> {
+    let header_values: Vec<&str> = headers
+        .get_all(auto_redact::AUTO_REDACT_HEADER)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+    let body_field = service_request
+        .extra
+        .get(auto_redact::AUTO_REDACT_BODY_FIELD);
+    let enabled = auto_redact::is_enabled(header_values.iter().copied(), body_field);
+
+    // Always strip the body field so providers with strict JSON schemas
+    // (e.g. Anthropic) don't 400 on unknown keys.
+    auto_redact::strip_body_field(&mut service_request.extra);
+
+    if !enabled {
+        return Ok((false, RedactionMap::new()));
+    }
+
+    let map = auto_redact::redact_messages(
+        &mut service_request.messages,
+        auto_redact::DEFAULT_PII_MODEL,
+        pool,
+    )
+    .await?;
+    Ok((true, map))
+}
+
+/// Convert an [`AutoRedactError`] into the user-facing error response.
+/// Detector-unavailable is 503 (fail-closed per design); internal errors
+/// are 500.
+fn auto_redact_error_response(err: AutoRedactError) -> Response {
+    match err {
+        AutoRedactError::DetectorUnavailable(msg) => {
+            tracing::error!(error = %msg, "auto_redact detector unavailable");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ResponseJson(ErrorResponse::new(
+                    "PII redaction service is unavailable. Retry, or omit auto_redact to send the prompt as-is.".to_string(),
+                    "auto_redact_unavailable".to_string(),
+                )),
+            )
+                .into_response()
+        }
+        AutoRedactError::Internal(msg) => {
+            tracing::error!(error = %msg, "auto_redact internal error");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "PII redaction failed".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Walk a non-streaming chat response's text fields and substitute
+/// placeholders with their originals. Mutates in place.
+fn unredact_chat_response_in_place(
+    response: &mut inference_providers::ChatCompletionResponse,
+    map: &RedactionMap,
+) {
+    for choice in &mut response.choices {
+        if let Some(content) = &mut choice.message.content {
+            *content = map.unredact(content);
+        }
+        if let Some(reasoning) = &mut choice.message.reasoning_content {
+            *reasoning = map.unredact(reasoning);
+        }
+        if let Some(reasoning) = &mut choice.message.reasoning {
+            *reasoning = map.unredact(reasoning);
+        }
+    }
+}
+
+/// Apply streaming un-redact to a single parsed chunk, mutating any text
+/// deltas (content + reasoning) in place. Stateful: the [`StreamUnredact`]
+/// instance carries the sliding tail buffer across calls.
+fn unredact_chunk_in_place(
+    chunk: &mut inference_providers::StreamChunk,
+    content_un: &mut StreamUnredact,
+    reasoning_un: &mut StreamUnredact,
+) {
+    match chunk {
+        inference_providers::StreamChunk::Chat(c) => {
+            for choice in &mut c.choices {
+                if let Some(delta) = &mut choice.delta {
+                    if let Some(content) = &mut delta.content {
+                        *content = content_un.process(content);
+                    }
+                    if let Some(reasoning) = &mut delta.reasoning_content {
+                        *reasoning = reasoning_un.process(reasoning);
+                    }
+                    if let Some(reasoning) = &mut delta.reasoning {
+                        *reasoning = reasoning_un.process(reasoning);
+                    }
+                }
+            }
+        }
+        inference_providers::StreamChunk::Text(c) => {
+            for choice in &mut c.choices {
+                choice.text = content_un.process(&choice.text);
+            }
+        }
+    }
+}
+
 // Convert HTTP CompletionRequest to service CompletionRequest
 fn convert_text_request_to_service(
     request: &CompletionRequest,
@@ -387,6 +506,21 @@ pub async fn chat_completions(
     // Add validated headers to service_request.extra
     insert_encryption_headers(&encryption_headers, &mut service_request.extra);
 
+    // Auto-redact (opt-in via x-auto-redact header or auto_redact body field).
+    // On success this may rewrite service_request.messages to substitute
+    // placeholders for PII; the returned map drives the response un-redact.
+    let (auto_redact_enabled, redaction_map) = match maybe_redact(
+        &headers,
+        &mut service_request,
+        &app_state.inference_provider_pool,
+    )
+    .await
+    {
+        Ok(out) => out,
+        Err(e) => return auto_redact_error_response(e),
+    };
+    let redaction_map = Arc::new(redaction_map);
+
     // Check if streaming is requested
     if request.stream == Some(true) {
         // Call the streaming completion service
@@ -426,6 +560,15 @@ pub async fn chat_completions(
                 let request_model = request.model.clone();
                 let organization_id = api_key.organization.id.0;
 
+                // Per-stream un-redact state. When auto-redact is off,
+                // these short-circuit to passthrough (no allocation).
+                let content_unredact = Arc::new(tokio::sync::Mutex::new(StreamUnredact::new(
+                    redaction_map.clone(),
+                )));
+                let reasoning_unredact = Arc::new(tokio::sync::Mutex::new(StreamUnredact::new(
+                    redaction_map.clone(),
+                )));
+
                 // Convert to raw bytes stream with proper SSE formatting
                 let byte_stream = peekable_stream
                     .then(move |result| {
@@ -433,15 +576,26 @@ pub async fn chat_completions(
                         let chat_id_inner = chat_id_clone.clone();
                         let error_count_inner = error_count_clone.clone();
                         let model_for_err = request_model.clone();
+                        let content_un = content_unredact.clone();
+                        let reasoning_un = reasoning_unredact.clone();
                         async move {
                             match result {
-                                Ok(event) => {
+                                Ok(mut event) => {
                                     // Extract chat_id from the parsed chunk
                                     {
                                         let mut cid = chat_id_inner.lock().await;
                                         if cid.is_none() {
                                             *cid = Some(extract_chat_id_from_chunk(&event.chunk));
                                         }
+                                    }
+
+                                    // Auto-redact: swap any minted placeholders in this
+                                    // chunk's text deltas back to their originals before
+                                    // we serialize and send.
+                                    if auto_redact_enabled {
+                                        let mut c = content_un.lock().await;
+                                        let mut r = reasoning_un.lock().await;
+                                        unredact_chunk_in_place(&mut event.chunk, &mut c, &mut r);
                                     }
 
                                     // Serialize the parsed chunk (normalized to OpenAI format)
@@ -538,13 +692,41 @@ pub async fn chat_completions(
             .create_chat_completion(service_request)
             .await
         {
-            Ok(response_with_bytes) => {
+            Ok(mut response_with_bytes) => {
                 // Extract inference ID from response ID (reuse same hashing as usage tracking)
                 let inference_id =
                     Some(hash_inference_id_to_uuid(&response_with_bytes.response.id));
 
-                // Return the exact bytes from the provider for hash verification
-                // This ensures clients can hash the response and compare with attestation endpoints
+                // When auto-redact is enabled, we substitute placeholders back to
+                // originals and re-serialize. The provider's raw_bytes are over the
+                // redacted form; we deliberately drop that signed payload because
+                // the client opted into munging the response.
+                let body_bytes = if auto_redact_enabled {
+                    unredact_chat_response_in_place(
+                        &mut response_with_bytes.response,
+                        &redaction_map,
+                    );
+                    match serde_json::to_vec(&response_with_bytes.response) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            tracing::error!(error = %e, "failed to re-serialize unredacted chat response");
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                ResponseJson(ErrorResponse::new(
+                                    "Failed to assemble response".to_string(),
+                                    "internal_server_error".to_string(),
+                                )),
+                            )
+                                .into_response();
+                        }
+                    }
+                } else {
+                    // Return the exact bytes from the provider for hash verification.
+                    // This ensures clients can hash the response and compare with
+                    // attestation endpoints.
+                    response_with_bytes.raw_bytes
+                };
+
                 let mut response_builder = Response::builder()
                     .status(StatusCode::OK)
                     .header(header::CONTENT_TYPE, "application/json");
@@ -556,9 +738,7 @@ pub async fn chat_completions(
                         .header("Access-Control-Expose-Headers", HEADER_INFERENCE_ID);
                 }
 
-                response_builder
-                    .body(Body::from(response_with_bytes.raw_bytes))
-                    .unwrap()
+                response_builder.body(Body::from(body_bytes)).unwrap()
             }
             Err(domain_error) => {
                 let status_code = map_domain_error_to_status(&domain_error);

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -372,36 +372,136 @@ fn unredact_chat_response_in_place(
     }
 }
 
+/// Per-choice, per-field streaming un-redact state. For `n > 1`
+/// completions the provider may interleave chunks for different choice
+/// indices; each choice needs its own sliding tail buffer or split
+/// placeholders get cross-contaminated. The three text fields (`content`,
+/// `reasoning_content`, `reasoning`) are kept independent for the same
+/// reason — a model may emit them concurrently.
+#[derive(Default)]
+struct StreamUnredactStates {
+    content: std::collections::HashMap<i64, StreamUnredact>,
+    reasoning_content: std::collections::HashMap<i64, StreamUnredact>,
+    reasoning: std::collections::HashMap<i64, StreamUnredact>,
+}
+
+fn unredact_field(
+    states: &mut std::collections::HashMap<i64, StreamUnredact>,
+    map: &Arc<RedactionMap>,
+    idx: i64,
+    text: &mut String,
+) {
+    let s = states
+        .entry(idx)
+        .or_insert_with(|| StreamUnredact::new(map.clone()));
+    *text = s.process(text);
+}
+
 /// Apply streaming un-redact to a single parsed chunk, mutating any text
-/// deltas (content + reasoning) in place. Stateful: the [`StreamUnredact`]
-/// instance carries the sliding tail buffer across calls.
+/// deltas (content + reasoning) in place. Stateful: per-choice tail
+/// buffers carry across calls via `states`.
 fn unredact_chunk_in_place(
     chunk: &mut inference_providers::StreamChunk,
-    content_un: &mut StreamUnredact,
-    reasoning_un: &mut StreamUnredact,
+    states: &mut StreamUnredactStates,
+    map: &Arc<RedactionMap>,
 ) {
     match chunk {
         inference_providers::StreamChunk::Chat(c) => {
             for choice in &mut c.choices {
+                let idx = choice.index;
                 if let Some(delta) = &mut choice.delta {
                     if let Some(content) = &mut delta.content {
-                        *content = content_un.process(content);
+                        unredact_field(&mut states.content, map, idx, content);
                     }
-                    if let Some(reasoning) = &mut delta.reasoning_content {
-                        *reasoning = reasoning_un.process(reasoning);
+                    if let Some(rc) = &mut delta.reasoning_content {
+                        unredact_field(&mut states.reasoning_content, map, idx, rc);
                     }
-                    if let Some(reasoning) = &mut delta.reasoning {
-                        *reasoning = reasoning_un.process(reasoning);
+                    if let Some(r) = &mut delta.reasoning {
+                        unredact_field(&mut states.reasoning, map, idx, r);
                     }
                 }
             }
         }
         inference_providers::StreamChunk::Text(c) => {
             for choice in &mut c.choices {
-                choice.text = content_un.process(&choice.text);
+                let idx = choice.index;
+                unredact_field(&mut states.content, map, idx, &mut choice.text);
             }
         }
     }
+}
+
+/// Snapshot of metadata from the first chunk we see in a stream, used to
+/// build a synthetic flush chunk at end-of-stream with matching id/model.
+/// Layout: `(id, model, created, system_fingerprint)`.
+type ChunkTemplate = Option<(String, String, i64, Option<String>)>;
+
+/// Drain a per-field state map at end-of-stream, emitting a synthetic
+/// final SSE chunk for each choice index that still has bytes held in its
+/// tail buffer. Without this, an upstream stream that ends mid-placeholder
+/// would silently truncate the client's view of the response.
+fn build_flush_chunks(states: &mut StreamUnredactStates, template: &ChunkTemplate) -> Vec<Bytes> {
+    let Some((id, model, created, system_fingerprint)) = template else {
+        return Vec::new();
+    };
+
+    let mut pending: std::collections::BTreeMap<i64, (String, String, String)> =
+        std::collections::BTreeMap::new();
+    for (idx, st) in states.content.drain() {
+        let text = st.flush();
+        if !text.is_empty() {
+            pending.entry(idx).or_default().0 = text;
+        }
+    }
+    for (idx, st) in states.reasoning_content.drain() {
+        let text = st.flush();
+        if !text.is_empty() {
+            pending.entry(idx).or_default().1 = text;
+        }
+    }
+    for (idx, st) in states.reasoning.drain() {
+        let text = st.flush();
+        if !text.is_empty() {
+            pending.entry(idx).or_default().2 = text;
+        }
+    }
+
+    let mut out = Vec::with_capacity(pending.len());
+    for (idx, (content, rc, r)) in pending {
+        let chunk = inference_providers::models::ChatCompletionChunk {
+            id: id.clone(),
+            object: "chat.completion.chunk".to_string(),
+            created: *created,
+            model: model.clone(),
+            system_fingerprint: system_fingerprint.clone(),
+            choices: vec![inference_providers::models::ChatChoice {
+                index: idx,
+                delta: Some(inference_providers::models::ChatDelta {
+                    role: None,
+                    content: if content.is_empty() {
+                        None
+                    } else {
+                        Some(content)
+                    },
+                    name: None,
+                    tool_call_id: None,
+                    tool_calls: None,
+                    reasoning_content: if rc.is_empty() { None } else { Some(rc) },
+                    reasoning: if r.is_empty() { None } else { Some(r) },
+                }),
+                logprobs: None,
+                finish_reason: None,
+                token_ids: None,
+            }],
+            usage: None,
+            prompt_token_ids: None,
+            modality: None,
+        };
+        if let Ok(s) = serde_json::to_string(&chunk) {
+            out.push(Bytes::from(format!("data: {s}\n\n")));
+        }
+    }
+    out
 }
 
 // Convert HTTP CompletionRequest to service CompletionRequest
@@ -509,7 +609,7 @@ pub async fn chat_completions(
     // Auto-redact (opt-in via x-auto-redact header or auto_redact body field).
     // On success this may rewrite service_request.messages to substitute
     // placeholders for PII; the returned map drives the response un-redact.
-    let (auto_redact_enabled, redaction_map) = match maybe_redact(
+    let (auto_redact_requested, redaction_map) = match maybe_redact(
         &headers,
         &mut service_request,
         &app_state.inference_provider_pool,
@@ -519,6 +619,12 @@ pub async fn chat_completions(
         Ok(out) => out,
         Err(e) => return auto_redact_error_response(e),
     };
+    // Treat auto-redact as effectively *enabled* only when the detector
+    // actually minted placeholders. A request that opts in but contains no
+    // PII has nothing to substitute, so we skip the response re-serialize
+    // (preserves raw-bytes signing) and the streaming wrap (preserves the
+    // existing debug log path).
+    let auto_redact_enabled = auto_redact_requested && !redaction_map.is_empty();
     let redaction_map = Arc::new(redaction_map);
 
     // Check if streaming is requested
@@ -560,14 +666,21 @@ pub async fn chat_completions(
                 let request_model = request.model.clone();
                 let organization_id = api_key.organization.id.0;
 
-                // Per-stream un-redact state. When auto-redact is off,
-                // these short-circuit to passthrough (no allocation).
-                let content_unredact = Arc::new(tokio::sync::Mutex::new(StreamUnredact::new(
-                    redaction_map.clone(),
-                )));
-                let reasoning_unredact = Arc::new(tokio::sync::Mutex::new(StreamUnredact::new(
-                    redaction_map.clone(),
-                )));
+                // Per-stream un-redact state, keyed by choice index so n>1
+                // completions don't cross-contaminate sliding tails. When
+                // auto-redact is off, the map stays empty and we skip the
+                // mutex hop entirely.
+                let unredact_states: Arc<tokio::sync::Mutex<StreamUnredactStates>> =
+                    Arc::new(tokio::sync::Mutex::new(StreamUnredactStates::default()));
+                // Capture the first chunk's metadata so the end-of-stream
+                // flush can synthesize a final SSE chunk with matching
+                // id/model/created.
+                let chunk_template: Arc<tokio::sync::Mutex<ChunkTemplate>> =
+                    Arc::new(tokio::sync::Mutex::new(None));
+                let chunk_template_for_chain = chunk_template.clone();
+                let unredact_states_for_chain = unredact_states.clone();
+                let accumulated_for_chain = accumulated_bytes.clone();
+                let redaction_map_for_chunks = redaction_map.clone();
 
                 // Convert to raw bytes stream with proper SSE formatting
                 let byte_stream = peekable_stream
@@ -576,8 +689,9 @@ pub async fn chat_completions(
                         let chat_id_inner = chat_id_clone.clone();
                         let error_count_inner = error_count_clone.clone();
                         let model_for_err = request_model.clone();
-                        let content_un = content_unredact.clone();
-                        let reasoning_un = reasoning_unredact.clone();
+                        let states = unredact_states.clone();
+                        let template = chunk_template.clone();
+                        let map = redaction_map_for_chunks.clone();
                         async move {
                             match result {
                                 Ok(mut event) => {
@@ -589,13 +703,29 @@ pub async fn chat_completions(
                                         }
                                     }
 
-                                    // Auto-redact: swap any minted placeholders in this
-                                    // chunk's text deltas back to their originals before
-                                    // we serialize and send.
                                     if auto_redact_enabled {
-                                        let mut c = content_un.lock().await;
-                                        let mut r = reasoning_un.lock().await;
-                                        unredact_chunk_in_place(&mut event.chunk, &mut c, &mut r);
+                                        // Cache a template for the synthetic
+                                        // flush chunk we may emit at end-of-stream.
+                                        {
+                                            let mut t = template.lock().await;
+                                            if t.is_none() {
+                                                if let inference_providers::StreamChunk::Chat(c) =
+                                                    &event.chunk
+                                                {
+                                                    *t = Some((
+                                                        c.id.clone(),
+                                                        c.model.clone(),
+                                                        c.created,
+                                                        c.system_fingerprint.clone(),
+                                                    ));
+                                                }
+                                            }
+                                        }
+
+                                        // Swap minted placeholders in this
+                                        // chunk's text deltas back to originals.
+                                        let mut s = states.lock().await;
+                                        unredact_chunk_in_place(&mut event.chunk, &mut s, &map);
                                     }
 
                                     // Serialize the parsed chunk (normalized to OpenAI format)
@@ -609,7 +739,14 @@ pub async fn chat_completions(
                                             );
                                             "{}".to_string()
                                         });
-                                    tracing::debug!("Completion stream event: {}", json_data);
+                                    // Suppress per-chunk debug logging when
+                                    // auto_redact is enabled: the chunk now
+                                    // holds the user's original PII (we just
+                                    // un-redacted it). Logging it would
+                                    // defeat the privacy guarantee at debug.
+                                    if !auto_redact_enabled {
+                                        tracing::debug!("Completion stream event: {}", json_data);
+                                    }
                                     // Format as SSE event with proper newlines
                                     let sse_bytes = Bytes::from(format!("data: {json_data}\n\n"));
                                     accumulated_inner.lock().await.extend_from_slice(&sse_bytes);
@@ -634,9 +771,23 @@ pub async fn chat_completions(
                         }
                     })
                     .chain(futures::stream::once({
+                        // End-of-stream tail: emit any flush chunks (held
+                        // tail bytes that the sliding window didn't get to
+                        // resolve) inline with [DONE]. They're framed as
+                        // separate SSE events by `\n\n` so the client sees
+                        // them as distinct deltas.
                         let organization_id = api_key.organization.id.0;
                         let model_name = request.model.clone();
                         async move {
+                            let mut combined: Vec<u8> = Vec::new();
+                            if auto_redact_enabled {
+                                let mut states = unredact_states_for_chain.lock().await;
+                                let template = chunk_template_for_chain.lock().await.clone();
+                                for bytes in build_flush_chunks(&mut states, &template) {
+                                    combined.extend_from_slice(&bytes);
+                                }
+                            }
+
                             let error_count_final =
                                 stream_error_count.load(std::sync::atomic::Ordering::Relaxed);
                             if error_count_final > 1 {
@@ -648,13 +799,13 @@ pub async fn chat_completions(
                                 );
                             }
 
-                            let done_bytes = Bytes::from_static(b"data: [DONE]\n\n");
-                            accumulated_bytes
+                            combined.extend_from_slice(b"data: [DONE]\n\n");
+                            let final_bytes = Bytes::from(combined);
+                            accumulated_for_chain
                                 .lock()
                                 .await
-                                .extend_from_slice(&done_bytes);
-
-                            Ok::<Bytes, Infallible>(done_bytes)
+                                .extend_from_slice(&final_bytes);
+                            Ok::<Bytes, Infallible>(final_bytes)
                         }
                     }));
 

--- a/crates/api/tests/e2e_all/auto_redact.rs
+++ b/crates/api/tests/e2e_all/auto_redact.rs
@@ -1,0 +1,373 @@
+//! E2E tests for `x-auto-redact` on /v1/chat/completions.
+//!
+//! The MockProvider's `privacy_classify_raw` does shape-based PII detection
+//! (email, SSN, phone), so we can exercise the full redact→provider→
+//! unredact loop in-process without a live privacy-filter model.
+
+use crate::common::*;
+use api::models::BatchUpdateModelApiRequest;
+
+/// Pull `choices[0].message.content` out of a chat completion response as
+/// a `&str`. Returns empty string if the path isn't there — tests assert
+/// non-empty content downstream.
+fn extract_choice_text(value: &serde_json::Value) -> String {
+    value
+        .pointer("/choices/0/message/content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Register openai/privacy-filter in the cloud-api models DB. Required for
+/// auto-redact to route the detector call through the provider pool.
+async fn setup_privacy_filter_model(server: &axum_test::TestServer) {
+    let mut batch = BatchUpdateModelApiRequest::new();
+    batch.insert(
+        "openai/privacy-filter".to_string(),
+        serde_json::from_value(serde_json::json!({
+            "inputCostPerToken": {"amount": 0, "scale": 9, "currency": "USD"},
+            "outputCostPerToken": {"amount": 0, "scale": 9, "currency": "USD"},
+            "costPerImage": {"amount": 0, "scale": 9, "currency": "USD"},
+            "modelDisplayName": "Privacy Filter",
+            "modelDescription": "PII span detection",
+            "contextLength": 512,
+            "verifiable": false,
+            "isActive": true
+        }))
+        .unwrap(),
+    );
+    let updated = admin_batch_upsert_models(server, batch, get_session_id()).await;
+    assert_eq!(updated.len(), 1);
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+}
+
+#[tokio::test]
+async fn auto_redact_off_passes_pii_through() {
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new("ok"))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{
+                "role": "user",
+                "content": "My email is alice@example.com"
+            }],
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    // With auto-redact off, the mock should have seen the raw PII.
+    let params = mock_provider
+        .last_chat_params()
+        .await
+        .expect("mock should have recorded a chat call");
+    let seen = serde_json::to_string(&params.messages).unwrap();
+    assert!(
+        seen.contains("alice@example.com"),
+        "expected unredacted PII to reach provider when auto_redact is off; got {seen}"
+    );
+}
+
+#[tokio::test]
+async fn auto_redact_header_redacts_prompt_and_restores_response() {
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    // Mock response references the minted placeholder so we can verify the
+    // un-redact path puts the original back.
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new(
+            "I'll email <email1> shortly.",
+        ))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .add_header("x-auto-redact", "on")
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{
+                "role": "user",
+                "content": "Please reach out to alice@example.com"
+            }],
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    // Provider must NOT have seen the original email.
+    let params = mock_provider
+        .last_chat_params()
+        .await
+        .expect("recorded call");
+    let seen = serde_json::to_string(&params.messages).unwrap();
+    assert!(
+        !seen.contains("alice@example.com"),
+        "provider saw raw PII: {seen}"
+    );
+    assert!(
+        seen.contains("<email1>"),
+        "provider should see placeholder: {seen}"
+    );
+
+    // Client must see the original PII in the response.
+    let body: serde_json::Value = resp.json();
+    let content = extract_choice_text(&body);
+    assert!(
+        content.contains("alice@example.com"),
+        "client should see un-redacted response; got {content}"
+    );
+    assert!(
+        !content.contains("<email1>"),
+        "placeholder should have been swapped back; got {content}"
+    );
+}
+
+#[tokio::test]
+async fn auto_redact_body_field_equivalent_to_header() {
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new(
+            "noted <email1>",
+        ))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{ "role": "user", "content": "ping bob@example.com" }],
+            "auto_redact": true,
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    // Provider saw placeholder, client gets original back.
+    let params = mock_provider.last_chat_params().await.unwrap();
+    let seen = serde_json::to_string(&params.messages).unwrap();
+    assert!(!seen.contains("bob@example.com"));
+    assert!(seen.contains("<email1>"));
+
+    // The body field must be stripped from extra so it isn't forwarded
+    // upstream — providers like Anthropic 422 on unknown fields.
+    let extra_keys: Vec<&String> = params.extra.keys().collect();
+    assert!(
+        !extra_keys.iter().any(|k| k.as_str() == "auto_redact"),
+        "auto_redact body field must be stripped before forwarding; saw keys {extra_keys:?}"
+    );
+
+    let body: serde_json::Value = resp.json();
+    let content = extract_choice_text(&body);
+    assert!(
+        content.contains("bob@example.com"),
+        "client should see un-redacted response; got {content}"
+    );
+}
+
+#[tokio::test]
+async fn auto_redact_streaming_splits_placeholder_across_chunks() {
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    // The MockProvider's default streaming behavior emits the response
+    // character-by-character, so a placeholder like `<email1>` will be
+    // split across SSE chunks — exactly the case the StreamUnredact tail
+    // is designed for.
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new(
+            "Sending to <email1> now.",
+        ))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .add_header("x-auto-redact", "on")
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{ "role": "user", "content": "email alice@example.com" }],
+            "stream": true,
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    // Concatenate all `delta.content` from the SSE stream.
+    let body_text = resp.text();
+    let mut assembled = String::new();
+    for line in body_text.lines() {
+        let payload = match line.strip_prefix("data: ") {
+            Some(p) => p,
+            None => continue,
+        };
+        if payload == "[DONE]" {
+            continue;
+        }
+        let Ok(chunk) = serde_json::from_str::<serde_json::Value>(payload) else {
+            continue;
+        };
+        if let Some(choices) = chunk.get("choices").and_then(|c| c.as_array()) {
+            for ch in choices {
+                if let Some(content) = ch
+                    .get("delta")
+                    .and_then(|d| d.get("content"))
+                    .and_then(|c| c.as_str())
+                {
+                    assembled.push_str(content);
+                }
+            }
+        }
+    }
+
+    assert!(
+        assembled.contains("alice@example.com"),
+        "streamed content should be un-redacted; got: {assembled:?}"
+    );
+    assert!(
+        !assembled.contains("<email1>"),
+        "no placeholder should leak to client; got: {assembled:?}"
+    );
+}
+
+#[tokio::test]
+async fn auto_redact_fail_closed_when_pii_model_missing() {
+    let (server, pool, _mock, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    // Force the PII detector to be unavailable by unregistering its mock
+    // entry from the pool. With no provider for openai/privacy-filter, the
+    // detector call must fail and the handler must refuse the request
+    // rather than send raw PII to the provider.
+    pool.unregister_provider("openai/privacy-filter").await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .add_header("x-auto-redact", "on")
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{ "role": "user", "content": "email alice@example.com" }],
+        }))
+        .await;
+    assert_eq!(
+        resp.status_code(),
+        503,
+        "must fail closed when PII detector is unavailable"
+    );
+    let body: serde_json::Value = resp.json();
+    assert_eq!(
+        body["error"]["type"].as_str(),
+        Some("auto_redact_unavailable"),
+        "expected typed error: {body}"
+    );
+}
+
+#[tokio::test]
+async fn auto_redact_off_when_header_is_falsy() {
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new("ok"))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .add_header("x-auto-redact", "off")
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{
+                "role": "user",
+                "content": "My SSN is 555-66-7777"
+            }],
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    let params = mock_provider.last_chat_params().await.unwrap();
+    let seen = serde_json::to_string(&params.messages).unwrap();
+    assert!(
+        seen.contains("555-66-7777"),
+        "off header must not redact: {seen}"
+    );
+}
+
+#[tokio::test]
+async fn auto_redact_multiple_pii_kinds_per_message() {
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new(
+            "Got it — emailing <email1> and texting <phone1>; SSN <account1> on file.",
+        ))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .add_header("x-auto-redact", "on")
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{
+                "role": "user",
+                "content": "contact alice@example.com phone +1-555-123-4567 ssn 555-66-7777"
+            }],
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    let params = mock_provider.last_chat_params().await.unwrap();
+    let seen = serde_json::to_string(&params.messages).unwrap();
+    for raw in ["alice@example.com", "+1-555-123-4567", "555-66-7777"] {
+        assert!(!seen.contains(raw), "raw {raw} leaked to provider: {seen}");
+    }
+    assert!(seen.contains("<email1>"));
+    assert!(seen.contains("<phone1>"));
+    assert!(seen.contains("<account1>"));
+
+    let body: serde_json::Value = resp.json();
+    let content = extract_choice_text(&body);
+    for raw in ["alice@example.com", "+1-555-123-4567", "555-66-7777"] {
+        assert!(
+            content.contains(raw),
+            "client should see raw {raw}; got: {content}"
+        );
+    }
+}

--- a/crates/api/tests/e2e_all/auto_redact.rs
+++ b/crates/api/tests/e2e_all/auto_redact.rs
@@ -325,6 +325,42 @@ async fn auto_redact_off_when_header_is_falsy() {
 }
 
 #[tokio::test]
+async fn auto_redact_skips_response_munging_when_no_pii_detected() {
+    // When auto_redact is requested but the prompt has no PII, the
+    // detector returns no spans, the placeholder map stays empty, and we
+    // should NOT munge / re-serialize the response. This preserves the
+    // raw_bytes signing path for clean inputs.
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    // Provider response contains a literal that *looks* like a placeholder.
+    // If we were re-serializing unconditionally, it would still pass
+    // through; this test mainly ensures the path stays the no-op one.
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new("hi there"))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .add_header("x-auto-redact", "on")
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{ "role": "user", "content": "what time is it" }],
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    let body: serde_json::Value = resp.json();
+    let content = extract_choice_text(&body);
+    assert_eq!(content, "hi there");
+}
+
+#[tokio::test]
 async fn auto_redact_multiple_pii_kinds_per_message() {
     let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
     setup_qwen_model(&server).await;

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -13,6 +13,7 @@ mod api_keys;
 mod audio_image;
 mod audio_transcriptions;
 mod auth_tokens;
+mod auto_redact;
 mod billing_and_models;
 mod chat_encryption;
 mod check_api_key;

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -24,6 +24,60 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, RwLock};
 
+/// Lightweight PII detector used only by [`MockProvider::privacy_classify_raw`]
+/// to simulate the privacy-filter model in tests. Matches obvious shapes:
+/// email, US-style phone, SSN-like sequences. Not used in production.
+///
+/// The output mirrors the privacy-filter response shape (per-span object
+/// with `category`, `start`, `end`, `score`, `text`).
+fn detect_simple_pii_spans(text: &str) -> Vec<serde_json::Value> {
+    use std::sync::LazyLock;
+    static EMAIL_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b").unwrap()
+    });
+    static SSN_RE: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap());
+    static PHONE_RE: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"\+?\d[\d\-\s]{7,}\d").unwrap());
+
+    let mut out: Vec<serde_json::Value> = Vec::new();
+    for m in EMAIL_RE.find_iter(text) {
+        out.push(serde_json::json!({
+            "category": "private_email",
+            "start": m.start(),
+            "end": m.end(),
+            "score": 0.99,
+            "text": m.as_str(),
+        }));
+    }
+    for m in SSN_RE.find_iter(text) {
+        out.push(serde_json::json!({
+            "category": "account_number",
+            "start": m.start(),
+            "end": m.end(),
+            "score": 0.99,
+            "text": m.as_str(),
+        }));
+    }
+    for m in PHONE_RE.find_iter(text) {
+        // Skip if this match is already covered by SSN (which also matches
+        // a 3-2-4 digit pattern); SSN is the more specific category.
+        let overlaps_ssn = SSN_RE
+            .find_iter(text)
+            .any(|s| !(m.end() <= s.start() || m.start() >= s.end()));
+        if !overlaps_ssn {
+            out.push(serde_json::json!({
+                "category": "private_phone",
+                "start": m.start(),
+                "end": m.end(),
+                "score": 0.99,
+                "text": m.as_str(),
+            }));
+        }
+    }
+    out
+}
+
 fn compute_sha256_hex(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
@@ -1094,17 +1148,43 @@ impl crate::InferenceProvider for MockProvider {
         _extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, PrivacyClassifyError> {
         // Echo the requested model so round-trip assertions in tests are meaningful.
-        let model = serde_json::from_slice::<serde_json::Value>(&body)
-            .ok()
-            .and_then(|v| v.get("model").and_then(|m| m.as_str()).map(str::to_string))
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+        let model = parsed
+            .get("model")
+            .and_then(|m| m.as_str())
+            .map(str::to_string)
             .unwrap_or_else(|| "mock-privacy-filter".to_string());
+
+        // Materialize the inputs into a Vec<String> regardless of whether the
+        // caller sent a single string or an array. We mirror the privacy-
+        // filter contract here so the auto_redact pipeline can be exercised
+        // without a live PII model.
+        let inputs: Vec<String> = match parsed.get("input") {
+            Some(serde_json::Value::String(s)) => vec![s.clone()],
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .map(|v| v.as_str().unwrap_or("").to_string())
+                .collect(),
+            _ => Vec::new(),
+        };
+
+        let data: Vec<serde_json::Value> = inputs
+            .iter()
+            .enumerate()
+            .map(|(i, text)| {
+                let spans = detect_simple_pii_spans(text);
+                serde_json::json!({
+                    "index": i,
+                    "spans": spans,
+                    "usage": {"input_tokens": text.split_whitespace().count() as i32}
+                })
+            })
+            .collect();
+
         let response_json = serde_json::json!({
             "model": model,
-            "data": [{
-                "index": 0,
-                "spans": [],
-                "usage": {"input_tokens": 10}
-            }]
+            "data": data,
         });
         let bytes = serde_json::to_vec(&response_json)
             .map_err(|e| PrivacyClassifyError::RequestFailed(e.to_string()))?;

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -1169,6 +1169,9 @@ impl crate::InferenceProvider for MockProvider {
             _ => Vec::new(),
         };
 
+        // Per-item usage matches the original mock contract (10 tokens) so
+        // tests asserting on billing math don't have to track input length.
+        // Only the `spans` field is computed from the input.
         let data: Vec<serde_json::Value> = inputs
             .iter()
             .enumerate()
@@ -1177,7 +1180,7 @@ impl crate::InferenceProvider for MockProvider {
                 serde_json::json!({
                     "index": i,
                     "spans": spans,
-                    "usage": {"input_tokens": text.split_whitespace().count() as i32}
+                    "usage": {"input_tokens": 10}
                 })
             })
             .collect();

--- a/crates/services/src/auto_redact/apply.rs
+++ b/crates/services/src/auto_redact/apply.rs
@@ -94,7 +94,6 @@ pub struct Span {
     pub category: String,
     pub start: usize,
     pub end: usize,
-    pub text: String,
 }
 
 /// Apply detected spans to a text fragment, replacing each PII span with a
@@ -102,9 +101,20 @@ pub struct Span {
 /// `start`; overlapping spans are resolved by preferring the earlier one
 /// (the later one is silently dropped — privacy-filter doesn't emit
 /// overlaps in practice).
-pub fn redact_one(text: &str, spans: &[Span], map: &mut super::RedactionMap) -> String {
+///
+/// **Fail-closed on malformed input.** If the detector returns spans whose
+/// byte offsets don't land on UTF-8 char boundaries, or whose bounds are
+/// outside the input, this returns `Err(AutoRedactError::Internal)` rather
+/// than silently passing the raw text through (which would leak PII to the
+/// upstream provider).
+pub fn redact_one(
+    text: &str,
+    spans: &[Span],
+    map: &mut super::RedactionMap,
+) -> Result<String, super::AutoRedactError> {
+    use super::AutoRedactError;
     if spans.is_empty() {
-        return text.to_string();
+        return Ok(text.to_string());
     }
     let bytes = text.as_bytes();
     let mut sorted: Vec<&Span> = spans.iter().collect();
@@ -118,31 +128,39 @@ pub fn redact_one(text: &str, spans: &[Span], map: &mut super::RedactionMap) -> 
             continue;
         }
         if span.end > bytes.len() || span.start > span.end {
-            // Malformed span — skip rather than panic on slice.
-            continue;
+            return Err(AutoRedactError::Internal(format!(
+                "malformed span: start={} end={} text_len={}",
+                span.start,
+                span.end,
+                bytes.len()
+            )));
         }
-        // Append the text between the previous span and this one.
-        if let Ok(s) = std::str::from_utf8(&bytes[cursor..span.start]) {
-            out.push_str(s);
-        } else {
-            // Non-UTF8 boundary; refuse to redact this fragment safely.
-            return text.to_string();
+        // Slicing the &str requires char-boundary offsets. We must use the
+        // `&str` path (not `from_utf8` on byte slices) so a span boundary
+        // that falls inside a multi-byte UTF-8 sequence fails closed.
+        if !text.is_char_boundary(cursor)
+            || !text.is_char_boundary(span.start)
+            || !text.is_char_boundary(span.end)
+        {
+            return Err(AutoRedactError::Internal(
+                "PII span boundary is not a UTF-8 char boundary".to_string(),
+            ));
         }
-        // Prefer the model's own `text` field when it's a clean UTF-8 slice
-        // of the input; fall back to the raw slice otherwise.
-        let original = std::str::from_utf8(&bytes[span.start..span.end])
-            .map(str::to_string)
-            .unwrap_or_else(|_| span.text.clone());
-        let placeholder = map.lookup_or_mint(&span.category, &original);
+        out.push_str(&text[cursor..span.start]);
+        let original = &text[span.start..span.end];
+        let placeholder = map.lookup_or_mint(&span.category, original);
         out.push_str(&placeholder);
         cursor = span.end;
     }
     if cursor < bytes.len() {
-        if let Ok(s) = std::str::from_utf8(&bytes[cursor..]) {
-            out.push_str(s);
+        if !text.is_char_boundary(cursor) {
+            return Err(AutoRedactError::Internal(
+                "PII span tail boundary is not a UTF-8 char boundary".to_string(),
+            ));
         }
+        out.push_str(&text[cursor..]);
     }
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -234,16 +252,14 @@ mod tests {
                 category: "private_email".into(),
                 start: 6,
                 end: 23,
-                text: "alice@example.com".into(),
             },
             Span {
                 category: "private_email".into(),
                 start: 27,
                 end: 42,
-                text: "bob@example.com".into(),
             },
         ];
-        let out = redact_one(text, &spans, &mut map);
+        let out = redact_one(text, &spans, &mut map).unwrap();
         assert_eq!(out, "Email <email1> or <email2>");
     }
 
@@ -256,17 +272,47 @@ mod tests {
                 category: "private_email".into(),
                 start: 3,
                 end: 14,
-                text: "alice@x.com".into(),
             },
             Span {
                 category: "private_email".into(),
                 start: 18,
                 end: 29,
-                text: "alice@x.com".into(),
             },
         ];
-        let out = redact_one(text, &spans, &mut map);
+        let out = redact_one(text, &spans, &mut map).unwrap();
         assert_eq!(out, "to <email1> or <email1> again");
+    }
+
+    #[test]
+    fn redact_one_fails_closed_on_non_char_boundary() {
+        let mut map = RedactionMap::new();
+        // "héllo" — `é` is 2 bytes (0xC3 0xA9). A span that ends inside
+        // the multi-byte sequence must be rejected, not silently passed
+        // through (which would leak the original text).
+        let text = "héllo";
+        let spans = vec![Span {
+            category: "private_name".into(),
+            start: 0,
+            end: 2,
+        }];
+        let err = redact_one(text, &spans, &mut map).unwrap_err();
+        assert!(
+            matches!(err, super::super::AutoRedactError::Internal(_)),
+            "expected Internal error on non-char boundary"
+        );
+    }
+
+    #[test]
+    fn redact_one_fails_closed_on_out_of_range_span() {
+        let mut map = RedactionMap::new();
+        let text = "short";
+        let spans = vec![Span {
+            category: "private_email".into(),
+            start: 0,
+            end: 999,
+        }];
+        let err = redact_one(text, &spans, &mut map).unwrap_err();
+        assert!(matches!(err, super::super::AutoRedactError::Internal(_)));
     }
 
     #[test]
@@ -279,23 +325,21 @@ mod tests {
                 category: "private_name".into(),
                 start: 0,
                 end: 5,
-                text: "Hello".into(),
             },
             Span {
                 category: "private_name".into(),
                 start: 2,
                 end: 7,
-                text: "llo w".into(),
             },
         ];
-        let out = redact_one(text, &spans, &mut map);
+        let out = redact_one(text, &spans, &mut map).unwrap();
         assert_eq!(out, "<name1> world");
     }
 
     #[test]
     fn redact_one_empty_spans_passthrough() {
         let mut map = RedactionMap::new();
-        let out = redact_one("nothing private", &[], &mut map);
+        let out = redact_one("nothing private", &[], &mut map).unwrap();
         assert_eq!(out, "nothing private");
         assert!(map.is_empty());
     }

--- a/crates/services/src/auto_redact/apply.rs
+++ b/crates/services/src/auto_redact/apply.rs
@@ -1,0 +1,302 @@
+//! Walk `CompletionMessage` content, pull out the text fragments that need
+//! to be sent to the PII detector, and write the redacted text back in.
+//!
+//! Message content in [`crate::completions::ports::CompletionMessage`] is a
+//! `serde_json::Value`:
+//! - `Value::String(s)` for simple text
+//! - `Value::Array([{"type":"text","text":s}, …])` for multimodal parts
+//!
+//! Only text fragments are extracted; non-text parts (image_url, audio,
+//! video, file) pass through unchanged. Order is preserved so the indices
+//! returned to the detector match the indices we write back.
+
+use crate::completions::ports::CompletionMessage;
+
+/// A reference into a `CompletionMessage` that points at a single text
+/// fragment. Pairs 1:1 with an entry in the texts vec we hand to the
+/// detector.
+#[derive(Debug, Clone)]
+pub enum TextRef {
+    /// `messages[msg_idx].content` is a `Value::String`.
+    Whole { msg_idx: usize },
+    /// `messages[msg_idx].content[part_idx]["text"]` is a text part.
+    Part { msg_idx: usize, part_idx: usize },
+}
+
+/// Pull every text fragment from `messages` along with a reference for
+/// writing it back. Non-text content (images, audio, etc.) is skipped.
+pub fn collect_text_fragments(messages: &[CompletionMessage]) -> (Vec<TextRef>, Vec<String>) {
+    let mut refs = Vec::new();
+    let mut texts = Vec::new();
+
+    for (msg_idx, msg) in messages.iter().enumerate() {
+        match &msg.content {
+            serde_json::Value::String(s) => {
+                if !s.is_empty() {
+                    refs.push(TextRef::Whole { msg_idx });
+                    texts.push(s.clone());
+                }
+            }
+            serde_json::Value::Array(parts) => {
+                for (part_idx, part) in parts.iter().enumerate() {
+                    if let Some(ty) = part.get("type").and_then(|v| v.as_str()) {
+                        if ty == "text" {
+                            if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                                if !text.is_empty() {
+                                    refs.push(TextRef::Part { msg_idx, part_idx });
+                                    texts.push(text.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // Null / number / bool / object: ignore.
+            _ => {}
+        }
+    }
+
+    (refs, texts)
+}
+
+/// Write `redacted` back to the locations pointed at by `refs`. Lengths
+/// must match (one redacted string per ref). Panics on mismatch — this is a
+/// caller bug, not a runtime condition.
+pub fn write_back(messages: &mut [CompletionMessage], refs: &[TextRef], redacted: Vec<String>) {
+    assert_eq!(
+        refs.len(),
+        redacted.len(),
+        "refs and redacted lengths must match"
+    );
+
+    for (r, new_text) in refs.iter().zip(redacted) {
+        match r {
+            TextRef::Whole { msg_idx } => {
+                messages[*msg_idx].content = serde_json::Value::String(new_text);
+            }
+            TextRef::Part { msg_idx, part_idx } => {
+                if let serde_json::Value::Array(parts) = &mut messages[*msg_idx].content {
+                    if let Some(part) = parts.get_mut(*part_idx) {
+                        if let Some(obj) = part.as_object_mut() {
+                            obj.insert("text".to_string(), serde_json::Value::String(new_text));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A single PII span as returned by the privacy-filter model. Byte offsets
+/// are into the original UTF-8 text.
+#[derive(Debug, Clone)]
+pub struct Span {
+    pub category: String,
+    pub start: usize,
+    pub end: usize,
+    pub text: String,
+}
+
+/// Apply detected spans to a text fragment, replacing each PII span with a
+/// placeholder minted (or reused) on `map`. Spans must be sorted by
+/// `start`; overlapping spans are resolved by preferring the earlier one
+/// (the later one is silently dropped — privacy-filter doesn't emit
+/// overlaps in practice).
+pub fn redact_one(text: &str, spans: &[Span], map: &mut super::RedactionMap) -> String {
+    if spans.is_empty() {
+        return text.to_string();
+    }
+    let bytes = text.as_bytes();
+    let mut sorted: Vec<&Span> = spans.iter().collect();
+    sorted.sort_by_key(|s| s.start);
+
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for span in sorted {
+        if span.start < cursor {
+            // Overlapping with the previous span: drop the offending one.
+            continue;
+        }
+        if span.end > bytes.len() || span.start > span.end {
+            // Malformed span — skip rather than panic on slice.
+            continue;
+        }
+        // Append the text between the previous span and this one.
+        if let Ok(s) = std::str::from_utf8(&bytes[cursor..span.start]) {
+            out.push_str(s);
+        } else {
+            // Non-UTF8 boundary; refuse to redact this fragment safely.
+            return text.to_string();
+        }
+        // Prefer the model's own `text` field when it's a clean UTF-8 slice
+        // of the input; fall back to the raw slice otherwise.
+        let original = std::str::from_utf8(&bytes[span.start..span.end])
+            .map(str::to_string)
+            .unwrap_or_else(|_| span.text.clone());
+        let placeholder = map.lookup_or_mint(&span.category, &original);
+        out.push_str(&placeholder);
+        cursor = span.end;
+    }
+    if cursor < bytes.len() {
+        if let Ok(s) = std::str::from_utf8(&bytes[cursor..]) {
+            out.push_str(s);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auto_redact::RedactionMap;
+    use serde_json::json;
+
+    fn msg(role: &str, content: serde_json::Value) -> CompletionMessage {
+        CompletionMessage {
+            role: role.to_string(),
+            content,
+            tool_call_id: None,
+            tool_calls: None,
+        }
+    }
+
+    #[test]
+    fn collect_string_content() {
+        let messages = vec![
+            msg("system", json!("be terse")),
+            msg("user", json!("hello world")),
+        ];
+        let (refs, texts) = collect_text_fragments(&messages);
+        assert_eq!(texts, vec!["be terse", "hello world"]);
+        assert!(matches!(refs[0], TextRef::Whole { msg_idx: 0 }));
+        assert!(matches!(refs[1], TextRef::Whole { msg_idx: 1 }));
+    }
+
+    #[test]
+    fn collect_skips_non_text_parts() {
+        let messages = vec![msg(
+            "user",
+            json!([
+                {"type": "text", "text": "look at this"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+                {"type": "text", "text": "and this"}
+            ]),
+        )];
+        let (refs, texts) = collect_text_fragments(&messages);
+        assert_eq!(texts, vec!["look at this", "and this"]);
+        assert!(matches!(
+            refs[0],
+            TextRef::Part {
+                msg_idx: 0,
+                part_idx: 0
+            }
+        ));
+        assert!(matches!(
+            refs[1],
+            TextRef::Part {
+                msg_idx: 0,
+                part_idx: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn write_back_round_trip() {
+        let mut messages = vec![
+            msg("user", json!("alpha")),
+            msg(
+                "user",
+                json!([
+                    {"type": "text", "text": "beta"},
+                    {"type": "image_url", "image_url": {"url": "x"}},
+                    {"type": "text", "text": "gamma"}
+                ]),
+            ),
+        ];
+        let (refs, texts) = collect_text_fragments(&messages);
+        assert_eq!(texts.len(), 3);
+        let new_texts = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        write_back(&mut messages, &refs, new_texts);
+
+        assert_eq!(messages[0].content, json!("A"));
+        let arr = messages[1].content.as_array().unwrap();
+        assert_eq!(arr[0]["text"], json!("B"));
+        assert_eq!(arr[1]["type"], json!("image_url"), "image part untouched");
+        assert_eq!(arr[2]["text"], json!("C"));
+    }
+
+    #[test]
+    fn redact_one_basic() {
+        let mut map = RedactionMap::new();
+        let text = "Email alice@example.com or bob@example.com";
+        let spans = vec![
+            Span {
+                category: "private_email".into(),
+                start: 6,
+                end: 23,
+                text: "alice@example.com".into(),
+            },
+            Span {
+                category: "private_email".into(),
+                start: 27,
+                end: 42,
+                text: "bob@example.com".into(),
+            },
+        ];
+        let out = redact_one(text, &spans, &mut map);
+        assert_eq!(out, "Email <email1> or <email2>");
+    }
+
+    #[test]
+    fn redact_one_dedup_same_email() {
+        let mut map = RedactionMap::new();
+        let text = "to alice@x.com or alice@x.com again";
+        let spans = vec![
+            Span {
+                category: "private_email".into(),
+                start: 3,
+                end: 14,
+                text: "alice@x.com".into(),
+            },
+            Span {
+                category: "private_email".into(),
+                start: 18,
+                end: 29,
+                text: "alice@x.com".into(),
+            },
+        ];
+        let out = redact_one(text, &spans, &mut map);
+        assert_eq!(out, "to <email1> or <email1> again");
+    }
+
+    #[test]
+    fn redact_one_drops_overlapping_span() {
+        let mut map = RedactionMap::new();
+        let text = "Hello world";
+        // Two spans where the second overlaps the first.
+        let spans = vec![
+            Span {
+                category: "private_name".into(),
+                start: 0,
+                end: 5,
+                text: "Hello".into(),
+            },
+            Span {
+                category: "private_name".into(),
+                start: 2,
+                end: 7,
+                text: "llo w".into(),
+            },
+        ];
+        let out = redact_one(text, &spans, &mut map);
+        assert_eq!(out, "<name1> world");
+    }
+
+    #[test]
+    fn redact_one_empty_spans_passthrough() {
+        let mut map = RedactionMap::new();
+        let out = redact_one("nothing private", &[], &mut map);
+        assert_eq!(out, "nothing private");
+        assert!(map.is_empty());
+    }
+}

--- a/crates/services/src/auto_redact/detect.rs
+++ b/crates/services/src/auto_redact/detect.rs
@@ -1,0 +1,168 @@
+//! Call the privacy-filter model via the inference provider pool, parsing
+//! the response into per-text [`Span`] lists.
+
+use super::apply::Span;
+use super::AutoRedactError;
+use crate::inference_provider_pool::InferenceProviderPool;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Default threshold for privacy-filter spans. Below this score we discard
+/// the span. Score distribution from the model concentrates near 1.0 for
+/// clean PII, so 0.5 trades off mild false-negatives for strong false-
+/// positive resistance.
+pub const DEFAULT_THRESHOLD: f64 = 0.5;
+
+/// Call the privacy-filter model with the list of input texts. Returns
+/// one Span vec per input, in the same order.
+///
+/// On any transport / parse / status error, returns `AutoRedactError`.
+/// Callers should fail closed (return 503 to the client) when this errors.
+pub async fn detect_pii(
+    texts: &[String],
+    model: &str,
+    pool: &InferenceProviderPool,
+) -> Result<Vec<Vec<Span>>, AutoRedactError> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let req_body = serde_json::json!({
+        "model": model,
+        "input": texts,
+        "threshold": DEFAULT_THRESHOLD,
+    });
+    let body_bytes = serde_json::to_vec(&req_body)
+        .map_err(|e| AutoRedactError::Internal(format!("encode detect req: {e}")))?;
+
+    let resp_bytes = pool
+        .privacy_classify(model, bytes::Bytes::from(body_bytes), HashMap::new())
+        .await
+        .map_err(|e| AutoRedactError::DetectorUnavailable(detector_error_message(&e)))?;
+
+    parse_response(&resp_bytes, texts.len())
+}
+
+/// Convert the inference-pool error into a sanitized public message.
+/// We deliberately drop any provider-specific detail that could leak
+/// state about other tenants or backends.
+fn detector_error_message(err: &inference_providers::PrivacyClassifyError) -> String {
+    use inference_providers::PrivacyClassifyError as E;
+    match err {
+        E::HttpError { status_code, .. } => {
+            format!("PII detector returned HTTP {status_code}")
+        }
+        E::RequestFailed(_) => "PII detector unreachable".to_string(),
+    }
+}
+
+/// Privacy-filter response shape:
+/// ```json
+/// {
+///   "model": "openai/privacy-filter",
+///   "data": [
+///     {"index": 0, "spans": [{"category": "...", "start": N, "end": N, "score": F, "text": "..."}, ...], "usage": {"input_tokens": N}},
+///     ...
+///   ]
+/// }
+/// ```
+#[derive(Deserialize)]
+struct DetectResponse {
+    #[serde(default)]
+    data: Vec<DetectItem>,
+}
+
+#[derive(Deserialize)]
+struct DetectItem {
+    #[serde(default)]
+    index: usize,
+    #[serde(default)]
+    spans: Vec<RawSpan>,
+}
+
+#[derive(Deserialize)]
+struct RawSpan {
+    category: String,
+    start: usize,
+    end: usize,
+    #[serde(default)]
+    text: String,
+}
+
+fn parse_response(bytes: &[u8], expected_len: usize) -> Result<Vec<Vec<Span>>, AutoRedactError> {
+    let parsed: DetectResponse = serde_json::from_slice(bytes)
+        .map_err(|e| AutoRedactError::Internal(format!("decode detect resp: {e}")))?;
+
+    let mut out: Vec<Vec<Span>> = (0..expected_len).map(|_| Vec::new()).collect();
+    for item in parsed.data {
+        if item.index >= expected_len {
+            // Defensive: model returned an index beyond what we asked for.
+            continue;
+        }
+        out[item.index] = item
+            .spans
+            .into_iter()
+            .map(|s| Span {
+                category: s.category,
+                start: s.start,
+                end: s.end,
+                text: s.text,
+            })
+            .collect();
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_basic_response() {
+        let body = br#"{
+            "model": "openai/privacy-filter",
+            "data": [
+                {"index": 0, "spans": [
+                    {"category": "private_email", "start": 6, "end": 23, "score": 0.99, "text": "alice@example.com"}
+                ], "usage": {"input_tokens": 5}},
+                {"index": 1, "spans": [], "usage": {"input_tokens": 2}}
+            ]
+        }"#;
+        let spans = parse_response(body, 2).unwrap();
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].len(), 1);
+        assert_eq!(spans[0][0].category, "private_email");
+        assert_eq!(spans[0][0].start, 6);
+        assert_eq!(spans[0][0].end, 23);
+        assert_eq!(spans[1].len(), 0);
+    }
+
+    #[test]
+    fn parse_pads_missing_indices() {
+        // If the detector omits index 1 entirely, we still return an empty
+        // span vec for it so apply.write_back stays index-aligned.
+        let body = br#"{"data": [{"index": 0, "spans": [], "usage": {"input_tokens": 1}}]}"#;
+        let spans = parse_response(body, 3).unwrap();
+        assert_eq!(spans.len(), 3);
+        for s in &spans {
+            assert!(s.is_empty());
+        }
+    }
+
+    #[test]
+    fn parse_drops_out_of_range_index() {
+        // index=5 but we only sent 2 texts — drop it rather than panicking.
+        let body = br#"{"data": [
+            {"index": 5, "spans": [{"category": "x", "start": 0, "end": 1, "score": 1.0, "text": "h"}], "usage": {"input_tokens": 1}}
+        ]}"#;
+        let spans = parse_response(body, 2).unwrap();
+        assert_eq!(spans.len(), 2);
+        assert!(spans.iter().all(|v| v.is_empty()));
+    }
+
+    #[test]
+    fn parse_garbage_errors() {
+        let err = parse_response(b"not json", 1).unwrap_err();
+        assert!(matches!(err, AutoRedactError::Internal(_)));
+    }
+}

--- a/crates/services/src/auto_redact/detect.rs
+++ b/crates/services/src/auto_redact/detect.rs
@@ -85,8 +85,6 @@ struct RawSpan {
     category: String,
     start: usize,
     end: usize,
-    #[serde(default)]
-    text: String,
 }
 
 fn parse_response(bytes: &[u8], expected_len: usize) -> Result<Vec<Vec<Span>>, AutoRedactError> {
@@ -99,16 +97,13 @@ fn parse_response(bytes: &[u8], expected_len: usize) -> Result<Vec<Vec<Span>>, A
             // Defensive: model returned an index beyond what we asked for.
             continue;
         }
-        out[item.index] = item
-            .spans
-            .into_iter()
-            .map(|s| Span {
-                category: s.category,
-                start: s.start,
-                end: s.end,
-                text: s.text,
-            })
-            .collect();
+        // Extend rather than replace: the detector may legitimately split
+        // detections for the same input across multiple data entries.
+        out[item.index].extend(item.spans.into_iter().map(|s| Span {
+            category: s.category,
+            start: s.start,
+            end: s.end,
+        }));
     }
     Ok(out)
 }

--- a/crates/services/src/auto_redact/mod.rs
+++ b/crates/services/src/auto_redact/mod.rs
@@ -1,8 +1,7 @@
 //! Auto-redact PII in completions requests before they reach a provider,
 //! then un-redact in the response so the client sees the original text.
 //!
-//! See `docs/auto-redact.md` (TBD) for the end-to-end design. Quick
-//! summary:
+//! End-to-end flow:
 //!
 //! ```text
 //! client → cloud-api (TEE)
@@ -122,7 +121,10 @@ pub async fn redact_messages(
 
     let mut redacted = Vec::with_capacity(texts.len());
     for (text, spans) in texts.iter().zip(spans_per_text.iter()) {
-        redacted.push(apply::redact_one(text, spans, &mut map));
+        // redact_one returns Err on malformed spans (out-of-range or non
+        // UTF-8 char boundary). Propagate so the handler fails closed
+        // rather than silently passing raw PII upstream.
+        redacted.push(apply::redact_one(text, spans, &mut map)?);
     }
     apply::write_back(messages, &refs, redacted);
     Ok(map)

--- a/crates/services/src/auto_redact/mod.rs
+++ b/crates/services/src/auto_redact/mod.rs
@@ -1,0 +1,188 @@
+//! Auto-redact PII in completions requests before they reach a provider,
+//! then un-redact in the response so the client sees the original text.
+//!
+//! See `docs/auto-redact.md` (TBD) for the end-to-end design. Quick
+//! summary:
+//!
+//! ```text
+//! client → cloud-api (TEE)
+//!   1. extract text fragments from messages
+//!   2. call privacy-filter for PII spans
+//!   3. mint placeholders <emailN>, <phoneN>, … and rewrite fragments
+//!   → provider sees only redacted text
+//! provider → cloud-api
+//!   4. walk response.choices[*].message.content (non-stream)
+//!      or wrap stream chunks with StreamUnredact (stream)
+//!   5. swap placeholders back to originals
+//! → client
+//! ```
+//!
+//! The mapping is per-request, lives on the handler stack, never persisted
+//! or logged.
+
+mod apply;
+mod detect;
+mod placeholders;
+mod stream_unredact;
+
+pub use apply::TextRef;
+pub use placeholders::{RedactionMap, MAX_PLACEHOLDER_LEN, PLACEHOLDER_RE};
+pub use stream_unredact::StreamUnredact;
+
+use crate::completions::ports::CompletionMessage;
+use crate::inference_provider_pool::InferenceProviderPool;
+
+/// Header name clients use to enable auto-redact. Equivalent to the body
+/// field `auto_redact: true`.
+pub const AUTO_REDACT_HEADER: &str = "x-auto-redact";
+
+/// Body field clients can use to enable auto-redact (OpenAI-idiomatic
+/// alternative to the header).
+pub const AUTO_REDACT_BODY_FIELD: &str = "auto_redact";
+
+/// Default PII model id. The model must be registered in the cloud-api
+/// model catalog with an `inference_url` pointing at a privacy-filter
+/// backend (see nearai/infra#86).
+pub const DEFAULT_PII_MODEL: &str = "openai/privacy-filter";
+
+#[derive(Debug, thiserror::Error)]
+pub enum AutoRedactError {
+    /// The PII detector is unreachable, timed out, or returned a non-2xx
+    /// response. Per design, handlers must fail closed (503) when this
+    /// fires.
+    #[error("auto_redact unavailable: {0}")]
+    DetectorUnavailable(String),
+    /// Internal error (serde, programmer bug). Mapped to 500.
+    #[error("auto_redact internal error: {0}")]
+    Internal(String),
+}
+
+/// True if the request body or header opts into auto-redact. Treats common
+/// affirmative spellings as enabled.
+pub fn is_enabled<'a, I>(header_values: I, body_field: Option<&serde_json::Value>) -> bool
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    if let Some(v) = body_field {
+        if value_enables(v) {
+            return true;
+        }
+    }
+    for h in header_values {
+        if str_enables(h) {
+            return true;
+        }
+    }
+    false
+}
+
+fn str_enables(s: &str) -> bool {
+    matches!(
+        s.trim().to_ascii_lowercase().as_str(),
+        "on" | "true" | "1" | "yes" | "required"
+    )
+}
+
+fn value_enables(v: &serde_json::Value) -> bool {
+    match v {
+        serde_json::Value::Bool(b) => *b,
+        serde_json::Value::String(s) => str_enables(s),
+        serde_json::Value::Number(n) => n.as_i64() == Some(1),
+        _ => false,
+    }
+}
+
+/// Detect PII across all text fragments in `messages`, mutate the messages
+/// to contain placeholders instead, and return the placeholder→original
+/// mapping. Empty mapping means no PII was detected.
+///
+/// On detector failure, returns [`AutoRedactError::DetectorUnavailable`]
+/// without mutating `messages`. Callers must fail closed.
+pub async fn redact_messages(
+    messages: &mut [CompletionMessage],
+    pii_model: &str,
+    pool: &InferenceProviderPool,
+) -> Result<RedactionMap, AutoRedactError> {
+    let (refs, texts) = apply::collect_text_fragments(messages);
+    if texts.is_empty() {
+        return Ok(RedactionMap::new());
+    }
+
+    let mut map = RedactionMap::new();
+    // Reserve any placeholder-shaped literals already in the input so we
+    // never mint a placeholder that collides with the user's own text.
+    for t in &texts {
+        for caps in PLACEHOLDER_RE.find_iter(t) {
+            map.reserve_literal(caps.as_str());
+        }
+    }
+
+    let spans_per_text = detect::detect_pii(&texts, pii_model, pool).await?;
+    debug_assert_eq!(spans_per_text.len(), texts.len());
+
+    let mut redacted = Vec::with_capacity(texts.len());
+    for (text, spans) in texts.iter().zip(spans_per_text.iter()) {
+        redacted.push(apply::redact_one(text, spans, &mut map));
+    }
+    apply::write_back(messages, &refs, redacted);
+    Ok(map)
+}
+
+/// Strip the `auto_redact` field from a `ServiceCompletionRequest.extra`
+/// map so it isn't forwarded to the upstream provider (Anthropic and
+/// others 422 on unknown fields under strict mode).
+pub fn strip_body_field(extra: &mut std::collections::HashMap<String, serde_json::Value>) {
+    extra.remove(AUTO_REDACT_BODY_FIELD);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn is_enabled_truthy_header() {
+        assert!(is_enabled(["on"], None));
+        assert!(is_enabled(["true"], None));
+        assert!(is_enabled(["1"], None));
+        assert!(is_enabled(["YES"], None));
+        assert!(is_enabled(["required"], None));
+    }
+
+    #[test]
+    fn is_enabled_falsy_header() {
+        assert!(!is_enabled(["off"], None));
+        assert!(!is_enabled(["false"], None));
+        assert!(!is_enabled([""], None));
+        assert!(!is_enabled(::std::iter::empty(), None));
+    }
+
+    #[test]
+    fn is_enabled_body_field() {
+        assert!(is_enabled(::std::iter::empty(), Some(&json!(true))));
+        assert!(is_enabled(::std::iter::empty(), Some(&json!("on"))));
+        assert!(is_enabled(::std::iter::empty(), Some(&json!(1))));
+        assert!(!is_enabled(::std::iter::empty(), Some(&json!(false))));
+        assert!(!is_enabled(::std::iter::empty(), Some(&json!(null))));
+    }
+
+    #[test]
+    fn is_enabled_header_or_body_wins() {
+        // header on, body absent -> enabled
+        assert!(is_enabled(["on"], None));
+        // header absent, body true -> enabled
+        assert!(is_enabled(::std::iter::empty(), Some(&json!(true))));
+        // both off -> disabled
+        assert!(!is_enabled(["off"], Some(&json!(false))));
+    }
+
+    #[test]
+    fn strip_body_field_removes_only_auto_redact() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("auto_redact".to_string(), json!(true));
+        extra.insert("temperature".to_string(), json!(0.5));
+        strip_body_field(&mut extra);
+        assert!(!extra.contains_key("auto_redact"));
+        assert!(extra.contains_key("temperature"));
+    }
+}

--- a/crates/services/src/auto_redact/placeholders.rs
+++ b/crates/services/src/auto_redact/placeholders.rs
@@ -5,8 +5,10 @@ use std::sync::LazyLock;
 /// Maximum byte length of any placeholder we mint. Bounds the streaming
 /// unredact tail buffer so we never split a placeholder across SSE chunks.
 ///
-/// `<account_number999>` is 19 bytes. We round up to 32 to leave headroom
-/// for any future category prefix.
+/// Today's longest minted placeholder is `<address9999>` (14 bytes) — see
+/// [`placeholder_prefix`]. We round up to 32 to leave headroom for any
+/// future category prefix; if a future prefix is longer than 30 chars,
+/// bump this.
 pub const MAX_PLACEHOLDER_LEN: usize = 32;
 
 /// Matches any well-formed placeholder we could have minted: `<` + lowercase

--- a/crates/services/src/auto_redact/placeholders.rs
+++ b/crates/services/src/auto_redact/placeholders.rs
@@ -1,0 +1,188 @@
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Maximum byte length of any placeholder we mint. Bounds the streaming
+/// unredact tail buffer so we never split a placeholder across SSE chunks.
+///
+/// `<account_number999>` is 19 bytes. We round up to 32 to leave headroom
+/// for any future category prefix.
+pub const MAX_PLACEHOLDER_LEN: usize = 32;
+
+/// Matches any well-formed placeholder we could have minted: `<` + lowercase
+/// letters/underscores + digits + `>`. Used by the unredact path to find
+/// candidate replacements without allocating per chunk.
+pub static PLACEHOLDER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<([a-z_]+)(\d+)>").expect("static regex is valid"));
+
+/// Map a privacy-filter category string to the placeholder prefix used in
+/// minted placeholders (e.g. `private_email` -> `email`). Unknown categories
+/// fall back to the generic `pii` prefix; this keeps streaming unredact
+/// matching simple while still distinguishing categories the model knows.
+pub fn placeholder_prefix(category: &str) -> &'static str {
+    match category {
+        "private_email" => "email",
+        "private_phone" => "phone",
+        "account_number" => "account",
+        "private_address" => "address",
+        "private_name" => "name",
+        _ => "pii",
+    }
+}
+
+/// Bidirectional placeholder ↔ original mapping for a single redaction call.
+///
+/// - Same literal PII text within the call is deduplicated and reuses the
+///   same placeholder.
+/// - Ordinals are monotonic per category.
+/// - If a candidate placeholder collides with a substring of the input,
+///   the ordinal is bumped until unique. The set of "input literals to
+///   avoid" is supplied at construction.
+#[derive(Debug, Default, Clone)]
+pub struct RedactionMap {
+    placeholder_to_original: HashMap<String, String>,
+    original_to_placeholder: HashMap<(String, String), String>,
+    next_ordinal: HashMap<String, u32>,
+    reserved_literals: std::collections::HashSet<String>,
+}
+
+impl RedactionMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark placeholders that already appear in the user's input so we never
+    /// mint them ourselves. Pass the regex matches from each input text.
+    pub fn reserve_literal(&mut self, placeholder: &str) {
+        self.reserved_literals.insert(placeholder.to_string());
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.placeholder_to_original.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.placeholder_to_original.len()
+    }
+
+    /// Return the placeholder for the given (category, original) — minting a
+    /// new one if needed and skipping any ordinal that collides with a
+    /// reserved literal.
+    pub fn lookup_or_mint(&mut self, category: &str, original: &str) -> String {
+        let prefix = placeholder_prefix(category);
+        let key = (prefix.to_string(), original.to_string());
+        if let Some(existing) = self.original_to_placeholder.get(&key) {
+            return existing.clone();
+        }
+
+        let n = self.next_ordinal.entry(prefix.to_string()).or_insert(1);
+        let mut placeholder = format!("<{prefix}{n}>");
+        while self.reserved_literals.contains(&placeholder) {
+            *n += 1;
+            placeholder = format!("<{prefix}{n}>");
+        }
+        *n += 1;
+
+        self.placeholder_to_original
+            .insert(placeholder.clone(), original.to_string());
+        self.original_to_placeholder
+            .insert(key, placeholder.clone());
+        placeholder
+    }
+
+    pub fn original_for(&self, placeholder: &str) -> Option<&str> {
+        self.placeholder_to_original
+            .get(placeholder)
+            .map(String::as_str)
+    }
+
+    /// Replace every placeholder in `text` with its original, leaving any
+    /// unknown placeholder-shaped tokens untouched (these are an LLM
+    /// hallucinating a token we never minted).
+    pub fn unredact(&self, text: &str) -> String {
+        if self.is_empty() {
+            return text.to_string();
+        }
+        PLACEHOLDER_RE
+            .replace_all(text, |caps: &regex::Captures<'_>| {
+                let whole = &caps[0];
+                self.placeholder_to_original
+                    .get(whole)
+                    .cloned()
+                    .unwrap_or_else(|| whole.to_string())
+            })
+            .into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_known_categories() {
+        assert_eq!(placeholder_prefix("private_email"), "email");
+        assert_eq!(placeholder_prefix("private_phone"), "phone");
+        assert_eq!(placeholder_prefix("account_number"), "account");
+        assert_eq!(placeholder_prefix("anything_else"), "pii");
+    }
+
+    #[test]
+    fn mint_monotonic_and_deduplicated() {
+        let mut map = RedactionMap::new();
+        let a1 = map.lookup_or_mint("private_email", "alice@example.com");
+        let a2 = map.lookup_or_mint("private_email", "alice@example.com");
+        let b = map.lookup_or_mint("private_email", "bob@example.com");
+        assert_eq!(a1, "<email1>");
+        assert_eq!(a2, "<email1>", "dedup: same original reuses placeholder");
+        assert_eq!(b, "<email2>");
+    }
+
+    #[test]
+    fn mint_skips_reserved_literals() {
+        let mut map = RedactionMap::new();
+        map.reserve_literal("<email1>");
+        map.reserve_literal("<email2>");
+        let first = map.lookup_or_mint("private_email", "alice@example.com");
+        assert_eq!(
+            first, "<email3>",
+            "should skip reserved <email1> and <email2>"
+        );
+    }
+
+    #[test]
+    fn unredact_replaces_known_placeholders_only() {
+        let mut map = RedactionMap::new();
+        map.lookup_or_mint("private_email", "alice@example.com");
+        let out = map.unredact("Send to <email1> and copy <email99> and <unknown1>.");
+        assert_eq!(
+            out, "Send to alice@example.com and copy <email99> and <unknown1>.",
+            "<email99> was never minted; <unknown1> uses a category we never produced"
+        );
+    }
+
+    #[test]
+    fn unredact_empty_map_returns_input_unchanged() {
+        let map = RedactionMap::new();
+        let s = "no placeholders here <email1> still no";
+        assert_eq!(map.unredact(s), s);
+    }
+
+    #[test]
+    fn placeholder_re_matches_expected_shapes() {
+        let m: Vec<&str> = PLACEHOLDER_RE
+            .find_iter("hi <email1> and <account_number2> and <bad-1> and < email3 >")
+            .map(|m| m.as_str())
+            .collect();
+        assert_eq!(m, vec!["<email1>", "<account_number2>"]);
+    }
+
+    #[test]
+    fn unredact_handles_adjacent_placeholders() {
+        let mut map = RedactionMap::new();
+        map.lookup_or_mint("private_email", "a@b.com");
+        map.lookup_or_mint("private_phone", "+1-555-0100");
+        let out = map.unredact("<email1><phone1>");
+        assert_eq!(out, "a@b.com+1-555-0100");
+    }
+}

--- a/crates/services/src/auto_redact/stream_unredact.rs
+++ b/crates/services/src/auto_redact/stream_unredact.rs
@@ -1,0 +1,227 @@
+//! Sliding-window stream unredact.
+//!
+//! Replaces placeholders in a stream of text chunks while never splitting a
+//! placeholder across emitted boundaries. The state machine holds back a
+//! short tail of pending text — at most `MAX_PLACEHOLDER_LEN` bytes — so an
+//! incomplete `<emailN>`-shaped token never escapes prematurely.
+
+use super::placeholders::{RedactionMap, MAX_PLACEHOLDER_LEN};
+
+/// Per-stream unredacter. One instance covers a single completion stream.
+#[derive(Debug)]
+pub struct StreamUnredact {
+    map: std::sync::Arc<RedactionMap>,
+    tail: String,
+}
+
+impl StreamUnredact {
+    pub fn new(map: std::sync::Arc<RedactionMap>) -> Self {
+        Self {
+            map,
+            tail: String::new(),
+        }
+    }
+
+    /// True if the underlying map has no minted placeholders. Callers can
+    /// short-circuit and skip wrapping the stream entirely.
+    pub fn is_noop(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Process the next chunk of text. Returns the prefix that is safe to
+    /// emit; any text that could be the start of an unfinished placeholder
+    /// is kept in the tail until the next call (or until `flush`).
+    pub fn process(&mut self, chunk: &str) -> String {
+        if self.map.is_empty() {
+            // Hot path: nothing to replace. Don't even buffer.
+            return chunk.to_string();
+        }
+
+        // Combine carryover tail with new chunk. We work on the combined
+        // buffer so a placeholder that straddles a chunk boundary is matched
+        // as a single token.
+        let mut buf = std::mem::take(&mut self.tail);
+        buf.push_str(chunk);
+
+        let split_at = safe_emit_boundary(&buf);
+        let hold = buf.split_off(split_at);
+        let emit = buf;
+        self.tail = hold;
+
+        self.map.unredact(&emit)
+    }
+
+    /// Emit any pending tail at end of stream. Unmatched placeholder-shaped
+    /// tokens are left as literal text (signal that the LLM hallucinated a
+    /// token we never minted).
+    pub fn flush(mut self) -> String {
+        if self.tail.is_empty() {
+            return String::new();
+        }
+        let tail = std::mem::take(&mut self.tail);
+        self.map.unredact(&tail)
+    }
+}
+
+/// Decide where to split the buffer between "emit now" and "hold for next
+/// chunk." The hold region must include any `<` that could still grow into
+/// a complete `<categoryN>` token.
+///
+/// Strategy: walk the rightmost `MAX_PLACEHOLDER_LEN` bytes and find the
+/// earliest `<` that has no `>` after it. Everything from that `<` onward
+/// must be held. If no such `<` exists, the entire buffer is safe to emit.
+fn safe_emit_boundary(buf: &str) -> usize {
+    let bytes = buf.as_bytes();
+    let n = bytes.len();
+    if n == 0 {
+        return 0;
+    }
+    let scan_from = n.saturating_sub(MAX_PLACEHOLDER_LEN);
+
+    let mut emit_until = n;
+    for i in scan_from..n {
+        if bytes[i] == b'<' {
+            // Is there a `>` somewhere after i?
+            let has_closing = bytes[i + 1..].contains(&b'>');
+            if !has_closing {
+                emit_until = i;
+                break;
+            }
+        }
+    }
+    // `<` is ASCII, so any byte offset we choose at a `<` is a char boundary.
+    emit_until
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn map_with(entries: &[(&str, &str)]) -> Arc<RedactionMap> {
+        let mut m = RedactionMap::new();
+        for (cat, val) in entries {
+            m.lookup_or_mint(cat, val);
+        }
+        Arc::new(m)
+    }
+
+    #[test]
+    fn passthrough_when_map_empty() {
+        let map = Arc::new(RedactionMap::new());
+        let mut u = StreamUnredact::new(map);
+        assert!(u.is_noop());
+        let s = u.process("hello world");
+        assert_eq!(s, "hello world");
+        assert_eq!(u.flush(), "");
+    }
+
+    #[test]
+    fn single_chunk_replacement() {
+        let map = map_with(&[("private_email", "a@b.com")]);
+        let mut u = StreamUnredact::new(map);
+        // <email1> is the placeholder for "a@b.com"
+        let out = u.process("Email: <email1>!");
+        let tail = u.flush();
+        assert_eq!(out + &tail, "Email: a@b.com!");
+    }
+
+    #[test]
+    fn split_placeholder_across_two_chunks() {
+        let map = map_with(&[("private_email", "alice@example.com")]);
+        let mut u = StreamUnredact::new(map);
+        let part1 = u.process("Email: <emai");
+        // The "<emai" must be held — nothing emitted from that point on.
+        assert_eq!(part1, "Email: ");
+        let part2 = u.process("l1>!");
+        // Once the placeholder is complete, full replacement.
+        let tail = u.flush();
+        assert_eq!(part1 + &part2 + &tail, "Email: alice@example.com!");
+    }
+
+    #[test]
+    fn split_placeholder_across_many_chunks() {
+        let map = map_with(&[("private_email", "x@y.z")]);
+        let mut u = StreamUnredact::new(map);
+        let mut acc = String::new();
+        for ch in "<email1>".chars() {
+            acc.push_str(&u.process(&ch.to_string()));
+        }
+        acc.push_str(&u.flush());
+        assert_eq!(acc, "x@y.z");
+    }
+
+    #[test]
+    fn multiple_placeholders_in_one_chunk() {
+        let map = map_with(&[
+            ("private_email", "a@b.com"),
+            ("private_phone", "+1-555-0100"),
+        ]);
+        let mut u = StreamUnredact::new(map);
+        let out = u.process("Call <phone1> at <email1>.") + &u.flush();
+        assert_eq!(out, "Call +1-555-0100 at a@b.com.");
+    }
+
+    #[test]
+    fn hallucinated_placeholder_passes_through_literally() {
+        let map = map_with(&[("private_email", "real@example.com")]);
+        let mut u = StreamUnredact::new(map);
+        // <email42> was never minted: appears as-is.
+        let out = u.process("hi <email42> there") + &u.flush();
+        assert_eq!(out, "hi <email42> there");
+    }
+
+    #[test]
+    fn dangling_open_angle_at_end_is_held_then_flushed_literally() {
+        let map = map_with(&[("private_email", "x@y.z")]);
+        let mut u = StreamUnredact::new(map);
+        let out = u.process("see this <") + &u.flush();
+        assert_eq!(out, "see this <");
+    }
+
+    #[test]
+    fn long_run_without_open_angle_emits_immediately() {
+        let map = map_with(&[("private_email", "x@y.z")]);
+        let mut u = StreamUnredact::new(map);
+        let payload = "a".repeat(1024);
+        let out = u.process(&payload);
+        assert_eq!(out, payload, "no '<' means no hold");
+    }
+
+    #[test]
+    fn adjacent_placeholders_split_at_boundary() {
+        let map = map_with(&[("private_email", "a@b.com"), ("private_phone", "+1-0")]);
+        let mut u = StreamUnredact::new(map);
+        // Split in the middle of "<email1><phone1>"
+        let a = u.process("<email1");
+        let b = u.process("><phone1>");
+        let flush = u.flush();
+        assert_eq!(a + &b + &flush, "a@b.com+1-0");
+    }
+
+    #[test]
+    fn utf8_multibyte_safe() {
+        // Build a chunk that ends in a multibyte char before a held `<`.
+        let map = map_with(&[("private_email", "x@y.z")]);
+        let mut u = StreamUnredact::new(map);
+        let out = u.process("héllo <emai") + &u.process("l1>!") + &u.flush();
+        assert_eq!(out, "héllo x@y.z!");
+    }
+
+    #[test]
+    fn long_held_buffer_eventually_releases() {
+        // If the held region grows past MAX_PLACEHOLDER_LEN with no `>`,
+        // the leading `<` is past the scan window and gets emitted.
+        let map = map_with(&[("private_email", "x@y.z")]);
+        let mut u = StreamUnredact::new(map);
+        // A `<` followed by lots of non-`>` chars — eventually we have to
+        // release it because no real placeholder is this long.
+        let first = u.process(&format!("<{}", "a".repeat(MAX_PLACEHOLDER_LEN * 2)));
+        // The `<` and the leading run of a's are emitted; the tail holds
+        // only the last MAX_PLACEHOLDER_LEN bytes (still no `>`).
+        let flushed = u.flush();
+        let combined = first + &flushed;
+        assert!(combined.starts_with('<'));
+        assert!(combined.contains('a'));
+    }
+}

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod attestation;
 pub mod auth;
+pub mod auto_redact;
 pub mod common;
 pub mod completions;
 pub mod conversations;


### PR DESCRIPTION
## Summary

Opt-in PII redaction on `/v1/chat/completions`. The user enables it with either:

- HTTP header: `x-auto-redact: on`
- Body field: `"auto_redact": true`

Both spellings are equivalent. The body field is stripped before forwarding so strict-schema providers (Anthropic) don't 422.

## How it works

1. The handler invokes the privacy-filter model via `pool.privacy_classify` (the endpoint added in #584) on the user's message text.
2. PII spans are replaced with stable placeholders: `<email1>`, `<phone1>`, `<account1>`, etc. Same literal PII within one request reuses the same placeholder (dedup). Ordinals are monotonic per category. If the user's own text already contains a `<categoryN>`-shaped literal, the allocator skips that ordinal to avoid collision.
3. The provider — vLLM or 3p — only ever sees the redacted form. **Provider-agnostic by design.**
4. The response is un-redacted before being returned to the client:
   - **Non-streaming**: walks `choices[*].message.content`, `reasoning_content`, and `reasoning`. Note: when auto-redact is on we re-serialize the response (drops the raw_bytes signing path — documented as an explicit tradeoff for the privacy guarantee).
   - **Streaming**: wraps each SSE chunk with a sliding-window unredacter. A 16-byte tail buffer holds any in-progress `<…>` token across chunks so a placeholder split mid-flight is never emitted partial.

## Fail-closed behavior

If the privacy-filter model is unreachable, errors, or isn't registered in the cloud-api models DB, the handler returns 503 with `\"type\": \"auto_redact_unavailable\"` rather than silently degrading to send raw PII upstream. This honors the privacy guarantee the user opted into.

## Out of scope (deferred)

- **/v1/completions** — the legacy handler currently returns 501. The new `maybe_redact` helper is generic over `ServiceCompletionRequest` so wiring it in is a 5-line copy when that handler is enabled.
- **/v1/responses** — depends on a separate conversation-history persistence decision (design memo discussed: store original PII in DB, redact fresh on each provider call).
- **Category opt-out filter** — all-or-nothing for v1. Easy to add via header `x-auto-redact-categories: …` if needed.
- **`raw_bytes` signing parity** with auto-redact on — the response is re-serialized post-unredact, breaking byte-for-byte signature verification. The user explicitly opted into munging the response; we accept this. (Signature verification still works when auto-redact is off.)
- **Token billing on the redacted form** is already what happens since the provider sees the redacted prompt and reports its own token usage — slightly cheaper for PII-heavy prompts.

## Module layout

\`\`\`
crates/services/src/auto_redact/
  mod.rs              — public API: is_enabled, redact_messages, strip_body_field
  placeholders.rs     — RedactionMap (bidirectional, collision-safe minting)
  detect.rs           — call privacy-filter via pool.privacy_classify
  apply.rs            — walk CompletionMessage content (string + parts arrays)
  stream_unredact.rs  — sliding 16-byte tail for SSE
\`\`\`

## Tests

- **34 unit tests** in services/auto_redact covering placeholder dedup, collision avoidance, span application, stream chunk-splitting, UTF-8 boundaries, hallucinated placeholders, etc.
- **7 e2e tests** in crates/api/tests/e2e_all/auto_redact.rs covering:
  - Header off → raw PII reaches provider
  - Header \"on\" → provider sees `<email1>`, client gets original back
  - Body field `auto_redact: true` is equivalent to header
  - Body field is stripped from \`extra\` before forwarding
  - Streaming: placeholder split across SSE chunks is reassembled
  - Fail-closed when PII model is unavailable (503 `auto_redact_unavailable`)
  - Header `off` is a true no-op
  - Multi-PII per message (email + phone + SSN) round-trips correctly

The MockProvider's `privacy_classify_raw` does shape-based detection (email, SSN, phone regex) so e2e tests exercise the full pipeline without a live privacy-filter model.

## Test plan

- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --bins -p services -p inference_providers -p api\` (258 unit pass)
- [x] \`cargo test --test e2e_all auto_redact -- --test-threads 1\` (7 e2e pass)
- [ ] Staging E2E: enable on a chat completion against a 3p model (e.g. anthropic/claude-sonnet-4-5) and verify provider logs don't contain the PII

Builds on #584. The privacy-filter model must be registered in the cloud-api models DB (already done on staging + prod after #584).