### PR TITLE
perf(api): enable response compression and add Cache-Control on public GETs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +50,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -806,6 +827,18 @@ name = "asn1_der"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
+
+[[package]]
+name = "async-compression"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-lock"
@@ -1621,6 +1654,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +1824,24 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -2838,6 +2910,16 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -4094,6 +4176,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -6488,6 +6580,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7165,13 +7263,17 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -23,7 +23,7 @@ services = { path = "../services" }
 inference_providers = { path = "../inference_providers" }
 # Authentication dependencies
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "compression-gzip", "compression-br", "set-header"] }
 uuid = { version = "1.23", features = ["v4", "serde"] }
 opentelemetry = { version = "0.31", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -49,7 +49,11 @@ use services::{
     web_search::WebSearchService,
 };
 use std::sync::Arc;
-use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tower_http::{
+    compression::CompressionLayer,
+    cors::{AllowOrigin, Any, CorsLayer},
+    set_header::SetResponseHeaderLayer,
+};
 use utoipa::OpenApi;
 
 // Audio transcription file size limit (25 MB for OpenAI Whisper API compatibility)
@@ -838,8 +842,12 @@ pub fn build_app_with_config(
     // Build OpenAPI and documentation routes
     let openapi_routes = build_openapi_routes();
 
-    // Build health check route (public, no auth required)
-    let health_routes = Router::new().route("/health", get(health_check));
+    // Build health check route (public, no auth required).
+    // Short cache window: enough to absorb thundering-herd from monitors that
+    // hammer /v1/health, but short enough that real outages surface quickly.
+    let health_routes = Router::new()
+        .route("/health", get(health_check))
+        .layer(cache_control_layer("public, max-age=5"));
 
     // Create metrics state for HTTP metrics middleware
     let metrics_state = middleware::MetricsState {
@@ -892,6 +900,13 @@ pub fn build_app_with_config(
             metrics_state,
             middleware::http_metrics_middleware,
         ))
+        // Response compression (gzip + brotli). Applied after metrics so it sees
+        // all routes. `CompressionLayer` auto-detects the response Content-Type
+        // and skips `text/event-stream` (SSE), so streaming chat completions and
+        // /v1/responses remain unaffected. Signed-response payloads (attestation
+        // endpoints) sign the *request* body hash, not the HTTP response body,
+        // so compression is safe for them as well.
+        .layer(CompressionLayer::new())
 }
 
 /// Build VPC authentication routes
@@ -1332,6 +1347,13 @@ pub fn build_model_routes(models_service: Arc<dyn ModelsServiceTrait>) -> Router
         .route("/model/list", get(list_models))
         .route("/model/{model_name}", get(get_model_by_name))
         .with_state(models_app_state)
+        // Public, anonymous, identical-for-all-clients responses that change
+        // only when an admin updates the model catalog. 30s fresh window plus
+        // 120s stale-while-revalidate lets CDNs/browsers serve cached copies
+        // instantly while refreshing in the background.
+        .layer(cache_control_layer(
+            "public, max-age=30, stale-while-revalidate=120",
+        ))
 }
 
 /// Build public services routes (no auth) — GET /v1/services, GET /v1/services/{service_name}
@@ -1346,6 +1368,21 @@ pub fn build_services_routes(pool: database::DbPool) -> Router {
         .route("/services", get(list_services))
         .route("/services/{service_name}", get(get_service_by_name))
         .with_state(state)
+        // Same rationale as `/v1/model/*` — public, anonymous, admin-write speed.
+        .layer(cache_control_layer(
+            "public, max-age=30, stale-while-revalidate=120",
+        ))
+}
+
+/// Build a `Cache-Control`-setting middleware layer for a route group.
+///
+/// Used only on public, anonymous endpoints whose responses do not vary by
+/// user/API-key/session. Do NOT add to authenticated or user-specific routes.
+fn cache_control_layer(value: &'static str) -> SetResponseHeaderLayer<axum::http::HeaderValue> {
+    SetResponseHeaderLayer::if_not_present(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static(value),
+    )
 }
 
 /// Build admin routes (authenticated endpoints)
@@ -1460,10 +1497,18 @@ pub fn build_admin_routes(
 
 /// Build OpenAPI documentation routes
 pub fn build_openapi_routes() -> Router {
-    Router::new().route("/docs", get(swagger_ui_handler)).route(
-        "/api-docs/openapi.json",
-        get(|| async { axum::Json(ApiDoc::openapi()) }),
-    )
+    Router::new()
+        .route("/docs", get(swagger_ui_handler))
+        .route(
+            "/api-docs/openapi.json",
+            get(|| async { axum::Json(ApiDoc::openapi()) }),
+        )
+        // OpenAPI spec + Scalar UI HTML change only on deploy. 5 min fresh +
+        // 1 h SWR keeps the docs snappy while still picking up new builds
+        // within ~5 minutes.
+        .layer(cache_control_layer(
+            "public, max-age=300, stale-while-revalidate=3600",
+        ))
 }
 
 /// Serve Scalar API Documentation UI

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -27,10 +27,12 @@ use crate::{
         responses,
     },
 };
-use axum::http::HeaderValue;
+use axum::extract::{Request, State};
+use axum::http::{header::CACHE_CONTROL, HeaderValue};
+use axum::response::Response;
 use axum::{
     extract::DefaultBodyLimit,
-    middleware::{from_fn, from_fn_with_state},
+    middleware::{from_fn, from_fn_with_state, Next},
     response::Html,
     routing::{get, post},
     Router,
@@ -52,7 +54,6 @@ use std::sync::Arc;
 use tower_http::{
     compression::CompressionLayer,
     cors::{AllowOrigin, Any, CorsLayer},
-    set_header::SetResponseHeaderLayer,
 };
 use utoipa::OpenApi;
 
@@ -1374,15 +1375,49 @@ pub fn build_services_routes(pool: database::DbPool) -> Router {
         ))
 }
 
+/// Middleware: only insert `Cache-Control` on successful (2xx) responses, and
+/// only if the handler did not already set one.
+///
+/// Setting `Cache-Control` on 4xx/5xx is unsafe: cooperating intermediaries
+/// (Cloudflare "Cache Everything", Fastly, browsers) may pin transient errors
+/// for the declared TTL. Gating on success ensures a single DB blip on
+/// `list_models` doesn't pin a 500 for ~2.5 minutes, and that a temporary
+/// "not found" on `get_model_by_name` clears the moment the model is added.
+async fn cache_control_on_success(
+    State(value): State<HeaderValue>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let mut res = next.run(req).await;
+    if res.status().is_success() && !res.headers().contains_key(CACHE_CONTROL) {
+        res.headers_mut().insert(CACHE_CONTROL, value);
+    }
+    res
+}
+
+// Type aliases for `cache_control_layer`'s return type. They name the
+// otherwise-unnameable function-pointer + future combination so the helper's
+// signature stays readable (and satisfies clippy::type_complexity).
+type CacheControlFuture =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Response> + Send + 'static>>;
+type CacheControlShim = fn(State<HeaderValue>, Request, Next) -> CacheControlFuture;
+type CacheControlLayer =
+    axum::middleware::FromFnLayer<CacheControlShim, HeaderValue, (State<HeaderValue>, Request)>;
+
 /// Build a `Cache-Control`-setting middleware layer for a route group.
 ///
 /// Used only on public, anonymous endpoints whose responses do not vary by
 /// user/API-key/session. Do NOT add to authenticated or user-specific routes.
-fn cache_control_layer(value: &'static str) -> SetResponseHeaderLayer<axum::http::HeaderValue> {
-    SetResponseHeaderLayer::if_not_present(
-        axum::http::header::CACHE_CONTROL,
-        axum::http::HeaderValue::from_static(value),
-    )
+///
+/// Only applies the header on success — see [`cache_control_on_success`].
+fn cache_control_layer(value: &'static str) -> CacheControlLayer {
+    // Coerce the async fn to a function pointer with a fully-nameable type so
+    // the helper's return type doesn't leak unnameable opaque generics.
+    fn shim(state: State<HeaderValue>, req: Request, next: Next) -> CacheControlFuture {
+        Box::pin(cache_control_on_success(state, req, next))
+    }
+    let f: CacheControlShim = shim;
+    from_fn_with_state(HeaderValue::from_static(value), f)
 }
 
 /// Build admin routes (authenticated endpoints)
@@ -1848,5 +1883,129 @@ mod tests {
         let config = test_cors_config();
         assert!(is_origin_allowed("https://preview-example.com", &config));
         assert!(is_origin_allowed("https://staging-example.com", &config));
+    }
+
+    // --- cache_control_layer tests -------------------------------------------
+    //
+    // These ensure the middleware only attaches a Cache-Control header to
+    // successful (2xx) responses, never to 4xx/5xx errors. Without this guard
+    // a transient DB failure or 404 could be pinned in CDNs and browsers for
+    // the declared TTL.
+
+    use axum::body::Body;
+    use axum::http::{Request as HttpRequest, StatusCode};
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    fn cache_test_app() -> Router {
+        async fn ok_handler() -> impl IntoResponse {
+            (StatusCode::OK, "ok")
+        }
+        async fn ok_with_header() -> Response {
+            let mut res = (StatusCode::OK, "ok").into_response();
+            res.headers_mut()
+                .insert(CACHE_CONTROL, HeaderValue::from_static("private, no-store"));
+            res
+        }
+        async fn internal_error() -> impl IntoResponse {
+            (StatusCode::INTERNAL_SERVER_ERROR, "boom")
+        }
+        async fn not_found() -> impl IntoResponse {
+            (StatusCode::NOT_FOUND, "missing")
+        }
+
+        Router::new()
+            .route("/ok", get(ok_handler))
+            .route("/ok-with-header", get(ok_with_header))
+            .route("/err500", get(internal_error))
+            .route("/err404", get(not_found))
+            .layer(cache_control_layer("public, max-age=30"))
+    }
+
+    #[tokio::test]
+    async fn cache_control_set_on_2xx() {
+        let app = cache_test_app();
+        let res = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/ok")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers()
+                .get(CACHE_CONTROL)
+                .map(|v| v.to_str().unwrap()),
+            Some("public, max-age=30"),
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_control_not_overridden_when_handler_sets_it() {
+        let app = cache_test_app();
+        let res = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/ok-with-header")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers()
+                .get(CACHE_CONTROL)
+                .map(|v| v.to_str().unwrap()),
+            Some("private, no-store"),
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_control_not_set_on_5xx() {
+        // The key bug-fix invariant: a 500 must NOT carry a cacheable
+        // Cache-Control header, or intermediaries may pin the failure.
+        let app = cache_test_app();
+        let res = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/err500")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(
+            res.headers().get(CACHE_CONTROL).is_none(),
+            "Cache-Control must not be set on 5xx responses, got: {:?}",
+            res.headers().get(CACHE_CONTROL),
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_control_not_set_on_4xx() {
+        // Same risk for transient 404s — admin adds a model 5s later, we must
+        // not be serving "missing" from cache for 30s.
+        let app = cache_test_app();
+        let res = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/err404")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        assert!(
+            res.headers().get(CACHE_CONTROL).is_none(),
+            "Cache-Control must not be set on 4xx responses, got: {:?}",
+            res.headers().get(CACHE_CONTROL),
+        );
     }
 }


### PR DESCRIPTION
## Why

Production measurements show `/v1/model/list` returns ~31 KB uncompressed even when the client sends `Accept-Encoding: gzip` — with gzip it drops to ~5 KB. Combined with the >100 ms RTT cost for users far from cpu01, every catalog refetch is unnecessarily slow. Public model/services endpoints also have no caching directives, so every browser/SDK re-fetches in full on every call.

## What

### Task A — Response compression (gzip + brotli)

- Added `compression-gzip` + `compression-br` features to `tower-http` in `crates/api/Cargo.toml`.
- Wrapped the main router with `tower_http::compression::CompressionLayer::new()` as the outermost layer in `routes()` (after CORS and metrics, so it applies to all responses).

**SSE / streaming endpoints (NOT excluded — they are auto-skipped):**

`CompressionLayer` inspects the response `Content-Type` and skips known streaming types, including `text/event-stream`. Both `/v1/chat/completions` (when `stream=true`) and `/v1/responses` set `Content-Type: text/event-stream` for the SSE path, so compression is a no-op there — clients continue to receive token deltas with normal latency.

**Attestation / signature endpoints:**

The body-hash middleware (`crates/api/src/middleware/body_hash.rs`) hashes the *request* body, not the response body. The `/v1/signature/{chat_id}` and `/v1/attestation/report` endpoints return JSON responses containing signatures over inference inputs/outputs computed inside services — they do NOT sign the HTTP response payload. So compressing the response is transparent to verification. No paths needed to be excluded from compression.

### Task B — Cache-Control on public, anonymous GETs

Implemented via a small `SetResponseHeaderLayer`-based helper (`cache_control_layer`) applied per route subgroup in `lib.rs`. `if_not_present` is used so handlers retain the ability to override per request if they ever need to.

| Endpoint(s) | TTL | Rationale |
|-------------|-----|-----------|
| `GET /v1/model/list`, `GET /v1/model/{name}` | `public, max-age=30, stale-while-revalidate=120` | Public, anonymous, identical for every caller. Changes only when an admin updates the catalog. SWR lets CDNs/browsers serve cached copies instantly while refreshing in the background. |
| `GET /v1/services`, `GET /v1/services/{name}` | `public, max-age=30, stale-while-revalidate=120` | Same shape — public, anonymous, admin-write speed (used by `chat-api` to fetch `web_search` pricing). |
| `GET /v1/health` | `public, max-age=5` | Short window absorbs thundering-herd from monitors/uptime probes; outages still surface within ~5 s. |
| `GET /docs`, `GET /api-docs/openapi.json` | `public, max-age=300, stale-while-revalidate=3600` | Spec + Scalar UI HTML change only on deploy. Five-minute fresh window with one-hour SWR. |

### Endpoints audited and intentionally NOT cached

- `/v1/users/me`, conversations, responses, workspaces, organizations, files, usage, billing, admin/* — authenticated and/or user-specific.
- `/v1/check_api_key` (gateway) — POST.
- `/login` — interactive OAuth flow page, response varies by request.
- Anything inside the auth/management plane.

## Verification

- `cargo build` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --lib --bins` — all 458 tests pass (260 in `api`, 117 in `services`, etc.)
- Full e2e (`cargo test --test e2e_all`) requires a local Postgres; not run here, but the changes are layer-only and do not touch any handler logic, repositories, or service traits.

## Test plan

- [ ] Hit `https://cloud-api.near.ai/v1/model/list` with `curl -H 'Accept-Encoding: gzip' -i` after deploy — expect `Content-Encoding: gzip` (or `br`) and `Cache-Control: public, max-age=30, stale-while-revalidate=120`.
- [ ] Hit `https://cloud-api.near.ai/v1/health` after deploy — expect `Cache-Control: public, max-age=5`.
- [ ] Hit `https://cloud-api.near.ai/api-docs/openapi.json -H 'Accept-Encoding: gzip'` — expect compression and `max-age=300`.
- [ ] Confirm a streaming `/v1/chat/completions` request with `stream=true` returns `Content-Type: text/event-stream` and NO `Content-Encoding` header (CompressionLayer should auto-skip SSE).
- [ ] Confirm `/v1/signature/{chat_id}` still verifies end-to-end with the existing verifier flow.