### PR TITLE
feat(http): return 529 when all inference backends are overloaded

### DIFF
--- a/crates/api/src/routes/common.rs
+++ b/crates/api/src/routes/common.rs
@@ -4,6 +4,16 @@ use services::completions::CompletionError;
 use services::organization::OrganizationError;
 use uuid::Uuid;
 
+/// HTTP 529 "Site Is Overloaded" — non-standard but widely used (Cloudflare,
+/// Anthropic) for "all backends exhausted; please retry with exponential
+/// backoff." Surfaced when `retry_with_fallback` has tried every inference
+/// backend for a model and they all rejected with 5xx — typically SGLang
+/// `--max-queued-requests` 503s under load. 503 stays reserved for narrower
+/// per-handler "this dependency is down" cases.
+pub fn status_overloaded() -> StatusCode {
+    StatusCode::from_u16(529).expect("529 is a valid HTTP status code")
+}
+
 /// Map domain errors to HTTP status codes
 pub fn map_domain_error_to_status(error: &CompletionError) -> StatusCode {
     match error {
@@ -14,7 +24,7 @@ pub fn map_domain_error_to_status(error: &CompletionError) -> StatusCode {
         CompletionError::ProviderError { status_code, .. } => {
             StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
         }
-        CompletionError::ServiceOverloaded(_) => StatusCode::SERVICE_UNAVAILABLE,
+        CompletionError::ServiceOverloaded(_) => status_overloaded(),
         CompletionError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
@@ -539,10 +549,7 @@ mod tests {
     #[test]
     fn test_map_domain_error_service_overloaded() {
         let error = CompletionError::ServiceOverloaded("overloaded".to_string());
-        assert_eq!(
-            map_domain_error_to_status(&error),
-            StatusCode::SERVICE_UNAVAILABLE
-        );
+        assert_eq!(map_domain_error_to_status(&error).as_u16(), 529);
     }
 
     #[test]

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -665,7 +665,8 @@ fn convert_text_request_to_service(
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 402, description = "Insufficient credits", body = ErrorResponse),
-        (status = 500, description = "Server error", body = ErrorResponse)
+        (status = 500, description = "Server error", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -1027,7 +1028,8 @@ pub async fn chat_completions(
         (status = 200, description = "Completion generated successfully", body = ChatCompletionResponse),
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
-        (status = 500, description = "Server error", body = ErrorResponse)
+        (status = 500, description = "Server error", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -1280,7 +1282,8 @@ mod tests {
         (status = 200, description = "Image generated successfully", body = ImageGenerationResponse),
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
-        (status = 500, description = "Server error", body = ErrorResponse)
+        (status = 500, description = "Server error", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -1533,6 +1536,7 @@ pub async fn image_generations(
         (status = 401, description = "Unauthorized (missing or invalid API key)", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]
@@ -1865,7 +1869,8 @@ pub async fn audio_transcriptions(
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 413, description = "Payload too large", body = ErrorResponse),
-        (status = 500, description = "Server error", body = ErrorResponse)
+        (status = 500, description = "Server error", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -2248,6 +2253,7 @@ pub async fn image_edits(
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Concurrent request limit exceeded for the organization. Max concurrent requests per model: 64 (configurable)", body = ErrorResponse),
         (status = 500, description = "Server error (billing failure, provider error)", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]
@@ -2545,7 +2551,8 @@ struct EmbeddingsResponseDoc {
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
-        (status = 500, description = "Server error", body = ErrorResponse)
+        (status = 500, description = "Server error", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -2847,6 +2854,7 @@ struct PrivacyClassifyResponseDoc {
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
     ),
     security(
@@ -3137,6 +3145,7 @@ pub async fn privacy_classify(
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Concurrent request limit exceeded for the organization. Max concurrent requests per model: 64 (configurable)", body = ErrorResponse),
         (status = 500, description = "Server error (billing failure, provider error)", body = ErrorResponse),
+        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1824,9 +1824,9 @@ pub async fn audio_transcriptions(
                 services::completions::ports::CompletionError::ServiceOverloaded(_) => {
                     tracing::warn!("Audio transcription service overloaded");
                     (
-                        StatusCode::SERVICE_UNAVAILABLE,
+                        crate::routes::common::status_overloaded(),
                         "service_overloaded",
-                        "The service is temporarily overloaded. Please retry with exponential backoff.".to_string(),
+                        "All inference backends are overloaded. Please retry with exponential backoff.".to_string(),
                     )
                 }
                 _ => {
@@ -2485,9 +2485,9 @@ pub async fn rerank(
                 services::completions::ports::CompletionError::ServiceOverloaded(_) => {
                     tracing::warn!("Rerank service overloaded");
                     (
-                        StatusCode::SERVICE_UNAVAILABLE,
+                        crate::routes::common::status_overloaded(),
                         "service_overloaded",
-                        "The service is temporarily overloaded. Please retry with exponential backoff.".to_string(),
+                        "All inference backends are overloaded. Please retry with exponential backoff.".to_string(),
                     )
                 }
                 _ => {
@@ -2781,9 +2781,9 @@ pub async fn embeddings(
                 services::completions::ports::CompletionError::ServiceOverloaded(_) => {
                     tracing::warn!("Embeddings service overloaded");
                     (
-                        StatusCode::SERVICE_UNAVAILABLE,
+                        crate::routes::common::status_overloaded(),
                         "service_overloaded",
-                        "The service is temporarily overloaded. Please retry with exponential backoff.".to_string(),
+                        "All inference backends are overloaded. Please retry with exponential backoff.".to_string(),
                     )
                 }
                 _ => {
@@ -3095,9 +3095,9 @@ pub async fn privacy_classify(
                 services::completions::ports::CompletionError::ServiceOverloaded(_) => {
                     tracing::warn!("Privacy classify service overloaded");
                     (
-                        StatusCode::SERVICE_UNAVAILABLE,
+                        crate::routes::common::status_overloaded(),
                         "service_overloaded",
-                        "The service is temporarily overloaded. Please retry with exponential backoff.".to_string(),
+                        "All inference backends are overloaded. Please retry with exponential backoff.".to_string(),
                     )
                 }
                 _ => {
@@ -3378,9 +3378,9 @@ pub async fn score(
                 services::completions::ports::CompletionError::ServiceOverloaded(_) => {
                     tracing::warn!("Score service overloaded");
                     (
-                        StatusCode::SERVICE_UNAVAILABLE,
+                        crate::routes::common::status_overloaded(),
                         "service_overloaded",
-                        "The service is temporarily overloaded. Please retry with exponential backoff.".to_string(),
+                        "All inference backends are overloaded. Please retry with exponential backoff.".to_string(),
                     )
                 }
                 _ => {

--- a/crates/api/tests/e2e_all/general.rs
+++ b/crates/api/tests/e2e_all/general.rs
@@ -1586,12 +1586,14 @@ async fn test_high_context_length_completion() {
 
         // Common acceptable errors:
         // - Model not found (404)
-        // - Model not available (503)
+        // - Model not available (503) — narrow per-handler dependency-down case
+        // - All backends overloaded (529) — retry_with_fallback exhausted
         assert!(
             response.status_code() == 404
                 || response.status_code() == 503
+                || response.status_code() == 529
                 || response.status_code() == 500,
-            "Expected 200, 404, 500, or 503, got: {}",
+            "Expected 200, 404, 500, 503, or 529, got: {}",
             response.status_code()
         );
 

--- a/crates/api/tests/e2e_all/provider_errors.rs
+++ b/crates/api/tests/e2e_all/provider_errors.rs
@@ -23,7 +23,9 @@ fn chat_request(model: &str, stream: bool) -> serde_json::Value {
 // Provider error propagation tests (vLLM-style, is_external: false)
 // ============================================
 
-/// Test that a 503 error from the provider is propagated to the client
+/// Test that a 503 from the provider, after `retry_with_fallback` exhausts
+/// every backend, surfaces to the client as HTTP 529 ("Site Is Overloaded").
+/// 503 stays reserved for narrower per-handler "this dependency is down" cases.
 #[tokio::test]
 async fn test_provider_error_503_propagated() {
     let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
@@ -48,8 +50,8 @@ async fn test_provider_error_503_propagated() {
 
     assert_eq!(
         response.status_code(),
-        503,
-        "Expected 503 Service Unavailable, got {}",
+        529,
+        "Expected 529 (all backends overloaded), got {}",
         response.status_code()
     );
 
@@ -212,8 +214,8 @@ async fn test_provider_error_message_preserved_in_streaming() {
 
     assert_eq!(
         response.status_code(),
-        503,
-        "Expected 503 for streaming request, got {}",
+        529,
+        "Expected 529 (all backends overloaded) for streaming request, got {}",
         response.status_code()
     );
 


### PR DESCRIPTION
## Summary

cloud-api currently returns **HTTP 503** when `retry_with_fallback` has exhausted every inference backend for a model with 5xx errors — most commonly SGLang's `--max-queued-requests` 503s under sustained load (cf. cvm-compose-files **v0.0.164** which added `--max-queued-requests 8` to GLM-5.1).

That conflates two distinct client signals:
- "This dependency is down" — per-handler 503 (e.g. PII detector unavailable, auth service unreachable).
- "Every backend for this model is overloaded; retry with backoff later."

This change surfaces the second case as **HTTP 529 "Site Is Overloaded"** — non-standard but widely used by Cloudflare and Anthropic for exactly this scenario. Clients already retrying on 5xx with backoff are unaffected; clients with status-specific handling can now distinguish "deploy issue, page someone" from "transient capacity pressure, back off and retry."

## Why this is safe to flip without a more nuanced detector

`retry_with_fallback` already walks **every** provider in the model pool with exponential backoff (3 rounds × N providers, 500ms→4s for connection/5xx, 1s→8s for 429) before surfacing `ServiceOverloaded`. By the time that variant reaches the route layer, we genuinely have tried every backend. Adding extra per-attempt status inspection would be redundant.

## Changes

- `routes/common.rs`: new `status_overloaded()` helper returning `StatusCode::from_u16(529)`. Centralized `map_domain_error_to_status` now returns 529 for `ServiceOverloaded`. Existing test updated to assert `.as_u16() == 529`.
- `routes/completions.rs`: five per-handler `ServiceOverloaded` arms (audio transcription, rerank, embeddings, privacy classify, score) call `status_overloaded()` instead of `StatusCode::SERVICE_UNAVAILABLE`. Message updated from "The service is temporarily overloaded" to "All inference backends are overloaded" — same advice ("retry with exponential backoff"), just clearer about scope.

Chat completions and Responses APIs already route through `map_domain_error_to_status`, so they inherit the change for free.

## Test plan

- [x] `cargo check`, `cargo fmt --check`, `cargo clippy --all-targets`
- [x] `cargo test --lib --bins -p api service_overloaded` — updated test passes
- [ ] Manual staging verification: with `--max-queued-requests 8` on GLM-5.1 backends, drive >8× concurrent requests at a single backend (e.g. via a single sticky pubkey) and confirm cloud-api returns 529 once retry_with_fallback exhausts every replica, not 503.

## Related

- cvm-compose-files **v0.0.164** — `--max-queued-requests 8` for GLM-5.1 (produces the upstream 503s).
- PR #618 — cache invalidation for the per-org concurrent-limit admin PATCH.
- No conflict with PR #611 (touches `ProviderError` arm of embeddings handler + `extract_error_message`).