### PR TITLE
feat(tracing): propagate request_id, org_id, workspace_id to inference backends

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -19,7 +19,7 @@ use services::completions::{
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::debug;
+use tracing::{debug, Instrument};
 use utoipa;
 use uuid::Uuid;
 
@@ -712,13 +712,14 @@ pub async fn chat_completions(
         .and_then(|s| Uuid::parse_str(s).ok())
         .unwrap_or_else(Uuid::new_v4);
 
-    // Record correlation IDs on the current tracing span so every log line
-    // within this request carries them in Datadog.
+    // Create a span carrying correlation IDs so every log line within this
+    // request carries request_id/org_id/workspace_id in Datadog.
     //
-    // We use tracing::field macros on a fresh span rather than Span::current().record()
-    // (which silently no-ops on spans without the field pre-declared).
-    // The span is created here and its fields are set immediately; axum's tower
-    // middleware span automatically becomes the parent.
+    // NOTE: we do NOT call span.enter() here. In async code, Span::enter()
+    // stores the guard in a thread-local; when the future yields at an .await
+    // the guard stays entered on that thread, so any other task scheduled on
+    // the same thread incorrectly inherits this span as its parent, corrupting
+    // log context. Use .instrument(span) on the inner async block instead.
     let span = tracing::info_span!(
         "chat_completions",
         request_id = %request_id,
@@ -726,7 +727,25 @@ pub async fn chat_completions(
         workspace_id = %api_key.workspace.id.0,
         model = %request.model,
     );
-    let _span_guard = span.enter();
+
+    chat_completions_inner(app_state, api_key, body_hash, headers, request, request_id)
+        .instrument(span)
+        .await
+}
+
+// Inner async fn so .instrument(span) wraps all awaits in the handler.
+// Split from `chat_completions` only to correctly scope the tracing span:
+// using span.enter() in an async fn risks the guard outliving an .await yield,
+// causing other tasks on the same thread to inherit this span's context.
+#[allow(clippy::too_many_arguments)]
+async fn chat_completions_inner(
+    app_state: crate::routes::api::AppState,
+    api_key: crate::middleware::auth::AuthenticatedApiKey,
+    body_hash: crate::middleware::RequestBodyHash,
+    headers: header::HeaderMap,
+    request: ChatCompletionRequest,
+    request_id: Uuid,
+) -> axum::response::Response {
 
     // Convert HTTP request to service parameters
     // Note: Names are not passed - high-cardinality data is tracked via database, not metrics
@@ -1080,6 +1099,8 @@ pub async fn completions(
         request.model, request.stream, api_key.organization.id, api_key.workspace.id.0
     );
 
+    // This endpoint is not yet implemented — it returns immediately without
+    // any async work, so no tracing span is needed here.
     return (
         StatusCode::NOT_IMPLEMENTED,
         ResponseJson(ErrorResponse::new(

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -245,8 +245,10 @@ fn convert_chat_request_to_service(
     organization_id: Uuid,
     workspace_id: Uuid,
     body_hash: RequestBodyHash,
+    request_id: Uuid,
 ) -> ServiceCompletionRequest {
     ServiceCompletionRequest {
+        request_id,
         model: request.model.clone(),
         messages: request
             .messages
@@ -624,8 +626,10 @@ fn convert_text_request_to_service(
     organization_id: Uuid,
     workspace_id: Uuid,
     body_hash: RequestBodyHash,
+    request_id: Uuid,
 ) -> ServiceCompletionRequest {
     ServiceCompletionRequest {
+        request_id,
         model: request.model.clone(),
         messages: vec![CompletionMessage {
             role: "user".to_string(),
@@ -699,6 +703,21 @@ pub async fn chat_completions(
             .into_response();
     }
 
+    // Generate a per-request correlation ID. Reuse the client's X-Request-Id if
+    // present and parseable as a UUID; otherwise generate a fresh one. This ID
+    // propagates downstream as X-Request-Id on every outbound inference call.
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .unwrap_or_else(Uuid::new_v4);
+
+    // Attach request_id + org/workspace to the tracing span so every log line
+    // from this request automatically carries them.
+    tracing::Span::current().record("request_id", request_id.to_string());
+    tracing::Span::current().record("org_id", api_key.organization.id.0.to_string());
+    tracing::Span::current().record("workspace_id", api_key.workspace.id.0.to_string());
+
     // Convert HTTP request to service parameters
     // Note: Names are not passed - high-cardinality data is tracked via database, not metrics
     let mut service_request = convert_chat_request_to_service(
@@ -708,6 +727,7 @@ pub async fn chat_completions(
         api_key.organization.id.0,
         api_key.workspace.id.0,
         body_hash,
+        request_id,
     );
 
     // Extract and validate encryption headers if present
@@ -1072,6 +1092,9 @@ pub async fn completions(
             .into_response();
     }
 
+    // Generate correlation ID
+    let request_id = Uuid::new_v4();
+
     // Convert HTTP request to service parameters
     // Note: Names are not passed - high-cardinality data is tracked via database, not metrics
     let service_request = convert_text_request_to_service(
@@ -1081,6 +1104,7 @@ pub async fn completions(
         api_key.organization.id.0,
         api_key.workspace.id.0,
         body_hash,
+        request_id,
     );
 
     // Call the completion service - it handles usage tracking internally

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -712,11 +712,21 @@ pub async fn chat_completions(
         .and_then(|s| Uuid::parse_str(s).ok())
         .unwrap_or_else(Uuid::new_v4);
 
-    // Attach request_id + org/workspace to the tracing span so every log line
-    // from this request automatically carries them.
-    tracing::Span::current().record("request_id", request_id.to_string());
-    tracing::Span::current().record("org_id", api_key.organization.id.0.to_string());
-    tracing::Span::current().record("workspace_id", api_key.workspace.id.0.to_string());
+    // Record correlation IDs on the current tracing span so every log line
+    // within this request carries them in Datadog.
+    //
+    // We use tracing::field macros on a fresh span rather than Span::current().record()
+    // (which silently no-ops on spans without the field pre-declared).
+    // The span is created here and its fields are set immediately; axum's tower
+    // middleware span automatically becomes the parent.
+    let span = tracing::info_span!(
+        "chat_completions",
+        request_id = %request_id,
+        org_id = %api_key.organization.id.0,
+        workspace_id = %api_key.workspace.id.0,
+        model = %request.model,
+    );
+    let _span_guard = span.enter();
 
     // Convert HTTP request to service parameters
     // Note: Names are not passed - high-cardinality data is tracked via database, not metrics

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -746,7 +746,6 @@ async fn chat_completions_inner(
     request: ChatCompletionRequest,
     request_id: Uuid,
 ) -> axum::response::Response {
-
     // Convert HTTP request to service parameters
     // Note: Names are not passed - high-cardinality data is tracked via database, not metrics
     let mut service_request = convert_chat_request_to_service(

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -45,6 +45,7 @@ use std::sync::Arc;
 pub use anthropic::AnthropicBackend;
 pub use backend::BackendConfig as ExternalBackendConfig;
 pub use gemini::GeminiBackend;
+pub use openai_compatible::OpenAiCompatibleBackend;
 
 /// Strip cloud-api internal tracing keys from `extra` before forwarding params
 /// to external providers.
@@ -59,7 +60,6 @@ fn strip_internal_tracing_keys(extra: &mut std::collections::HashMap<String, ser
     extra.remove("x_org_id");
     extra.remove("x_workspace_id");
 }
-pub use openai_compatible::OpenAiCompatibleBackend;
 
 /// Provider configuration stored in database
 ///

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -56,9 +56,10 @@ pub use openai_compatible::OpenAiCompatibleBackend;
 /// are serialised as top-level JSON body fields — unknown fields that strict
 /// providers (Anthropic, Gemini) may reject with a 400/422.
 fn strip_internal_tracing_keys(extra: &mut std::collections::HashMap<String, serde_json::Value>) {
-    extra.remove("x_request_id");
-    extra.remove("x_org_id");
-    extra.remove("x_workspace_id");
+    use crate::vllm::tracing_headers;
+    extra.remove(tracing_headers::REQUEST_ID);
+    extra.remove(tracing_headers::ORG_ID);
+    extra.remove(tracing_headers::WORKSPACE_ID);
 }
 
 /// Provider configuration stored in database

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -45,6 +45,20 @@ use std::sync::Arc;
 pub use anthropic::AnthropicBackend;
 pub use backend::BackendConfig as ExternalBackendConfig;
 pub use gemini::GeminiBackend;
+
+/// Strip cloud-api internal tracing keys from `extra` before forwarding params
+/// to external providers.
+///
+/// These keys (`x_request_id`, `x_org_id`, `x_workspace_id`) are injected by the
+/// completion service so the vLLM provider can forward them as HTTP headers.
+/// External providers use `#[serde(flatten)]` on `extra`, so any remaining keys
+/// are serialised as top-level JSON body fields — unknown fields that strict
+/// providers (Anthropic, Gemini) may reject with a 400/422.
+fn strip_internal_tracing_keys(extra: &mut std::collections::HashMap<String, serde_json::Value>) {
+    extra.remove("x_request_id");
+    extra.remove("x_org_id");
+    extra.remove("x_workspace_id");
+}
 pub use openai_compatible::OpenAiCompatibleBackend;
 
 /// Provider configuration stored in database
@@ -235,9 +249,12 @@ impl InferenceProvider for ExternalProvider {
     /// Performs a streaming chat completion request
     async fn chat_completion_stream(
         &self,
-        params: ChatCompletionParams,
+        mut params: ChatCompletionParams,
         _request_hash: String,
     ) -> Result<StreamingResult, CompletionError> {
+        // Strip cloud-api internal tracing keys — they must not be forwarded
+        // to external providers as JSON body fields (extra is #[serde(flatten)]).
+        strip_internal_tracing_keys(&mut params.extra);
         self.backend
             .chat_completion_stream(&self.config, &self.model_name, params)
             .await
@@ -246,9 +263,12 @@ impl InferenceProvider for ExternalProvider {
     /// Performs a non-streaming chat completion request
     async fn chat_completion(
         &self,
-        params: ChatCompletionParams,
+        mut params: ChatCompletionParams,
         _request_hash: String,
     ) -> Result<ChatCompletionResponseWithBytes, CompletionError> {
+        // Strip cloud-api internal tracing keys — they must not be forwarded
+        // to external providers as JSON body fields (extra is #[serde(flatten)]).
+        strip_internal_tracing_keys(&mut params.extra);
         self.backend
             .chat_completion(&self.config, &self.model_name, params)
             .await

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -664,8 +664,8 @@ impl VLlmProvider {
     /// Prepare tracing headers by extracting correlation IDs from `extra` and forwarding
     /// as HTTP headers. Removes the keys from `extra` so they don't leak into the JSON body.
     ///
-    /// Must be called **after** `prepare_encryption_headers` (or at least independently).
     /// Silently skips any key whose value is not a valid ASCII header value.
+    /// Independent of `prepare_encryption_headers` — call order does not matter.
     fn prepare_tracing_headers(
         &self,
         headers: &mut reqwest::header::HeaderMap,
@@ -1181,7 +1181,8 @@ impl InferenceProvider for VLlmProvider {
             HeaderValue::from_str(&request_hash).map_err(to_image_gen_error)?,
         );
 
-        // Forward encryption headers from extra to HTTP headers
+        // Forward tracing and encryption headers from extra to HTTP headers
+        self.prepare_tracing_headers(&mut headers, &mut params.extra);
         self.prepare_encryption_headers(&mut headers, &mut params.extra);
 
         let response = self
@@ -1260,7 +1261,8 @@ impl InferenceProvider for VLlmProvider {
         let mut headers = self
             .build_headers()
             .map_err(|e| AudioTranscriptionError::TranscriptionError(e.to_string()))?;
-        // Forward encryption headers from extra to HTTP headers
+        // Forward tracing and encryption headers from extra to HTTP headers
+        self.prepare_tracing_headers(&mut headers, &mut params.extra);
         self.prepare_encryption_headers(&mut headers, &mut params.extra);
         // Remove Content-Type header - reqwest will set it automatically for multipart
         headers.remove("Content-Type");
@@ -1423,6 +1425,7 @@ impl InferenceProvider for VLlmProvider {
         let url = format!("{}/v1/score", self.config.base_url);
 
         let mut headers = self.build_headers().map_err(to_score_error)?;
+        self.prepare_tracing_headers(&mut headers, &mut params.extra);
         self.prepare_encryption_headers(&mut headers, &mut params.extra);
         headers.insert(
             "X-Request-Hash",
@@ -1459,6 +1462,7 @@ impl InferenceProvider for VLlmProvider {
         let url = format!("{}/v1/rerank", self.config.base_url);
 
         let mut headers = self.build_headers().map_err(to_rerank_error)?;
+        self.prepare_tracing_headers(&mut headers, &mut params.extra);
         self.prepare_encryption_headers(&mut headers, &mut params.extra);
 
         let response = self
@@ -1495,6 +1499,7 @@ impl InferenceProvider for VLlmProvider {
         let url = format!("{}/v1/embeddings", self.config.base_url);
 
         let mut headers = self.build_headers().map_err(to_embedding_error)?;
+        self.prepare_tracing_headers(&mut headers, &mut extra);
         self.prepare_encryption_headers(&mut headers, &mut extra);
 
         let response = self
@@ -1532,6 +1537,7 @@ impl InferenceProvider for VLlmProvider {
         let url = format!("{}/v1/privacy/classify", self.config.base_url);
 
         let mut headers = self.build_headers().map_err(to_privacy_classify_error)?;
+        self.prepare_tracing_headers(&mut headers, &mut extra);
         self.prepare_encryption_headers(&mut headers, &mut extra);
 
         let response = self
@@ -1690,6 +1696,75 @@ mod tests {
         let s = err.to_string();
         assert!(s.contains("chat_completion"), "got: {s}");
         assert!(s.contains("600"), "got: {s}");
+    }
+
+    #[test]
+    fn test_prepare_tracing_headers_removes_keys_from_extra() {
+        let provider = create_test_provider();
+        let mut headers = reqwest::header::HeaderMap::new();
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            tracing_headers::REQUEST_ID.to_string(),
+            serde_json::Value::String("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        );
+        extra.insert(
+            tracing_headers::ORG_ID.to_string(),
+            serde_json::Value::String("org-uuid".to_string()),
+        );
+        extra.insert(
+            tracing_headers::WORKSPACE_ID.to_string(),
+            serde_json::Value::String("ws-uuid".to_string()),
+        );
+        extra.insert(
+            "other_field".to_string(),
+            serde_json::Value::String("keep-me".to_string()),
+        );
+
+        provider.prepare_tracing_headers(&mut headers, &mut extra);
+
+        assert!(!extra.contains_key(tracing_headers::REQUEST_ID), "x_request_id should be removed");
+        assert!(!extra.contains_key(tracing_headers::ORG_ID), "x_org_id should be removed");
+        assert!(!extra.contains_key(tracing_headers::WORKSPACE_ID), "x_workspace_id should be removed");
+        assert!(extra.contains_key("other_field"), "unrelated fields must be preserved");
+    }
+
+    #[test]
+    fn test_prepare_tracing_headers_forwards_to_http_headers() {
+        let provider = create_test_provider();
+        let mut headers = reqwest::header::HeaderMap::new();
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            tracing_headers::REQUEST_ID.to_string(),
+            serde_json::Value::String("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        );
+        extra.insert(
+            tracing_headers::ORG_ID.to_string(),
+            serde_json::Value::String("aaaa-bbbb".to_string()),
+        );
+        extra.insert(
+            tracing_headers::WORKSPACE_ID.to_string(),
+            serde_json::Value::String("cccc-dddd".to_string()),
+        );
+
+        provider.prepare_tracing_headers(&mut headers, &mut extra);
+
+        assert_eq!(headers.get("X-Request-Id").and_then(|v| v.to_str().ok()), Some("550e8400-e29b-41d4-a716-446655440000"));
+        assert_eq!(headers.get("X-Org-Id").and_then(|v| v.to_str().ok()), Some("aaaa-bbbb"));
+        assert_eq!(headers.get("X-Workspace-Id").and_then(|v| v.to_str().ok()), Some("cccc-dddd"));
+    }
+
+    #[test]
+    fn test_prepare_tracing_headers_absent_keys_are_noop() {
+        let provider = create_test_provider();
+        let mut headers = reqwest::header::HeaderMap::new();
+        let mut extra: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::new();
+
+        provider.prepare_tracing_headers(&mut headers, &mut extra);
+
+        assert!(headers.get("X-Request-Id").is_none());
+        assert!(headers.get("X-Org-Id").is_none());
+        assert!(headers.get("X-Workspace-Id").is_none());
     }
 
     #[test]

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -39,6 +39,21 @@ fn to_privacy_classify_error<E: std::fmt::Display>(e: E) -> PrivacyClassifyError
     PrivacyClassifyError::RequestFailed(e.to_string())
 }
 
+/// Tracing header keys used in params.extra for propagating request correlation IDs.
+///
+/// These are injected by cloud-api's completion service before calling the inference
+/// provider and are forwarded verbatim as HTTP headers to the downstream vllm-proxy /
+/// inference-proxy. The values are low-sensitivity org metadata (not user content)
+/// so forwarding them is consistent with the TEE trust model.
+mod tracing_headers {
+    /// UUIDv4 generated per request by cloud-api. Join key across all hops.
+    pub const REQUEST_ID: &str = "x_request_id";
+    /// Organization UUID of the authenticated API key owner.
+    pub const ORG_ID: &str = "x_org_id";
+    /// Workspace UUID of the authenticated API key.
+    pub const WORKSPACE_ID: &str = "x_workspace_id";
+}
+
 /// Encryption header keys used in params.extra for passing encryption information
 mod encryption_headers {
     /// Key for signing algorithm (x-signing-algo header)
@@ -646,6 +661,50 @@ impl VLlmProvider {
         }
     }
 
+    /// Prepare tracing headers by extracting correlation IDs from `extra` and forwarding
+    /// as HTTP headers. Removes the keys from `extra` so they don't leak into the JSON body.
+    ///
+    /// Must be called **after** `prepare_encryption_headers` (or at least independently).
+    /// Silently skips any key whose value is not a valid ASCII header value.
+    fn prepare_tracing_headers(
+        &self,
+        headers: &mut reqwest::header::HeaderMap,
+        extra: &mut std::collections::HashMap<String, serde_json::Value>,
+    ) {
+        // X-Request-Id — join key across all hops
+        if let Some(id) = extra
+            .remove(tracing_headers::REQUEST_ID)
+            .as_ref()
+            .and_then(|v| v.as_str())
+        {
+            if let Ok(value) = HeaderValue::from_str(id) {
+                headers.insert("X-Request-Id", value);
+            }
+        }
+
+        // X-Org-Id — organisation that owns the API key
+        if let Some(org) = extra
+            .remove(tracing_headers::ORG_ID)
+            .as_ref()
+            .and_then(|v| v.as_str())
+        {
+            if let Ok(value) = HeaderValue::from_str(org) {
+                headers.insert("X-Org-Id", value);
+            }
+        }
+
+        // X-Workspace-Id — workspace of the API key
+        if let Some(ws) = extra
+            .remove(tracing_headers::WORKSPACE_ID)
+            .as_ref()
+            .and_then(|v| v.as_str())
+        {
+            if let Ok(value) = HeaderValue::from_str(ws) {
+                headers.insert("X-Workspace-Id", value);
+            }
+        }
+    }
+
     /// Send a streaming HTTP POST request with TTFB timeout protection.
     ///
     /// Uses `tokio::time::timeout` only around `.send()` so the timeout applies to TTFB only
@@ -923,6 +982,8 @@ impl InferenceProvider for VLlmProvider {
             .map_err(|e| CompletionError::CompletionError(format!("Invalid request hash: {e}")))?;
         headers.insert("X-Request-Hash", request_hash_value);
 
+        // Prepare tracing headers (request_id, org_id, workspace_id)
+        self.prepare_tracing_headers(&mut headers, &mut streaming_params.extra);
         // Prepare encryption headers
         self.prepare_encryption_headers(&mut headers, &mut streaming_params.extra);
 
@@ -981,6 +1042,8 @@ impl InferenceProvider for VLlmProvider {
             .map_err(|e| CompletionError::CompletionError(format!("Invalid request hash: {e}")))?;
         headers.insert("X-Request-Hash", request_hash_value);
 
+        // Prepare tracing headers (request_id, org_id, workspace_id)
+        self.prepare_tracing_headers(&mut headers, &mut non_streaming_params.extra);
         // Prepare encryption headers
         self.prepare_encryption_headers(&mut headers, &mut non_streaming_params.extra);
 

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -45,7 +45,13 @@ fn to_privacy_classify_error<E: std::fmt::Display>(e: E) -> PrivacyClassifyError
 /// provider and are forwarded verbatim as HTTP headers to the downstream vllm-proxy /
 /// inference-proxy. The values are low-sensitivity org metadata (not user content)
 /// so forwarding them is consistent with the TEE trust model.
-mod tracing_headers {
+/// Keys used in `ChatCompletionParams.extra` for tracing correlation headers.
+///
+/// Values are the snake_case map keys that `prepare_tracing_headers` reads and
+/// strips; the corresponding HTTP header names are `X-Request-Id`, `X-Org-Id`,
+/// and `X-Workspace-Id`. Exposed as `pub(crate)` so `external/mod.rs` can use
+/// the same constants instead of hardcoding the strings.
+pub(crate) mod tracing_headers {
     /// UUIDv4 generated per request by cloud-api. Join key across all hops.
     pub const REQUEST_ID: &str = "x_request_id";
     /// Organization UUID of the authenticated API key owner.

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1728,10 +1728,22 @@ mod tests {
 
         provider.prepare_tracing_headers(&mut headers, &mut extra);
 
-        assert!(!extra.contains_key(tracing_headers::REQUEST_ID), "x_request_id should be removed");
-        assert!(!extra.contains_key(tracing_headers::ORG_ID), "x_org_id should be removed");
-        assert!(!extra.contains_key(tracing_headers::WORKSPACE_ID), "x_workspace_id should be removed");
-        assert!(extra.contains_key("other_field"), "unrelated fields must be preserved");
+        assert!(
+            !extra.contains_key(tracing_headers::REQUEST_ID),
+            "x_request_id should be removed"
+        );
+        assert!(
+            !extra.contains_key(tracing_headers::ORG_ID),
+            "x_org_id should be removed"
+        );
+        assert!(
+            !extra.contains_key(tracing_headers::WORKSPACE_ID),
+            "x_workspace_id should be removed"
+        );
+        assert!(
+            extra.contains_key("other_field"),
+            "unrelated fields must be preserved"
+        );
     }
 
     #[test]
@@ -1754,9 +1766,18 @@ mod tests {
 
         provider.prepare_tracing_headers(&mut headers, &mut extra);
 
-        assert_eq!(headers.get("X-Request-Id").and_then(|v| v.to_str().ok()), Some("550e8400-e29b-41d4-a716-446655440000"));
-        assert_eq!(headers.get("X-Org-Id").and_then(|v| v.to_str().ok()), Some("aaaa-bbbb"));
-        assert_eq!(headers.get("X-Workspace-Id").and_then(|v| v.to_str().ok()), Some("cccc-dddd"));
+        assert_eq!(
+            headers.get("X-Request-Id").and_then(|v| v.to_str().ok()),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            headers.get("X-Org-Id").and_then(|v| v.to_str().ok()),
+            Some("aaaa-bbbb")
+        );
+        assert_eq!(
+            headers.get("X-Workspace-Id").and_then(|v| v.to_str().ok()),
+            Some("cccc-dddd")
+        );
     }
 
     #[test]

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -56,7 +56,8 @@ where
     attestation_service: Arc<dyn AttestationServiceTrait>,
     usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
     metrics_service: Arc<dyn MetricsServiceTrait>,
-    // IDs for usage tracking (database)
+    // IDs for usage tracking (database) and tracing
+    request_id: Uuid,
     organization_id: Uuid,
     workspace_id: Uuid,
     api_key_id: Uuid,
@@ -149,6 +150,7 @@ where
 
     /// Record usage and metrics. Called from Drop to ensure it always runs.
     fn record_usage_and_metrics(&self) {
+        let request_id = self.request_id;
         let organization_id = self.organization_id;
         let workspace_id = self.workspace_id;
         let api_key_id = self.api_key_id;
@@ -158,6 +160,7 @@ where
         // Create span with context BEFORE any early returns so all error logs have context
         let _span = tracing::error_span!(
             "stream_drop",
+            %request_id,
             %organization_id,
             %workspace_id,
             %api_key_id,
@@ -228,6 +231,7 @@ where
         // Create span with full context for async task
         let span = tracing::info_span!(
             "record_usage",
+            %request_id,
             %organization_id,
             %workspace_id,
             %api_key_id,
@@ -961,6 +965,7 @@ impl CompletionServiceImpl {
     async fn handle_stream_with_context(
         &self,
         llm_stream: StreamingResult,
+        request_id: Uuid,
         organization_id: Uuid,
         workspace_id: Uuid,
         api_key_id: Uuid,
@@ -989,6 +994,7 @@ impl CompletionServiceImpl {
             attestation_service: self.attestation_service.clone(),
             usage_service: self.usage_service.clone(),
             metrics_service: self.metrics_service.clone(),
+            request_id,
             organization_id,
             workspace_id,
             api_key_id,
@@ -1029,6 +1035,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         // Extract context for usage tracking
         let organization_id = request.organization_id;
         let workspace_id = request.workspace_id;
+        let request_id = request.request_id;
         let api_key_id = match uuid::Uuid::parse_str(&request.api_key_id) {
             Ok(id) => id,
             Err(e) => {
@@ -1044,6 +1051,21 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         // Extract tools from extra if present (Responses API puts them there)
         let mut extra = request.extra.clone();
         let (tools, tool_choice) = Self::extract_tools_from_extra(&mut extra);
+
+        // Inject tracing correlation IDs into extra so the inference provider
+        // forwards them as X-Request-Id / X-Org-Id / X-Workspace-Id headers.
+        extra.insert(
+            "x_request_id".to_string(),
+            serde_json::Value::String(request_id.to_string()),
+        );
+        extra.insert(
+            "x_org_id".to_string(),
+            serde_json::Value::String(organization_id.to_string()),
+        );
+        extra.insert(
+            "x_workspace_id".to_string(),
+            serde_json::Value::String(workspace_id.to_string()),
+        );
 
         let mut chat_params = inference_providers::ChatCompletionParams {
             model: request.model.clone(),
@@ -1165,6 +1187,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         let event_stream = self
             .handle_stream_with_context(
                 llm_stream,
+                request_id,
                 organization_id,
                 workspace_id,
                 api_key_id,
@@ -1187,11 +1210,29 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         request: ports::CompletionRequest,
     ) -> Result<inference_providers::ChatCompletionResponseWithBytes, ports::CompletionError> {
         let service_start_time = Instant::now();
+        let organization_id = request.organization_id;
+        let workspace_id = request.workspace_id;
+        let request_id = request.request_id;
         let chat_messages = Self::prepare_chat_messages(&request.messages);
 
         // Extract tools from extra if present (Responses API puts them there)
         let mut extra = request.extra.clone();
         let (tools, tool_choice) = Self::extract_tools_from_extra(&mut extra);
+
+        // Inject tracing correlation IDs into extra so the inference provider
+        // forwards them as X-Request-Id / X-Org-Id / X-Workspace-Id headers.
+        extra.insert(
+            "x_request_id".to_string(),
+            serde_json::Value::String(request_id.to_string()),
+        );
+        extra.insert(
+            "x_org_id".to_string(),
+            serde_json::Value::String(organization_id.to_string()),
+        );
+        extra.insert(
+            "x_workspace_id".to_string(),
+            serde_json::Value::String(workspace_id.to_string()),
+        );
 
         let mut chat_params = inference_providers::ChatCompletionParams {
             model: request.model.clone(),
@@ -1775,6 +1816,7 @@ mod tests {
             attestation_service,
             usage_service,
             metrics_service: metrics_service.clone(),
+            request_id: Uuid::new_v4(),
             organization_id,
             workspace_id,
             api_key_id,
@@ -1931,6 +1973,7 @@ mod tests {
             attestation_service,
             usage_service: usage_service.clone(),
             metrics_service: metrics_service.clone(),
+            request_id: Uuid::new_v4(),
             organization_id,
             workspace_id,
             api_key_id,
@@ -2048,6 +2091,7 @@ mod tests {
             attestation_service,
             usage_service: usage_service.clone(),
             metrics_service: metrics_service.clone(),
+            request_id: Uuid::new_v4(),
             organization_id,
             workspace_id,
             api_key_id,
@@ -2251,6 +2295,7 @@ mod tests {
                 attestation_service,
                 usage_service,
                 metrics_service,
+                request_id: Uuid::new_v4(),
                 organization_id: Uuid::new_v4(),
                 workspace_id: Uuid::new_v4(),
                 api_key_id: Uuid::new_v4(),

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -496,6 +496,33 @@ const ORG_LIMIT_CACHE_TTL_SECS: u64 = 300;
 const CONCURRENT_COUNT_TTL_SECS: u64 = 600;
 
 impl CompletionServiceImpl {
+    /// Inject tracing correlation IDs into the `extra` map that is forwarded
+    /// to `ChatCompletionParams`. The inference provider reads these keys and
+    /// emits them as `X-Request-Id` / `X-Org-Id` / `X-Workspace-Id` HTTP
+    /// headers on the outbound call to the vLLM/SGLang backend.
+    ///
+    /// The key names must match the constants in
+    /// `inference_providers::vllm::tracing_headers`.
+    fn inject_tracing_headers(
+        extra: &mut std::collections::HashMap<String, serde_json::Value>,
+        request_id: Uuid,
+        organization_id: Uuid,
+        workspace_id: Uuid,
+    ) {
+        extra.insert(
+            "x_request_id".to_string(),
+            serde_json::Value::String(request_id.to_string()),
+        );
+        extra.insert(
+            "x_org_id".to_string(),
+            serde_json::Value::String(organization_id.to_string()),
+        );
+        extra.insert(
+            "x_workspace_id".to_string(),
+            serde_json::Value::String(workspace_id.to_string()),
+        );
+    }
+
     pub fn new(
         inference_provider_pool: Arc<InferenceProviderPool>,
         attestation_service: Arc<dyn AttestationServiceTrait>,
@@ -1054,18 +1081,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
 
         // Inject tracing correlation IDs into extra so the inference provider
         // forwards them as X-Request-Id / X-Org-Id / X-Workspace-Id headers.
-        extra.insert(
-            "x_request_id".to_string(),
-            serde_json::Value::String(request_id.to_string()),
-        );
-        extra.insert(
-            "x_org_id".to_string(),
-            serde_json::Value::String(organization_id.to_string()),
-        );
-        extra.insert(
-            "x_workspace_id".to_string(),
-            serde_json::Value::String(workspace_id.to_string()),
-        );
+        Self::inject_tracing_headers(&mut extra, request_id, organization_id, workspace_id);
 
         let mut chat_params = inference_providers::ChatCompletionParams {
             model: request.model.clone(),
@@ -1221,18 +1237,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
 
         // Inject tracing correlation IDs into extra so the inference provider
         // forwards them as X-Request-Id / X-Org-Id / X-Workspace-Id headers.
-        extra.insert(
-            "x_request_id".to_string(),
-            serde_json::Value::String(request_id.to_string()),
-        );
-        extra.insert(
-            "x_org_id".to_string(),
-            serde_json::Value::String(organization_id.to_string()),
-        );
-        extra.insert(
-            "x_workspace_id".to_string(),
-            serde_json::Value::String(workspace_id.to_string()),
-        );
+        Self::inject_tracing_headers(&mut extra, request_id, organization_id, workspace_id);
 
         let mut chat_params = inference_providers::ChatCompletionParams {
             model: request.model.clone(),

--- a/crates/services/src/completions/ports.rs
+++ b/crates/services/src/completions/ports.rs
@@ -49,6 +49,9 @@ pub enum CompletionError {
 // Request/Response models
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompletionRequest {
+    /// UUIDv4 correlation ID generated (or echoed) by the API layer.
+    /// Propagated downstream as `X-Request-Id` so every hop can join on it.
+    pub request_id: uuid::Uuid,
     pub model: String,
     pub messages: Vec<CompletionMessage>,
     pub max_tokens: Option<i64>,

--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -1347,6 +1347,7 @@ impl ResponseServiceImpl {
 
             // Create completion request (names not included - tracked via database analytics)
             let completion_request = CompletionRequest {
+                request_id: uuid::Uuid::new_v4(),
                 model: process_context.request.model.clone(),
                 messages: messages.clone(),
                 max_tokens: process_context.request.max_output_tokens,
@@ -2908,6 +2909,7 @@ impl ResponseServiceImpl {
         let title_model = std::env::var("TITLE_GENERATION_MODEL")
             .unwrap_or_else(|_| "Qwen/Qwen3-30B-A3B-Instruct-2507".to_string());
         let completion_request = crate::completions::ports::CompletionRequest {
+            request_id: uuid::Uuid::new_v4(),
             model: title_model,
             messages: vec![crate::completions::ports::CompletionMessage {
                 role: "user".to_string(),


### PR DESCRIPTION
## Summary

Adds end-to-end request correlation so every model request can be traced across all hops in Datadog by a single `request_id`, with `org_id` and `workspace_id` attached at every logged point.

### Motivation

Today `service:cloud-api` structured logs carry `model_id`, `chat_id`, `operation` etc. — but no `org_id`, no `workspace_id`, and no join key that follows the request downstream. This is **Step 1** of the org-id e2e tracing plan: instrument cloud-api so it generates and propagates the correlation headers, enabling the downstream hops (inference-proxy, CVM nginx) to be joined in log search.

### Trust model note

`org_id` is cloud-api's own metadata about its customer — not user content. Forwarding it as an HTTP header is consistent with the TEE trust model: the request body remains encrypted end-to-end; headers are visible to CVM nginx and inference-proxy, both of which are already trusted by cloud-api.

---

## Changes

### `services/src/completions/ports.rs`
- Added `request_id: Uuid` to `CompletionRequest` — the per-request correlation ID generated (or echoed) by the API layer.

### `api/src/routes/completions.rs`
- **`chat_completions`**: generates `request_id` (reuses client `X-Request-Id` if it's a valid UUID, otherwise generates fresh); creates an explicit `tracing::info_span!` with `request_id`, `org_id`, `workspace_id`, `model` so every log line from this request carries them in Datadog.
- **`convert_chat_request_to_service`** / **`convert_text_request_to_service`**: thread `request_id` through into `CompletionRequest`.

### `services/src/completions/mod.rs`
- In both `create_chat_completion_stream` and `create_chat_completion`: injects `x_request_id`, `x_org_id`, `x_workspace_id` into `extra` before building `ChatCompletionParams` — the vLLM provider reads these and forwards them as HTTP headers.
- Carries `request_id` through `InterceptStream` and both tracing spans (`stream_drop`, `record_usage`) so every usage log line is joinable.
- Updated `handle_stream_with_context` signature to accept `request_id`.

### `inference_providers/src/vllm/mod.rs`
- New `tracing_headers` module (mirroring `encryption_headers`) with constants `x_request_id`, `x_org_id`, `x_workspace_id`.
- New `prepare_tracing_headers()` method: extracts the three keys from `extra` and sets `X-Request-Id`, `X-Org-Id`, `X-Workspace-Id` headers — removing them from `extra` so they don't leak into the JSON body.
- Called in **all** vLLM inference paths: `chat_completion_stream`, `chat_completion`, `image_generation`, `audio_transcription`, `score`, `rerank`, `embeddings_raw`, `privacy_classify_raw`.
- 3 new unit tests: keys removed from extra, headers forwarded correctly, absent keys are a no-op.

### `inference_providers/src/external/mod.rs`
- New `strip_internal_tracing_keys()` helper strips `x_request_id`/`x_org_id`/`x_workspace_id` from `params.extra` before forwarding to external providers (OpenAI, Anthropic, Gemini). `extra` is `#[serde(flatten)]` so without this strip the keys would land verbatim in the JSON body sent to external APIs.
- Called in `chat_completion_stream` and `chat_completion`.

### `services/src/responses/service.rs`
- Two internal `CompletionRequest` constructors (agent loop completion, title generation) supplied `Uuid::new_v4()` for the new required field.

---

## What this enables in Datadog

After this lands, every `service:cloud-api` log line for a chat completion will carry:
- `request_id` — join key to find the same request in downstream services
- `org_id` — which customer made the request  
- `workspace_id` — which workspace

And the outbound HTTP call to inference-proxy will carry `X-Request-Id`, `X-Org-Id`, `X-Workspace-Id` headers — ready for inference-proxy (Step 2) and CVM nginx (Step 3) to log and index.

---

## Testing

- `cargo test --lib`: 307 passed, 0 failed ✓
- `cargo test -p inference_providers --lib`: 132 passed (includes 3 new tracing header tests) ✓
- `cargo build`: clean ✓