### PR TITLE
feat: rotation-SNI discovery + rapid-eviction pin set

### DIFF
--- a/crates/inference_providers/src/spki_verifier.rs
+++ b/crates/inference_providers/src/spki_verifier.rs
@@ -57,6 +57,24 @@ impl FingerprintState {
         // Don't block if already Pinned — keep existing verified fingerprints
     }
 
+    /// Replace the pinned set wholesale.
+    ///
+    /// Called once per discovery cycle when the cycle achieved complete
+    /// coverage (every healthy backend produced exactly one verified
+    /// fingerprint). Lets the pin set track the *current* healthy set rather
+    /// than accumulating every backend the proxy ever routed to — when a
+    /// backend goes unhealthy or its cert rotates, its old fingerprint is
+    /// dropped within one refresh interval.
+    ///
+    /// Transitions Bootstrap → Pinned and Blocked → Pinned, matching
+    /// `add_fingerprint`. An empty `fps` is permitted; callers treat that as
+    /// "no healthy backends right now" and the provider-level fail-closed
+    /// path keeps connections rejected until a future cycle re-pins
+    /// something.
+    pub fn replace_with(&mut self, fps: HashSet<String>) {
+        *self = FingerprintState::Pinned(fps);
+    }
+
     /// Number of pinned fingerprints (0 for Bootstrap/Blocked).
     pub fn pinned_count(&self) -> usize {
         match self {
@@ -265,5 +283,66 @@ mod tests {
         state.add_fingerprint("abc".to_string());
         assert!(matches!(state, FingerprintState::Pinned(_)));
         assert_eq!(state.pinned_count(), 1);
+    }
+
+    #[test]
+    fn test_replace_with_from_bootstrap() {
+        let mut state = FingerprintState::Bootstrap;
+        let mut fps = HashSet::new();
+        fps.insert("a".to_string());
+        fps.insert("b".to_string());
+        state.replace_with(fps);
+        assert!(matches!(state, FingerprintState::Pinned(_)));
+        assert_eq!(state.pinned_count(), 2);
+    }
+
+    #[test]
+    fn test_replace_with_shrinks_pinned() {
+        let mut state = FingerprintState::Bootstrap;
+        for fp in ["a", "b", "c", "d", "e"] {
+            state.add_fingerprint(fp.to_string());
+        }
+        assert_eq!(state.pinned_count(), 5);
+
+        // Backend went away — pin set tracks the new healthy set.
+        let mut shrunk = HashSet::new();
+        shrunk.insert("a".to_string());
+        shrunk.insert("b".to_string());
+        shrunk.insert("c".to_string());
+        shrunk.insert("d".to_string());
+        state.replace_with(shrunk);
+        assert_eq!(state.pinned_count(), 4);
+        if let FingerprintState::Pinned(set) = &state {
+            assert!(set.contains("a"));
+            assert!(!set.contains("e"), "evicted fingerprint must be gone");
+        } else {
+            panic!("expected Pinned");
+        }
+    }
+
+    #[test]
+    fn test_replace_with_from_blocked() {
+        // Blocked → Pinned mirrors add_fingerprint's recovery path.
+        let mut state = FingerprintState::Bootstrap;
+        state.block();
+        assert!(matches!(state, FingerprintState::Blocked));
+
+        let mut fps = HashSet::new();
+        fps.insert("recovered".to_string());
+        state.replace_with(fps);
+        assert!(matches!(state, FingerprintState::Pinned(_)));
+        assert_eq!(state.pinned_count(), 1);
+    }
+
+    #[test]
+    fn test_replace_with_empty_set_is_permitted() {
+        // Caller may pass an empty set to express "no healthy backends".
+        // The provider-level fail-closed path is responsible for rejecting
+        // connections; FingerprintState just stores the (empty) Pinned set.
+        let mut state = FingerprintState::Bootstrap;
+        state.add_fingerprint("a".to_string());
+        state.replace_with(HashSet::new());
+        assert!(matches!(state, FingerprintState::Pinned(_)));
+        assert_eq!(state.pinned_count(), 0);
     }
 }

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -8,41 +8,6 @@ use std::collections::HashSet;
 
 const NVIDIA_NRAS_URL: &str = "https://nras.attestation.nvidia.com/v3/attest/gpu";
 
-/// Number of parallel attestation calls per model to discover TLS fingerprints
-/// from multiple backends behind L4 load balancing.
-///
-/// Each cloud-api instance runs its own discovery, so the effective load on a
-/// model is `PARALLELISM * cloud-api instance count` per refresh cycle. Keep
-/// this modest to avoid piling attestation work on inference backends.
-pub const ATTESTATION_DISCOVERY_PARALLELISM: usize = 5;
-
-/// Number of cumulative attestation calls per reused provider on each refresh.
-///
-/// Each cycle adds a small number of fresh-TCP discovery calls to a reused
-/// provider, which accumulates new backend fingerprints into the shared
-/// `FingerprintState`. Over several cycles this covers every backend behind
-/// the L4 LB, even when the initial discovery only hit one. Kept small so
-/// steady-state refresh load stays low.
-pub const CUMULATIVE_DISCOVERY_CALLS: usize = 2;
-
-/// Inter-model stagger for cumulative discovery on each refresh cycle (milliseconds).
-///
-/// When the provider pool refreshes, it runs cumulative attestation discovery
-/// for every reused model. Without staggering, all models fire their first
-/// discovery call at t=0, creating a burst that saturates the GPU evidence
-/// worker on dense hosts (e.g. gpu04 runs 8+ model instances).
-///
-/// With this stagger, model i starts its discovery after `i * MODEL_DISCOVERY_STAGGER_MS`
-/// delay. At 2 s/model the burst is spread across tens of seconds rather than
-/// a single wall-clock instant, while still completing well within the 5-minute
-/// refresh interval even for large pools.
-///
-/// Note: the cumulative discovery loop runs inside `buffer_unordered(10)`, so
-/// tasks at index >= 10 begin their sleep only after a concurrency slot opens.
-/// Their effective wall-clock delay is therefore ≥ i × STAGGER_MS, making the
-/// spread more conservative (not less) for pools larger than 10 models.
-pub const MODEL_DISCOVERY_STAGGER_MS: u64 = 2_000;
-
 /// Result of verifying an attestation report from an inference backend.
 #[derive(Debug, Clone)]
 pub struct VerifiedAttestation {

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1,3 +1,5 @@
+mod rotation;
+
 use crate::attestation::AttestationVerifier;
 use crate::common::encryption_headers;
 use config::ExternalProvidersConfig;
@@ -36,10 +38,16 @@ pub trait ExternalModelsSource: Send + Sync {
 /// Result of an attestation-discovery pass against a model URL.
 ///
 /// `discover_model` mutates the shared `fingerprint_state` as a side effect
-/// (pinning new verified fingerprints). This struct summarizes what happened
-/// for the caller's logging and decision-making.
+/// (pinning verified fingerprints — additively on partial coverage, replacing
+/// the set on complete coverage). This struct summarizes what happened for
+/// the caller's logging and decision-making.
 #[derive(Debug)]
 struct DiscoveryOutcome {
+    /// Healthy backend count reported by `GET /backends/count` this cycle.
+    /// `0` means we couldn't get a count (model-proxy unreachable, 404, etc.)
+    /// — see `failure_reasons` for the category. `discover_model` returns
+    /// without issuing any rotation calls in that case.
+    backend_count: usize,
     /// Number of discovery HTTP calls that returned a response.
     successful_calls: usize,
     /// Number of discovery HTTP calls that failed (timeout, transport error, 4xx/5xx).
@@ -47,31 +55,111 @@ struct DiscoveryOutcome {
     /// Number of previously-unknown verified fingerprints added to `fingerprint_state`
     /// during this pass.
     new_fingerprints: usize,
-    /// Total pinned fingerprints in `fingerprint_state` after this pass (cumulative).
+    /// Total pinned fingerprints in `fingerprint_state` after this pass.
     total_pinned: usize,
     /// Signing pubkeys extracted from verified reports, keyed by signing algorithm
     /// ("ecdsa" / "ed25519"). Pubkeys are derived from the TEE compose hash so
     /// they're identical across backends of the same model.
     pubkeys_by_algo: HashMap<String, String>,
     /// Per-call verified TLS fingerprints observed in this pass, in launch
-    /// order (by `attempt` index — `futures::future::join_all` preserves the
-    /// input order, not completion order). Same fingerprint appearing multiple
-    /// times means the L4 LB routed several calls to the same backend —
-    /// exactly the signal needed to debug why cumulative discovery isn't
-    /// expanding the pin set. Length equals `successful_calls - verify_failures`.
+    /// order (by index — `futures::future::join_all` preserves the input
+    /// order, not completion order). With rotation, each index lands on a
+    /// distinct backend, so under complete coverage every entry is unique
+    /// and `observed_fingerprints.len() == backend_count`.
     observed_fingerprints: Vec<String>,
     /// Per-call failure reasons that prevented a fingerprint observation, in
     /// launch order. Each entry is `"{category}: {detail}"` where category
-    /// is one of: `client_build`, `query_encode`, `connect`, `send_timeout`,
-    /// `request`, `send`, `timeout`, `status`, `malformed_json`, `verify`.
+    /// is one of: `count_connect`, `count_timeout`, `count_send`,
+    /// `count_status`, `count_decode`, `client_build`, `query_encode`,
+    /// `connect`, `send_timeout`, `request`, `send`, `timeout`, `status`,
+    /// `malformed_json`, `verify`.
     /// Note: post-HTTP verify failures are included here even though the
     /// underlying call succeeded HTTP-wise, so
-    /// `failure_reasons.len() == failed_calls + verify_failures`.
+    /// `failure_reasons.len() == failed_calls + verify_failures` plus at
+    /// most one `count_*` entry per cycle.
     failure_reasons: Vec<String>,
     /// Number of HTTP-successful calls whose attestation verification failed
     /// (TDX quote rejection, report-data mismatch, etc.). These are *not*
     /// counted in `failed_calls`, which only covers transport-layer failures.
     verify_failures: usize,
+    /// True when this cycle achieved complete coverage of every healthy
+    /// backend (no failures, every index produced a verified fingerprint,
+    /// no duplicate fingerprints across indices) and the pin set was
+    /// REPLACED rather than augmented. Lets a backend that went unhealthy
+    /// or had its cert rotated drop out of the pin set within one refresh
+    /// interval. `false` on any partial cycle to avoid evicting fingerprints
+    /// we just couldn't reconfirm.
+    replaced_state: bool,
+}
+
+/// Outcome of applying the cycle's verified fingerprints to a
+/// `FingerprintState`. Split into its own type so the policy is testable
+/// without spinning up a real attestation pipeline.
+struct PinUpdate {
+    /// Fingerprints that weren't in the pin set before this cycle.
+    newly_pinned: Vec<String>,
+    /// Fingerprints that were pinned before this cycle but are no longer
+    /// pinned after the replacement. Empty in the additive path.
+    evicted: Vec<String>,
+    /// Pinned count after the update.
+    total_pinned: usize,
+    /// True iff the cycle achieved complete coverage and the pin set was
+    /// replaced wholesale (vs. additively merged).
+    replaced: bool,
+}
+
+/// Apply this cycle's verified fingerprint set to the shared pin state.
+///
+/// Rule: replace the pin set with `verified` iff this cycle achieved
+/// **complete coverage** — every healthy backend produced exactly one
+/// verified fingerprint and no failures occurred. Otherwise additively
+/// merge (only grow). This is what lets a backend that just went unhealthy
+/// drop out of the pin set within one refresh interval, without false
+/// evictions on transient per-call hiccups.
+fn apply_pin_update(
+    state: &Arc<std::sync::RwLock<FingerprintState>>,
+    verified: &HashSet<String>,
+    backend_count: usize,
+    failed_calls: usize,
+    verify_failures: usize,
+) -> PinUpdate {
+    let complete_coverage = backend_count > 0
+        && failed_calls == 0
+        && verify_failures == 0
+        && verified.len() == backend_count;
+
+    let mut state = state.write().unwrap_or_else(|e| e.into_inner());
+    let before: HashSet<String> = match &*state {
+        FingerprintState::Pinned(set) => set.clone(),
+        _ => HashSet::new(),
+    };
+
+    if complete_coverage {
+        let newly_pinned: Vec<String> = verified.difference(&before).cloned().collect();
+        let evicted: Vec<String> = before.difference(verified).cloned().collect();
+        state.replace_with(verified.clone());
+        PinUpdate {
+            newly_pinned,
+            evicted,
+            total_pinned: state.pinned_count(),
+            replaced: true,
+        }
+    } else {
+        let mut newly_pinned: Vec<String> = Vec::new();
+        for fp in verified {
+            let before_count = state.pinned_count();
+            state.add_fingerprint(fp.clone());
+            if state.pinned_count() > before_count {
+                newly_pinned.push(fp.clone());
+            }
+        }
+        PinUpdate {
+            newly_pinned,
+            evicted: Vec::new(),
+            total_pinned: state.pinned_count(),
+            replaced: false,
+        }
+    }
 }
 
 /// Combined provider mappings updated atomically to prevent race conditions
@@ -561,8 +649,14 @@ impl InferenceProviderPool {
     /// Why a fresh client per call: reqwest with HTTP/2 multiplexes many
     /// concurrent requests onto a single TCP connection, which hashes to a
     /// single L4 backend. Separate clients force separate TCP handshakes,
-    /// letting each call land on a different backend. Over a few calls this
-    /// discovers the fingerprints of most/all backends behind the L4 LB.
+    /// letting each call land on a different backend.
+    ///
+    /// Why rotation SNI per call: model-proxy publishes `<canonical>-i<N>.<base>`
+    /// (see model-proxy PR #27). A fresh-TCP probe to that SNI is routed
+    /// deterministically to `backends_sorted_by_address[N % healthy_count]`,
+    /// bypassing the least-connections LB. We fetch the healthy count from
+    /// `/backends/count`, then fan out one call per backend index. One cycle
+    /// = full coverage.
     ///
     /// Why an isolated Bootstrap state per call: if discovery calls shared
     /// the caller's `fingerprint_state`, the first call that completed and
@@ -571,38 +665,65 @@ impl InferenceProviderPool {
     /// rejected inside the SPKI verifier (fingerprint not in `{A}`). Each
     /// call therefore uses its own `Bootstrap` state for the TLS verifier,
     /// and verified fingerprints are merged into the caller's shared
-    /// accumulator *after* the HTTP call returns.
+    /// accumulator *after* the HTTP calls return.
     ///
     /// Why extract pubkeys here: the attestation report already contains
     /// `signing_public_key` for the requested `signing_algo`. Alternating
-    /// algos across the N calls yields both keys in one pass — no separate
-    /// post-pin round-trip. Pubkeys are derived from the TEE compose hash
-    /// so they're identical across backends of the same model; the first
-    /// verified response per algo wins.
+    /// algos across the N calls yields both keys in one pass. Pubkeys are
+    /// derived from the TEE compose hash so they're identical across
+    /// backends of the same model+algo; the first verified response per
+    /// algo wins.
     ///
-    /// Why staggered: 200ms offsets spread load and encourage separate L4
-    /// hashes by giving each call its own TCP handshake window.
-    ///
-    /// Fingerprints are only pinned after attestation verification succeeds.
-    /// Existing fingerprints in `fingerprint_state` are preserved; new ones
-    /// are added. Calling this with `num_calls=2` on an already-`Pinned`
-    /// state is the cumulative-discovery path: it expands the pinned set
-    /// over time without disrupting in-flight requests.
+    /// Rapid eviction: when every healthy backend produced exactly one
+    /// verified fingerprint, the pin set is REPLACED with the observed set
+    /// — a backend that just went unhealthy or had its cert rotated is
+    /// dropped from the pin set within one refresh interval. On partial
+    /// coverage (any failure, or fewer distinct fingerprints than the
+    /// reported healthy count) we fall back to additive merging so a
+    /// transient hiccup doesn't evict verified fingerprints we just
+    /// couldn't reconfirm.
     ///
     /// The caller owns the `fingerprint_state` Arc and decides when to
     /// transition it to `Blocked` (e.g., when `outcome.total_pinned == 0`
     /// on initial discovery).
+    /// Build a DiscoveryOutcome representing "cycle bailed before issuing any
+    /// rotation calls" (URL didn't parse, count fetch failed, etc.). Reads
+    /// the current `total_pinned` from the shared state so callers see what
+    /// remains pinned, but reports `successful_calls == 0` and never
+    /// replaces the pin set.
+    fn empty_outcome(
+        fingerprint_state: &Arc<std::sync::RwLock<FingerprintState>>,
+        backend_count: usize,
+        failure_reasons: Vec<String>,
+    ) -> DiscoveryOutcome {
+        let total_pinned = fingerprint_state
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .pinned_count();
+        DiscoveryOutcome {
+            backend_count,
+            successful_calls: 0,
+            failed_calls: 0,
+            new_fingerprints: 0,
+            total_pinned,
+            pubkeys_by_algo: HashMap::new(),
+            observed_fingerprints: Vec::new(),
+            failure_reasons,
+            verify_failures: 0,
+            replaced_state: false,
+        }
+    }
+
     async fn discover_model(
         url: &str,
         api_key: &Option<String>,
         model_name: &str,
-        num_calls: usize,
         fingerprint_state: Arc<std::sync::RwLock<FingerprintState>>,
         tls_roots: &SharedTlsRoots,
         verifier: &AttestationVerifier,
     ) -> DiscoveryOutcome {
         const PER_CALL_TIMEOUT: Duration = Duration::from_secs(10);
-        const STAGGER_MS: u64 = 200;
+        const COUNT_TIMEOUT: Duration = Duration::from_secs(3);
         const ALGOS: [&str; 2] = ["ecdsa", "ed25519"];
 
         /// Query parameters for `/v1/attestation/report`. Matches
@@ -618,31 +739,76 @@ impl InferenceProviderPool {
             include_tls_fingerprint: Option<bool>,
         }
 
-        let futures = (0..num_calls)
+        let mut failure_reasons: Vec<String> = Vec::new();
+
+        // Pre-flight: parse the URL into its rotation parts. If the URL
+        // doesn't conform (one-label host, IP literal, etc.) we can't issue
+        // rotation calls; record the reason and return a no-op outcome.
+        let url_parsed = match url::Url::parse(url) {
+            Ok(u) => u,
+            Err(e) => {
+                failure_reasons.push(format!("url_parse: {e}"));
+                return Self::empty_outcome(&fingerprint_state, 0, failure_reasons);
+            }
+        };
+        let parts = match rotation::split_inference_url(&url_parsed) {
+            Some(p) => p,
+            None => {
+                failure_reasons.push("url_parse: host is not a child of a multi-label base".into());
+                return Self::empty_outcome(&fingerprint_state, 0, failure_reasons);
+            }
+        };
+
+        // Step 1: fetch the healthy backend count.
+        //
+        // The count endpoint terminates TLS at completions.near.ai (model-proxy
+        // base domain) with a normal Let's Encrypt cert, so an unpinned
+        // (Bootstrap) verifier is appropriate — there's no per-backend SPKI
+        // to bind to here. We reuse the existing tls_roots so we don't build
+        // yet another crypto provider.
+        let count_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
+        let count_client = match reqwest::Client::builder()
+            .use_preconfigured_tls(tls_roots.build_config(count_state))
+            .connect_timeout(Duration::from_secs(3))
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                failure_reasons.push(format!("count_client_build: {e}"));
+                return Self::empty_outcome(&fingerprint_state, 0, failure_reasons);
+            }
+        };
+        let backend_count =
+            match rotation::fetch_backend_count(&count_client, &parts, COUNT_TIMEOUT).await {
+                rotation::CountFetch::Ok(0) => {
+                    // Authoritatively no healthy backends right now. Don't issue
+                    // calls; don't replace the pin set (transient registry hiccup
+                    // shouldn't evict verified state). Provider-level fail-closed
+                    // paths handle the no-backend case at request time.
+                    return Self::empty_outcome(&fingerprint_state, 0, failure_reasons);
+                }
+                rotation::CountFetch::Ok(n) => n,
+                rotation::CountFetch::Err(reason) => {
+                    failure_reasons.push(reason);
+                    return Self::empty_outcome(&fingerprint_state, 0, failure_reasons);
+                }
+            };
+
+        // Step 2: fan out one attestation call per backend index, in
+        // parallel (no stagger — each call lands on a distinct backend, so
+        // per-backend pressure is exactly one attestation per cycle).
+        let futures = (0..backend_count)
             .map(|i| {
-                let url = url.to_string();
+                let parts = parts.clone();
                 let api_key = api_key.clone();
                 let model = model_name.to_string();
                 let tls_roots = tls_roots.clone();
                 let algo = ALGOS[i % ALGOS.len()].to_string();
                 async move {
-                    if i > 0 {
-                        tokio::time::sleep(Duration::from_millis(STAGGER_MS * i as u64)).await;
-                    }
-
-                    // Isolated Bootstrap state per call. Critical: peers share
-                    // neither the TLS verifier state nor connection pools, so
-                    // if peer #0 pins backend A's fingerprint during its
-                    // verifier callback, this call's handshake (to backend B
-                    // via a different L4 hash) isn't rejected for not matching
-                    // {A}. Verified fingerprints are merged into the caller's
-                    // shared accumulator below, outside the per-call future.
+                    // Isolated Bootstrap state per call — see function doc.
                     let local_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
                     let rustls_config = tls_roots.build_config(local_state);
 
-                    // Minimal client for one attestation round-trip — no bucket
-                    // clients, no prefix router. ~1 reqwest::Client instead of
-                    // the ~129 a full VLlmProvider would spin up.
                     let client = match reqwest::Client::builder()
                         .use_preconfigured_tls(rustls_config)
                         .connect_timeout(Duration::from_secs(5))
@@ -653,9 +819,8 @@ impl InferenceProviderPool {
                         Err(e) => {
                             debug!(
                                 model = %model,
-                                url = %url,
+                                index = i,
                                 algo = %algo,
-                                attempt = i,
                                 error = %e,
                                 "Failed to build discovery client"
                             );
@@ -663,9 +828,14 @@ impl InferenceProviderPool {
                         }
                     };
 
+                    let mut request_url = match rotation::rotation_base_url(&parts, i as u64) {
+                        Some(u) => u,
+                        None => return Err("rotation_url_build: failed".to_string()),
+                    };
+                    request_url.set_path("/v1/attestation/report");
+
                     let nonce_bytes: [u8; 32] = rand::random();
                     let nonce = hex::encode(nonce_bytes);
-
                     let qs = match serde_urlencoded::to_string(&Query {
                         model: &model,
                         signing_algo: Some(&algo),
@@ -675,9 +845,9 @@ impl InferenceProviderPool {
                         Ok(q) => q,
                         Err(e) => return Err(format!("query_encode: {e}")),
                     };
-                    let request_url = format!("{}/v1/attestation/report?{}", url, qs);
+                    request_url.set_query(Some(&qs));
 
-                    let mut req = client.get(&request_url);
+                    let mut req = client.get(request_url.clone());
                     if let Some(key) = api_key.as_ref() {
                         req = req.header("Authorization", format!("Bearer {}", key));
                     }
@@ -691,15 +861,12 @@ impl InferenceProviderPool {
                         Ok(Err(e)) => {
                             debug!(
                                 model = %model,
-                                url = %url,
+                                index = i,
                                 algo = %algo,
-                                attempt = i,
                                 elapsed_ms,
                                 error = %e,
                                 "Discovery call failed"
                             );
-                            // Categorize so the outcome aggregate stays readable at INFO.
-                            // reqwest's full error is verbose; classify common causes.
                             let category = if e.is_connect() {
                                 "connect"
                             } else if e.is_timeout() {
@@ -714,9 +881,8 @@ impl InferenceProviderPool {
                         Err(_) => {
                             debug!(
                                 model = %model,
-                                url = %url,
+                                index = i,
                                 algo = %algo,
-                                attempt = i,
                                 elapsed_ms,
                                 "Discovery call timed out"
                             );
@@ -728,9 +894,8 @@ impl InferenceProviderPool {
                         let status = resp.status().as_u16();
                         debug!(
                             model = %model,
-                            url = %url,
+                            index = i,
                             algo = %algo,
-                            attempt = i,
                             status = status,
                             elapsed_ms,
                             "Discovery call returned non-2xx"
@@ -743,9 +908,8 @@ impl InferenceProviderPool {
                         Err(e) => {
                             debug!(
                                 model = %model,
-                                url = %url,
+                                index = i,
                                 algo = %algo,
-                                attempt = i,
                                 error = %e,
                                 "Discovery call returned malformed JSON"
                             );
@@ -754,9 +918,8 @@ impl InferenceProviderPool {
                     };
                     debug!(
                         model = %model,
-                        url = %url,
+                        index = i,
                         algo = %algo,
-                        attempt = i,
                         elapsed_ms,
                         "Discovery call succeeded"
                     );
@@ -769,11 +932,9 @@ impl InferenceProviderPool {
 
         let mut successful_calls = 0usize;
         let mut failed_calls = 0usize;
-        let mut new_fingerprints = 0usize;
         let mut pubkeys_by_algo: HashMap<String, String> = HashMap::new();
         let mut verified_this_round: HashSet<String> = HashSet::new();
         let mut observed_fingerprints: Vec<String> = Vec::new();
-        let mut failure_reasons: Vec<String> = Vec::new();
         let mut verify_failures = 0usize;
 
         for r in results {
@@ -791,25 +952,7 @@ impl InferenceProviderPool {
                 Ok(verified) => {
                     if let Some(ref vfp) = verified.tls_cert_fingerprint {
                         observed_fingerprints.push(vfp.clone());
-                        if verified_this_round.insert(vfp.clone()) {
-                            let added = {
-                                let mut state =
-                                    fingerprint_state.write().unwrap_or_else(|e| e.into_inner());
-                                let before = state.pinned_count();
-                                state.add_fingerprint(vfp.clone());
-                                state.pinned_count() > before
-                            };
-                            if added {
-                                new_fingerprints += 1;
-                                info!(
-                                    model = %model_name,
-                                    url = %url,
-                                    fingerprint = %vfp,
-                                    algo = %algo,
-                                    "Pinned new TLS SPKI fingerprint from attestation discovery"
-                                );
-                            }
-                        }
+                        verified_this_round.insert(vfp.clone());
                     }
                     // Pubkey is trustworthy once the report is verified. Pubkeys
                     // are derived from the TEE compose hash so they match
@@ -835,12 +978,35 @@ impl InferenceProviderPool {
             }
         }
 
-        let total_pinned = fingerprint_state
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .pinned_count();
+        let update = apply_pin_update(
+            &fingerprint_state,
+            &verified_this_round,
+            backend_count,
+            failed_calls,
+            verify_failures,
+        );
+        for fp in &update.newly_pinned {
+            info!(
+                model = %model_name,
+                url = %url,
+                fingerprint = %fp,
+                "Pinned new TLS SPKI fingerprint from attestation discovery"
+            );
+        }
+        for fp in &update.evicted {
+            info!(
+                model = %model_name,
+                url = %url,
+                fingerprint = %fp,
+                "Evicted TLS SPKI fingerprint — backend no longer in healthy set"
+            );
+        }
+        let new_fingerprints = update.newly_pinned.len();
+        let total_pinned = update.total_pinned;
+        let replaced_state = update.replaced;
 
         DiscoveryOutcome {
+            backend_count,
             successful_calls,
             failed_calls,
             new_fingerprints,
@@ -849,6 +1015,7 @@ impl InferenceProviderPool {
             observed_fingerprints,
             failure_reasons,
             verify_failures,
+            replaced_state,
         }
     }
 
@@ -2071,15 +2238,12 @@ impl InferenceProviderPool {
         }
 
         // Phase 1: Create providers for new/changed URLs, probe attestation, and verify.
-        // For each new URL: N discovery calls (each on a fresh reqwest::Client →
-        // fresh TCP connection → different L4 backend), alternating signing algos
-        // so we harvest ECDSA + Ed25519 signing pubkeys in the same pass (no
-        // separate post-pin round trip). The serving provider shares the
-        // per-URL `FingerprintState` with discovery, so every pin propagates.
+        // Discovery uses rotation SNI (model-proxy PR #27): fetch the healthy
+        // backend count, then fan out one fresh-TCP call per backend index.
+        // One cycle = full coverage. The serving provider shares the per-URL
+        // `FingerprintState` with discovery, so every pin propagates.
         let verifier = self.attestation_verifier.clone();
         let tls_roots = self.tls_roots.clone();
-        let discovery_parallelism =
-            crate::attestation::verification::ATTESTATION_DISCOVERY_PARALLELISM;
         let endpoint_futures: Vec<_> = needs_creation
             .iter()
             .map(|(model_name, url)| {
@@ -2096,7 +2260,6 @@ impl InferenceProviderPool {
                         &url,
                         &api_key,
                         &model_name,
-                        discovery_parallelism,
                         state.clone(),
                         &tls_roots,
                         &verifier,
@@ -2138,12 +2301,13 @@ impl InferenceProviderPool {
                         info!(
                             model = %model_name,
                             url = %url,
-                            calls = discovery_parallelism,
+                            backend_count = outcome.backend_count,
                             successful_calls = outcome.successful_calls,
                             failed_calls = outcome.failed_calls,
                             verify_failures = outcome.verify_failures,
                             new_fingerprints = outcome.new_fingerprints,
                             total_pinned = outcome.total_pinned,
+                            replaced_state = outcome.replaced_state,
                             pubkey_algos = ?outcome.pubkeys_by_algo.keys().collect::<Vec<_>>(),
                             observed_fingerprints = ?outcome.observed_fingerprints,
                             failure_reasons = ?outcome.failure_reasons,
@@ -2207,7 +2371,6 @@ impl InferenceProviderPool {
         // For reused providers WITHOUT tracked fingerprint state (e.g., mock
         // providers injected directly into the cache by tests), fall back to the
         // legacy per-algo refetch path which works against the trait object.
-        let cumulative_calls = crate::attestation::verification::CUMULATIVE_DISCOVERY_CALLS;
         {
             // Snapshot `pubkey_to_providers` as an immutable set of `(pubkey,
             // provider_ptr)` pairs. Using pairs (not just pointers) is key:
@@ -2250,11 +2413,10 @@ impl InferenceProviderPool {
             };
 
             // Classify each reused provider and build parallel work queues.
-            // Running the N discovery/refetch calls concurrently keeps refresh
-            // latency bounded regardless of how many models are in the pool:
-            // with dozens of models and CUMULATIVE_DISCOVERY_CALLS=2 (~10s
-            // worst case per provider), a sequential loop could add minutes
-            // per cycle and starve the background refresh task.
+            // Running the per-provider discovery/refetch calls concurrently
+            // keeps refresh latency bounded regardless of pool size — with
+            // dozens of models, a sequential loop could add minutes per
+            // cycle and starve the background refresh task.
             #[derive(Debug)]
             enum ReusedClassification {
                 /// Blocked state — short-circuit, no network call, evict.
@@ -2352,27 +2514,16 @@ impl InferenceProviderPool {
                         let api_key = api_key.clone();
                         let verifier = verifier.clone();
                         let tls_roots = tls_roots.clone();
-                        // Stagger index: model i waits i × MODEL_DISCOVERY_STAGGER_MS before
-                        // firing its first discovery call. This spreads the per-refresh burst
-                        // across time instead of hitting all backends simultaneously, preventing
-                        // GPU evidence worker saturation on dense hosts (e.g. multiple models
-                        // on the same inference host).
-                        let stagger_idx = discovery_tasks.len();
-                        let model_stagger_ms =
-                            crate::attestation::verification::MODEL_DISCOVERY_STAGGER_MS;
+                        // No inter-model stagger: rotation routes each call
+                        // to a distinct backend, so per-backend GPU evidence
+                        // pressure per cycle is exactly one attestation,
+                        // regardless of how many models refresh together.
                         discovery_tasks.push(
                             async move {
-                                if stagger_idx > 0 {
-                                    tokio::time::sleep(Duration::from_millis(
-                                        model_stagger_ms.saturating_mul(stagger_idx as u64),
-                                    ))
-                                    .await;
-                                }
                                 let outcome = Self::discover_model(
                                     &url,
                                     &api_key,
                                     &model_name,
-                                    cumulative_calls,
                                     state,
                                     &tls_roots,
                                     &verifier,
@@ -2434,33 +2585,29 @@ impl InferenceProviderPool {
             let (discovery_results, legacy_results) = tokio::join!(drive_discovery, drive_legacy);
 
             for (model_name, url, provider, outcome) in discovery_results {
-                if outcome.new_fingerprints > 0 {
+                if outcome.new_fingerprints > 0 || outcome.replaced_state {
                     info!(
                         model = %model_name,
                         url = %url,
+                        backend_count = outcome.backend_count,
                         new_fingerprints = outcome.new_fingerprints,
                         total_pinned = outcome.total_pinned,
                         verify_failures = outcome.verify_failures,
+                        replaced_state = outcome.replaced_state,
                         observed_fingerprints = ?outcome.observed_fingerprints,
                         failure_reasons = ?outcome.failure_reasons,
                         "Cumulative discovery expanded pinned backend set"
                     );
                 } else {
-                    // Promoted from DEBUG to INFO so production can observe
-                    // *why* the pin set isn't growing: every cycle records the
-                    // fingerprints the L4 LB routed to (showing whether load
-                    // balancing is collapsing onto already-pinned backends) and
-                    // any per-call failure reasons (TLS reject, timeout, 5xx,
-                    // etc.). Frequency is bounded by the refresh interval
-                    // (default 300s) × model count, so volume stays modest.
                     info!(
                         model = %model_name,
                         url = %url,
-                        calls = cumulative_calls,
+                        backend_count = outcome.backend_count,
                         successful_calls = outcome.successful_calls,
                         failed_calls = outcome.failed_calls,
                         verify_failures = outcome.verify_failures,
                         total_pinned = outcome.total_pinned,
+                        replaced_state = outcome.replaced_state,
                         observed_fingerprints = ?outcome.observed_fingerprints,
                         failure_reasons = ?outcome.failure_reasons,
                         "Cumulative discovery cycle (no new fingerprints)"
@@ -2881,6 +3028,161 @@ impl InferenceProviderPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Helper for `apply_pin_update` tests: build a state, run the policy,
+    /// return the (PinUpdate, current pinned-set) pair.
+    fn run_pin_update(
+        initial: Option<&[&str]>,
+        observed: &[&str],
+        backend_count: usize,
+        failed_calls: usize,
+        verify_failures: usize,
+    ) -> (PinUpdate, HashSet<String>) {
+        let state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
+        if let Some(initial) = initial {
+            let mut guard = state.write().unwrap();
+            for fp in initial {
+                guard.add_fingerprint((*fp).to_string());
+            }
+        }
+        let verified: HashSet<String> = observed.iter().map(|s| (*s).to_string()).collect();
+        let update = apply_pin_update(
+            &state,
+            &verified,
+            backend_count,
+            failed_calls,
+            verify_failures,
+        );
+        let after = match &*state.read().unwrap() {
+            FingerprintState::Pinned(s) => s.clone(),
+            _ => HashSet::new(),
+        };
+        (update, after)
+    }
+
+    #[test]
+    fn pin_update_complete_coverage_replaces_set() {
+        // Steady state: pin set already has 5 fingerprints, cycle reconfirms
+        // all 5. Coverage is complete → replace (no-op replacement).
+        let (update, after) = run_pin_update(
+            Some(&["a", "b", "c", "d", "e"]),
+            &["a", "b", "c", "d", "e"],
+            5,
+            0,
+            0,
+        );
+        assert!(update.replaced);
+        assert_eq!(update.total_pinned, 5);
+        assert!(update.newly_pinned.is_empty());
+        assert!(update.evicted.is_empty());
+        assert_eq!(after.len(), 5);
+    }
+
+    #[test]
+    fn pin_update_complete_coverage_evicts_dead_backend() {
+        // Backend "e" just went unhealthy → count drops to 4, cycle observes
+        // 4 distinct fingerprints, full coverage → replace → "e" is gone.
+        let (update, after) = run_pin_update(
+            Some(&["a", "b", "c", "d", "e"]),
+            &["a", "b", "c", "d"],
+            4,
+            0,
+            0,
+        );
+        assert!(update.replaced);
+        assert_eq!(update.total_pinned, 4);
+        assert!(update.newly_pinned.is_empty());
+        assert_eq!(update.evicted, vec!["e".to_string()]);
+        assert!(!after.contains("e"));
+        assert!(after.contains("a"));
+    }
+
+    #[test]
+    fn pin_update_partial_cycle_keeps_existing_fingerprints() {
+        // One backend failed mid-cycle (failed_calls=1). We observed 4 of 5
+        // healthy. Cannot safely evict the missing one — additive merge.
+        let (update, after) = run_pin_update(
+            Some(&["a", "b", "c", "d", "e"]),
+            &["a", "b", "c", "d"],
+            5,
+            1,
+            0,
+        );
+        assert!(!update.replaced);
+        assert_eq!(update.total_pinned, 5, "no eviction on partial cycle");
+        assert!(after.contains("e"));
+    }
+
+    #[test]
+    fn pin_update_partial_cycle_with_new_fingerprint_grows_additively() {
+        // A previously-unknown backend showed up mid-cycle (perhaps the
+        // count grew). One other call failed, so coverage is partial — but
+        // we still pin the new fingerprint we did verify.
+        let (update, after) = run_pin_update(Some(&["a", "b"]), &["a", "b", "f"], 4, 1, 0);
+        assert!(!update.replaced);
+        assert_eq!(update.newly_pinned, vec!["f".to_string()]);
+        assert_eq!(update.total_pinned, 3);
+        assert!(after.contains("f"));
+    }
+
+    #[test]
+    fn pin_update_duplicate_observations_are_not_complete_coverage() {
+        // backend_count=5 but the proxy routed two of our calls to the same
+        // backend (e.g. registry race during a deploy). We only see 4
+        // distinct fingerprints — fall back to additive so we don't drop
+        // the missing one.
+        let (update, _after) = run_pin_update(
+            Some(&["a", "b", "c", "d", "e"]),
+            &["a", "a", "b", "c", "d"],
+            5,
+            0,
+            0,
+        );
+        assert!(!update.replaced);
+        assert_eq!(update.total_pinned, 5);
+    }
+
+    #[test]
+    fn pin_update_verify_failure_blocks_replacement() {
+        // The HTTP call succeeded but attestation verification rejected
+        // it. Even if we saw `backend_count` distinct verified fingerprints
+        // among the *other* calls, we treat the cycle as partial — a
+        // verification failure on a real backend means we can't confidently
+        // say the healthy set matches our observations.
+        let (update, after) = run_pin_update(
+            Some(&["a", "b", "c", "d", "e"]),
+            &["a", "b", "c", "d"],
+            4,
+            0,
+            1,
+        );
+        assert!(!update.replaced);
+        assert_eq!(
+            update.total_pinned, 5,
+            "stale 'e' is kept; we couldn't verify the cycle was complete"
+        );
+        assert!(after.contains("e"));
+    }
+
+    #[test]
+    fn pin_update_zero_backend_count_is_partial() {
+        // backend_count=0 means we couldn't get a count or proxy reports
+        // no healthy backends — never replace.
+        let (update, after) = run_pin_update(Some(&["a", "b"]), &[], 0, 0, 0);
+        assert!(!update.replaced);
+        assert_eq!(after.len(), 2, "must not evict on zero-count cycle");
+    }
+
+    #[test]
+    fn pin_update_from_bootstrap_first_full_coverage() {
+        // First-ever discovery: state starts Bootstrap, all calls succeed,
+        // full coverage. Result is Pinned with exactly the observed set.
+        let (update, after) = run_pin_update(None, &["a", "b", "c"], 3, 0, 0);
+        assert!(update.replaced);
+        assert_eq!(update.newly_pinned.len(), 3);
+        assert!(update.evicted.is_empty());
+        assert_eq!(after.len(), 3);
+    }
 
     #[test]
     fn test_classify_error_kind() {

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -784,7 +784,11 @@ impl InferenceProviderPool {
                     // Authoritatively no healthy backends right now. Don't issue
                     // calls; don't replace the pin set (transient registry hiccup
                     // shouldn't evict verified state). Provider-level fail-closed
-                    // paths handle the no-backend case at request time.
+                    // paths handle the no-backend case at request time. Record
+                    // `count_zero` so DD can distinguish this from a count-fetch
+                    // failure (which would carry a `count_*:` reason instead).
+                    failure_reasons
+                        .push("count_zero: proxy reports 0 healthy backends".to_string());
                     return Self::empty_outcome(&fingerprint_state, 0, failure_reasons);
                 }
                 rotation::CountFetch::Ok(n) => n,
@@ -793,6 +797,28 @@ impl InferenceProviderPool {
                     return Self::empty_outcome(&fingerprint_state, 0, failure_reasons);
                 }
             };
+
+        // Defense-in-depth: cap the fan-out. A bogus registry reading (race
+        // during a deploy, partial split) could otherwise spawn an unbounded
+        // number of fresh-TCP TLS handshakes per cycle per model. The cap is
+        // far above any realistic backend pool; hitting it is logged so it
+        // surfaces in ops without silently dropping coverage.
+        const MAX_ROTATION_FANOUT: usize = 256;
+        let backend_count = if backend_count > MAX_ROTATION_FANOUT {
+            warn!(
+                model = %model_name,
+                url = %url,
+                reported = backend_count,
+                capped_at = MAX_ROTATION_FANOUT,
+                "backend count from proxy exceeds sanity cap, truncating fan-out"
+            );
+            failure_reasons.push(format!(
+                "count_capped: proxy reported {backend_count} > {MAX_ROTATION_FANOUT}"
+            ));
+            MAX_ROTATION_FANOUT
+        } else {
+            backend_count
+        };
 
         // Step 2: fan out one attestation call per backend index, in
         // parallel (no stagger — each call lands on a distinct backend, so
@@ -876,7 +902,12 @@ impl InferenceProviderPool {
                             } else {
                                 "send"
                             };
-                            return Err(format!("{category}: {e}"));
+                            // reqwest::Error's Display embeds the request URL,
+                            // which includes our random per-call `nonce` query
+                            // param. Stripping it keeps `failure_reasons` low-
+                            // cardinality for DD ingestion; the full error
+                            // remains at DEBUG above.
+                            return Err(format!("{category}: {}", e.without_url()));
                         }
                         Err(_) => {
                             debug!(
@@ -913,7 +944,7 @@ impl InferenceProviderPool {
                                 error = %e,
                                 "Discovery call returned malformed JSON"
                             );
-                            return Err(format!("malformed_json: {e}"));
+                            return Err(format!("malformed_json: {}", e.without_url()));
                         }
                     };
                     debug!(
@@ -3144,18 +3175,12 @@ mod tests {
 
     #[test]
     fn pin_update_verify_failure_blocks_replacement() {
-        // The HTTP call succeeded but attestation verification rejected
-        // it. Even if we saw `backend_count` distinct verified fingerprints
-        // among the *other* calls, we treat the cycle as partial — a
-        // verification failure on a real backend means we can't confidently
-        // say the healthy set matches our observations.
-        let (update, after) = run_pin_update(
-            Some(&["a", "b", "c", "d", "e"]),
-            &["a", "b", "c", "d"],
-            4,
-            0,
-            1,
-        );
+        // Realistic per-cycle shape: 4 fan-outs, 3 verified, 1 verify
+        // failure. backend_count == verified.len() can't both hold when
+        // verify_failures > 0, so the policy must treat this as partial
+        // and keep the stale 'e' from a previous cycle pinned.
+        let (update, after) =
+            run_pin_update(Some(&["a", "b", "c", "d", "e"]), &["a", "b", "c"], 4, 0, 1);
         assert!(!update.replaced);
         assert_eq!(
             update.total_pinned, 5,

--- a/crates/services/src/inference_provider_pool/rotation.rs
+++ b/crates/services/src/inference_provider_pool/rotation.rs
@@ -1,0 +1,233 @@
+//! Rotation-SNI helpers for backend-deterministic attestation discovery.
+//!
+//! Model-proxy publishes a synthetic SNI scheme `<canonical>-i<N>.<base>` that
+//! routes a fresh-TCP connection to backend `N % healthy_count`, bypassing the
+//! least-connections LB that otherwise collapses our probes onto a stable
+//! subset. Cloud-api combines this with `GET /backends/count?domain=<host>` to
+//! learn the live healthy count per cycle and iterate every backend in one
+//! pass.
+//!
+//! See model-proxy PR #27.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use tracing::debug;
+use url::Url;
+
+/// Pieces of an inference URL that the rotation path needs.
+///
+/// `host` is the original SNI/Host the provider was registered with
+/// (`glm-5-1.completions.near.ai`), `canonical_label` is just the leftmost
+/// DNS label (`glm-5-1`), and `base` is everything after that
+/// (`completions.near.ai`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct UrlParts {
+    pub host: String,
+    pub canonical_label: String,
+    pub base: String,
+    /// Scheme + optional port preserved so we can rebuild URLs without
+    /// dropping non-default ports (e.g. mock servers on `:8443`).
+    scheme: String,
+    port: Option<u16>,
+}
+
+/// Decompose an inference URL into the parts needed for rotation routing.
+///
+/// Returns `None` when the URL's host doesn't look like a child of a single
+/// base domain (one-label hostnames, IP literals, missing host). Callers
+/// treat that as "skip rotation for this URL" — there is no other path in
+/// this PR, so the discovery cycle records zero observations and the
+/// existing fail-closed eviction logic runs.
+pub(super) fn split_inference_url(url: &Url) -> Option<UrlParts> {
+    let host = url.host_str()?;
+    // IP literals (`url::Host::Ipv4` / `Ipv6`) parse into `host_str` too, so
+    // gate on the URL host *type*: only Domain is meaningful for SNI rotation.
+    if !matches!(url.host()?, url::Host::Domain(_)) {
+        return None;
+    }
+    let host = host.to_ascii_lowercase();
+    let (canonical_label, base) = host.split_once('.')?;
+    if canonical_label.is_empty() || base.is_empty() || !base.contains('.') {
+        // base must itself be a multi-label name (e.g. completions.near.ai),
+        // otherwise we'd treat `localhost`-style two-label hosts as valid.
+        return None;
+    }
+
+    Some(UrlParts {
+        host: host.clone(),
+        canonical_label: canonical_label.to_string(),
+        base: base.to_string(),
+        scheme: url.scheme().to_string(),
+        port: url.port(),
+    })
+}
+
+/// Build the rotation URL for index `i`:
+/// `https://<canonical>-i<i>.<base>/v1/attestation/report?...`
+///
+/// The caller appends the query string itself; this helper only builds the
+/// authority part. Returns `None` only if URL construction fails (which
+/// requires a malformed `UrlParts`, an unreachable state given that
+/// `split_inference_url` validated the inputs).
+pub(super) fn rotation_base_url(parts: &UrlParts, index: u64) -> Option<Url> {
+    let host = format!("{}-i{}.{}", parts.canonical_label, index, parts.base);
+    let authority = match parts.port {
+        Some(p) => format!("{}://{}:{}", parts.scheme, host, p),
+        None => format!("{}://{}", parts.scheme, host),
+    };
+    Url::parse(&authority).ok()
+}
+
+/// Build the count endpoint URL for this provider's base:
+/// `https://<base>/backends/count?domain=<host>`
+pub(super) fn count_url(parts: &UrlParts) -> Option<Url> {
+    let authority = match parts.port {
+        Some(p) => format!("{}://{}:{}", parts.scheme, parts.base, p),
+        None => format!("{}://{}", parts.scheme, parts.base),
+    };
+    let mut u = Url::parse(&authority).ok()?;
+    u.set_path("/backends/count");
+    u.query_pairs_mut().append_pair("domain", &parts.host);
+    Some(u)
+}
+
+#[derive(Deserialize)]
+struct CountResponse {
+    healthy: usize,
+    #[serde(default)]
+    #[allow(dead_code)]
+    total: usize,
+}
+
+/// Outcome of `/backends/count` fetch.
+///
+/// `Ok(healthy)` means model-proxy authoritatively reported the live healthy
+/// count for this domain. `Err(reason)` means we couldn't get a count and
+/// must skip the rotation cycle; the reason is recorded in
+/// `DiscoveryOutcome::failure_reasons` for observability and the cycle ends
+/// with zero observations.
+pub(super) enum CountFetch {
+    Ok(usize),
+    Err(String),
+}
+
+pub(super) async fn fetch_backend_count(
+    client: &reqwest::Client,
+    parts: &UrlParts,
+    timeout: Duration,
+) -> CountFetch {
+    let Some(url) = count_url(parts) else {
+        return CountFetch::Err("count_url_build: failed to build count URL".to_string());
+    };
+    let send = client.get(url.clone()).timeout(timeout).send();
+    let res = match send.await {
+        Ok(r) => r,
+        Err(e) => {
+            debug!(error = %e, url = %url, "backend count fetch failed");
+            let category = if e.is_connect() {
+                "count_connect"
+            } else if e.is_timeout() {
+                "count_timeout"
+            } else {
+                "count_send"
+            };
+            return CountFetch::Err(format!("{category}: {e}"));
+        }
+    };
+    let status = res.status();
+    if !status.is_success() {
+        return CountFetch::Err(format!("count_status: {status}"));
+    }
+    match res.json::<CountResponse>().await {
+        Ok(payload) => CountFetch::Ok(payload.healthy),
+        Err(e) => CountFetch::Err(format!("count_decode: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parts(url: &str) -> UrlParts {
+        split_inference_url(&Url::parse(url).unwrap()).expect("expected parseable URL")
+    }
+
+    #[test]
+    fn split_basic() {
+        let p = parts("https://glm-5-1.completions.near.ai");
+        assert_eq!(p.host, "glm-5-1.completions.near.ai");
+        assert_eq!(p.canonical_label, "glm-5-1");
+        assert_eq!(p.base, "completions.near.ai");
+    }
+
+    #[test]
+    fn split_canonical_with_internal_dashes() {
+        let p = parts("https://qwen35-122b.completions.near.ai");
+        assert_eq!(p.canonical_label, "qwen35-122b");
+        assert_eq!(p.base, "completions.near.ai");
+    }
+
+    #[test]
+    fn split_lowercases_host() {
+        let p = parts("https://GLM-5-1.COMPLETIONS.NEAR.AI");
+        assert_eq!(p.host, "glm-5-1.completions.near.ai");
+        assert_eq!(p.canonical_label, "glm-5-1");
+        assert_eq!(p.base, "completions.near.ai");
+    }
+
+    #[test]
+    fn split_preserves_port() {
+        let p = parts("https://glm-5-1.completions.near.ai:8443");
+        assert_eq!(p.port, Some(8443));
+        let r = rotation_base_url(&p, 3).unwrap();
+        assert_eq!(r.host_str(), Some("glm-5-1-i3.completions.near.ai"));
+        assert_eq!(r.port(), Some(8443));
+        let c = count_url(&p).unwrap();
+        assert_eq!(c.host_str(), Some("completions.near.ai"));
+        assert_eq!(c.port(), Some(8443));
+    }
+
+    #[test]
+    fn split_rejects_one_label_hostnames() {
+        assert!(split_inference_url(&Url::parse("https://localhost").unwrap()).is_none());
+    }
+
+    #[test]
+    fn split_rejects_two_label_hostnames_with_single_label_base() {
+        // `foo.localhost` would map to canonical=foo + base=localhost, but
+        // base needs to be a multi-label domain for the rotation scheme to
+        // be meaningful.
+        assert!(split_inference_url(&Url::parse("https://foo.localhost").unwrap()).is_none());
+    }
+
+    #[test]
+    fn split_rejects_ip_hosts() {
+        assert!(split_inference_url(&Url::parse("https://10.0.0.1").unwrap()).is_none());
+        assert!(split_inference_url(&Url::parse("https://[::1]").unwrap()).is_none());
+    }
+
+    #[test]
+    fn rotation_url_shape() {
+        let p = parts("https://glm-5-1.completions.near.ai");
+        let r = rotation_base_url(&p, 3).unwrap();
+        assert_eq!(r.as_str(), "https://glm-5-1-i3.completions.near.ai/");
+    }
+
+    #[test]
+    fn rotation_url_index_zero_is_valid() {
+        let p = parts("https://glm-5-1.completions.near.ai");
+        let r = rotation_base_url(&p, 0).unwrap();
+        assert_eq!(r.host_str(), Some("glm-5-1-i0.completions.near.ai"));
+    }
+
+    #[test]
+    fn count_url_shape() {
+        let p = parts("https://glm-5-1.completions.near.ai");
+        let c = count_url(&p).unwrap();
+        assert_eq!(c.scheme(), "https");
+        assert_eq!(c.host_str(), Some("completions.near.ai"));
+        assert_eq!(c.path(), "/backends/count");
+        assert_eq!(c.query(), Some("domain=glm-5-1.completions.near.ai"));
+    }
+}

--- a/crates/services/src/inference_provider_pool/rotation.rs
+++ b/crates/services/src/inference_provider_pool/rotation.rs
@@ -132,7 +132,9 @@ pub(super) async fn fetch_backend_count(
             } else {
                 "count_send"
             };
-            return CountFetch::Err(format!("{category}: {e}"));
+            // Strip the URL from the display string — keeps `failure_reasons`
+            // low-cardinality for DD ingestion. Full error stays at DEBUG.
+            return CountFetch::Err(format!("{category}: {}", e.without_url()));
         }
     };
     let status = res.status();
@@ -141,7 +143,7 @@ pub(super) async fn fetch_backend_count(
     }
     match res.json::<CountResponse>().await {
         Ok(payload) => CountFetch::Ok(payload.healthy),
-        Err(e) => CountFetch::Err(format!("count_decode: {e}")),
+        Err(e) => CountFetch::Err(format!("count_decode: {}", e.without_url())),
     }
 }
 


### PR DESCRIPTION
## Why

Cumulative TLS-SPKI discovery used to stall on multi-backend models because model-proxy's least-connections LB collapses our fresh-TCP probes onto a stable subset of backends. We worked around it with parallelism (5 calls per new provider, 2 per refresh cycle) and inter-model staggering, but the shape was fundamentally O(luck): some replicas kept missing some backends forever and got TLS-handshake-rejected when the LB later routed them there.

Customer-visible symptom: **~42 %** of `/v1/attestation/report?model=zai-org/GLM-latest` calls fail with `error sending request`. Investigation thread in PR #595 + analysis in nearai/model-proxy#27.

[model-proxy PR #27](https://github.com/nearai/model-proxy/pull/27) (merged, deployed to staging) published two routing knobs:

- `GET /backends/count?domain=<host>` → reports the current healthy backend count for a domain.
- Synthetic SNI `<canonical>-i<N>.<base>` → routes to `healthy_backends_sorted_by_address[N % healthy]`, bypassing the LB.

This PR rewrites cloud-api's `discover_model` on top of those two pieces.

## What changes

Each discovery cycle now:
1. Fetches the healthy backend count from `/backends/count` (single round-trip, ~ms, no caching).
2. Fans out **one fresh-TCP attestation call per backend index**, in parallel, no stagger. Each call lands on a distinct backend by construction.
3. Applies the verified fingerprints with the new `apply_pin_update` policy:
   - **Complete coverage** (no failures, `verify_failures == 0`, distinct observed fingerprints == `backend_count`): **REPLACE** the pin set with the observed set. A backend that just went unhealthy or had its cert rotated drops out within one refresh interval — *rapid eviction*.
   - **Anything less**: additive merge. A transient hiccup never evicts verified fingerprints we just couldn't reconfirm this cycle.

## What goes away

- `ATTESTATION_DISCOVERY_PARALLELISM = 5`
- `CUMULATIVE_DISCOVERY_CALLS = 2`
- `STAGGER_MS = 200` (intra-model)
- `MODEL_DISCOVERY_STAGGER_MS = 2_000` (inter-model)

`discover_model` loses its `num_calls` parameter; both call sites (new-provider phase + cumulative refresh) become identical.

## What's not in this PR (out of scope)

- No feature flag.
- No env-var override for the base domain — it's derived from each inference URL's host.
- No `/backends/count` caching across cycles — every cycle re-fetches.
- No bucket-warm rotation — that's [issue #600](https://github.com/nearai/cloud-api/issues/600).

## Observability

`DiscoveryOutcome` adds two fields, surfaced on the existing INFO logs from #595:

- `backend_count: usize` — healthy count this cycle (`0` if the fetch failed; see `failure_reasons`).
- `replaced_state: bool` — true iff complete coverage was achieved and the pin set was wholesale replaced.

DD query to validate rapid eviction once staging is on:
```
service:cloud-api host:*-staging
@fields.message:"Cumulative discovery cycle (no new fingerprints)"
@fields.model:zai-org/GLM-5.1-FP8
```
Expect `backend_count == observed_fingerprints.len() == total_pinned`, `replaced_state: true`.

## URL handling

The base domain is derived per URL by stripping the leftmost DNS label of the host. Works for every URL we have today (`*.completions{,-stg}.near.ai`). URLs that don't fit (one-label hosts, IP literals) return an empty outcome with a `url_parse:` failure reason; existing fail-closed logic handles them.

## Tests

- **`spki_verifier`**: 4 new state-transition tests for `replace_with` (Bootstrap → Pinned, Pinned shrink, Blocked → Pinned recovery, empty set).
- **`rotation`**: 10 URL-helper tests covering canonicals with internal dashes, case insensitivity, port preservation, IP-host / one-label rejection, count-URL shape.
- **`inference_provider_pool::pin_update_*`**: 8 policy tests covering steady state, eviction on shrinking count, partial-cycle additive preservation, duplicate-observation safety, `verify_failures` blocking replacement, zero-count safety, bootstrap first cycle.

511 workspace lib tests pass. Clippy clean.

## Rollout

PR #595 already shipped the observability needed to validate this. After merge:
1. Build pushes `staging` image to docker hub.
2. Existing rolling deploy applies it.
3. Verify per the DD query above on each replica.
4. Smoke `/v1/attestation/report?model=zai-org/GLM-latest` in a loop and confirm 0 failures.

Rollback is a normal revert + redeploy. No state migration, no config change.

## Follow-ups

- [#600](https://github.com/nearai/cloud-api/issues/600) — apply the same rotation pattern to bucket pre-warm.
- Lower `MODEL_DISCOVERY_REFRESH_INTERVAL` (currently `300`s) once we have a few days of clean data. The new path is cheap enough that a 60 s interval would give us ~1 min eviction latency at a still-tiny load.