### PR TITLE
perf(inference_provider_pool): skip attestation on cold-bucket-fill when fingerprint already pinned

### DIFF
--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -420,28 +420,38 @@ impl PoolBackendVerifier {
         if let Some(ref key) = self.api_key {
             request = request.header("Authorization", format!("Bearer {key}"));
         }
-        let response = tokio::time::timeout(Duration::from_secs(5), request.send())
-            .await
-            .map_err(|_| "Fast-path probe timed out".to_string())?
-            .map_err(|e| format!("Fast-path probe failed: {e}"))?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            return Err(format!("Fast-path probe HTTP {status}"));
-        }
-
-        // Drain the body so reqwest can reuse the underlying H2 connection
-        // (see CLAUDE.md note on draining bytes before drop in the inference-proxy
-        // / cloud-api auth retry pattern).
+        // Wrap the entire probe — request send, status check, and body drain —
+        // in a single 5-second timeout. A single budget is simpler and more
+        // correct than two separate timeouts: any stall anywhere in the probe
+        // should abort and fall through to the slow path within 5 s total.
         //
-        // The drain is bounded by a separate 5s timeout (not the request.send()
-        // timeout above, which only covers headers). /v1/models returns a tiny
-        // static payload (~1 KB) that is typically already in the TCP receive
-        // buffer by the time headers arrive, so this completes instantly in
-        // practice. The explicit timeout guards against a misbehaving backend
-        // that sends headers quickly but stalls on the body.
-        let _ = tokio::time::timeout(Duration::from_secs(5), response.bytes()).await;
+        // Body drain is required so reqwest can return the H2 stream to the
+        // connection pool for the subsequent inference request. /v1/models
+        // returns a tiny static payload (~1 KB) so this completes instantly
+        // in practice.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let response = request
+                .send()
+                .await
+                .map_err(|e| format!("Fast-path probe failed: {e}"))?;
+            if !response.status().is_success() {
+                let status = response.status();
+                return Err(format!("Fast-path probe HTTP {status}"));
+            }
+            response
+                .bytes()
+                .await
+                .map_err(|e| format!("Failed to drain probe body: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|_| "Fast-path probe timed out".to_string())??;
 
+        // No fingerprint is added to the shared `fingerprint_state` here —
+        // the snapshot was already derived from it, so there is nothing new
+        // to pin. Discovery (every ~5 min) remains the sole writer of the
+        // shared state; contrast with the slow path's lines above that call
+        // `shared.add_fingerprint` after a fresh attestation.
         Ok(client)
     }
 }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -254,9 +254,16 @@ impl inference_providers::BackendVerifier for PoolBackendVerifier {
                 .unwrap_or_else(|e| e.into_inner());
             guard.clone()
         };
-        if pinned_snapshot.pinned_count() > 0 {
+        let pinned_count = pinned_snapshot.pinned_count();
+        if pinned_count > 0 {
             match self.try_pinned_fast_path(base_url, pinned_snapshot).await {
-                Ok(client) => return Ok(client),
+                Ok(client) => {
+                    tracing::debug!(
+                        pinned_count,
+                        "Fast-path TLS probe succeeded, skipping attestation"
+                    );
+                    return Ok(client);
+                }
                 Err(reason) => {
                     tracing::debug!(
                         reason = %reason,
@@ -272,26 +279,9 @@ impl inference_providers::BackendVerifier for PoolBackendVerifier {
         //
         // 1. Build a client with isolated Bootstrap state (accepts any WebPKI cert
         //    for the initial connection to discover the backend's fingerprint).
-        // read_timeout is the per-chunk idle timeout; for non-streaming chat
-        // completion the connection sits silent the entire inference time, so
-        // it must match the configured completion budget — otherwise a long
-        // reasoning request fires read_timeout (~300s) before our `.timeout()`
-        // (default 600s). Track `VLLM_PROVIDER_COMPLETION_TIMEOUT` so the env
-        // override applies here too.
-        let read_timeout =
-            Duration::from_secs(VLlmConfig::completion_timeout_from_env().max(0) as u64);
         let client_state = Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
-        let builder = reqwest::Client::builder()
-            .use_preconfigured_tls(self.tls_roots.build_config(client_state.clone()))
-            .pool_max_idle_per_host(1)
-            .http2_adaptive_window(true)
-            .connect_timeout(Duration::from_secs(5))
-            .read_timeout(read_timeout);
-        // Bucket clients need the H2 connection to stay sticky to a single
-        // backend across long idle gaps; see
-        // `inference_providers::bucket_keepalive`.
-        let client = inference_providers::bucket_keepalive::apply(builder)
-            .build()
+        let client = self
+            .build_bucket_client(client_state.clone())
             .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 
         // 2. Fetch attestation report — this establishes the H2 connection.
@@ -375,6 +365,32 @@ impl inference_providers::BackendVerifier for PoolBackendVerifier {
 }
 
 impl PoolBackendVerifier {
+    /// Build a bucket-flavored `reqwest::Client` with TLS verification driven
+    /// by the supplied `FingerprintState`. Centralizing this here means the
+    /// fast and slow paths can't drift on pool/timeout/keepalive settings.
+    ///
+    /// `read_timeout` is the per-chunk idle timeout; for non-streaming chat
+    /// completion the connection sits silent the entire inference time, so it
+    /// must match the configured completion budget — otherwise a long
+    /// reasoning request fires `read_timeout` (~300s) before our `.timeout()`
+    /// (default 600s). `VLLM_PROVIDER_COMPLETION_TIMEOUT` env override applies
+    /// here too. `bucket_keepalive::apply` keeps the H2 connection sticky to
+    /// a single backend across long idle gaps.
+    fn build_bucket_client(
+        &self,
+        state: Arc<std::sync::RwLock<FingerprintState>>,
+    ) -> Result<reqwest::Client, reqwest::Error> {
+        let read_timeout =
+            Duration::from_secs(VLlmConfig::completion_timeout_from_env().max(0) as u64);
+        let builder = reqwest::Client::builder()
+            .use_preconfigured_tls(self.tls_roots.build_config(state))
+            .pool_max_idle_per_host(1)
+            .http2_adaptive_window(true)
+            .connect_timeout(Duration::from_secs(5))
+            .read_timeout(read_timeout);
+        inference_providers::bucket_keepalive::apply(builder).build()
+    }
+
     /// Fast path for `create_verified_client` when discovery has already pinned
     /// fingerprints for this model's backends.
     ///
@@ -399,19 +415,16 @@ impl PoolBackendVerifier {
         base_url: &str,
         pinned_snapshot: FingerprintState,
     ) -> Result<reqwest::Client, String> {
-        let read_timeout =
-            Duration::from_secs(VLlmConfig::completion_timeout_from_env().max(0) as u64);
         let client_state = Arc::new(std::sync::RwLock::new(pinned_snapshot));
-        let builder = reqwest::Client::builder()
-            .use_preconfigured_tls(self.tls_roots.build_config(client_state))
-            .pool_max_idle_per_host(1)
-            .http2_adaptive_window(true)
-            .connect_timeout(Duration::from_secs(5))
-            .read_timeout(read_timeout);
-        let client = inference_providers::bucket_keepalive::apply(builder)
-            .build()
+        let client = self
+            .build_bucket_client(client_state)
             .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 
+        // `/v1/models` is assumed to accept the same bearer token used for
+        // inference (or to be unauthenticated). If a backend ever required a
+        // different key here, the probe would 401 and we'd fall back to the
+        // slow path — same outcome, just slower. The probe's value comes from
+        // the TLS handshake, not the response body.
         let url = format!("{base_url}/v1/models");
         let mut request = client.get(&url);
         if let Some(ref key) = self.api_key {
@@ -4537,5 +4550,219 @@ mod tests {
                 "Model backed by a Blocked provider should be removed from model_to_providers"
             );
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Fast-path tests for `PoolBackendVerifier`
+    //
+    // The fast path runs an HTTP probe against `/v1/models` and returns
+    // the client without re-attestation when the TLS handshake succeeds.
+    // These tests use plain HTTP (the rustls verifier is only consulted
+    // for HTTPS URLs, so the TLS-pinning layer is short-circuited) and a
+    // hand-rolled TCP responder — same pattern as
+    // `crates/inference_providers/src/vllm/mod.rs`. The goal is to verify
+    // the control flow (Bootstrap → skip fast path; pinned + 200 → return;
+    // pinned + 5xx → fall back; pinned + hang → time out and fall back),
+    // not the TLS verifier itself which has its own tests.
+    // -------------------------------------------------------------------
+
+    use inference_providers::spki_verifier::SharedTlsRoots;
+    use inference_providers::BackendVerifier as _;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Behavior of the mock HTTP server when `/v1/models` is hit.
+    #[derive(Clone, Copy)]
+    enum ModelsBehavior {
+        /// Reply with the given status code and body.
+        Reply(u16, &'static str),
+        /// Accept the TCP connection but never reply — exercises the
+        /// 5-second probe timeout.
+        Hang,
+    }
+
+    struct FastPathTestServer {
+        addr: std::net::SocketAddr,
+        models_hits: Arc<AtomicUsize>,
+        attestation_hits: Arc<AtomicUsize>,
+        _acceptor: tokio::task::JoinHandle<()>,
+    }
+
+    /// Spawn a minimal HTTP/1.1 responder. `/v1/attestation/report` always
+    /// returns 500 (so the slow-path call from the Bootstrap test errors
+    /// out quickly); `/v1/models` is governed by `models_behavior`.
+    async fn start_fast_path_server(models_behavior: ModelsBehavior) -> FastPathTestServer {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let models_hits = Arc::new(AtomicUsize::new(0));
+        let attestation_hits = Arc::new(AtomicUsize::new(0));
+        let m = models_hits.clone();
+        let a = attestation_hits.clone();
+        let acceptor = tokio::spawn(async move {
+            // Sockets that we choose to leave hanging — kept alive so the
+            // peer reads "no data yet" rather than an immediate EOF.
+            let mut held = Vec::new();
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = [0u8; 1024];
+                let n = match sock.read(&mut buf).await {
+                    Ok(n) if n > 0 => n,
+                    _ => continue,
+                };
+                let head = String::from_utf8_lossy(&buf[..n.min(256)]);
+                let path = head
+                    .lines()
+                    .next()
+                    .and_then(|l| l.split_whitespace().nth(1))
+                    .unwrap_or("");
+                if path.starts_with("/v1/models") {
+                    m.fetch_add(1, AtomicOrdering::SeqCst);
+                    match models_behavior {
+                        ModelsBehavior::Reply(status, body) => {
+                            let resp = format!(
+                                "HTTP/1.1 {status} X\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                                body.len(),
+                                body
+                            );
+                            let _ = sock.write_all(resp.as_bytes()).await;
+                        }
+                        ModelsBehavior::Hang => {
+                            held.push(sock);
+                        }
+                    }
+                } else if path.starts_with("/v1/attestation") {
+                    a.fetch_add(1, AtomicOrdering::SeqCst);
+                    let body = "{\"error\":\"test\"}";
+                    let resp = format!(
+                        "HTTP/1.1 500 X\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                }
+            }
+        });
+        FastPathTestServer {
+            addr,
+            models_hits,
+            attestation_hits,
+            _acceptor: acceptor,
+        }
+    }
+
+    fn pinned_state(fps: &[&str]) -> FingerprintState {
+        let mut s = FingerprintState::Bootstrap;
+        for fp in fps {
+            s.add_fingerprint((*fp).to_string());
+        }
+        s
+    }
+
+    fn make_verifier(state: FingerprintState) -> PoolBackendVerifier {
+        PoolBackendVerifier {
+            api_key: None,
+            model_name: "test-model".to_string(),
+            tls_roots: SharedTlsRoots::load(),
+            attestation_verifier: Arc::new(AttestationVerifier::new(HashSet::new(), None, false)),
+            fingerprint_state: Arc::new(std::sync::RwLock::new(state)),
+        }
+    }
+
+    #[tokio::test]
+    async fn fast_path_returns_client_on_200() {
+        let server = start_fast_path_server(ModelsBehavior::Reply(200, "{}")).await;
+        let verifier = make_verifier(pinned_state(&["aa", "bb"]));
+        let base_url = format!("http://{}", server.addr);
+        let result = verifier
+            .try_pinned_fast_path(&base_url, pinned_state(&["aa", "bb"]))
+            .await;
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(server.models_hits.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(server.attestation_hits.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn fast_path_returns_err_on_http_5xx() {
+        let server = start_fast_path_server(ModelsBehavior::Reply(503, "down")).await;
+        let verifier = make_verifier(pinned_state(&["aa"]));
+        let base_url = format!("http://{}", server.addr);
+        let result = verifier
+            .try_pinned_fast_path(&base_url, pinned_state(&["aa"]))
+            .await;
+        let err = result.expect_err("expected Err on HTTP 503");
+        assert!(
+            err.contains("503"),
+            "err should mention status code, got: {err}"
+        );
+        assert_eq!(server.models_hits.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn create_verified_client_skips_fast_path_in_bootstrap() {
+        // Bootstrap state → fast path must not be invoked, slow path runs
+        // instead. We don't care that the slow path fails (mock /v1/attestation
+        // returns 500); we only assert which endpoint(s) were hit.
+        let server = start_fast_path_server(ModelsBehavior::Reply(200, "{}")).await;
+        let verifier = make_verifier(FingerprintState::Bootstrap);
+        let base_url = format!("http://{}", server.addr);
+        let _ = verifier.create_verified_client(&base_url).await;
+        assert_eq!(
+            server.models_hits.load(AtomicOrdering::SeqCst),
+            0,
+            "fast path probe must not run when fingerprint_state is Bootstrap"
+        );
+        assert!(
+            server.attestation_hits.load(AtomicOrdering::SeqCst) >= 1,
+            "slow path should have attempted /v1/attestation/report"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_verified_client_uses_fast_path_when_pinned() {
+        let server = start_fast_path_server(ModelsBehavior::Reply(200, "{}")).await;
+        let verifier = make_verifier(pinned_state(&["aa"]));
+        let base_url = format!("http://{}", server.addr);
+        let client = verifier
+            .create_verified_client(&base_url)
+            .await
+            .expect("fast path should succeed");
+        // Successful fast path means the slow path is never reached.
+        assert_eq!(server.models_hits.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(
+            server.attestation_hits.load(AtomicOrdering::SeqCst),
+            0,
+            "slow path must not run when fast path succeeds"
+        );
+        drop(client);
+    }
+
+    /// Probe must time out within ~5 s when the backend accepts the
+    /// connection but never replies, and the error message must surface
+    /// the timeout reason so the fallback debug log is informative.
+    #[tokio::test]
+    async fn fast_path_returns_err_on_timeout() {
+        let server = start_fast_path_server(ModelsBehavior::Hang).await;
+        let verifier = make_verifier(pinned_state(&["aa"]));
+        let base_url = format!("http://{}", server.addr);
+        let start = std::time::Instant::now();
+        let result = verifier
+            .try_pinned_fast_path(&base_url, pinned_state(&["aa"]))
+            .await;
+        let elapsed = start.elapsed();
+        let err = result.expect_err("expected Err on hanging probe");
+        assert!(
+            err.contains("timed out"),
+            "err should mention timeout, got: {err}"
+        );
+        // The probe budget is 5 s. Allow scheduler jitter but make sure
+        // we're not waiting on a longer timeout by mistake.
+        assert!(
+            elapsed < Duration::from_secs(7),
+            "probe should give up within ~5s, took {elapsed:?}"
+        );
+        assert_eq!(server.models_hits.load(AtomicOrdering::SeqCst), 1);
     }
 }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -433,7 +433,14 @@ impl PoolBackendVerifier {
         // Drain the body so reqwest can reuse the underlying H2 connection
         // (see CLAUDE.md note on draining bytes before drop in the inference-proxy
         // / cloud-api auth retry pattern).
-        let _ = response.bytes().await;
+        //
+        // The drain is bounded by a separate 5s timeout (not the request.send()
+        // timeout above, which only covers headers). /v1/models returns a tiny
+        // static payload (~1 KB) that is typically already in the TCP receive
+        // buffer by the time headers arrive, so this completes instantly in
+        // practice. The explicit timeout guards against a misbehaving backend
+        // that sends headers quickly but stalls on the body.
+        let _ = tokio::time::timeout(Duration::from_secs(5), response.bytes()).await;
 
         Ok(client)
     }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -236,6 +236,43 @@ struct PoolBackendVerifier {
 #[async_trait::async_trait]
 impl inference_providers::BackendVerifier for PoolBackendVerifier {
     async fn create_verified_client(&self, base_url: &str) -> Result<reqwest::Client, String> {
+        // Fast path: if discovery has already pinned fingerprints for this
+        // model's backends, skip the per-bucket attestation round-trip. The
+        // shared `fingerprint_state` is updated every discovery cycle (~5 min)
+        // with fresh GPU evidence; that cadence is the right freshness signal
+        // for the attestation chain. Per-bucket re-attestation is redundant
+        // work that adds ~1-3s of cold-bucket tail latency for no security
+        // benefit — TLS SPKI pinning already proves backend identity continuity.
+        //
+        // The probe uses `GET /v1/models` (cheap static response) rather than
+        // `/v1/attestation/report` (triggers backend-side GPU evidence
+        // collection and signing).
+        let pinned_snapshot = {
+            let guard = self
+                .fingerprint_state
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+            guard.clone()
+        };
+        if pinned_snapshot.pinned_count() > 0 {
+            match self
+                .try_pinned_fast_path(base_url, pinned_snapshot)
+                .await
+            {
+                Ok(client) => return Ok(client),
+                Err(reason) => {
+                    tracing::debug!(
+                        reason = %reason,
+                        "Fast-path TLS probe failed, falling back to full attestation"
+                    );
+                }
+            }
+        }
+
+        // Slow path: no pinned fingerprints yet, or the fast-path probe failed
+        // (unknown backend, TLS rejection, or HTTP error). Run the full
+        // attestation chain.
+        //
         // 1. Build a client with isolated Bootstrap state (accepts any WebPKI cert
         //    for the initial connection to discover the backend's fingerprint).
         // read_timeout is the per-chunk idle timeout; for non-streaming chat
@@ -336,6 +373,68 @@ impl inference_providers::BackendVerifier for PoolBackendVerifier {
 
         // 5. Return the client — its H2 connection is to the verified backend,
         //    and its TLS verifier only accepts that backend on reconnection.
+        Ok(client)
+    }
+}
+
+impl PoolBackendVerifier {
+    /// Fast path for `create_verified_client` when discovery has already pinned
+    /// fingerprints for this model's backends.
+    ///
+    /// Builds a client seeded with the snapshot of known-good fingerprints,
+    /// then sends a cheap `GET /v1/models` request to validate via TLS handshake
+    /// that the backend's cert SPKI is in the pinned set. On success, returns
+    /// the established client without fetching attestation. On TLS rejection
+    /// (unknown backend) or HTTP error, returns Err so the caller can fall
+    /// back to the full attestation path.
+    ///
+    /// The H2 connection sits inside the returned client's pool. Subsequent
+    /// requests on the same `reqwest::Client` reuse it. If the H2 connection
+    /// drops and reqwest reconnects, the TLS verifier accepts any cert whose
+    /// SPKI is in the snapshot — meaning a reconnect *can* land on a different
+    /// attested backend. This is a deliberate relaxation of the prior
+    /// "narrowed to one fingerprint per bucket" behavior: both backends are
+    /// attested, so a cross-backend reconnect is secure even if it costs a
+    /// prefix-cache miss on that one request. Avoiding the attestation chain
+    /// on every cold-bucket-fill is worth that tradeoff.
+    async fn try_pinned_fast_path(
+        &self,
+        base_url: &str,
+        pinned_snapshot: FingerprintState,
+    ) -> Result<reqwest::Client, String> {
+        let read_timeout =
+            Duration::from_secs(VLlmConfig::completion_timeout_from_env().max(0) as u64);
+        let client_state = Arc::new(std::sync::RwLock::new(pinned_snapshot));
+        let builder = reqwest::Client::builder()
+            .use_preconfigured_tls(self.tls_roots.build_config(client_state))
+            .pool_max_idle_per_host(1)
+            .http2_adaptive_window(true)
+            .connect_timeout(Duration::from_secs(5))
+            .read_timeout(read_timeout);
+        let client = inference_providers::bucket_keepalive::apply(builder)
+            .build()
+            .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+
+        let url = format!("{base_url}/v1/models");
+        let mut request = client.get(&url);
+        if let Some(ref key) = self.api_key {
+            request = request.header("Authorization", format!("Bearer {key}"));
+        }
+        let response = tokio::time::timeout(Duration::from_secs(5), request.send())
+            .await
+            .map_err(|_| "Fast-path probe timed out".to_string())?
+            .map_err(|e| format!("Fast-path probe failed: {e}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            return Err(format!("Fast-path probe HTTP {status}"));
+        }
+
+        // Drain the body so reqwest can reuse the underlying H2 connection
+        // (see CLAUDE.md note on draining bytes before drop in the inference-proxy
+        // / cloud-api auth retry pattern).
+        let _ = response.bytes().await;
+
         Ok(client)
     }
 }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -255,10 +255,7 @@ impl inference_providers::BackendVerifier for PoolBackendVerifier {
             guard.clone()
         };
         if pinned_snapshot.pinned_count() > 0 {
-            match self
-                .try_pinned_fast_path(base_url, pinned_snapshot)
-                .await
-            {
+            match self.try_pinned_fast_path(base_url, pinned_snapshot).await {
                 Ok(client) => return Ok(client),
                 Err(reason) => {
                     tracing::debug!(


### PR DESCRIPTION
## Summary

`PoolBackendVerifier::create_verified_client` currently fetches `/v1/attestation/report` with a fresh nonce and runs the full NRAS + dcap-qvl + RTMR3 + image-hash verification chain on **every cold-bucket-fill**, even when the shared `fingerprint_state` already has the backend's SPKI fingerprint pinned from the most recent discovery cycle (which runs every 5 min).

This PR adds a fast path: when discovery has populated fingerprint_state, build the client with that pinned set and probe `GET /v1/models`. If the TLS handshake succeeds the backend's identity is already verified via SPKI pinning — return the client without re-attestation. On TLS rejection (unknown/rotated backend) or HTTP error, fall through to the existing slow path unchanged.

## Why

The slow-path cost (~1-3 s per cold bucket, dominated by the NRAS round-trip) surfaces as a multi-second TTFT P95 on cloud-api workloads. Tracking the data across recent benches:

| Bench | Qwen3.6 ShareGPT P95 TTFT (cloud-api) |
| --- | --- |
| v4 (2026-05-19 AM) | 5821 ms |
| v5 (2026-05-19 PM, after rotation-SNI) | 4138 ms |
| v6 (2026-05-20) | 3942 ms |

Each step reduced the *frequency* of cold-bucket events (rotation-SNI #603 cut provider eviction churn). This PR removes the cost of the cold-bucket event itself.

Discovery runs every 5 min and re-attests every backend, so it remains the source of fresh GPU evidence — the right cadence for the attestation freshness signal. Per-bucket re-attestation was redundant work.

## Tradeoff

The per-bucket client's TLS state starts at `Pinned(shared_set)` instead of narrowing to `Pinned({this_backend_fp})`. If the H2 connection drops and reqwest reconnects, the verifier accepts any pinned (attested) backend rather than only the specific one this bucket first served. A cross-backend reconnect is still secure (both attested) but loses prefix-cache locality for that single request.

The current code's narrowing-then-clear-bucket behavior was the source of a category of cold-bucket events (H2 reconnect lands on a different attested backend → clear_bucket → full re-verification). Removing the narrowing also removes those gratuitous re-verifications.

## What it preserves

- TLS SPKI pinning verification on every TLS handshake — same per-request identity check.
- Full attestation chain on the slow path — fired when fingerprint_state is empty (cold cloud-api boot, pre-discovery) or when the fast-path probe fails (rotated cert, unknown new backend).
- Discovery's 5-minute attestation cadence — unchanged.
- Per-completion signature flow (`/v1/signature/<chat_id>`) — unchanged.

## Test plan

- [ ] All 307 existing `cargo test -p services --lib --bins` tests pass (verified locally)
- [ ] `cargo clippy -p services --no-deps` clean (verified locally)
- [ ] Deploy to staging, monitor `service:cloud-api env:staging`:
  - `@fields.message:"Inline verification pinned new TLS fingerprint"` count should not increase (discovery still pins via the slow path on fresh fingerprints)
  - `@fields.message:"Fast-path TLS probe failed"` debug log should be rare (only on real fingerprint mismatches)
  - `@fields.message:"Bucket pre-warm complete"` debug log should appear within seconds of provider creation (was previously much slower)
- [ ] Run `scaleway-bench/qwen_cloud_vs_direct_sharegpt.yaml` against staging cloud-api; expect Qwen3.6 ShareGPT P95 TTFT < 2 s (was 3.9 s in v6)
- [ ] Verify SPKI pinning still rejects unknown backends — synthetic test: register a fake endpoint in model-proxy with a different cert, confirm cloud-api 502s with "Inline backend verification failed" in logs

## Rollback

Single revert. The slow path remains the byte-for-byte original.