### PR TITLE
fix(embeddings): propagate upstream HTTP status instead of 502 'try again later'

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -2905,16 +2905,30 @@ pub async fn embeddings(
                 }
                 services::completions::ports::CompletionError::ProviderError {
                     status_code,
-                    ..
+                    message,
                 } => {
-                    tracing::error!("Embeddings provider error");
                     let http_status = StatusCode::from_u16(status_code)
                         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-                    (
-                        http_status,
-                        "server_error",
-                        "Embeddings request failed. Please try again later.".to_string(),
-                    )
+                    // For client errors (4xx), surface the upstream message so users
+                    // see *why* their request was rejected (e.g. "dimensions parameter
+                    // is not supported for this model") instead of a generic "try
+                    // again later" that trains them into useless retries.
+                    // For 5xx, keep a generic message — the upstream body is more
+                    // likely to be a stack trace or internal detail.
+                    if http_status.is_client_error() {
+                        tracing::warn!(
+                            status = status_code,
+                            "Embeddings rejected by upstream with client error"
+                        );
+                        (http_status, "invalid_request_error", message)
+                    } else {
+                        tracing::error!(status = status_code, "Embeddings provider error");
+                        (
+                            http_status,
+                            "server_error",
+                            "Embeddings request failed. Please try again later.".to_string(),
+                        )
+                    }
                 }
                 services::completions::ports::CompletionError::InvalidModel(msg) => {
                     tracing::warn!("Embeddings model not found");

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1266,6 +1266,92 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_provider_error_404_surfaces_message() {
+        let (status, error_type, message) =
+            classify_provider_error(404, "model 'foo' not found".to_string());
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(error_type, "not_found_error");
+        assert_eq!(message, "model 'foo' not found");
+    }
+
+    #[test]
+    fn test_classify_provider_error_429_surfaces_message() {
+        let (status, error_type, message) =
+            classify_provider_error(429, "too many concurrent requests".to_string());
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(error_type, "rate_limit_error");
+        assert_eq!(message, "too many concurrent requests");
+    }
+
+    #[test]
+    fn test_classify_provider_error_400_surfaces_message() {
+        let (status, error_type, message) = classify_provider_error(
+            400,
+            "dimensions is not supported for this model".to_string(),
+        );
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error_type, "invalid_request_error");
+        assert_eq!(message, "dimensions is not supported for this model");
+    }
+
+    #[test]
+    fn test_classify_provider_error_422_preserves_upstream_status() {
+        let (status, error_type, message) =
+            classify_provider_error(422, "validation failed".to_string());
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(error_type, "invalid_request_error");
+        assert_eq!(message, "validation failed");
+    }
+
+    #[test]
+    fn test_classify_provider_error_401_masked_as_5xx() {
+        // 401 from upstream means *our* credentials are wrong — the client
+        // did nothing to cause it, so we must not echo the auth error.
+        let (status, error_type, message) =
+            classify_provider_error(401, "Invalid API key 'sk-***'".to_string());
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error_type, "server_error");
+        assert!(
+            !message.contains("sk-"),
+            "must not leak upstream credentials in surfaced message"
+        );
+        assert!(message.contains("try again later"));
+    }
+
+    #[test]
+    fn test_classify_provider_error_403_masked_as_5xx() {
+        let (status, error_type, message) =
+            classify_provider_error(403, "Forbidden: backend ACL denied".to_string());
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error_type, "server_error");
+        assert_eq!(
+            message,
+            "Embeddings request failed. Please try again later."
+        );
+    }
+
+    #[test]
+    fn test_classify_provider_error_407_masked_as_5xx() {
+        let (status, error_type, _) =
+            classify_provider_error(407, "proxy auth required".to_string());
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error_type, "server_error");
+    }
+
+    #[test]
+    fn test_classify_provider_error_5xx_masked() {
+        // 5xx bodies may contain stack traces or internal details — never echo.
+        let (status, error_type, message) = classify_provider_error(
+            502,
+            "RuntimeError: traceback...internal-host:9000".to_string(),
+        );
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error_type, "server_error");
+        assert!(!message.contains("traceback"));
+        assert!(!message.contains("internal-host"));
+    }
+
+    #[test]
     fn test_stream_chunk_serialization_preserves_field_order() {
         // Verify that StreamChunk::Chat serializes with struct field order
         // (not alphabetical), matching what serde_json::to_string produces.
@@ -2675,6 +2761,49 @@ struct EmbeddingsResponseDoc {
     data: serde_json::Value,
 }
 
+/// Classify an upstream provider HTTP error into the (status, error_type, message)
+/// triple we surface to the client.
+///
+/// Rules:
+/// - 401/403/407 from upstream mean *our* credentials to the backend are wrong
+///   (or our backend's auth config is broken). The client did nothing to cause
+///   it, so we return 500 with a generic message instead of echoing an auth
+///   failure that would be misleading.
+/// - 404 → 404 not_found_error (e.g. model not found at this provider).
+/// - 429 → 429 rate_limit_error.
+/// - Other 4xx → preserve upstream status with `invalid_request_error`. The
+///   upstream message is surfaced so the user can see *why* their request was
+///   rejected (e.g. "dimensions is not supported for this model").
+/// - 5xx (and anything else) → 500 server_error with a generic message. The
+///   upstream body may contain stack traces or internal details we don't want
+///   to leak.
+fn classify_provider_error(
+    upstream_status: u16,
+    upstream_message: String,
+) -> (StatusCode, &'static str, String) {
+    let generic = || {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "Embeddings request failed. Please try again later.".to_string(),
+        )
+    };
+    match upstream_status {
+        401 | 403 | 407 => generic(),
+        404 => (StatusCode::NOT_FOUND, "not_found_error", upstream_message),
+        429 => (
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate_limit_error",
+            upstream_message,
+        ),
+        s if (400..=499).contains(&s) => {
+            let http_status = StatusCode::from_u16(s).unwrap_or(StatusCode::BAD_REQUEST);
+            (http_status, "invalid_request_error", upstream_message)
+        }
+        _ => generic(),
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/v1/embeddings",
@@ -2907,28 +3036,16 @@ pub async fn embeddings(
                     status_code,
                     message,
                 } => {
-                    let http_status = StatusCode::from_u16(status_code)
-                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-                    // For client errors (4xx), surface the upstream message so users
-                    // see *why* their request was rejected (e.g. "dimensions parameter
-                    // is not supported for this model") instead of a generic "try
-                    // again later" that trains them into useless retries.
-                    // For 5xx, keep a generic message — the upstream body is more
-                    // likely to be a stack trace or internal detail.
-                    if http_status.is_client_error() {
+                    let classified = classify_provider_error(status_code, message);
+                    if classified.0.is_client_error() {
                         tracing::warn!(
-                            status = status_code,
+                            upstream_status = status_code,
                             "Embeddings rejected by upstream with client error"
                         );
-                        (http_status, "invalid_request_error", message)
                     } else {
-                        tracing::error!(status = status_code, "Embeddings provider error");
-                        (
-                            http_status,
-                            "server_error",
-                            "Embeddings request failed. Please try again later.".to_string(),
-                        )
+                        tracing::error!(upstream_status = status_code, "Embeddings provider error");
                     }
+                    classified
                 }
                 services::completions::ports::CompletionError::InvalidModel(msg) => {
                     tracing::warn!("Embeddings model not found");

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -115,8 +115,9 @@ pub trait BackendVerifier: Send + Sync {
 ///
 /// Supports common formats:
 ///   - OpenAI/Anthropic: `{"error": {"message": "..."}}`
+///   - vLLM flat: `{"object": "error", "message": "...", "type": "..."}`
 ///   - vLLM/FastAPI: `{"detail": "..."}`
-///   - Falls back to the raw body if neither matches
+///   - Falls back to the raw body if none match
 pub fn extract_error_message(body: &str) -> String {
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(body) {
         // OpenAI/Anthropic format: {"error": {"message": "..."}}
@@ -127,13 +128,20 @@ pub fn extract_error_message(body: &str) -> String {
         {
             return msg.to_string();
         }
-        // vLLM/FastAPI format: {"detail": "..."}
+        // vLLM flat format: {"object":"error","message":"...","type":"..."}
+        // Distinguished from envelope JSON by the top-level `message` field
+        // (we don't want to pick up `message` fields nested deep elsewhere).
+        if let Some(msg) = json.get("message").and_then(|m| m.as_str()) {
+            return msg.to_string();
+        }
+        // FastAPI format: {"detail": "..."}
         if let Some(detail) = json.get("detail").and_then(|d| d.as_str()) {
             return detail.to_string();
         }
     }
     body.to_string()
 }
+
 
 /// Type alias for streaming completion results
 ///
@@ -281,4 +289,51 @@ pub trait InferenceProvider {
         params: AudioTranscriptionParams,
         request_hash: String,
     ) -> Result<AudioTranscriptionResponse, AudioTranscriptionError>;
+}
+
+#[cfg(test)]
+mod extract_error_message_tests {
+    use super::extract_error_message;
+
+    #[test]
+    fn test_openai_nested_format() {
+        let body = r#"{"error":{"message":"Invalid API key","type":"auth_error"}}"#;
+        assert_eq!(extract_error_message(body), "Invalid API key");
+    }
+
+    #[test]
+    fn test_vllm_flat_format() {
+        // vLLM/sglang emit this shape for validation errors.
+        let body = r#"{"object":"error","message":"dimensions parameter is not supported for this model","type":"BadRequestError","param":null,"code":400}"#;
+        assert_eq!(
+            extract_error_message(body),
+            "dimensions parameter is not supported for this model"
+        );
+    }
+
+    #[test]
+    fn test_fastapi_detail_format() {
+        let body = r#"{"detail":"Validation failed"}"#;
+        assert_eq!(extract_error_message(body), "Validation failed");
+    }
+
+    #[test]
+    fn test_unknown_json_falls_back_to_body() {
+        let body = r#"{"weird_shape":true}"#;
+        assert_eq!(extract_error_message(body), body);
+    }
+
+    #[test]
+    fn test_non_json_falls_back_to_body() {
+        let body = "plain text error";
+        assert_eq!(extract_error_message(body), body);
+    }
+
+    #[test]
+    fn test_prefers_nested_error_over_flat_message() {
+        // If both shapes are present, prefer the explicit error envelope.
+        let body =
+            r#"{"error":{"message":"from envelope"},"message":"from flat","type":"whatever"}"#;
+        assert_eq!(extract_error_message(body), "from envelope");
+    }
 }

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -142,7 +142,6 @@ pub fn extract_error_message(body: &str) -> String {
     body.to_string()
 }
 
-
 /// Type alias for streaming completion results
 ///
 /// This represents a stream of SSE events where each event contains:

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -689,15 +689,16 @@ impl MockProvider {
 
     /// Set an error override — when set, all chat completion calls return this error
     /// instead of generating a response. Pass `None` to clear the override.
-    /// Override the embeddings response with an error (useful for testing error paths).
-    pub async fn set_embedding_error_override(&self, error: Option<EmbeddingError>) {
-        let mut config = self.config.lock().await;
-        config.embedding_error_override = error;
-    }
-
     pub async fn set_error_override(&self, error: Option<CompletionError>) {
         let mut config = self.config.lock().await;
         config.error_override = error;
+    }
+
+    /// Override the embeddings response with an error (useful for testing error paths).
+    /// Pass `None` to clear the override.
+    pub async fn set_embedding_error_override(&self, error: Option<EmbeddingError>) {
+        let mut config = self.config.lock().await;
+        config.embedding_error_override = error;
     }
 
     /// Generate a completion ID

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -552,6 +552,8 @@ struct MockConfig {
     default_response: ResponseTemplate,
     /// When set, all chat completion calls return this error instead of generating a response
     error_override: Option<CompletionError>,
+    /// When set, all embeddings calls return this error instead of generating a response
+    embedding_error_override: Option<EmbeddingError>,
 }
 
 /// Builder for configuring a single expectation
@@ -601,6 +603,7 @@ impl MockProvider {
                 expectations: Vec::new(),
                 default_response: ResponseTemplate::new("1. 2. 3."),
                 error_override: None,
+                embedding_error_override: None,
             })),
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -618,6 +621,7 @@ impl MockProvider {
                 expectations: Vec::new(),
                 default_response: ResponseTemplate::new("1. 2. 3."),
                 error_override: None,
+                embedding_error_override: None,
             })),
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -633,6 +637,7 @@ impl MockProvider {
                 expectations: Vec::new(),
                 default_response: ResponseTemplate::new("1. 2. 3."),
                 error_override: None,
+                embedding_error_override: None,
             })),
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -684,6 +689,12 @@ impl MockProvider {
 
     /// Set an error override — when set, all chat completion calls return this error
     /// instead of generating a response. Pass `None` to clear the override.
+    /// Override the embeddings response with an error (useful for testing error paths).
+    pub async fn set_embedding_error_override(&self, error: Option<EmbeddingError>) {
+        let mut config = self.config.lock().await;
+        config.embedding_error_override = error;
+    }
+
     pub async fn set_error_override(&self, error: Option<CompletionError>) {
         let mut config = self.config.lock().await;
         config.error_override = error;
@@ -1123,6 +1134,12 @@ impl crate::InferenceProvider for MockProvider {
         _body: bytes::Bytes,
         _extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, EmbeddingError> {
+        {
+            let config = self.config.lock().await;
+            if let Some(ref error) = config.embedding_error_override {
+                return Err(error.clone());
+            }
+        }
         let embedding: Vec<f64> = vec![0.0; 384];
         let response_json = serde_json::json!({
             "object": "list",

--- a/crates/inference_providers/src/models.rs
+++ b/crates/inference_providers/src/models.rs
@@ -1248,7 +1248,7 @@ pub enum ScoreError {
     HttpError { status_code: u16, message: String },
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("Embedding request failed: {0}")]
     RequestFailed(String),

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1467,13 +1467,13 @@ impl InferenceProvider for VLlmProvider {
 
         if !response.status().is_success() {
             let status_code = response.status().as_u16();
-            let message = response
+            let error_text = response
                 .text()
                 .await
                 .unwrap_or_else(|_| "Unknown error".to_string());
             return Err(EmbeddingError::HttpError {
                 status_code,
-                message,
+                message: crate::extract_error_message(&error_text),
             });
         }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -2173,13 +2173,27 @@ impl InferenceProviderPool {
             }
         }
 
-        let error_msg = last_error
-            .map(|e| Self::sanitize_error_message(&e.to_string()))
-            .unwrap_or_else(|| "No providers available for embeddings".to_string());
-
-        Err(inference_providers::EmbeddingError::RequestFailed(
-            error_msg,
-        ))
+        // Preserve the HttpError variant so the caller can see the upstream
+        // status code and propagate a meaningful response (e.g. 400 for a
+        // client-side parameter error). Collapsing to RequestFailed loses the
+        // status code and forces every upstream error to surface as 502.
+        Err(match last_error {
+            Some(inference_providers::EmbeddingError::HttpError {
+                status_code,
+                message,
+            }) => inference_providers::EmbeddingError::HttpError {
+                status_code,
+                message: Self::sanitize_error_message(&message),
+            },
+            Some(inference_providers::EmbeddingError::RequestFailed(msg)) => {
+                inference_providers::EmbeddingError::RequestFailed(Self::sanitize_error_message(
+                    &msg,
+                ))
+            }
+            None => inference_providers::EmbeddingError::RequestFailed(
+                "No providers available for embeddings".to_string(),
+            ),
+        })
     }
 
     pub async fn privacy_classify(
@@ -4764,5 +4778,80 @@ mod tests {
             "probe should give up within ~5s, took {elapsed:?}"
         );
         assert_eq!(server.models_hits.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    // ==================== Embeddings Error Propagation Tests ====================
+
+    #[tokio::test]
+    async fn test_embeddings_preserves_http_error_status_code() {
+        // Upstream rejects an embedding request with HTTP 400 (e.g. unsupported
+        // `dimensions` param). The pool MUST preserve the HttpError variant so
+        // the route can return HTTP 400 — not collapse it to RequestFailed,
+        // which previously caused every upstream error to surface as HTTP 502.
+        use inference_providers::mock::MockProvider;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model_id = "Qwen/Qwen3-Embedding-0.6B".to_string();
+        let mock = Arc::new(MockProvider::new_accept_all());
+        mock.set_embedding_error_override(Some(inference_providers::EmbeddingError::HttpError {
+            status_code: 400,
+            message: "dimensions parameter is not supported for this model".to_string(),
+        }))
+        .await;
+        pool.register_provider(model_id.clone(), mock).await;
+
+        let body = bytes::Bytes::from(
+            r#"{"model":"Qwen/Qwen3-Embedding-0.6B","input":"hi","dimensions":256}"#,
+        );
+        let result = pool
+            .embeddings(&model_id, body, std::collections::HashMap::new())
+            .await;
+
+        match result {
+            Err(inference_providers::EmbeddingError::HttpError {
+                status_code,
+                message,
+            }) => {
+                assert_eq!(status_code, 400);
+                assert!(
+                    message.contains("dimensions parameter is not supported"),
+                    "Expected upstream message to be preserved, got: {message}"
+                );
+            }
+            other => panic!("Expected HttpError(400, ...), got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_embeddings_request_failed_stays_request_failed() {
+        // Non-HTTP errors (e.g. network/connection failure) should still
+        // surface as RequestFailed so the route maps them to 502.
+        use inference_providers::mock::MockProvider;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model_id = "Qwen/Qwen3-Embedding-0.6B".to_string();
+        let mock = Arc::new(MockProvider::new_accept_all());
+        mock.set_embedding_error_override(Some(
+            inference_providers::EmbeddingError::RequestFailed(
+                "connection reset by peer".to_string(),
+            ),
+        ))
+        .await;
+        pool.register_provider(model_id.clone(), mock).await;
+
+        let result = pool
+            .embeddings(
+                &model_id,
+                bytes::Bytes::from(r#"{"model":"x","input":"hi"}"#),
+                std::collections::HashMap::new(),
+            )
+            .await;
+
+        match result {
+            Err(inference_providers::EmbeddingError::RequestFailed(msg)) => {
+                assert!(msg.contains("connection reset"));
+            }
+            other => panic!("Expected RequestFailed, got: {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## Summary
Surface the real upstream HTTP status and message for embeddings errors, so users see why their request was rejected instead of a misleading 502.

## Reproduced before
\`\`\`
POST /v1/embeddings  {"model":"Qwen/Qwen3-Embedding-0.6B","input":"hi","dimensions":256}
→ HTTP 502 {"error":{"message":"Embeddings request failed. Please try again later.","type":"server_error",...}}
\`\`\`

## Root cause
Three bugs combined to mask every error as 502:

1. **Pool** (\`inference_provider_pool::embeddings\`) collapsed \`EmbeddingError::HttpError\` into \`RequestFailed\`, discarding the upstream status code.
2. **vLLM provider** (\`embeddings_raw\`) stored the raw upstream JSON body in the message field. Other endpoints already use \`extract_error_message\`; embeddings did not.
3. **Route handler** hardcoded \"Embeddings request failed. Please try again later.\" for every \`ProviderError\`, overriding the real upstream message.

## What changes
- Pool preserves \`HttpError\` variant when present (sanitized message kept).
- \`vllm::embeddings_raw\` runs upstream JSON through \`extract_error_message\`.
- Route returns upstream status + message for 4xx; keeps the generic message for 5xx.
- \`extract_error_message\` learns vLLM's flat \`{\"object\":\"error\",\"message\":\"...\",\"type\":\"...\"}\` shape (previously fell through to raw body — affected other endpoints too).

## After the fix
\`\`\`
POST /v1/embeddings  {... \"dimensions\":256}
→ HTTP 400 {\"error\":{\"message\":\"dimensions is not supported for this model\",\"type\":\"invalid_request_error\",...}}
\`\`\`

## Out of scope
- Making \`dimensions\` actually work for Qwen3-Embedding (would need an MRL flag in cvm-compose-files; see #605 §2).
- Same error-handling pattern in \`audio_transcription\` (same hardcoded message bug) — left for a follow-up.

## Test plan
- [x] \`cargo test --lib --bins\` — 301 services + 6 inference_providers + others, all pass
- [x] New pool tests cover HttpError preservation and RequestFailed pass-through
- [x] 6 new \`extract_error_message\` tests cover vLLM flat, OpenAI nested, FastAPI detail, fallback paths
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --lib --tests --bins -- -D warnings\` clean

Closes #605