### PR TITLE
ci: date+sha stamped staging/prod docker tags for rollback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,14 @@ jobs:
         if: env.ALSO_TAG_STAGING == 'true'
         run: |
           STAGING_REF="${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:staging"
+          # Immutable date+sha staging tag for rollback (format: staging-YYYYMMDD-<shortsha>)
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          STAMP=$(date -u +%Y%m%d)
+          STAGING_STAMPED_REF="${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:staging-${STAMP}-${SHORT_SHA}"
           skopeo copy oci-archive:./oci.tar "docker://${STAGING_REF}"
+          skopeo copy oci-archive:./oci.tar "docker://${STAGING_STAMPED_REF}"
           echo "STAGING_REFERENCE=${STAGING_REF}" >> "$GITHUB_ENV"
+          echo "STAGING_STAMPED_REFERENCE=${STAGING_STAMPED_REF}" >> "$GITHUB_ENV"
 
       - name: Trigger staging deployment
         if: env.ALSO_TAG_STAGING == 'true'
@@ -126,5 +132,6 @@ jobs:
             echo "- sigstore: https://search.sigstore.dev/?hash=${{ env.IMAGE_DIGEST }}"
             if [[ "${{ env.ALSO_TAG_STAGING }}" == 'true' ]]; then
               echo "- staging: \`${{ env.STAGING_REFERENCE }}\`"
+              echo "- staging (stamped): \`${{ env.STAGING_STAMPED_REFERENCE }}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -22,6 +22,7 @@ on:
 
 env:
   REGISTRY: docker.io
+  IMAGE_NAME: cloud-api
   IMAGE: docker.io/${{ vars.DOCKER_REGISTRY_USER }}/cloud-api
 
 jobs:
@@ -48,46 +49,52 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo jq
 
-      - name: Copy image → :prod
+      # Resolve the source digest BEFORE copying to :prod. This avoids the
+      # inspect-after-write race where reading back :prod could in theory hit a
+      # stale registry replica. Also recovers the source git short-sha by
+      # finding the matching staging-YYYYMMDD-<shortsha> tag pushed by build.yml.
+      - name: Resolve source digest and SHA
+        id: resolve
         run: |
+          set -euo pipefail
           DIGEST_INPUT="${{ inputs.digest }}"
           if [ -n "$DIGEST_INPUT" ]; then
             echo "Promoting by digest: ${DIGEST_INPUT}"
             SOURCE="${{ env.IMAGE }}@${DIGEST_INPUT}"
+            DIGEST="$DIGEST_INPUT"
           else
             echo "Promoting :staging tag"
             SOURCE="${{ env.IMAGE }}:staging"
+            DIGEST=$(skopeo inspect "docker://${SOURCE}" | jq -r '.Digest')
           fi
-          echo "PROMOTE_SOURCE=${SOURCE}" >> "$GITHUB_ENV"
-          skopeo copy "docker://${SOURCE}" "docker://${{ env.IMAGE }}:prod"
-
-      # Resolve the underlying digest of what we just promoted, and try to
-      # recover the source git short-sha by finding the matching
-      # staging-YYYYMMDD-<shortsha> tag pushed by build.yml. Falls back to
-      # "unknown" if no matching staging tag exists (e.g. promoted by
-      # arbitrary digest input).
-      - name: Resolve source digest and SHA
-        id: resolve
-        run: |
-          DIGEST=$(skopeo inspect docker://${{ env.IMAGE }}:prod | jq -r '.Digest')
           if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
-            echo "::error::Failed to retrieve image digest"
+            echo "::error::Failed to resolve source image digest"
             exit 1
           fi
+          echo "PROMOTE_SOURCE=${SOURCE}" >> "$GITHUB_ENV"
           echo "IMAGE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
+          echo "Source digest: ${DIGEST}"
 
-          # Search staging-* tags for one whose digest matches
+          # Search staging-* tags for one whose digest matches, to recover the
+          # source git short-sha. Bounded by --max-time (per-call) and a max
+          # iteration count to defend against malformed pagination cursors.
           SHORT_SHA="unknown"
-          PAGE_URL="https://hub.docker.com/v2/namespaces/${{ vars.DOCKER_REGISTRY_USER }}/repositories/cloud-api/tags?page_size=100"
-          while [ -n "$PAGE_URL" ] && [ "$PAGE_URL" != "null" ]; do
-            RESP=$(curl -fsS "$PAGE_URL")
+          PAGE_URL="https://hub.docker.com/v2/namespaces/${{ vars.DOCKER_REGISTRY_USER }}/repositories/${{ env.IMAGE_NAME }}/tags?page_size=100"
+          MAX_PAGES=50
+          PAGE_COUNT=0
+          while [ -n "$PAGE_URL" ] && [ "$PAGE_URL" != "null" ] && [ "$PAGE_COUNT" -lt "$MAX_PAGES" ]; do
+            RESP=$(curl -fsS --max-time 30 --retry 2 --retry-delay 2 "$PAGE_URL")
             MATCH=$(echo "$RESP" | jq -r --arg d "$DIGEST" '.results[] | select(.digest==$d) | select(.name | test("^staging-[0-9]{8}-[0-9a-f]{7}$")) | .name' | head -n1)
             if [ -n "$MATCH" ]; then
               SHORT_SHA=$(echo "$MATCH" | sed -E 's/^staging-[0-9]{8}-//')
               break
             fi
             PAGE_URL=$(echo "$RESP" | jq -r '.next')
+            PAGE_COUNT=$((PAGE_COUNT + 1))
           done
+          if [ "$PAGE_COUNT" -ge "$MAX_PAGES" ]; then
+            echo "::warning::Reached MAX_PAGES=${MAX_PAGES} during staging-* tag search; using digest-derived suffix."
+          fi
           # If no matching staging-* tag was found (e.g. promotion by arbitrary
           # digest input), fall back to first 7 hex chars of the image digest so
           # the stamped tag is still unique and immutable. Prevents same-day
@@ -98,6 +105,15 @@ jobs:
           fi
           echo "SOURCE_SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_ENV"
           echo "Resolved source short-sha: ${SHORT_SHA}"
+
+      - name: Copy image → :prod
+        run: |
+          set -euo pipefail
+          # Copy directly from the resolved digest (not the SOURCE tag) so the
+          # bytes pushed to :prod and to the stamped tag are provably identical,
+          # regardless of any concurrent staging push that might race the
+          # :staging tag during this run.
+          skopeo copy "docker://${{ env.IMAGE }}@${IMAGE_DIGEST}" "docker://${{ env.IMAGE }}:prod"
 
       # Immutable rollback tag — format: prod-YYYYMMDD-<shortsha>.
       # Provides addressable history for cvm-ansible-playbooks rollback workflow.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -61,7 +61,13 @@ jobs:
           echo "PROMOTE_SOURCE=${SOURCE}" >> "$GITHUB_ENV"
           skopeo copy "docker://${SOURCE}" "docker://${{ env.IMAGE }}:prod"
 
-      - name: Output digest
+      # Resolve the underlying digest of what we just promoted, and try to
+      # recover the source git short-sha by finding the matching
+      # staging-YYYYMMDD-<shortsha> tag pushed by build.yml. Falls back to
+      # "unknown" if no matching staging tag exists (e.g. promoted by
+      # arbitrary digest input).
+      - name: Resolve source digest and SHA
+        id: resolve
         run: |
           DIGEST=$(skopeo inspect docker://${{ env.IMAGE }}:prod | jq -r '.Digest')
           if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
@@ -69,25 +75,77 @@ jobs:
             exit 1
           fi
           echo "IMAGE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
+
+          # Search staging-* tags for one whose digest matches
+          SHORT_SHA="unknown"
+          PAGE_URL="https://hub.docker.com/v2/namespaces/${{ vars.DOCKER_REGISTRY_USER }}/repositories/cloud-api/tags?page_size=100"
+          while [ -n "$PAGE_URL" ] && [ "$PAGE_URL" != "null" ]; do
+            RESP=$(curl -fsS "$PAGE_URL")
+            MATCH=$(echo "$RESP" | jq -r --arg d "$DIGEST" '.results[] | select(.digest==$d) | select(.name | test("^staging-[0-9]{8}-[0-9a-f]{7}$")) | .name' | head -n1)
+            if [ -n "$MATCH" ]; then
+              SHORT_SHA=$(echo "$MATCH" | sed -E 's/^staging-[0-9]{8}-//')
+              break
+            fi
+            PAGE_URL=$(echo "$RESP" | jq -r '.next')
+          done
+          # If no matching staging-* tag was found (e.g. promotion by arbitrary
+          # digest input), fall back to first 7 hex chars of the image digest so
+          # the stamped tag is still unique and immutable. Prevents same-day
+          # collisions overwriting an earlier 'prod-YYYYMMDD-unknown' tag.
+          if [ "$SHORT_SHA" = "unknown" ]; then
+            SHORT_SHA=$(echo "${DIGEST}" | sed 's/^sha256://' | cut -c1-7)
+            echo "No matching staging-* tag found; using digest-derived suffix: ${SHORT_SHA}"
+          fi
+          echo "SOURCE_SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_ENV"
+          echo "Resolved source short-sha: ${SHORT_SHA}"
+
+      # Immutable rollback tag — format: prod-YYYYMMDD-<shortsha>.
+      # Provides addressable history for cvm-ansible-playbooks rollback workflow.
+      # Copy from the resolved digest (not the :prod tag) to avoid any
+      # eventual-consistency race after the previous :prod write.
+      - name: Push stamped prod tag
+        run: |
+          set -euo pipefail
+          STAMP=$(date -u +%Y%m%d)
+          STAMPED_TAG="prod-${STAMP}-${SOURCE_SHORT_SHA}"
+          STAMPED_REF="${{ env.IMAGE }}:${STAMPED_TAG}"
+          skopeo copy "docker://${{ env.IMAGE }}@${IMAGE_DIGEST}" "docker://${STAMPED_REF}"
+          echo "PROD_STAMPED_TAG=${STAMPED_TAG}" >> "$GITHUB_ENV"
+          echo "PROD_STAMPED_REF=${STAMPED_REF}" >> "$GITHUB_ENV"
+
+      - name: Output digest summary
+        run: |
           echo "## Promotion: ${PROMOTE_SOURCE} → prod" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- digest: \`${DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- digest: \`${IMAGE_DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- stamped tag: \`${PROD_STAMPED_REF}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- source short-sha: \`${SOURCE_SHORT_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="prod-$(date -u +%Y%m%d-%H%M%S)"
-          gh release create "$TAG" \
-            --title "Production Release ${TAG}" \
-            --notes "$(cat <<EOF
+          # GH release tag mirrors the stamped docker tag for easy correlation.
+          # Use edit-or-create to make manual retries idempotent (same-day
+          # re-runs of promote.yml won't fail on duplicate tag).
+          TAG="${PROD_STAMPED_TAG}"
+          NOTES=$(cat <<EOF
           ## Production Promotion
 
           - **Image**: \`${{ env.IMAGE }}:prod\`
+          - **Stamped image**: \`${PROD_STAMPED_REF}\`
           - **Digest**: \`${IMAGE_DIGEST}\`
           - **Promoted from**: \`${PROMOTE_SOURCE}\`
+          - **Source short-sha**: \`${SOURCE_SHORT_SHA}\`
           - **Sigstore**: https://search.sigstore.dev/?hash=${IMAGE_DIGEST}
           EOF
-          )" \
-            --latest
+          )
+          # --latest only on create. On edit we preserve whatever latest state
+          # the release already had (avoids re-marking an older same-day release
+          # as latest when re-running for an idempotent retry).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "Production Release ${TAG}" --notes "$NOTES"
+          else
+            gh release create "$TAG" --title "Production Release ${TAG}" --notes "$NOTES" --latest
+          fi
           echo "- release: [\`${TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${TAG})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Motivation

`:prod` and `:staging` are mutable docker tags — every promotion overwrites them. Once promoted, the previous prod image is only addressable by digest pulled from GH release notes, which makes rollbacks painful (manual digest lookup → manual extra-vars override on the ansible playbook).

This PR adds **immutable date+sha stamped tags** alongside the moving `:prod` / `:staging` tags, so rollback consumers in [`nearai/cvm-ansible-playbooks`](https://github.com/nearai/cvm-ansible-playbooks) can roll back by tag name without digging up digests.

Paired with: rollback workflows in `nearai/cvm-ansible-playbooks` (separate PR).

## Changes

### `build.yml`
- When pushing `:staging` on main, also push `staging-YYYYMMDD-<shortsha>` using `GITHUB_SHA`.
- Skipped during Tue/Wed staging freeze (same as `:staging` itself).

### `promote.yml`
- After copying source → `:prod`, search Docker Hub for a `staging-YYYYMMDD-<shortsha>` tag whose digest matches the just-promoted digest, to recover the source git short-sha.
- If no match found (e.g. promoted by arbitrary digest input), fall back to first 7 hex chars of the image digest as a uniqueness suffix. This guarantees the stamped tag is unique even on unusual promotion paths.
- Push `prod-YYYYMMDD-<shortsha>` from the resolved digest (not from `:prod`) to avoid registry eventual-consistency races.
- GH release tag mirrors the stamped docker tag (`prod-YYYYMMDD-<shortsha>`) for easy correlation between docker image and GH release.
- Release creation is now idempotent (`gh release view ... || create`), so manual same-day re-runs don't fail on duplicate tag. `--latest` flag is only set on create, not edit.

## Notes

- **Bootstrap**: the first prod rollback after merge has no `prod-*` stamped tag history. Either wait for 2 promotions to accumulate, or manually `skopeo tag` the current `:prod` once.
- **Tag retention**: not addressed in this PR. Staging accumulates a tag per build; revisit cleanup if/when Docker Hub tag list becomes noisy.
- No changes to image content, signing, or attestation flow.

## Testing

YAML linted. To verify end-to-end after merge:
1. Trigger build.yml on main → expect `:staging` and `staging-<today>-<sha>` both pushed.
2. Trigger promote.yml manually → expect `:prod` and `prod-<today>-<sha>` both pushed, GH release `prod-<today>-<sha>` created.
3. Verify both stamped tags resolve to the same digest as the moving tag.
