### PR TITLE
feat(privacy): add POST /v1/privacy/redact endpoint

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -19,7 +19,7 @@ use crate::{
         billing::{get_billing_costs, BillingRouteState},
         completions::{
             audio_transcriptions, chat_completions, embeddings, image_edits, image_generations,
-            models, privacy_classify, rerank, score,
+            models, privacy_classify, privacy_redact, rerank, score,
         },
         conversations,
         health::health_check,
@@ -1013,6 +1013,12 @@ pub fn build_completion_routes(
         .route(
             "/privacy/classify",
             post(privacy_classify).layer(DefaultBodyLimit::max(PRIVACY_CLASSIFY_MAX_BODY_SIZE)),
+        )
+        // /privacy/redact runs a classify call under the hood, so the same
+        // 256 KB cap applies.
+        .route(
+            "/privacy/redact",
+            post(privacy_redact).layer(DefaultBodyLimit::max(PRIVACY_CLASSIFY_MAX_BODY_SIZE)),
         )
         .layer(DefaultBodyLimit::max(AUDIO_TRANSCRIPTION_MAX_BODY_SIZE))
         .with_state(app_state.clone())

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -50,6 +50,7 @@ use utoipa::{Modify, OpenApi};
         crate::routes::completions::rerank,
         crate::routes::completions::score,
         crate::routes::completions::privacy_classify,
+        crate::routes::completions::privacy_redact,
         // crate::routes::completions::completions,
         crate::routes::completions::models,
         // Model endpoints (public model catalog)

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -3275,6 +3275,24 @@ pub async fn privacy_redact(
             .into_response();
     }
 
+    if let Some(t) = parsed.threshold {
+        // Boundary validation: range-check before forwarding upstream so a
+        // bad value surfaces as a 400 here, not a confusing 5xx from the
+        // model. NaN must be rejected explicitly — `0.0..=1.0` would let
+        // it slip through because all comparisons against NaN are false
+        // (so `!contains` is false too).
+        if t.is_nan() || !(0.0..=1.0).contains(&t) {
+            return (
+                StatusCode::BAD_REQUEST,
+                ResponseJson(ErrorResponse::new(
+                    "threshold must be a number in [0.0, 1.0]".to_string(),
+                    "invalid_request_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    }
+
     let model_name = parsed.model;
 
     debug!(
@@ -3328,11 +3346,17 @@ pub async fn privacy_redact(
     // through: the redact endpoint accepts the same wire shape as classify,
     // but we want a single canonical form (array input) for the upstream
     // call so downstream parsing always yields one data entry per text.
-    let upstream_body = serde_json::json!({
+    //
+    // Threshold passes through verbatim — only include it if the client
+    // sent one. Injecting a default here would diverge from /privacy/classify
+    // (which is a pure passthrough and lets the model pick its own default).
+    let mut upstream_body = serde_json::json!({
         "model": &model_name,
         "input": &texts,
-        "threshold": parsed.threshold.unwrap_or(services::auto_redact::DEFAULT_THRESHOLD_PUBLIC),
     });
+    if let Some(t) = parsed.threshold {
+        upstream_body["threshold"] = serde_json::json!(t);
+    }
     let upstream_bytes = match serde_json::to_vec(&upstream_body) {
         Ok(b) => bytes::Bytes::from(b),
         Err(e) => {
@@ -3408,12 +3432,13 @@ pub async fn privacy_redact(
         }
     };
 
-    // Apply spans locally. Fail-closed: malformed spans return 500 rather
-    // than leak raw text through.
+    // Apply spans locally. `apply_detected_spans` only does in-process work
+    // (JSON parse + UTF-8 boundary checks), so only `Internal` can fire here
+    // — handle every variant uniformly as a 500.
     let redacted = match services::auto_redact::apply_detected_spans(&texts, &response_bytes) {
         Ok(r) => r,
-        Err(AutoRedactError::Internal(msg)) => {
-            tracing::error!(error = %msg, "Privacy redact apply failed");
+        Err(e) => {
+            tracing::error!(error = %e, "Privacy redact apply failed");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ResponseJson(ErrorResponse::new(
@@ -3423,24 +3448,11 @@ pub async fn privacy_redact(
             )
                 .into_response();
         }
-        Err(AutoRedactError::DetectorUnavailable(msg)) => {
-            tracing::error!(error = %msg, "Privacy redact detector unavailable");
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                ResponseJson(ErrorResponse::new(
-                    "PII detector unavailable".to_string(),
-                    "service_unavailable".to_string(),
-                )),
-            )
-                .into_response();
-        }
     };
 
     // Pull per-entry usage from the upstream response (same shape as
     // classify) so we can both bill the org and surface per-entry
-    // input_tokens to the client. Also tracks the maximum data.index
-    // returned by the provider so the anomaly check below can flag any
-    // out-of-range index — defense in depth against a buggy provider.
+    // input_tokens to the client.
     #[derive(serde::Deserialize)]
     struct UsageExtract {
         #[serde(default)]
@@ -3461,18 +3473,26 @@ pub async fn privacy_redact(
     let parsed_usage: UsageExtract =
         serde_json::from_slice(&response_bytes).unwrap_or(UsageExtract { data: Vec::new() });
 
+    // Dedupe by index *before* summing. A buggy provider that returns two
+    // entries with the same `index` would otherwise be billed twice while
+    // the client only sees the last entry's `usage` in the response —
+    // that's a billing/UI inconsistency. Last-write-wins keeps the bill
+    // and the surfaced per-entry usage in sync.
     let mut per_index_usage: std::collections::HashMap<usize, UsageFields> =
         std::collections::HashMap::new();
-    let token_sum_i64: i64 = parsed_usage
-        .data
-        .iter()
-        .filter(|d| d.index < texts.len())
-        .filter_map(|d| d.usage.map(|u| (d.index, u)))
-        .map(|(idx, u)| {
-            per_index_usage.insert(idx, u);
-            u.input_tokens.filter(|t| *t >= 0).unwrap_or(0) as i64
-        })
-        .fold(0i64, i64::saturating_add);
+    for d in &parsed_usage.data {
+        if d.index >= texts.len() {
+            continue;
+        }
+        if let Some(u) = d.usage {
+            per_index_usage.insert(d.index, u);
+        }
+    }
+    let token_sum_i64: i64 = per_index_usage
+        .values()
+        .filter_map(|u| u.input_tokens)
+        .filter(|t| *t >= 0)
+        .fold(0i64, |acc, t| acc.saturating_add(t as i64));
     let mut token_count = token_sum_i64.clamp(0, i32::MAX as i64) as i32;
 
     const MAX_REASONABLE_TOKENS: i32 = 1_000_000;

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -3138,6 +3138,486 @@ pub async fn privacy_classify(
     }
 }
 
+/// Privacy redaction endpoint
+///
+/// Sends each input text through the privacy-filter model and returns it
+/// rewritten with realistic-looking dummies in place of detected PII
+/// (e.g. `redacted1@example.com`, `+1-555-0100`, `Redacted001`). Useful as
+/// a one-shot sanitizer ahead of calling a third-party LLM. The original
+/// PII is **never** echoed back; only the redacted form is returned.
+///
+/// Internally this is a `/v1/privacy/classify` call plus local span-apply
+/// — same billing (one input_tokens charge per input), same concurrency
+/// limits, same model routing.
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+struct PrivacyRedactRequestDoc {
+    /// ID of the model to use for redaction (typically `openai/privacy-filter`).
+    model: String,
+    /// Text or list of texts to redact. Either a string or array of strings.
+    #[serde(default)]
+    input: serde_json::Value,
+    /// Optional minimum confidence score for redacted spans (0.0–1.0).
+    #[serde(default)]
+    threshold: Option<f64>,
+}
+
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+struct PrivacyRedactDataEntryDoc {
+    /// Index of this entry into the input list (matches input order).
+    index: usize,
+    /// Input text rewritten with placeholders in place of detected PII.
+    redacted: String,
+    /// Per-input usage (input_tokens billed for this entry).
+    #[serde(default)]
+    usage: serde_json::Value,
+}
+
+#[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+struct PrivacyRedactResponseDoc {
+    /// Model identifier that produced the redaction.
+    #[serde(default)]
+    model: String,
+    /// Per-input redaction results.
+    data: Vec<PrivacyRedactDataEntryDoc>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/privacy/redact",
+    tag = "Privacy",
+    request_body = PrivacyRedactRequestDoc,
+    responses(
+        (status = 200, description = "Privacy redaction completed successfully", body = PrivacyRedactResponseDoc),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 404, description = "Model not found", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+        (status = 500, description = "Server error", body = ErrorResponse)
+    ),
+    security(
+        ("api_key" = [])
+    )
+)]
+pub async fn privacy_redact(
+    State(app_state): State<AppState>,
+    Extension(api_key): Extension<AuthenticatedApiKey>,
+    Extension(_body_hash): Extension<RequestBodyHash>,
+    headers: header::HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    #[derive(serde::Deserialize)]
+    struct RedactRequest {
+        model: String,
+        #[serde(default)]
+        input: serde_json::Value,
+        #[serde(default)]
+        threshold: Option<f64>,
+    }
+
+    let parsed = match serde_json::from_slice::<RedactRequest>(&body) {
+        Ok(req) => req,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                ResponseJson(ErrorResponse::new(
+                    format!("Invalid request body: {e}"),
+                    "invalid_request_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    // Normalize input into Vec<String>. Accept either a single string or
+    // an array of strings — matches the privacy-filter request shape and
+    // the classify endpoint's behavior.
+    let texts: Vec<String> = match &parsed.input {
+        serde_json::Value::String(s) => vec![s.clone()],
+        serde_json::Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for (i, item) in items.iter().enumerate() {
+                match item.as_str() {
+                    Some(s) => out.push(s.to_string()),
+                    None => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            ResponseJson(ErrorResponse::new(
+                                format!("input[{i}] must be a string"),
+                                "invalid_request_error".to_string(),
+                            )),
+                        )
+                            .into_response();
+                    }
+                }
+            }
+            out
+        }
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                ResponseJson(ErrorResponse::new(
+                    "input must be a string or array of strings".to_string(),
+                    "invalid_request_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    if texts.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "input must not be empty".to_string(),
+                "invalid_request_error".to_string(),
+            )),
+        )
+            .into_response();
+    }
+
+    let model_name = parsed.model;
+
+    debug!(
+        "Privacy redact request: model={}, org={}, workspace={}, n_inputs={}",
+        model_name,
+        api_key.organization.id,
+        api_key.workspace.id.0,
+        texts.len()
+    );
+
+    let model = match app_state
+        .models_service
+        .get_model_by_name(&model_name)
+        .await
+    {
+        Ok(model) => model,
+        Err(services::models::ModelsError::NotFound(_)) => {
+            return (
+                StatusCode::NOT_FOUND,
+                ResponseJson(ErrorResponse::new(
+                    format!("Model '{}' not found", model_name),
+                    "not_found_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to resolve model for privacy redact");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to resolve model".to_string(),
+                    "server_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+    let model_id = model.id;
+    let organization_id = api_key.organization.id.0;
+
+    let encryption_headers = match crate::routes::common::validate_encryption_headers(&headers) {
+        Ok(headers) => headers,
+        Err(err) => return err.into_response(),
+    };
+    let mut extra = std::collections::HashMap::new();
+    insert_encryption_headers(&encryption_headers, &mut extra);
+
+    // Forward a normalized classify request to the upstream model. We
+    // deliberately rebuild the body rather than passing the client body
+    // through: the redact endpoint accepts the same wire shape as classify,
+    // but we want a single canonical form (array input) for the upstream
+    // call so downstream parsing always yields one data entry per text.
+    let upstream_body = serde_json::json!({
+        "model": &model_name,
+        "input": &texts,
+        "threshold": parsed.threshold.unwrap_or(services::auto_redact::DEFAULT_THRESHOLD_PUBLIC),
+    });
+    let upstream_bytes = match serde_json::to_vec(&upstream_body) {
+        Ok(b) => bytes::Bytes::from(b),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to encode upstream redact body");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to encode upstream request".to_string(),
+                    "server_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let response_bytes = match app_state
+        .completion_service
+        .try_privacy_classify(
+            organization_id,
+            model_id,
+            &model_name,
+            upstream_bytes,
+            extra,
+        )
+        .await
+    {
+        Ok(b) => b,
+        Err(e) => {
+            let (status_code, error_type, message) = match e {
+                services::completions::ports::CompletionError::RateLimitExceeded(msg) => {
+                    tracing::warn!("Concurrent request limit exceeded for privacy redact");
+                    (StatusCode::TOO_MANY_REQUESTS, "rate_limit_error", msg)
+                }
+                services::completions::ports::CompletionError::ProviderError {
+                    status_code,
+                    ..
+                } => {
+                    tracing::error!("Privacy redact provider error");
+                    let http_status = StatusCode::from_u16(status_code)
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    (
+                        http_status,
+                        "server_error",
+                        "Privacy redact request failed. Please try again later.".to_string(),
+                    )
+                }
+                services::completions::ports::CompletionError::InvalidModel(msg) => {
+                    tracing::warn!("Privacy redact model not found");
+                    (StatusCode::NOT_FOUND, "not_found_error", msg)
+                }
+                services::completions::ports::CompletionError::ServiceOverloaded(_) => {
+                    tracing::warn!("Privacy redact service overloaded");
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "service_overloaded",
+                        "The service is temporarily overloaded. Please retry with exponential backoff.".to_string(),
+                    )
+                }
+                _ => {
+                    tracing::error!("Unexpected privacy redact error");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Privacy redact request failed".to_string(),
+                    )
+                }
+            };
+            return (
+                status_code,
+                ResponseJson(ErrorResponse::new(message, error_type.to_string())),
+            )
+                .into_response();
+        }
+    };
+
+    // Apply spans locally. Fail-closed: malformed spans return 500 rather
+    // than leak raw text through.
+    let redacted = match services::auto_redact::apply_detected_spans(&texts, &response_bytes) {
+        Ok(r) => r,
+        Err(AutoRedactError::Internal(msg)) => {
+            tracing::error!(error = %msg, "Privacy redact apply failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to apply redactions".to_string(),
+                    "server_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+        Err(AutoRedactError::DetectorUnavailable(msg)) => {
+            tracing::error!(error = %msg, "Privacy redact detector unavailable");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ResponseJson(ErrorResponse::new(
+                    "PII detector unavailable".to_string(),
+                    "service_unavailable".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    // Pull per-entry usage from the upstream response (same shape as
+    // classify) so we can both bill the org and surface per-entry
+    // input_tokens to the client. Also tracks the maximum data.index
+    // returned by the provider so the anomaly check below can flag any
+    // out-of-range index — defense in depth against a buggy provider.
+    #[derive(serde::Deserialize)]
+    struct UsageExtract {
+        #[serde(default)]
+        data: Vec<DataEntry>,
+    }
+    #[derive(serde::Deserialize)]
+    struct DataEntry {
+        #[serde(default)]
+        index: usize,
+        #[serde(default)]
+        usage: Option<UsageFields>,
+    }
+    #[derive(serde::Deserialize, Clone, Copy)]
+    struct UsageFields {
+        input_tokens: Option<i32>,
+    }
+
+    let parsed_usage: UsageExtract =
+        serde_json::from_slice(&response_bytes).unwrap_or(UsageExtract { data: Vec::new() });
+
+    let mut per_index_usage: std::collections::HashMap<usize, UsageFields> =
+        std::collections::HashMap::new();
+    let token_sum_i64: i64 = parsed_usage
+        .data
+        .iter()
+        .filter(|d| d.index < texts.len())
+        .filter_map(|d| d.usage.map(|u| (d.index, u)))
+        .map(|(idx, u)| {
+            per_index_usage.insert(idx, u);
+            u.input_tokens.filter(|t| *t >= 0).unwrap_or(0) as i64
+        })
+        .fold(0i64, i64::saturating_add);
+    let mut token_count = token_sum_i64.clamp(0, i32::MAX as i64) as i32;
+
+    const MAX_REASONABLE_TOKENS: i32 = 1_000_000;
+    let mut token_anomaly_detected = false;
+    if token_count > MAX_REASONABLE_TOKENS {
+        tracing::error!(
+            token_count = token_count,
+            max_expected = MAX_REASONABLE_TOKENS,
+            model = %model_name,
+            organization_id = %organization_id,
+            "Provider returned unreasonable token count for privacy redact - capping"
+        );
+        token_anomaly_detected = true;
+        let model_tag = format!("model:{}", model_name);
+        let reason_tag = format!(
+            "reason:{}",
+            services::metrics::consts::REASON_TOKEN_OVERFLOW
+        );
+        let anomaly_tags = [model_tag.as_str(), reason_tag.as_str()];
+        app_state.metrics_service.record_count(
+            services::metrics::consts::METRIC_PROVIDER_TOKEN_ANOMALIES,
+            1,
+            &anomaly_tags,
+        );
+        token_count = MAX_REASONABLE_TOKENS;
+    }
+    if token_count == 0 {
+        tracing::warn!(
+            model = %model_name,
+            organization_id = %organization_id,
+            "Provider returned zero tokens for privacy redact"
+        );
+        token_anomaly_detected = true;
+        let model_tag = format!("model:{}", model_name);
+        let reason_tag = format!("reason:{}", services::metrics::consts::REASON_MISSING_USAGE);
+        let zero_tokens_tags = [model_tag.as_str(), reason_tag.as_str()];
+        app_state.metrics_service.record_count(
+            services::metrics::consts::METRIC_PROVIDER_ZERO_TOKENS,
+            1,
+            &zero_tokens_tags,
+        );
+    }
+    if token_anomaly_detected {
+        tracing::info!(
+            model = %model_name,
+            organization_id = %organization_id,
+            final_token_count = token_count,
+            "Token count anomaly: Provider data quality issue detected."
+        );
+    }
+
+    let workspace_id = api_key.workspace.id.0;
+    let api_key_id = match Uuid::parse_str(&api_key.api_key.id.0) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!(error = %e, "Invalid API key ID for usage tracking");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to record usage".to_string(),
+                    "server_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let inference_id = uuid::Uuid::new_v4();
+    let usage_request = services::usage::RecordUsageServiceRequest {
+        organization_id,
+        workspace_id,
+        api_key_id,
+        model_id,
+        input_tokens: token_count,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        // Redact reuses the privacy-filter classifier under the hood, so
+        // bill it the same way. If we ever want analytics to distinguish
+        // redact vs classify, add a separate InferenceType variant and a
+        // DB-schema-compatible migration.
+        inference_type: services::usage::ports::InferenceType::PrivacyClassify,
+        ttft_ms: None,
+        avg_itl_ms: None,
+        inference_id: Some(inference_id),
+        provider_request_id: None,
+        stop_reason: Some(services::usage::StopReason::Completed),
+        response_id: None,
+        image_count: None,
+    };
+
+    if let Err(e) = app_state.usage_service.record_usage(usage_request).await {
+        tracing::error!(error = %e, "Failed to record privacy redact usage");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ResponseJson(ErrorResponse::new(
+                "Failed to record usage - please retry".to_string(),
+                "server_error".to_string(),
+            )),
+        )
+            .into_response();
+    }
+
+    let data: Vec<serde_json::Value> = redacted
+        .into_iter()
+        .enumerate()
+        .map(|(idx, redacted_text)| {
+            let usage_json = per_index_usage
+                .get(&idx)
+                .and_then(|u| u.input_tokens)
+                .map(|t| serde_json::json!({ "input_tokens": t }))
+                .unwrap_or_else(|| serde_json::json!({}));
+            serde_json::json!({
+                "index": idx,
+                "redacted": redacted_text,
+                "usage": usage_json,
+            })
+        })
+        .collect();
+
+    let body = serde_json::json!({
+        "model": model_name,
+        "data": data,
+    });
+    let body_bytes = match serde_json::to_vec(&body) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to encode privacy redact response");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to encode response".to_string(),
+                    "server_error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body_bytes))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
 /// Text similarity scoring endpoint
 ///
 /// Scores the similarity between two texts using a scoring/ranking model.

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -39,6 +39,7 @@ mod oauth_frontend_callback;
 mod org_system_prompt;
 mod pagination_validation;
 mod privacy_classify;
+mod privacy_redact;
 mod provider_errors;
 mod repositories;
 mod rerank;

--- a/crates/api/tests/e2e_all/privacy_redact.rs
+++ b/crates/api/tests/e2e_all/privacy_redact.rs
@@ -1,0 +1,320 @@
+//! E2E tests for /v1/privacy/redact
+//!
+//! Mirrors the privacy_classify suite: the MockProvider's
+//! `privacy_classify_raw` does shape-based PII detection (email/SSN/phone),
+//! so we can assert on the redacted output without a live PII model.
+
+use crate::common::*;
+use api::models::{BatchUpdateModelApiRequest, ErrorResponse};
+
+async fn setup_privacy_filter_model(server: &axum_test::TestServer) -> String {
+    let mut batch = BatchUpdateModelApiRequest::new();
+    batch.insert(
+        "openai/privacy-filter".to_string(),
+        serde_json::from_value(serde_json::json!({
+            "inputCostPerToken": {
+                "amount": 1000000,
+                "currency": "USD"
+            },
+            "outputCostPerToken": {
+                "amount": 0,
+                "currency": "USD"
+            },
+            "costPerImage": {
+                "amount": 0,
+                "currency": "USD"
+            },
+            "modelDisplayName": "Privacy Filter",
+            "modelDescription": "PII span detection (token classification)",
+            "contextLength": 512,
+            "verifiable": false,
+            "isActive": true
+        }))
+        .unwrap(),
+    );
+    let updated = admin_batch_upsert_models(server, batch, get_session_id()).await;
+    assert_eq!(updated.len(), 1, "Should have updated 1 model");
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    "openai/privacy-filter".to_string()
+}
+
+#[tokio::test]
+async fn test_privacy_redact_basic_email() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": "Email alice@example.com please"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200, "Privacy redact should succeed");
+
+    let body: serde_json::Value = response.json();
+    let data = body["data"].as_array().expect("data should be array");
+    assert_eq!(data.len(), 1);
+    let redacted = data[0]["redacted"]
+        .as_str()
+        .expect("redacted should be string");
+    assert!(
+        !redacted.contains("alice@example.com"),
+        "Original PII must NOT appear in redacted output: {redacted}"
+    );
+    assert!(
+        redacted.contains("redacted1@example.com"),
+        "Expected category-shaped dummy in redacted output: {redacted}"
+    );
+}
+
+#[tokio::test]
+async fn test_privacy_redact_array_input_preserves_order() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": ["alice@example.com", "no pii here", "bob@example.com"]
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+
+    let body: serde_json::Value = response.json();
+    let data = body["data"].as_array().expect("data should be array");
+    assert_eq!(data.len(), 3);
+    assert_eq!(data[0]["index"].as_u64(), Some(0));
+    assert_eq!(data[1]["index"].as_u64(), Some(1));
+    assert_eq!(data[2]["index"].as_u64(), Some(2));
+
+    let r0 = data[0]["redacted"].as_str().unwrap();
+    let r1 = data[1]["redacted"].as_str().unwrap();
+    let r2 = data[2]["redacted"].as_str().unwrap();
+    assert!(!r0.contains("alice@example.com"));
+    assert_eq!(r1, "no pii here", "Non-PII input passes through unchanged");
+    assert!(!r2.contains("bob@example.com"));
+    // Different originals must produce different dummies.
+    assert_ne!(r0, r2);
+}
+
+#[tokio::test]
+async fn test_privacy_redact_no_pii_passthrough() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": "the quick brown fox"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["data"][0]["redacted"], "the quick brown fox");
+}
+
+#[tokio::test]
+async fn test_privacy_redact_model_not_found() {
+    let server = setup_test_server().await;
+
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "NonExistent/Model",
+            "input": "Hello"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 404);
+    let error: ErrorResponse = response.json();
+    assert!(
+        error.error.message.contains("not found"),
+        "Error message should mention model not found"
+    );
+}
+
+#[tokio::test]
+async fn test_privacy_redact_missing_api_key() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": "Hello"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 401);
+}
+
+#[tokio::test]
+async fn test_privacy_redact_invalid_request_missing_model() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "input": "Hello"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+}
+
+#[tokio::test]
+async fn test_privacy_redact_empty_input_rejected() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": []
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+}
+
+#[tokio::test]
+async fn test_privacy_redact_non_string_array_element_rejected() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": ["ok", 42, "also ok"]
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+}
+
+#[tokio::test]
+async fn test_privacy_redact_body_size_limit() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    // ~300 KB payload, above the 256 KB per-route cap.
+    let oversized_input = "x".repeat(300 * 1024);
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": oversized_input,
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        413,
+        "Should reject body larger than 256 KB cap"
+    );
+}
+
+#[tokio::test]
+async fn test_privacy_redact_costs_deducted() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 100_000_000_000i64).await;
+    let org_id = org.id.clone();
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    let initial_balance_response = server
+        .get(format!("/v1/organizations/{}/usage/balance", org_id).as_str())
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(initial_balance_response.status_code(), 200);
+    let initial_balance = serde_json::from_str::<api::routes::usage::OrganizationBalanceResponse>(
+        &initial_balance_response.text(),
+    )
+    .expect("Failed to parse initial balance");
+    let initial_spent = initial_balance.total_spent;
+
+    let response = server
+        .post("/v1/privacy/redact")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "model": "openai/privacy-filter",
+            "input": "My SSN is 123-45-6789"
+        }))
+        .await;
+    assert_eq!(response.status_code(), 200);
+
+    let final_balance_response = server
+        .get(format!("/v1/organizations/{}/usage/balance", org_id).as_str())
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(final_balance_response.status_code(), 200);
+    let final_balance = serde_json::from_str::<api::routes::usage::OrganizationBalanceResponse>(
+        &final_balance_response.text(),
+    )
+    .expect("Failed to parse final balance");
+
+    // Mock returns usage.input_tokens=10 per entry, price is 1_000_000 USD-9-decimals per token.
+    // One input -> 10 tokens × 1_000_000 = 10_000_000.
+    let delta = final_balance.total_spent - initial_spent;
+    assert_eq!(
+        delta, 10_000_000,
+        "Privacy redact should bill 10 tokens × 1_000_000 = 10_000_000",
+    );
+}

--- a/crates/api/tests/e2e_all/privacy_redact.rs
+++ b/crates/api/tests/e2e_all/privacy_redact.rs
@@ -240,6 +240,60 @@ async fn test_privacy_redact_non_string_array_element_rejected() {
 }
 
 #[tokio::test]
+async fn test_privacy_redact_rejects_out_of_range_threshold() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    for bad in [-0.1, 1.5, f64::NAN] {
+        let response = server
+            .post("/v1/privacy/redact")
+            .add_header("Authorization", format!("Bearer {api_key}"))
+            .add_header("User-Agent", MOCK_USER_AGENT)
+            .json(&serde_json::json!({
+                "model": "openai/privacy-filter",
+                "input": "hi",
+                "threshold": bad,
+            }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            400,
+            "threshold={bad:?} should be rejected",
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_privacy_redact_accepts_valid_threshold() {
+    let server = setup_test_server().await;
+
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    for good in [0.0, 0.5, 1.0] {
+        let response = server
+            .post("/v1/privacy/redact")
+            .add_header("Authorization", format!("Bearer {api_key}"))
+            .add_header("User-Agent", MOCK_USER_AGENT)
+            .json(&serde_json::json!({
+                "model": "openai/privacy-filter",
+                "input": "hi",
+                "threshold": good,
+            }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            200,
+            "threshold={good} should be accepted",
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_privacy_redact_body_size_limit() {
     let server = setup_test_server().await;
 

--- a/crates/services/src/auto_redact/detect.rs
+++ b/crates/services/src/auto_redact/detect.rs
@@ -87,7 +87,10 @@ struct RawSpan {
     end: usize,
 }
 
-fn parse_response(bytes: &[u8], expected_len: usize) -> Result<Vec<Vec<Span>>, AutoRedactError> {
+pub(super) fn parse_response(
+    bytes: &[u8],
+    expected_len: usize,
+) -> Result<Vec<Vec<Span>>, AutoRedactError> {
     let parsed: DetectResponse = serde_json::from_slice(bytes)
         .map_err(|e| AutoRedactError::Internal(format!("decode detect resp: {e}")))?;
 

--- a/crates/services/src/auto_redact/mod.rs
+++ b/crates/services/src/auto_redact/mod.rs
@@ -28,11 +28,6 @@ pub use apply::TextRef;
 pub use placeholders::{RedactionMap, MAX_PLACEHOLDER_LEN};
 pub use stream_unredact::StreamUnredact;
 
-/// Default minimum confidence score for spans the privacy-filter returns.
-/// Re-exported so the `/v1/privacy/redact` handler can fill in the same
-/// threshold the auto-redact path uses when the client omits it.
-pub const DEFAULT_THRESHOLD_PUBLIC: f64 = detect::DEFAULT_THRESHOLD;
-
 use crate::completions::ports::CompletionMessage;
 use crate::inference_provider_pool::InferenceProviderPool;
 

--- a/crates/services/src/auto_redact/mod.rs
+++ b/crates/services/src/auto_redact/mod.rs
@@ -28,6 +28,11 @@ pub use apply::TextRef;
 pub use placeholders::{RedactionMap, MAX_PLACEHOLDER_LEN};
 pub use stream_unredact::StreamUnredact;
 
+/// Default minimum confidence score for spans the privacy-filter returns.
+/// Re-exported so the `/v1/privacy/redact` handler can fill in the same
+/// threshold the auto-redact path uses when the client omits it.
+pub const DEFAULT_THRESHOLD_PUBLIC: f64 = detect::DEFAULT_THRESHOLD;
+
 use crate::completions::ports::CompletionMessage;
 use crate::inference_provider_pool::InferenceProviderPool;
 
@@ -154,6 +159,32 @@ async fn redact_messages_inner(
     }
     apply::write_back(messages, &refs, redacted);
     Ok(map)
+}
+
+/// Apply privacy-filter spans (parsed from a raw classify response) to a
+/// batch of texts. Returns one redacted string per input text, in the
+/// same order. Used by the `/v1/privacy/redact` endpoint after a passthrough
+/// classify call: the handler already has the response bytes for billing,
+/// and this function consumes them to perform the redaction locally.
+///
+/// Fails closed (returns `AutoRedactError::Internal`) on malformed spans
+/// or non-UTF-8 boundaries, so the caller must surface 5xx rather than
+/// pass the raw text through.
+pub fn apply_detected_spans(
+    texts: &[String],
+    response_bytes: &[u8],
+) -> Result<Vec<String>, AutoRedactError> {
+    let spans_per_text = detect::parse_response(response_bytes, texts.len())?;
+    let mut map = RedactionMap::new();
+    // Same haystack rule as redact_messages_inner: a minted dummy must
+    // not appear in any input fragment, so substring substitution stays
+    // unambiguous.
+    let haystack: String = texts.join("\u{0001}");
+    let mut out = Vec::with_capacity(texts.len());
+    for (text, spans) in texts.iter().zip(spans_per_text.iter()) {
+        out.push(apply::redact_one(text, spans, &mut map, &haystack)?);
+    }
+    Ok(out)
 }
 
 /// Strip the `auto_redact` field from a `ServiceCompletionRequest.extra`


### PR DESCRIPTION
## Summary

Adds `POST /v1/privacy/redact`: a one-shot text sanitizer that runs the privacy-filter and returns each input rewritten with realistic-looking dummies in place of detected PII. The original PII is **never echoed back** — only the redacted form. Useful as a pre-step before sending prompts to a third-party LLM.

## Request / response

Request mirrors `/v1/privacy/classify`:

```json
POST /v1/privacy/redact
{
  "model": "openai/privacy-filter",
  "input": "Email alice@example.com please",
  "threshold": 0.5
}
```

Response is redacted text only — no original PII, no spans:

```json
{
  "model": "openai/privacy-filter",
  "data": [
    { "index": 0, "redacted": "Email redacted1@example.com please", "usage": { "input_tokens": 10 } }
  ]
}
```

`input` accepts either a string or an array of strings; the array case preserves order.

## How it works

1. Handler parses body, normalizes `input` to `Vec<String>`.
2. Calls `try_privacy_classify` against the same `openai/privacy-filter` model — inherits concurrency limit, error mapping, and provider routing for free.
3. Parses the upstream span response and applies redactions locally via the new `auto_redact::apply_detected_spans` helper (reuses `redact_one` + `RedactionMap`).
4. Records usage under `InferenceType::PrivacyClassify` since the billable inference call is identical (one input_tokens charge per input). If we ever want to distinguish redact-vs-classify in analytics, we can add a new variant + migration later.
5. Returns `data[*].redacted` + per-entry `usage.input_tokens`.

## Fail-closed behavior

- Malformed spans / non-UTF-8 boundaries from the upstream → 500, never pass the raw text through.
- Detector unreachable → 503.
- Same anomaly checks as classify (zero-tokens warning, max-tokens cap).

## Stacking

Based on `feat/auto-redact-natural-placeholders` (#599) because the endpoint relies on:
- `redact_one(text, spans, map, haystack)` (4-arg form with haystack collision avoidance)
- Realistic-dummy `RedactionMap::lookup_or_mint` with `would_collide` closure

Once #599 lands on main, I'll rebase this onto main.

## Test plan

- [x] `cargo build -p api` clean
- [x] `cargo clippy -p api -p services --tests` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p services auto_redact` — 47/47 pass
- [ ] E2E tests (need Postgres; will run in CI): basic email, array order preservation, no-PII passthrough, 404 unknown model, 401 missing key, 400 missing model / empty input / non-string element, 413 body cap, billing parity with classify