### PR TITLE
fix(gemini): tolerate truncated content on MAX_TOKENS responses

### DIFF
--- a/crates/inference_providers/src/external/gemini/converter.rs
+++ b/crates/inference_providers/src/external/gemini/converter.rs
@@ -641,5 +641,8 @@ mod tests {
         assert_eq!(response.candidates.len(), 1);
         assert_eq!(response.candidates[0].content.role, "model");
         assert!(response.candidates[0].content.parts.is_empty());
+        let (text, tool_calls) = extract_response_content(&response.candidates[0].content.parts);
+        assert!(text.is_none());
+        assert!(tool_calls.is_none());
     }
 }

--- a/crates/inference_providers/src/external/gemini/converter.rs
+++ b/crates/inference_providers/src/external/gemini/converter.rs
@@ -81,12 +81,11 @@ pub struct GeminiFunctionResponse {
 
 /// Gemini content format
 ///
-/// `role` and `parts` are marked `#[serde(default)]` because Google's
-/// `generateContent` response omits one or both fields when generation ends
-/// with `finishReason: MAX_TOKENS` before producing any output tokens
-/// (observed in `gemini-3-flash-preview` returning `content: {}` and
-/// `gemini-2.5-flash` returning `content: {"role": "model"}`). The strict
-/// schema rejected these payloads and surfaced as 502s to clients.
+/// Both `role` and `parts` are marked `#[serde(default)]` because Google's
+/// `generateContent` response may omit either field when no usable output
+/// was produced (typically when `finishReason` is `MAX_TOKENS`, `SAFETY`, or
+/// `RECITATION`). Defaulting to empty values lets the parser succeed and the
+/// downstream code treat it as an empty completion.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GeminiContent {
     #[serde(default)]
@@ -150,10 +149,16 @@ pub struct GeminiRequest {
 // =============================================================================
 
 /// Gemini response candidate
+///
+/// `content` is `Option` because Google omits the field entirely on some
+/// terminal-only responses (e.g. safety-blocked candidates that return only
+/// `finishReason`). Consumers must treat a missing `content` the same as a
+/// content with empty `parts`.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GeminiCandidate {
-    pub content: GeminiContent,
+    #[serde(default)]
+    pub content: Option<GeminiContent>,
     pub finish_reason: Option<String>,
 }
 
@@ -424,8 +429,13 @@ impl SSEEventParser for GeminiEventParser {
         let is_first = state.chunk_index == 0;
         state.chunk_index += 1;
 
-        // Extract text and function calls from parts
-        let (text, tool_calls) = extract_response_content(&candidate.content.parts);
+        // Extract text and function calls from parts. `content` may be absent
+        // entirely (e.g. safety-blocked candidates); treat it as empty parts.
+        let parts: &[GeminiPart] = candidate
+            .content
+            .as_ref()
+            .map_or(&[], |c| c.parts.as_slice());
+        let (text, tool_calls) = extract_response_content(parts);
 
         // Determine finish reason
         let has_function_call = tool_calls.is_some();
@@ -573,7 +583,8 @@ mod tests {
         }"#;
 
         let response: GeminiResponse = serde_json::from_str(json).unwrap();
-        let (text, tool_calls) = extract_response_content(&response.candidates[0].content.parts);
+        let content = response.candidates[0].content.as_ref().unwrap();
+        let (text, tool_calls) = extract_response_content(&content.parts);
 
         assert!(text.is_none());
         assert!(tool_calls.is_some());
@@ -595,11 +606,12 @@ mod tests {
         assert_eq!(map_finish_reason(None), None);
     }
 
-    // Regression: Google returns truncated content when MAX_TOKENS hits with
-    // no output. The strict schema previously rejected both variants and
-    // surfaced as 502s. Captured from live `gemini-3-flash-preview` and
-    // `gemini-2.5-flash` responses.
+    // Regression: Google may omit response fields when no usable output is
+    // produced (typically MAX_TOKENS / SAFETY / RECITATION). The strict schema
+    // previously rejected these payloads and surfaced as 502s. The four tests
+    // below cover every shape we have observed or that the reviewer flagged.
 
+    /// Payload captured from `gemini-3-flash-preview`: `content` is `{}`.
     #[test]
     fn test_parse_response_with_empty_content_on_max_tokens() {
         let json = r#"{
@@ -615,14 +627,15 @@ mod tests {
         }"#;
 
         let response: GeminiResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.candidates.len(), 1);
-        assert_eq!(response.candidates[0].content.role, "");
-        assert!(response.candidates[0].content.parts.is_empty());
-        let (text, tool_calls) = extract_response_content(&response.candidates[0].content.parts);
+        let content = response.candidates[0].content.as_ref().unwrap();
+        assert_eq!(content.role, "");
+        assert!(content.parts.is_empty());
+        let (text, tool_calls) = extract_response_content(&content.parts);
         assert!(text.is_none());
         assert!(tool_calls.is_none());
     }
 
+    /// Payload captured from `gemini-2.5-flash`: `parts` omitted, `role` present.
     #[test]
     fn test_parse_response_with_role_only_content_on_max_tokens() {
         let json = r#"{
@@ -638,11 +651,53 @@ mod tests {
         }"#;
 
         let response: GeminiResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.candidates.len(), 1);
-        assert_eq!(response.candidates[0].content.role, "model");
-        assert!(response.candidates[0].content.parts.is_empty());
-        let (text, tool_calls) = extract_response_content(&response.candidates[0].content.parts);
+        let content = response.candidates[0].content.as_ref().unwrap();
+        assert_eq!(content.role, "model");
+        assert!(content.parts.is_empty());
+        let (text, tool_calls) = extract_response_content(&content.parts);
         assert!(text.is_none());
         assert!(tool_calls.is_none());
+    }
+
+    /// Reviewer-flagged variant: `content` field absent entirely on the
+    /// candidate (observed in safety-blocked responses).
+    #[test]
+    fn test_parse_response_with_missing_content_field() {
+        let json = r#"{
+            "candidates": [{
+                "finishReason": "SAFETY",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 8,
+                "totalTokenCount": 8
+            }
+        }"#;
+
+        let response: GeminiResponse = serde_json::from_str(json).unwrap();
+        assert!(response.candidates[0].content.is_none());
+        assert_eq!(
+            response.candidates[0].finish_reason.as_deref(),
+            Some("SAFETY")
+        );
+    }
+
+    /// `content: null` — the explicit-null form.
+    #[test]
+    fn test_parse_response_with_null_content() {
+        let json = r#"{
+            "candidates": [{
+                "content": null,
+                "finishReason": "SAFETY",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 8,
+                "totalTokenCount": 8
+            }
+        }"#;
+
+        let response: GeminiResponse = serde_json::from_str(json).unwrap();
+        assert!(response.candidates[0].content.is_none());
     }
 }

--- a/crates/inference_providers/src/external/gemini/converter.rs
+++ b/crates/inference_providers/src/external/gemini/converter.rs
@@ -80,9 +80,18 @@ pub struct GeminiFunctionResponse {
 }
 
 /// Gemini content format
+///
+/// `role` and `parts` are marked `#[serde(default)]` because Google's
+/// `generateContent` response omits one or both fields when generation ends
+/// with `finishReason: MAX_TOKENS` before producing any output tokens
+/// (observed in `gemini-3-flash-preview` returning `content: {}` and
+/// `gemini-2.5-flash` returning `content: {"role": "model"}`). The strict
+/// schema rejected these payloads and surfaced as 502s to clients.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GeminiContent {
+    #[serde(default)]
     pub role: String,
+    #[serde(default)]
     pub parts: Vec<GeminiPart>,
 }
 
@@ -584,5 +593,53 @@ mod tests {
             Some(crate::FinishReason::Length)
         );
         assert_eq!(map_finish_reason(None), None);
+    }
+
+    // Regression: Google returns truncated content when MAX_TOKENS hits with
+    // no output. The strict schema previously rejected both variants and
+    // surfaced as 502s. Captured from live `gemini-3-flash-preview` and
+    // `gemini-2.5-flash` responses.
+
+    #[test]
+    fn test_parse_response_with_empty_content_on_max_tokens() {
+        let json = r#"{
+            "candidates": [{
+                "content": {},
+                "finishReason": "MAX_TOKENS",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 5,
+                "totalTokenCount": 5
+            }
+        }"#;
+
+        let response: GeminiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.candidates.len(), 1);
+        assert_eq!(response.candidates[0].content.role, "");
+        assert!(response.candidates[0].content.parts.is_empty());
+        let (text, tool_calls) = extract_response_content(&response.candidates[0].content.parts);
+        assert!(text.is_none());
+        assert!(tool_calls.is_none());
+    }
+
+    #[test]
+    fn test_parse_response_with_role_only_content_on_max_tokens() {
+        let json = r#"{
+            "candidates": [{
+                "content": {"role": "model"},
+                "finishReason": "MAX_TOKENS",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 5,
+                "totalTokenCount": 5
+            }
+        }"#;
+
+        let response: GeminiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.candidates.len(), 1);
+        assert_eq!(response.candidates[0].content.role, "model");
+        assert!(response.candidates[0].content.parts.is_empty());
     }
 }

--- a/crates/inference_providers/src/external/gemini/mod.rs
+++ b/crates/inference_providers/src/external/gemini/mod.rs
@@ -16,12 +16,95 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use converter::{
     convert_messages, convert_tools, extract_response_content, map_finish_reason_string,
-    GeminiEventParser, GeminiGenerationConfig, GeminiParserState, GeminiRequest, GeminiResponse,
+    GeminiEventParser, GeminiGenerationConfig, GeminiParserState, GeminiPart, GeminiRequest,
+    GeminiResponse,
 };
 use futures_util::Stream;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+/// Convert a parsed Gemini `generateContent` response into the OpenAI-shaped
+/// response we expose to clients.
+///
+/// Centralised so the empty/missing-content handling has a single source of
+/// truth and can be exercised end-to-end in unit tests without an HTTP layer.
+/// Emits a `tracing::warn!` when a candidate has no usable content (parts
+/// empty or `content` missing) and the finish reason is *not* `MAX_TOKENS` —
+/// that combination is the silent-regression case worth flagging: under the
+/// old strict schema it would have surfaced as a 502, and we want Datadog to
+/// catch it if Google ships a real upstream regression that produces empty
+/// responses with `STOP`/`SAFETY`/etc.
+fn convert_to_openai_response(
+    gemini_response: GeminiResponse,
+    model: &str,
+) -> Result<ChatCompletionResponse, CompletionError> {
+    if gemini_response.candidates.is_empty() {
+        return Err(CompletionError::CompletionError(
+            "No candidates in Gemini response".to_string(),
+        ));
+    }
+
+    let candidate = &gemini_response.candidates[0];
+    let parts: &[GeminiPart] = candidate
+        .content
+        .as_ref()
+        .map_or(&[], |c| c.parts.as_slice());
+    let (content, tool_calls) = extract_response_content(parts);
+
+    if content.is_none() && tool_calls.is_none() {
+        let fr = candidate.finish_reason.as_deref().unwrap_or("");
+        if fr != "MAX_TOKENS" {
+            tracing::warn!(
+                model = %model,
+                finish_reason = %fr,
+                "Gemini returned a candidate with no usable content and finish_reason != MAX_TOKENS"
+            );
+        }
+    }
+
+    // Determine finish reason - tool_calls if we have function calls
+    let finish_reason = if tool_calls.is_some() {
+        Some("tool_calls".to_string())
+    } else {
+        map_finish_reason_string(candidate.finish_reason.as_ref())
+    };
+
+    Ok(ChatCompletionResponse {
+        id: format!("gemini-{}", Uuid::new_v4()),
+        object: "chat.completion".to_string(),
+        created: chrono::Utc::now().timestamp(),
+        model: model.to_string(),
+        choices: vec![ChatCompletionResponseChoice {
+            index: 0,
+            message: ChatResponseMessage {
+                role: MessageRole::Assistant,
+                content,
+                refusal: None,
+                annotations: None,
+                audio: None,
+                function_call: None,
+                tool_calls,
+                reasoning_content: None,
+                reasoning: None,
+            },
+            logprobs: None,
+            finish_reason,
+            token_ids: None,
+        }],
+        service_tier: None,
+        system_fingerprint: None,
+        usage: TokenUsage {
+            prompt_tokens: gemini_response.usage_metadata.prompt_token_count,
+            completion_tokens: gemini_response.usage_metadata.candidates_token_count,
+            total_tokens: gemini_response.usage_metadata.total_token_count,
+            prompt_tokens_details: None,
+        },
+        prompt_logprobs: None,
+        prompt_token_ids: None,
+        kv_transfer_params: None,
+    })
+}
 
 /// Gemini backend - handles HTTP communication with Google's Gemini API
 pub struct GeminiBackend {
@@ -270,56 +353,7 @@ impl ExternalBackend for GeminiBackend {
             CompletionError::CompletionError(format!("Failed to parse response: {e}"))
         })?;
 
-        if gemini_response.candidates.is_empty() {
-            return Err(CompletionError::CompletionError(
-                "No candidates in Gemini response".to_string(),
-            ));
-        }
-
-        let candidate = &gemini_response.candidates[0];
-        let (content, tool_calls) = extract_response_content(&candidate.content.parts);
-
-        // Determine finish reason - tool_calls if we have function calls
-        let finish_reason = if tool_calls.is_some() {
-            Some("tool_calls".to_string())
-        } else {
-            map_finish_reason_string(candidate.finish_reason.as_ref())
-        };
-
-        let openai_response = ChatCompletionResponse {
-            id: format!("gemini-{}", Uuid::new_v4()),
-            object: "chat.completion".to_string(),
-            created: chrono::Utc::now().timestamp(),
-            model: model.to_string(),
-            choices: vec![ChatCompletionResponseChoice {
-                index: 0,
-                message: ChatResponseMessage {
-                    role: MessageRole::Assistant,
-                    content,
-                    refusal: None,
-                    annotations: None,
-                    audio: None,
-                    function_call: None,
-                    tool_calls,
-                    reasoning_content: None,
-                    reasoning: None,
-                },
-                logprobs: None,
-                finish_reason,
-                token_ids: None,
-            }],
-            service_tier: None,
-            system_fingerprint: None,
-            usage: TokenUsage {
-                prompt_tokens: gemini_response.usage_metadata.prompt_token_count,
-                completion_tokens: gemini_response.usage_metadata.candidates_token_count,
-                total_tokens: gemini_response.usage_metadata.total_token_count,
-                prompt_tokens_details: None,
-            },
-            prompt_logprobs: None,
-            prompt_token_ids: None,
-            kv_transfer_params: None,
-        };
+        let openai_response = convert_to_openai_response(gemini_response, model)?;
 
         // Serialize our normalized response. We intentionally overwrite fields
         // like `usage` (and any future cost-related fields derived from it) instead of passing
@@ -468,5 +502,79 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert!(events[0].is_ok());
+    }
+
+    // End-to-end conversion: a MAX_TOKENS-with-empty-content payload from Google
+    // produces an OpenAI-shaped response with `content: null` and
+    // `finish_reason: "length"`. Locks in the user-visible contract.
+    #[test]
+    fn test_convert_to_openai_response_max_tokens_empty_content() {
+        let json = r#"{
+            "candidates": [{
+                "content": {},
+                "finishReason": "MAX_TOKENS",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 7,
+                "candidatesTokenCount": 0,
+                "totalTokenCount": 7
+            }
+        }"#;
+        let response: GeminiResponse = serde_json::from_str(json).unwrap();
+        let openai = convert_to_openai_response(response, "google/gemini-3-pro").unwrap();
+
+        assert_eq!(openai.choices.len(), 1);
+        let choice = &openai.choices[0];
+        assert!(choice.message.content.is_none());
+        assert!(choice.message.tool_calls.is_none());
+        assert_eq!(choice.finish_reason.as_deref(), Some("length"));
+        assert_eq!(openai.usage.prompt_tokens, 7);
+        assert_eq!(openai.usage.completion_tokens, 0);
+        assert_eq!(openai.model, "google/gemini-3-pro");
+    }
+
+    // Same contract when the entire `content` field is absent (safety-block shape).
+    #[test]
+    fn test_convert_to_openai_response_missing_content() {
+        let json = r#"{
+            "candidates": [{
+                "finishReason": "SAFETY",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 9,
+                "totalTokenCount": 9
+            }
+        }"#;
+        let response: GeminiResponse = serde_json::from_str(json).unwrap();
+        let openai = convert_to_openai_response(response, "google/gemini-3-pro").unwrap();
+        let choice = &openai.choices[0];
+        assert!(choice.message.content.is_none());
+        assert!(choice.message.tool_calls.is_none());
+        // SAFETY maps to "content_filter" via map_finish_reason_string.
+        assert!(choice.finish_reason.is_some());
+    }
+
+    // Normal STOP response with text round-trips into a populated content field.
+    #[test]
+    fn test_convert_to_openai_response_normal_stop() {
+        let json = r#"{
+            "candidates": [{
+                "content": {"role": "model", "parts": [{"text": "Hi!"}]},
+                "finishReason": "STOP",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 3,
+                "candidatesTokenCount": 2,
+                "totalTokenCount": 5
+            }
+        }"#;
+        let response: GeminiResponse = serde_json::from_str(json).unwrap();
+        let openai = convert_to_openai_response(response, "google/gemini-3-pro").unwrap();
+        let choice = &openai.choices[0];
+        assert_eq!(choice.message.content.as_deref(), Some("Hi!"));
+        assert_eq!(choice.finish_reason.as_deref(), Some("stop"));
     }
 }


### PR DESCRIPTION
## Summary
- `GeminiContent` rejected Google's truncated `content` objects when `finishReason: MAX_TOKENS` hit before any output tokens, surfacing to clients as 502 "The model is currently unavailable."
- Added `#[serde(default)]` to `role` and `parts` so both observed payload shapes parse cleanly.
- Made `GeminiCandidate.content` an `Option` so the safety-block / terminal-only shape (where the field is absent entirely) also parses.
- Extracted the response conversion to `convert_to_openai_response()` so the user-visible contract (content/finish_reason mapping) is exercised end-to-end in unit tests.
- `tracing::warn!` when a candidate yields no usable content and `finish_reason != MAX_TOKENS`, so any future upstream regression that silently returns empty `STOP`/`SAFETY` responses is visible in Datadog instead of being lost in the relaxed-schema fallthrough.
- Doc on `GeminiContent` rewritten to describe behaviour, not enumerate model variants.

## Why

`google/gemini-3-pro` on prod cloud-api was failing ~30% of the time (more at low `max_tokens`). Logged on `cpu01-cloud-api-prod` / `cpu02-cloud-api-prod`:

```
WARN  Provider failed, will try next provider if available
  error_detail: "Failed to perform completion: Failed to parse response:
                 missing field `role` at line 4 column 19"
  model_id: "google/gemini-3-pro"
  retry_decision: "non_retryable_no_keyword_match"
```

Direct calls to Google's v1beta endpoint reproduced the truncated payloads on the first attempt:

```
gemini-3-flash-preview → {"candidates":[{"content":{}, "finishReason":"MAX_TOKENS", ...}]}
gemini-2.5-flash       → {"candidates":[{"content":{"role":"model"}, "finishReason":"MAX_TOKENS", ...}]}
```

Reviewer flagged a third variant where `content` is absent entirely (safety-blocked responses). Now covered by `Option<GeminiContent>`.

## Behaviour change

- **Before**: parse error → cloud-api drops the request and renders 502 to client; not retried because parser errors aren't in the retry-keyword set.
- **After**: parse succeeds. `extract_response_content(&[])` returns `(None, None)`, producing an OpenAI-canonical `content: null, finish_reason: "length"` response — the shape clients already expect on a MAX_TOKENS-with-no-output completion. `SAFETY` finish reasons round-trip identically with `content: null`.
- **Silent-regression guard**: if Google ever returns empty content with `finish_reason != MAX_TOKENS`, a `tracing::warn!` fires with the model id and finish reason (no request/response content — privacy rule compliance).

## Test plan
- [x] `cargo test -p inference_providers --lib gemini` — **19/19 pass** including:
  - 2 captured-payload regression tests (`content: {}`, `content: {"role": "model"}`)
  - 2 new schema tests (`content: null`, `content` field absent)
  - 3 end-to-end conversion tests through `convert_to_openai_response` (MAX_TOKENS-empty, SAFETY-missing, normal-STOP)
- [x] `cargo check --all-targets` clean across the workspace
- [ ] **After merge + staging deploy**: re-run a **30× reproduction** (was 10× — bumped on review feedback for a tighter confidence interval) of `google/gemini-3-pro` at `max_tokens: 32`. Prior baseline 7/10; acceptance ≥ 28/30 succeed.
- [ ] **After prod promote**: confirm `test_chat_completion[gemini-3-pro]` and `test_tool_calling[gemini-3-pro]` drop off the Allure Product-defects list over 4 consecutive infra-tests runs.

## Streaming path

The SSE parser (`GeminiEventParser` in `converter.rs`) consumes the same `GeminiResponse` / `GeminiCandidate` types, so the schema relaxation applies there too. The Option-handling change to the SSE consumer at `converter.rs:428` is in this PR; the silent-regression warn is currently only in the non-streaming path. If we observe an analogous regression on streaming, we can add a parallel warn in the parser state machine.

## Related
- Diagnosis: nearai/infra#108
- Parent: nearai/infra#104 (infra-tests pass rate to 95%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)