### PR TITLE
observability: surface cumulative discovery cycles at INFO

### DIFF
--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -53,15 +53,25 @@ struct DiscoveryOutcome {
     /// ("ecdsa" / "ed25519"). Pubkeys are derived from the TEE compose hash so
     /// they're identical across backends of the same model.
     pubkeys_by_algo: HashMap<String, String>,
-    /// Per-call verified TLS fingerprints observed in this pass, in call order.
-    /// Order is the order in which discovery's parallel calls returned (not the
-    /// order they were launched). Same fingerprint appears multiple times when
-    /// the L4 LB routed several calls to the same backend — exactly the signal
-    /// needed to debug why cumulative discovery isn't expanding the pin set.
+    /// Per-call verified TLS fingerprints observed in this pass, in launch
+    /// order (by `attempt` index — `futures::future::join_all` preserves the
+    /// input order, not completion order). Same fingerprint appearing multiple
+    /// times means the L4 LB routed several calls to the same backend —
+    /// exactly the signal needed to debug why cumulative discovery isn't
+    /// expanding the pin set. Length equals `successful_calls - verify_failures`.
     observed_fingerprints: Vec<String>,
     /// Per-call failure reasons that prevented a fingerprint observation, in
-    /// the order they occurred. Empty when all calls succeeded.
+    /// launch order. Each entry is `"{category}: {detail}"` where category
+    /// is one of: `client_build`, `query_encode`, `connect`, `send_timeout`,
+    /// `request`, `send`, `timeout`, `status`, `malformed_json`, `verify`.
+    /// Note: post-HTTP verify failures are included here even though the
+    /// underlying call succeeded HTTP-wise, so
+    /// `failure_reasons.len() == failed_calls + verify_failures`.
     failure_reasons: Vec<String>,
+    /// Number of HTTP-successful calls whose attestation verification failed
+    /// (TDX quote rejection, report-data mismatch, etc.). These are *not*
+    /// counted in `failed_calls`, which only covers transport-layer failures.
+    verify_failures: usize,
 }
 
 /// Combined provider mappings updated atomically to prevent race conditions
@@ -764,6 +774,7 @@ impl InferenceProviderPool {
         let mut verified_this_round: HashSet<String> = HashSet::new();
         let mut observed_fingerprints: Vec<String> = Vec::new();
         let mut failure_reasons: Vec<String> = Vec::new();
+        let mut verify_failures = 0usize;
 
         for r in results {
             let (report, nonce, algo) = match r {
@@ -819,6 +830,7 @@ impl InferenceProviderPool {
                         "Attestation verification failed for discovered backend"
                     );
                     failure_reasons.push(format!("verify: {e}"));
+                    verify_failures += 1;
                 }
             }
         }
@@ -836,6 +848,7 @@ impl InferenceProviderPool {
             pubkeys_by_algo,
             observed_fingerprints,
             failure_reasons,
+            verify_failures,
         }
     }
 
@@ -2117,6 +2130,7 @@ impl InferenceProviderPool {
                             url = %url,
                             successful_calls = outcome.successful_calls,
                             failed_calls = outcome.failed_calls,
+                            verify_failures = outcome.verify_failures,
                             failure_reasons = ?outcome.failure_reasons,
                             "No TLS fingerprints pinned during initial discovery — provider will reject connections until attestation succeeds"
                         );
@@ -2127,6 +2141,7 @@ impl InferenceProviderPool {
                             calls = discovery_parallelism,
                             successful_calls = outcome.successful_calls,
                             failed_calls = outcome.failed_calls,
+                            verify_failures = outcome.verify_failures,
                             new_fingerprints = outcome.new_fingerprints,
                             total_pinned = outcome.total_pinned,
                             pubkey_algos = ?outcome.pubkeys_by_algo.keys().collect::<Vec<_>>(),
@@ -2425,6 +2440,7 @@ impl InferenceProviderPool {
                         url = %url,
                         new_fingerprints = outcome.new_fingerprints,
                         total_pinned = outcome.total_pinned,
+                        verify_failures = outcome.verify_failures,
                         observed_fingerprints = ?outcome.observed_fingerprints,
                         failure_reasons = ?outcome.failure_reasons,
                         "Cumulative discovery expanded pinned backend set"
@@ -2443,6 +2459,7 @@ impl InferenceProviderPool {
                         calls = cumulative_calls,
                         successful_calls = outcome.successful_calls,
                         failed_calls = outcome.failed_calls,
+                        verify_failures = outcome.verify_failures,
                         total_pinned = outcome.total_pinned,
                         observed_fingerprints = ?outcome.observed_fingerprints,
                         failure_reasons = ?outcome.failure_reasons,

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -53,6 +53,15 @@ struct DiscoveryOutcome {
     /// ("ecdsa" / "ed25519"). Pubkeys are derived from the TEE compose hash so
     /// they're identical across backends of the same model.
     pubkeys_by_algo: HashMap<String, String>,
+    /// Per-call verified TLS fingerprints observed in this pass, in call order.
+    /// Order is the order in which discovery's parallel calls returned (not the
+    /// order they were launched). Same fingerprint appears multiple times when
+    /// the L4 LB routed several calls to the same backend — exactly the signal
+    /// needed to debug why cumulative discovery isn't expanding the pin set.
+    observed_fingerprints: Vec<String>,
+    /// Per-call failure reasons that prevented a fingerprint observation, in
+    /// the order they occurred. Empty when all calls succeeded.
+    failure_reasons: Vec<String>,
 }
 
 /// Combined provider mappings updated atomically to prevent race conditions
@@ -640,7 +649,7 @@ impl InferenceProviderPool {
                                 error = %e,
                                 "Failed to build discovery client"
                             );
-                            return None;
+                            return Err(format!("client_build: {e}"));
                         }
                     };
 
@@ -654,7 +663,7 @@ impl InferenceProviderPool {
                         include_tls_fingerprint: Some(true),
                     }) {
                         Ok(q) => q,
-                        Err(_) => return None,
+                        Err(e) => return Err(format!("query_encode: {e}")),
                     };
                     let request_url = format!("{}/v1/attestation/report?{}", url, qs);
 
@@ -679,7 +688,18 @@ impl InferenceProviderPool {
                                 error = %e,
                                 "Discovery call failed"
                             );
-                            return None;
+                            // Categorize so the outcome aggregate stays readable at INFO.
+                            // reqwest's full error is verbose; classify common causes.
+                            let category = if e.is_connect() {
+                                "connect"
+                            } else if e.is_timeout() {
+                                "send_timeout"
+                            } else if e.is_request() {
+                                "request"
+                            } else {
+                                "send"
+                            };
+                            return Err(format!("{category}: {e}"));
                         }
                         Err(_) => {
                             debug!(
@@ -690,21 +710,22 @@ impl InferenceProviderPool {
                                 elapsed_ms,
                                 "Discovery call timed out"
                             );
-                            return None;
+                            return Err(format!("timeout: {elapsed_ms}ms"));
                         }
                     };
 
                     if !resp.status().is_success() {
+                        let status = resp.status().as_u16();
                         debug!(
                             model = %model,
                             url = %url,
                             algo = %algo,
                             attempt = i,
-                            status = resp.status().as_u16(),
+                            status = status,
                             elapsed_ms,
                             "Discovery call returned non-2xx"
                         );
-                        return None;
+                        return Err(format!("status: {status}"));
                     }
                     let report: serde_json::Map<String, serde_json::Value> = match resp.json().await
                     {
@@ -718,7 +739,7 @@ impl InferenceProviderPool {
                                 error = %e,
                                 "Discovery call returned malformed JSON"
                             );
-                            return None;
+                            return Err(format!("malformed_json: {e}"));
                         }
                     };
                     debug!(
@@ -729,7 +750,7 @@ impl InferenceProviderPool {
                         elapsed_ms,
                         "Discovery call succeeded"
                     );
-                    Some((report, nonce, algo))
+                    Ok((report, nonce, algo))
                 }
             })
             .collect::<Vec<_>>();
@@ -741,17 +762,24 @@ impl InferenceProviderPool {
         let mut new_fingerprints = 0usize;
         let mut pubkeys_by_algo: HashMap<String, String> = HashMap::new();
         let mut verified_this_round: HashSet<String> = HashSet::new();
+        let mut observed_fingerprints: Vec<String> = Vec::new();
+        let mut failure_reasons: Vec<String> = Vec::new();
 
         for r in results {
-            let Some((report, nonce, algo)) = r else {
-                failed_calls += 1;
-                continue;
+            let (report, nonce, algo) = match r {
+                Ok(t) => t,
+                Err(reason) => {
+                    failed_calls += 1;
+                    failure_reasons.push(reason);
+                    continue;
+                }
             };
             successful_calls += 1;
 
             match verifier.verify_attestation_report(&report, &nonce).await {
                 Ok(verified) => {
                     if let Some(ref vfp) = verified.tls_cert_fingerprint {
+                        observed_fingerprints.push(vfp.clone());
                         if verified_this_round.insert(vfp.clone()) {
                             let added = {
                                 let mut state =
@@ -790,6 +818,7 @@ impl InferenceProviderPool {
                         error = %e,
                         "Attestation verification failed for discovered backend"
                     );
+                    failure_reasons.push(format!("verify: {e}"));
                 }
             }
         }
@@ -805,6 +834,8 @@ impl InferenceProviderPool {
             new_fingerprints,
             total_pinned,
             pubkeys_by_algo,
+            observed_fingerprints,
+            failure_reasons,
         }
     }
 
@@ -2086,6 +2117,7 @@ impl InferenceProviderPool {
                             url = %url,
                             successful_calls = outcome.successful_calls,
                             failed_calls = outcome.failed_calls,
+                            failure_reasons = ?outcome.failure_reasons,
                             "No TLS fingerprints pinned during initial discovery — provider will reject connections until attestation succeeds"
                         );
                     } else {
@@ -2098,6 +2130,8 @@ impl InferenceProviderPool {
                             new_fingerprints = outcome.new_fingerprints,
                             total_pinned = outcome.total_pinned,
                             pubkey_algos = ?outcome.pubkeys_by_algo.keys().collect::<Vec<_>>(),
+                            observed_fingerprints = ?outcome.observed_fingerprints,
+                            failure_reasons = ?outcome.failure_reasons,
                             "Initial attestation discovery complete"
                         );
                         // Pre-warm all bucket clients in the background so the
@@ -2391,17 +2425,28 @@ impl InferenceProviderPool {
                         url = %url,
                         new_fingerprints = outcome.new_fingerprints,
                         total_pinned = outcome.total_pinned,
+                        observed_fingerprints = ?outcome.observed_fingerprints,
+                        failure_reasons = ?outcome.failure_reasons,
                         "Cumulative discovery expanded pinned backend set"
                     );
                 } else {
-                    debug!(
+                    // Promoted from DEBUG to INFO so production can observe
+                    // *why* the pin set isn't growing: every cycle records the
+                    // fingerprints the L4 LB routed to (showing whether load
+                    // balancing is collapsing onto already-pinned backends) and
+                    // any per-call failure reasons (TLS reject, timeout, 5xx,
+                    // etc.). Frequency is bounded by the refresh interval
+                    // (default 300s) × model count, so volume stays modest.
+                    info!(
                         model = %model_name,
                         url = %url,
                         calls = cumulative_calls,
                         successful_calls = outcome.successful_calls,
                         failed_calls = outcome.failed_calls,
                         total_pinned = outcome.total_pinned,
-                        "Cumulative discovery cycle"
+                        observed_fingerprints = ?outcome.observed_fingerprints,
+                        failure_reasons = ?outcome.failure_reasons,
+                        "Cumulative discovery cycle (no new fingerprints)"
                     );
                 }
 


### PR DESCRIPTION
## Why

Production cloud-api intermittently returns 503 for `GET /v1/attestation/report?model=zai-org/GLM-latest` (and other multi-backend models). Root cause is that some replicas only have a partial TLS SPKI pin set for `glm-5-1.completions.near.ai` (5 backends behind the L4 SNI proxy), and cumulative discovery is *not* expanding the set after startup.

After startup we see **zero** `"Pinned new TLS SPKI fingerprint"` or `"Cumulative discovery expanded pinned backend set"` events for GLM on either prod host in 6+ hours, even though `"Loaded inference_url models"` fires every 5 min. The no-new-fingerprints branch logs at **DEBUG** (filtered in prod), so we can't tell from logs whether cumulative actually ran, which backends the L4 LB routed it to, or whether per-call failures (TLS reject / timeout / 5xx) are silently eating cycles.

## What this PR does

Adds two fields to `DiscoveryOutcome` so every discovery pass produces enough INFO-level data to find the root cause on prod:

- `observed_fingerprints: Vec<String>` — every verified TLS SPKI fingerprint a cycle saw, in call order. **Repeats** mean the L4 LB sent multiple calls to the same backend (load-balancing collapse). **Missing-from-prod-pin-set** entries mean the LB *did* route to a new backend but something else (e.g. `verify`) failed.
- `failure_reasons: Vec<String>` — a category-prefixed reason per call that didn't produce a fingerprint. Categories: `connect` / `send_timeout` / `timeout` / `request` / `send` / `status:NNN` / `malformed_json` / `query_encode` / `client_build` / `verify`.

These fields are surfaced on three existing log events:

1. **`Cumulative discovery cycle (no new fingerprints)`** — promoted from DEBUG to INFO and renamed. This is the key signal — it now fires once per provider per refresh cycle in prod.
2. **`Cumulative discovery expanded pinned backend set`** — already INFO; gains `observed_fingerprints` and `failure_reasons`.
3. **`Initial attestation discovery complete`** — already INFO; same additions, so startup diagnostics show what each replica saw.

Per-call DEBUG logs are unchanged.

## Volume

Aggregate INFO log fires once per provider per cumulative cycle. With default `refresh_interval_secs = 300` and ~11 reused models, that's ~2-3 log-lines/sec per replica during steady state — well within budget.

## Privacy

No customer data. Fingerprints are server-cert SPKI hashes (already logged at INFO in `"Pinned new TLS SPKI fingerprint"`). Failure reasons are bounded categorical strings + reqwest error display, no request/response bodies.

## What we expect to see once this ships

For the GLM stall, one of:
- `observed_fingerprints` contains only the already-pinned values every cycle → L4 LB is collapsing onto known backends; fix is on the model-proxy / discovery-routing side (PR for `select_backend_excluding`).
- `failure_reasons` contains `connect` / `timeout` / `verify` consistently → upstream backend or attestation path is the blocker.
- Mixed → we can quantify each.

Without this PR we cannot distinguish these on prod.

## Test plan

- [x] `cargo check -p services` clean
- [x] `cargo test --lib -p services inference_provider_pool` — 31/31 passing
- [ ] Deploy to staging, confirm `Cumulative discovery cycle (no new fingerprints)` events appear with non-empty `observed_fingerprints` for healthy multi-backend models
- [ ] Deploy to prod, query DD for `service:cloud-api @fields.model:zai-org/GLM-5.1-FP8 @fields.message:"Cumulative discovery cycle"`, confirm whether observations repeat or rotate

## Follow-ups (out of scope)

Once we have the data we can pick the right fix from:
- Bump `CUMULATIVE_DISCOVERY_CALLS` from 2 → 5 to match initial parallelism.
- Have discovery request `select_backend_excluding(already_pinned)` so model-proxy rotates to undiscovered backends.
- Run one cumulative cycle ~30s after startup instead of waiting for the first interval tick.