### PR TITLE
fix(admin): invalidate org concurrent-limit cache on PATCH

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -834,6 +834,7 @@ pub fn build_app_with_config(
         app_state.inference_provider_pool.clone(),
         analytics_service,
         domain_services.models_service.clone(),
+        domain_services.completion_service.clone(),
     );
 
     let invitation_routes =
@@ -1437,6 +1438,7 @@ pub fn build_admin_routes(
     inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
     analytics_service: Arc<services::admin::AnalyticsService>,
     models_service: Arc<services::models::ModelsServiceImpl>,
+    completion_service: Arc<services::CompletionServiceImpl>,
 ) -> Router {
     use crate::middleware::admin_middleware;
     use crate::routes::admin::{
@@ -1462,10 +1464,13 @@ pub fn build_admin_routes(
     // The admin service holds a reference to the `models_service` so it can
     // invalidate the public `/v1/model/list` cache after admin writes
     // (`upsert`, `delete`, `deprecate`) that mutate the `models` or
-    // `model_aliases` tables.
+    // `model_aliases` tables. It also holds the `completion_service` so it
+    // can invalidate the per-org concurrent-limit cache after a PATCH to
+    // `/v1/admin/organizations/{org_id}/concurrent-limit`.
     let admin_service = Arc::new(AdminServiceImpl::new(
         admin_repository as Arc<dyn services::admin::AdminRepository>,
         models_service as Arc<dyn services::models::ModelsServiceTrait>,
+        completion_service.clone() as Arc<dyn services::completions::CompletionServiceTrait>,
     )) as Arc<dyn services::admin::AdminService + Send + Sync>;
 
     let admin_app_state = AdminAppState {

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -9,6 +9,7 @@ pub use analytics::{
 pub use ports::{PlatformServiceInfo, *};
 use std::sync::Arc;
 
+use crate::completions::CompletionServiceTrait;
 use crate::models::ModelsServiceTrait;
 
 pub struct AdminServiceImpl {
@@ -16,16 +17,22 @@ pub struct AdminServiceImpl {
     /// Used solely to invalidate the public `/v1/model/list` cache after
     /// admin writes that mutate the `models` or `model_aliases` tables.
     models_service: Arc<dyn ModelsServiceTrait>,
+    /// Used to invalidate the per-org concurrent-limit cache after a PATCH
+    /// to `/v1/admin/organizations/{org_id}/concurrent-limit`, so admin
+    /// changes take effect immediately instead of waiting for the 5-minute TTL.
+    completion_service: Arc<dyn CompletionServiceTrait>,
 }
 
 impl AdminServiceImpl {
     pub fn new(
         repository: Arc<dyn AdminRepository>,
         models_service: Arc<dyn ModelsServiceTrait>,
+        completion_service: Arc<dyn CompletionServiceTrait>,
     ) -> Self {
         Self {
             repository,
             models_service,
+            completion_service,
         }
     }
 }
@@ -309,7 +316,16 @@ impl AdminService for AdminServiceImpl {
                 } else {
                     AdminError::InternalError(error_msg)
                 }
-            })
+            })?;
+
+        // Drop the cached limit so the next request reads the freshly-written
+        // value. Without this, admin PATCHes only take effect after the
+        // 5-minute TTL expires.
+        self.completion_service
+            .invalidate_org_concurrent_limit(organization_id)
+            .await;
+
+        Ok(())
     }
 
     async fn get_organization_concurrent_limit(

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -2194,6 +2194,45 @@ mod tests {
         );
     }
 
+    /// Mirrors the cache shape used by `CompletionServiceImpl::org_concurrent_limits`
+    /// and `get_org_concurrent_limit`: `moka::future::Cache<Uuid, u32>` populated
+    /// via `get_with` (load-on-miss with the closure return becoming the cached
+    /// value). Asserts that `Cache::invalidate(&key)` forces the next `get_with`
+    /// call to re-run its loader — which is exactly the contract
+    /// `invalidate_org_concurrent_limit` relies on for admin PATCHes to take
+    /// effect immediately instead of waiting for the 5-minute TTL.
+    #[tokio::test]
+    async fn test_org_concurrent_limit_cache_invalidates() {
+        let cache: Cache<Uuid, u32> = Cache::builder()
+            .time_to_live(Duration::from_secs(ORG_LIMIT_CACHE_TTL_SECS))
+            .max_capacity(10_000)
+            .build();
+
+        let org_id = Uuid::new_v4();
+
+        // First load: repo returns 64 (default).
+        let v = cache.get_with(org_id, async { 64u32 }).await;
+        assert_eq!(v, 64);
+
+        // Second call with a different loader return — should still hit the
+        // cached 64 because the entry is alive.
+        let v = cache.get_with(org_id, async { 2u32 }).await;
+        assert_eq!(
+            v, 64,
+            "stale cached value should survive without invalidate"
+        );
+
+        // Simulate admin PATCH writing a new limit to the DB and the service
+        // invalidating the cache. After this, the next get_with must re-load.
+        cache.invalidate(&org_id).await;
+
+        let v = cache.get_with(org_id, async { 2u32 }).await;
+        assert_eq!(
+            v, 2,
+            "after invalidate, next get_with should run the loader and pick up the new value"
+        );
+    }
+
     #[tokio::test]
     async fn test_intercept_stream_decrements_on_drop() {
         // Test that InterceptStream decrements the counter when dropped

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -1694,6 +1694,10 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
     ) -> std::sync::Arc<crate::inference_provider_pool::InferenceProviderPool> {
         self.inference_provider_pool.clone()
     }
+
+    async fn invalidate_org_concurrent_limit(&self, org_id: Uuid) {
+        self.org_concurrent_limits.invalidate(&org_id).await;
+    }
 }
 
 pub use ports::*;

--- a/crates/services/src/completions/ports.rs
+++ b/crates/services/src/completions/ports.rs
@@ -205,4 +205,12 @@ pub trait CompletionServiceTrait: Send + Sync {
     fn get_inference_provider_pool(
         &self,
     ) -> std::sync::Arc<crate::inference_provider_pool::InferenceProviderPool>;
+
+    /// Drop the cached concurrent-limit entry for an organization so the next
+    /// request reads the freshly-written value from the repository.
+    ///
+    /// Called by the admin service after a successful PATCH of
+    /// `organizations.concurrent_limit` so admin changes take effect
+    /// immediately instead of waiting for the 5-minute TTL.
+    async fn invalidate_org_concurrent_limit(&self, org_id: Uuid);
 }


### PR DESCRIPTION
## Summary

The per-org concurrent-request limit was already enforced end-to-end (`try_acquire_concurrent_slot` in `crates/services/src/completions/mod.rs:914`), but admin PATCHes to `/v1/admin/organizations/{org_id}/concurrent-limit` only wrote the DB row — they did not invalidate `CompletionServiceImpl.org_concurrent_limits`, which caches the value with a 5-minute TTL (`ORG_LIMIT_CACHE_TTL_SECS = 300`, mod.rs:484).

Operators setting a lower limit on a noisy tenant observed *"no effect"* because the cached default (64) stayed live for up to 5 min after each change. Same gap that the models cache had — fixed there with `models_service.invalidate_models_cache()` after each write.

## Change

Mirror that pattern for concurrent limits:

- Add `invalidate_org_concurrent_limit(org_id)` to `CompletionServiceTrait` (`completions/ports.rs`). Implementation just calls `self.org_concurrent_limits.invalidate(&org_id).await` (`completions/mod.rs`).
- Thread `Arc<dyn CompletionServiceTrait>` into `AdminServiceImpl::new` (`services/admin/mod.rs`) and call it after the repository write in `update_organization_concurrent_limit`.
- Update `build_admin_routes` (`api/src/lib.rs`) to forward `completion_service` to the admin service constructor.

## Test plan

- [x] `cargo check`, `cargo fmt --check`, `cargo clippy --all-targets`
- [x] `cargo test --lib --bins -p services concurrent` — both existing concurrent-limit tests pass.
- [ ] Manual verification on staging after merge: `PATCH /v1/admin/organizations/{org_id}/concurrent-limit` with `{"concurrent_limit": 2}` then immediately fire 3 parallel chat completions on a model; expect the 3rd to 429 without waiting out the 5-min TTL.

## Operational context

GLM-5.1 backend was queue-saturated under one tenant's traffic on 2026-05-19; admin tried to throttle the tenant via the existing concurrent-limit endpoint but observed no effect during the incident window. Root-caused to this cache miss. Pairs with a separate cvm-compose-files change adding `--max-queued-requests 8` to SGLang as defense in depth.