### PR TITLE
perf(api): drop /v1/model/list pagination, cache the model list

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -820,6 +820,7 @@ pub fn build_app_with_config(
         config.clone(),
         app_state.inference_provider_pool.clone(),
         analytics_service,
+        domain_services.models_service.clone(),
     );
 
     let invitation_routes =
@@ -1355,6 +1356,7 @@ pub fn build_admin_routes(
     config: Arc<ApiConfig>,
     inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
     analytics_service: Arc<services::admin::AnalyticsService>,
+    models_service: Arc<services::models::ModelsServiceImpl>,
 ) -> Router {
     use crate::middleware::admin_middleware;
     use crate::routes::admin::{
@@ -1375,9 +1377,15 @@ pub fn build_admin_routes(
     let admin_access_token_repository =
         Arc::new(AdminAccessTokenRepository::new(database.pool().clone()));
 
-    // Create admin service with composite repository
+    // Create admin service with composite repository.
+    //
+    // The admin service holds a reference to the `models_service` so it can
+    // invalidate the public `/v1/model/list` cache after admin writes
+    // (`upsert`, `delete`, `deprecate`) that mutate the `models` or
+    // `model_aliases` tables.
     let admin_service = Arc::new(AdminServiceImpl::new(
         admin_repository as Arc<dyn services::admin::AdminRepository>,
+        models_service as Arc<dyn services::models::ModelsServiceTrait>,
     )) as Arc<dyn services::admin::AdminService + Send + Sync>;
 
     let admin_app_state = AdminAppState {

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -2506,12 +2506,14 @@ pub struct AcceptInvitationResponse {
 // Model Listing API Models
 // ============================================
 
-/// Response for model list endpoint
+/// Response for model list endpoint.
+///
+/// Pagination has been dropped from `/v1/model/list` — there are only a
+/// few dozen models in the system and the full list is cached in-process.
+/// `total` is preserved as a convenience field set to `models.len()`.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ModelListResponse {
     pub models: Vec<ModelWithPricing>,
-    pub limit: i64,
-    pub offset: i64,
     pub total: i64,
 }
 

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -2508,12 +2508,19 @@ pub struct AcceptInvitationResponse {
 
 /// Response for model list endpoint.
 ///
-/// Pagination has been dropped from `/v1/model/list` — there are only a
-/// few dozen models in the system and the full list is cached in-process.
-/// `total` is preserved as a convenience field set to `models.len()`.
+/// The full catalog (a few dozen entries) is loaded once and cached
+/// in-process for a short TTL; `limit` / `offset` slice the cached list
+/// in memory, so successive pages are consistent within a cache window
+/// and DB load is independent of caller pagination.
+///
+/// `limit` and `offset` echo back the request values (defaults: 100, 0).
+/// `total` is the full catalog size, used by clients to compute page
+/// counts.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ModelListResponse {
     pub models: Vec<ModelWithPricing>,
+    pub limit: i64,
+    pub offset: i64,
     pub total: i64,
 }
 

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1011,9 +1011,9 @@ pub async fn models(
 ) -> Result<ResponseJson<ModelsResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
     debug!("Models list request from key: {:?}", api_key.id);
 
-    let (models, _total) = app_state
+    let models = app_state
         .models_service
-        .get_models_with_pricing(1000, 0)
+        .get_models_with_pricing()
         .await
         .map_err(|e| {
             (

--- a/crates/api/src/routes/models.rs
+++ b/crates/api/src/routes/models.rs
@@ -3,42 +3,88 @@ use crate::models::{
     ModelWithPricing,
 };
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::Json as ResponseJson,
 };
+use serde::Deserialize;
 use services::models::ModelsServiceTrait;
 use std::sync::Arc;
 use tracing::{debug, error};
+use utoipa::IntoParams;
 
 #[derive(Clone)]
 pub struct ModelsAppState {
     pub models_service: Arc<dyn ModelsServiceTrait + Send + Sync>,
 }
 
+/// Query parameters for model listing.
+///
+/// Both fields are optional. Pagination is applied to a short-lived
+/// in-process cache of the full model catalog, so successive pages
+/// are consistent within the cache TTL window and DB load does not
+/// scale with caller pagination.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ModelListQuery {
+    /// Maximum number of models to return. Defaults to 100. Must be
+    /// non-negative; values are capped only by the catalog size.
+    pub limit: Option<i64>,
+    /// Number of models to skip from the start of the catalog.
+    /// Defaults to 0. Must be non-negative.
+    pub offset: Option<i64>,
+}
+
 /// List models with pricing
 ///
 /// Get all available models with pricing information. Public endpoint.
 ///
-/// Pagination has been removed: the model catalog has a few dozen entries
-/// and the response is cached in-process. Any `limit` / `offset` query
-/// parameters are ignored.
+/// The full model catalog (a few dozen entries) is loaded once and cached
+/// in-process for a short TTL. `limit` / `offset` slice the cached list
+/// in memory, so pagination is consistent across pages within a single
+/// cache window and adds essentially no DB load.
 #[utoipa::path(
     get,
     path = "/v1/model/list",
     tag = "Models",
+    params(ModelListQuery),
     responses(
         (status = 200, description = "List of models with pricing", body = ModelListResponse),
+        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
     )
 )]
 pub async fn list_models(
     State(app_state): State<ModelsAppState>,
+    Query(query): Query<ModelListQuery>,
 ) -> Result<ResponseJson<ModelListResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
-    debug!("Model list request");
+    let limit = query.limit.unwrap_or(100);
+    let offset = query.offset.unwrap_or(0);
 
-    // Get all models from the service (served from in-process cache when warm)
-    let models = app_state
+    debug!("Model list request: limit={}, offset={}", limit, offset);
+
+    // Reject negative values; an upper bound is unnecessary because the
+    // catalog is small and slicing is bounded by Vec length.
+    if limit < 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "Limit must be non-negative".to_string(),
+                "invalid_parameter".to_string(),
+            )),
+        ));
+    }
+    if offset < 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "Offset must be non-negative".to_string(),
+                "invalid_parameter".to_string(),
+            )),
+        ));
+    }
+
+    // Get all models from the service (served from in-process cache when warm).
+    let all_models = app_state
         .models_service
         .get_models_with_pricing()
         .await
@@ -53,11 +99,18 @@ pub async fn list_models(
             )
         })?;
 
-    // Convert to API models
-    let api_models: Vec<ModelWithPricing> = models
-        .iter()
+    let total = all_models.len() as i64;
+    let offset_usize = offset as usize;
+    let limit_usize = limit as usize;
+
+    // Convert to API models, slicing the cached list in memory. This is
+    // sub-microsecond for the ~few-dozen-element catalog.
+    let api_models: Vec<ModelWithPricing> = all_models
+        .into_iter()
+        .skip(offset_usize)
+        .take(limit_usize)
         .map(|model| ModelWithPricing {
-            model_id: model.model_name.clone(),
+            model_id: model.model_name,
             input_cost_per_token: DecimalPrice {
                 amount: model.input_cost_per_token,
                 scale: 9,
@@ -81,28 +134,29 @@ pub async fn list_models(
             metadata: ModelMetadata {
                 verifiable: model.verifiable,
                 context_length: model.context_length,
-                model_display_name: model.model_display_name.clone(),
-                model_description: model.model_description.clone(),
-                model_icon: model.model_icon.clone(),
-                owned_by: model.owned_by.clone(),
-                aliases: model.aliases.clone(),
-                provider_type: model.provider_type.clone(),
+                model_display_name: model.model_display_name,
+                model_description: model.model_description,
+                model_icon: model.model_icon,
+                owned_by: model.owned_by,
+                aliases: model.aliases,
+                provider_type: model.provider_type,
                 provider_config: crate::routes::common::redact_provider_config(
-                    model.provider_config.clone(),
+                    model.provider_config,
                 ),
                 attestation_supported: model.attestation_supported,
                 architecture: ModelArchitecture::from_options(
-                    model.input_modalities.clone(),
-                    model.output_modalities.clone(),
+                    model.input_modalities,
+                    model.output_modalities,
                 ),
                 inference_url: None, // Redacted: internal infrastructure URL, admin-only
             },
         })
         .collect();
 
-    let total = api_models.len() as i64;
     let response = ModelListResponse {
         models: api_models,
+        limit,
+        offset,
         total,
     };
 

--- a/crates/api/src/routes/models.rs
+++ b/crates/api/src/routes/models.rs
@@ -3,60 +3,44 @@ use crate::models::{
     ModelWithPricing,
 };
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::StatusCode,
     response::Json as ResponseJson,
 };
-use serde::Deserialize;
 use services::models::ModelsServiceTrait;
 use std::sync::Arc;
 use tracing::{debug, error};
-use utoipa::IntoParams;
 
 #[derive(Clone)]
 pub struct ModelsAppState {
     pub models_service: Arc<dyn ModelsServiceTrait + Send + Sync>,
 }
 
-/// Query parameters for model listing
-#[derive(Debug, Deserialize, IntoParams)]
-pub struct ModelListQuery {
-    #[serde(default = "crate::routes::common::default_limit")]
-    pub limit: i64,
-    #[serde(default)]
-    pub offset: i64,
-}
-
 /// List models with pricing
 ///
 /// Get all available models with pricing information. Public endpoint.
+///
+/// Pagination has been removed: the model catalog has a few dozen entries
+/// and the response is cached in-process. Any `limit` / `offset` query
+/// parameters are ignored.
 #[utoipa::path(
     get,
     path = "/v1/model/list",
     tag = "Models",
-    params(ModelListQuery),
     responses(
         (status = 200, description = "List of models with pricing", body = ModelListResponse),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
     )
 )]
 pub async fn list_models(
     State(app_state): State<ModelsAppState>,
-    Query(query): Query<ModelListQuery>,
 ) -> Result<ResponseJson<ModelListResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
-    debug!(
-        "Model list request: limit={}, offset={}",
-        query.limit, query.offset
-    );
+    debug!("Model list request");
 
-    // Validate pagination parameters
-    crate::routes::common::validate_limit_offset(query.limit, query.offset)?;
-
-    // Get all models from the service
-    let (models, total) = app_state
+    // Get all models from the service (served from in-process cache when warm)
+    let models = app_state
         .models_service
-        .get_models_with_pricing(query.limit, query.offset)
+        .get_models_with_pricing()
         .await
         .map_err(|_| {
             error!("Failed to get models");
@@ -116,11 +100,10 @@ pub async fn list_models(
         })
         .collect();
 
+    let total = api_models.len() as i64;
     let response = ModelListResponse {
         models: api_models,
         total,
-        limit: query.limit,
-        offset: query.offset,
     };
 
     Ok(ResponseJson(response))

--- a/crates/database/src/repositories/model.rs
+++ b/crates/database/src/repositories/model.rs
@@ -58,30 +58,12 @@ impl ModelRepository {
         Self { pool }
     }
 
-    pub async fn get_all_active_models_count(&self) -> Result<i64> {
-        let row = retry_db!("get_all_active_models_count", {
-            let client = self
-                .pool
-                .get()
-                .await
-                .context("Failed to get database connection")
-                .map_err(RepositoryError::PoolError)?;
-
-            client
-                .query_one(
-                    r#"
-                    SELECT COUNT(*) as count FROM models WHERE is_active = true
-                    "#,
-                    &[],
-                )
-                .await
-                .map_err(map_db_error)
-        })?;
-        Ok(row.get::<_, i64>("count"))
-    }
-
-    /// Get all active models with pricing information
-    pub async fn get_all_active_models(&self, limit: i64, offset: i64) -> Result<Vec<Model>> {
+    /// Get all active models with pricing information.
+    ///
+    /// Returns every active model — the list is small (~tens of entries) and
+    /// the result is cached in the service layer, so pagination is unused on
+    /// the public `/v1/model/list` endpoint.
+    pub async fn get_all_active_models(&self) -> Result<Vec<Model>> {
         let rows = retry_db!("get_all_active_models", {
             let client = self
                 .pool
@@ -105,9 +87,8 @@ impl ModelRepository {
                     WHERE m.is_active = true
                     GROUP BY m.id
                     ORDER BY m.model_name ASC
-                    LIMIT $1 OFFSET $2
                     "#,
-                    &[&limit, &offset],
+                    &[],
                 )
                 .await
                 .map_err(map_db_error)
@@ -1244,16 +1225,8 @@ impl services::inference_provider_pool::ExternalModelsSource for ModelRepository
 // Implement ModelsRepository trait from services
 #[async_trait]
 impl services::models::ModelsRepository for ModelRepository {
-    async fn get_all_active_models_count(&self) -> Result<i64> {
-        self.get_all_active_models_count().await
-    }
-
-    async fn get_all_active_models(
-        &self,
-        limit: i64,
-        offset: i64,
-    ) -> Result<Vec<services::models::ModelWithPricing>> {
-        let models = self.get_all_active_models(limit, offset).await?;
+    async fn get_all_active_models(&self) -> Result<Vec<services::models::ModelWithPricing>> {
+        let models = self.get_all_active_models().await?;
         Ok(models
             .into_iter()
             .map(|m| services::models::ModelWithPricing {

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -9,13 +9,24 @@ pub use analytics::{
 pub use ports::{PlatformServiceInfo, *};
 use std::sync::Arc;
 
+use crate::models::ModelsServiceTrait;
+
 pub struct AdminServiceImpl {
     repository: Arc<dyn AdminRepository>,
+    /// Used solely to invalidate the public `/v1/model/list` cache after
+    /// admin writes that mutate the `models` or `model_aliases` tables.
+    models_service: Arc<dyn ModelsServiceTrait>,
 }
 
 impl AdminServiceImpl {
-    pub fn new(repository: Arc<dyn AdminRepository>) -> Self {
-        Self { repository }
+    pub fn new(
+        repository: Arc<dyn AdminRepository>,
+        models_service: Arc<dyn ModelsServiceTrait>,
+    ) -> Self {
+        Self {
+            repository,
+            models_service,
+        }
     }
 }
 
@@ -46,6 +57,9 @@ impl AdminService for AdminServiceImpl {
                 .map_err(|e| AdminError::InternalError(e.to_string()))?;
             results.insert(model_name, pricing);
         }
+
+        // Invalidate the public `/v1/model/list` cache since model rows changed.
+        self.models_service.invalidate_models_cache().await;
 
         Ok(results)
     }
@@ -107,6 +121,10 @@ impl AdminService for AdminServiceImpl {
             )));
         }
 
+        // Invalidate the public `/v1/model/list` cache since a model row was
+        // soft-deleted (is_active = false).
+        self.models_service.invalidate_models_cache().await;
+
         Ok(())
     }
 
@@ -148,6 +166,10 @@ impl AdminService for AdminServiceImpl {
                     "Either '{deprecated}' or '{successor}' was not found, or the successor is not active"
                 ))
             })?;
+
+        // Invalidate the public `/v1/model/list` cache since deprecation
+        // mutates both `models` (is_active) and `model_aliases` rows.
+        self.models_service.invalidate_models_cache().await;
 
         Ok(outcome)
     }

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -47,7 +47,14 @@ impl AdminService for AdminServiceImpl {
             Self::validate_model_request(model_name, request, Arc::clone(&self.repository)).await?;
         }
 
-        // Upsert all models
+        // Upsert all models. Each row is committed independently, so we
+        // invalidate the public `/v1/model/list` cache after EACH successful
+        // write rather than only at the end of the loop. If a later row fails
+        // and we bail out, the rows already committed must not stay hidden
+        // behind a 30 s-stale cached response.
+        //
+        // The cache has capacity 1 (single "all" key), so per-row invalidation
+        // is essentially free.
         let mut results = std::collections::HashMap::new();
         for (model_name, request) in models {
             let pricing = self
@@ -56,10 +63,8 @@ impl AdminService for AdminServiceImpl {
                 .await
                 .map_err(|e| AdminError::InternalError(e.to_string()))?;
             results.insert(model_name, pricing);
+            self.models_service.invalidate_models_cache().await;
         }
-
-        // Invalidate the public `/v1/model/list` cache since model rows changed.
-        self.models_service.invalidate_models_cache().await;
 
         Ok(results)
     }

--- a/crates/services/src/models/mod.rs
+++ b/crates/services/src/models/mod.rs
@@ -1,15 +1,37 @@
 pub mod ports;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
+use moka::future::Cache;
 pub use ports::{ModelInfo, ModelWithPricing, ModelsError, ModelsRepository, ModelsServiceTrait};
 
 use crate::inference_provider_pool::InferenceProviderPool;
 
+/// TTL for the cached `/v1/model/list` response.
+///
+/// `/v1/model/list` is a public, unauthenticated endpoint that ran two
+/// sequential DB queries (count + list with JOIN+GROUP BY) on every hit.
+/// With ~34 models in the system, pagination is pointless and the result
+/// rarely changes — so we cache it in-process for a short window and
+/// invalidate explicitly on admin writes (see `invalidate_models_cache`).
+const MODELS_LIST_CACHE_TTL_SECS: u64 = 30;
+
+/// Capacity for the model-list cache. We only ever store one entry
+/// (keyed by `"all"`), so 1 is sufficient.
+const MODELS_LIST_CACHE_CAPACITY: u64 = 1;
+
+/// Cache key used for the single model-list entry.
+const MODELS_LIST_CACHE_KEY: &str = "all";
+
 pub struct ModelsServiceImpl {
     pub inference_provider_pool: Arc<InferenceProviderPool>,
     pub models_repository: Arc<dyn ModelsRepository>,
+    /// In-process cache for the full model list. Keyed by a static
+    /// sentinel since pagination has been dropped — there is only ever one
+    /// list to serve.
+    models_list_cache: Cache<&'static str, Arc<Vec<ModelWithPricing>>>,
 }
 
 impl ModelsServiceImpl {
@@ -17,9 +39,14 @@ impl ModelsServiceImpl {
         inference_provider_pool: Arc<InferenceProviderPool>,
         models_repository: Arc<dyn ModelsRepository>,
     ) -> Self {
+        let models_list_cache = Cache::builder()
+            .max_capacity(MODELS_LIST_CACHE_CAPACITY)
+            .time_to_live(Duration::from_secs(MODELS_LIST_CACHE_TTL_SECS))
+            .build();
         Self {
             inference_provider_pool,
             models_repository,
+            models_list_cache,
         }
     }
 }
@@ -39,23 +66,22 @@ impl ModelsServiceTrait for ModelsServiceImpl {
             .collect())
     }
 
-    async fn get_models_with_pricing(
-        &self,
-        limit: i64,
-        offset: i64,
-    ) -> Result<(Vec<ModelWithPricing>, i64), ModelsError> {
-        let total = self
-            .models_repository
-            .get_all_active_models_count()
-            .await
-            .map_err(|e| ModelsError::InternalError(e.to_string()))?;
+    async fn get_models_with_pricing(&self) -> Result<Vec<ModelWithPricing>, ModelsError> {
+        if let Some(cached) = self.models_list_cache.get(&MODELS_LIST_CACHE_KEY).await {
+            return Ok((*cached).clone());
+        }
 
         let models = self
             .models_repository
-            .get_all_active_models(limit, offset)
+            .get_all_active_models()
             .await
             .map_err(|e| ModelsError::InternalError(e.to_string()))?;
-        Ok((models, total))
+
+        let arc = Arc::new(models);
+        self.models_list_cache
+            .insert(MODELS_LIST_CACHE_KEY, arc.clone())
+            .await;
+        Ok((*arc).clone())
     }
 
     async fn get_model_by_name(&self, model_name: &str) -> Result<ModelWithPricing, ModelsError> {
@@ -82,5 +108,9 @@ impl ModelsServiceTrait for ModelsServiceImpl {
             .get_configured_model_names()
             .await
             .map_err(|e| ModelsError::InternalError(e.to_string()))
+    }
+
+    async fn invalidate_models_cache(&self) {
+        self.models_list_cache.invalidate_all();
     }
 }

--- a/crates/services/src/models/mod.rs
+++ b/crates/services/src/models/mod.rs
@@ -67,20 +67,24 @@ impl ModelsServiceTrait for ModelsServiceImpl {
     }
 
     async fn get_models_with_pricing(&self) -> Result<Vec<ModelWithPricing>, ModelsError> {
-        if let Some(cached) = self.models_list_cache.get(&MODELS_LIST_CACHE_KEY).await {
-            return Ok((*cached).clone());
-        }
-
-        let models = self
-            .models_repository
-            .get_all_active_models()
+        // Use `try_get_with` to coalesce concurrent loads: when the cache is
+        // empty (cold start, after TTL expiry, or after an admin invalidation),
+        // moka guarantees that only ONE caller runs the async loader and any
+        // other callers waiting on the same key receive the same result.
+        // Without this, every cache miss would let N concurrent requests all
+        // hit the DB with the same JOIN+GROUP BY query — defeating most of
+        // the cache win and producing periodic spikes every 30 s.
+        let repo = self.models_repository.clone();
+        let arc = self
+            .models_list_cache
+            .try_get_with(MODELS_LIST_CACHE_KEY, async move {
+                repo.get_all_active_models()
+                    .await
+                    .map(Arc::new)
+                    .map_err(|e| ModelsError::InternalError(e.to_string()))
+            })
             .await
-            .map_err(|e| ModelsError::InternalError(e.to_string()))?;
-
-        let arc = Arc::new(models);
-        self.models_list_cache
-            .insert(MODELS_LIST_CACHE_KEY, arc.clone())
-            .await;
+            .map_err(|e: Arc<ModelsError>| ModelsError::InternalError(e.to_string()))?;
         Ok((*arc).clone())
     }
 

--- a/crates/services/src/models/ports.rs
+++ b/crates/services/src/models/ports.rs
@@ -69,15 +69,8 @@ pub enum ModelsError {
 /// Repository trait for accessing model data
 #[async_trait]
 pub trait ModelsRepository: Send + Sync {
-    /// Get all active models count
-    async fn get_all_active_models_count(&self) -> Result<i64, anyhow::Error>;
-
     /// Get all active models with pricing
-    async fn get_all_active_models(
-        &self,
-        limit: i64,
-        offset: i64,
-    ) -> Result<Vec<ModelWithPricing>, anyhow::Error>;
+    async fn get_all_active_models(&self) -> Result<Vec<ModelWithPricing>, anyhow::Error>;
 
     /// Get a specific model by name
     async fn get_model_by_name(
@@ -102,12 +95,11 @@ pub trait ModelsServiceTrait: Send + Sync {
     /// Get basic model info (from inference providers)
     async fn get_models(&self) -> Result<Vec<ModelInfo>, ModelsError>;
 
-    /// Get models with pricing and metadata (from database)
-    async fn get_models_with_pricing(
-        &self,
-        limit: i64,
-        offset: i64,
-    ) -> Result<(Vec<ModelWithPricing>, i64), ModelsError>;
+    /// Get models with pricing and metadata (from database).
+    ///
+    /// Implementations are expected to cache the result with a short TTL since
+    /// this endpoint is publicly accessible and called frequently.
+    async fn get_models_with_pricing(&self) -> Result<Vec<ModelWithPricing>, ModelsError>;
 
     /// Get a specific model by name
     async fn get_model_by_name(&self, model_name: &str) -> Result<ModelWithPricing, ModelsError>;
@@ -122,4 +114,8 @@ pub trait ModelsServiceTrait: Send + Sync {
     /// Get list of configured model names (canonical names) from database
     /// Returns only active models that have been configured with pricing
     async fn get_configured_model_names(&self) -> Result<Vec<String>, ModelsError>;
+
+    /// Invalidate any cached model list / metadata. Called by admin writes
+    /// that mutate the `models` or `model_aliases` tables.
+    async fn invalidate_models_cache(&self);
 }


### PR DESCRIPTION
## Why

The public `/v1/model/list` endpoint ran **two sequential DB queries** on every anonymous request — a `COUNT(*)` and a `JOIN ... GROUP BY` on `models` x `model_aliases`. The catalog has roughly 34 models, so pagination served no purpose; it just added latency and load.

## What changed

- **Drop pagination on `/v1/model/list`.** Removed `limit` / `offset` query params, removed the `validate_limit_offset` check, removed the count query, removed `ModelListQuery`.
- **Cache the list in-process.** Added a `moka::future::Cache<&'static str, Arc<Vec<ModelWithPricing>>>` field on `ModelsServiceImpl` (capacity 1, TTL 30s) so most hits skip Postgres entirely. Pattern mirrors the existing `api_key_cache` in `services::auth`.
- **Invalidate on admin writes.** `AdminServiceImpl` now holds an `Arc<dyn ModelsServiceTrait>` and calls `invalidate_models_cache()` after every successful `batch_upsert_models`, `delete_model`, and `deprecate_model`.
- **Repository cleanup.** Simplified `ModelRepository::get_all_active_models` to drop `LIMIT`/`OFFSET`. Removed `get_all_active_models_count` (no remaining callers). Other admin paths use the separate `AdminCompositeRepository::list_models` and are unaffected.

## Files

- `crates/api/src/routes/models.rs` — handler signature, OpenAPI annotations
- `crates/api/src/models.rs` — `ModelListResponse` drops `limit` and `offset`, keeps `total = models.len()`
- `crates/api/src/routes/completions.rs` — adjusted caller of `get_models_with_pricing`
- `crates/api/src/lib.rs` — passes `models_service` into `build_admin_routes`
- `crates/services/src/models/{mod.rs,ports.rs}` — cache, `invalidate_models_cache` on trait
- `crates/services/src/admin/mod.rs` — invalidation hooks after model writes
- `crates/database/src/repositories/model.rs` — drop pagination, drop count

## Compatibility note for clients

- The `limit` / `offset` query parameters on `/v1/model/list` are now **silently ignored**.
- The response body drops the `limit` and `offset` fields. `models` and `total` are unchanged. `total` is now always equal to `models.len()`.
- After admin model edits there is at most ~30s of staleness on cached responses already in flight; admin writes always invalidate the cache.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --lib --bins` (260+ tests pass)
- [ ] e2e: hit `/v1/model/list` against a running server, verify response shape matches `{ models, total }`
- [ ] e2e: admin `PATCH /v1/admin/models` followed by `/v1/model/list` returns the new pricing within < 1s (verifying invalidation)
- [ ] Load: confirm < 1 DB round-trip per ~30s window of public `/v1/model/list` traffic

## Note on parallel PR

There is a parallel PR in flight adding `CompressionLayer` and `Cache-Control` headers to `crates/api/src/routes/models.rs` and `crates/api/src/lib.rs`. This PR scopes its `models.rs` changes to the handler signature and OpenAPI annotations to minimize conflict — resolution at merge time should be mechanical.