### PR TITLE
ci: ignore deadpool bumps until deadpool-postgres catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+    ignore:
+      # deadpool 0.13 cannot be adopted until deadpool-postgres releases a
+      # 0.13-compatible version (latest is 0.14.1, still requires deadpool ^0.12).
+      # Bumping our direct dep produces a split lockfile and breaks type
+      # compatibility on PoolConfig.queue_mode / Runtime::Tokio1.
+      - dependency-name: "deadpool"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     commit-message:
       prefix: "deps"
 


### PR DESCRIPTION
## Summary

- Adds an `ignore` entry for the `deadpool` crate in `.github/dependabot.yml` so future grouped Rust-deps bumps don't keep proposing the broken 0.13 upgrade.

## Why

`deadpool-postgres` 0.14.1 (the latest release, Dec 2024) still requires `deadpool ^0.12`. Bumping our direct `deadpool` dep to 0.13 produces a split lockfile (0.12 + 0.13 side-by-side) and breaks type compatibility on `PoolConfig.queue_mode` (deadpool::managed::QueueMode mismatch) and `Runtime::Tokio1` (variant removed in 0.13). This is exactly the failure mode that closed #592.

Both major and minor bumps are ignored — for 0.x crates, minor is semver-breaking, and the next compatible release will likely be 0.13 (minor) at the same time `deadpool-postgres` releases its next major. We can lift this once `deadpool-postgres` ships a 0.13-compatible version.

## Test plan
- [ ] Confirm dependabot's next weekly run skips deadpool in the grouped PR.