### PR TITLE
fix(vllm): preserve reqwest error.source() chain so transport failures are debuggable

### DIFF
--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -39,6 +39,26 @@ fn to_privacy_classify_error<E: std::fmt::Display>(e: E) -> PrivacyClassifyError
     PrivacyClassifyError::RequestFailed(e.to_string())
 }
 
+/// Format an error including its full `source()` chain.
+///
+/// `reqwest::Error`'s `Display` impl returns only the outer wrapper
+/// (e.g. `"error sending request for url (...)"`). The underlying cause —
+/// `"connection closed before message completed"`, `"broken pipe"`,
+/// hyper/h2 stream resets, rustls handshake errors — lives in
+/// `source()` and is otherwise discarded when we convert to
+/// `CompletionError::CompletionError(String)`. Walk the chain so the
+/// transport-level reason ends up in logs.
+fn format_error_chain<E: std::error::Error>(e: &E) -> String {
+    let mut out = e.to_string();
+    let mut source: Option<&dyn std::error::Error> = e.source();
+    while let Some(err) = source {
+        out.push_str(": caused by: ");
+        out.push_str(&err.to_string());
+        source = err.source();
+    }
+    out
+}
+
 /// Encryption header keys used in params.extra for passing encryption information
 mod encryption_headers {
     /// Key for signing algorithm (x-signing-algo header)
@@ -678,7 +698,7 @@ impl VLlmProvider {
             operation: "chat_completion_stream".to_string(),
             timeout_seconds: ttfb_timeout_secs,
         })?
-        .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
+        .map_err(|e| CompletionError::CompletionError(format_error_chain(&e)))?;
 
         if !response.status().is_success() {
             let status_code = response.status().as_u16();
@@ -747,13 +767,13 @@ impl InferenceProvider for VLlmProvider {
                 .timeout(timeout)
                 .send()
                 .await
-                .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
+                .map_err(|e| CompletionError::CompletionError(format_error_chain(&e)))?;
 
             if response.status().is_success() {
                 let signature = response
                     .json()
                     .await
-                    .map_err(|e| CompletionError::CompletionError(e.to_string()))?;
+                    .map_err(|e| CompletionError::CompletionError(format_error_chain(&e)))?;
                 return Ok(signature);
             }
 
@@ -1010,7 +1030,7 @@ impl InferenceProvider for VLlmProvider {
                     timeout_seconds: timeout_secs,
                 }
             } else {
-                CompletionError::CompletionError(e.to_string())
+                CompletionError::CompletionError(format_error_chain(&e))
             }
         };
 
@@ -1503,6 +1523,55 @@ impl InferenceProvider for VLlmProvider {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[derive(Debug)]
+    struct ChainedErr {
+        msg: &'static str,
+        source: Option<Box<dyn std::error::Error + 'static>>,
+    }
+
+    impl std::fmt::Display for ChainedErr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.msg)
+        }
+    }
+
+    impl std::error::Error for ChainedErr {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.source.as_deref()
+        }
+    }
+
+    #[test]
+    fn format_error_chain_flat_error() {
+        let e = ChainedErr {
+            msg: "outer",
+            source: None,
+        };
+        assert_eq!(format_error_chain(&e), "outer");
+    }
+
+    #[test]
+    fn format_error_chain_walks_all_sources() {
+        let inner = ChainedErr {
+            msg: "broken pipe",
+            source: None,
+        };
+        let middle = ChainedErr {
+            msg: "connection closed before message completed",
+            source: Some(Box::new(inner)),
+        };
+        let outer = ChainedErr {
+            msg: "error sending request for url (https://x/v1/signature/y)",
+            source: Some(Box::new(middle)),
+        };
+        assert_eq!(
+            format_error_chain(&outer),
+            "error sending request for url (https://x/v1/signature/y)\
+             : caused by: connection closed before message completed\
+             : caused by: broken pipe"
+        );
+    }
 
     fn create_test_provider() -> VLlmProvider {
         VLlmProvider::new(VLlmConfig {


### PR DESCRIPTION
## Why

reqwest's `Display` impl only emits the outer wrapper — for any send-side failure that's `"error sending request for url (...)"`. The underlying cause (`"connection closed before message completed"`, `"broken pipe"`, h2 stream resets, rustls handshake errors) lives in `e.source()` and is discarded when we collapse via `e.to_string()` into `CompletionError::CompletionError(String)`.

Concretely, today every `"Failed to store chat signature"` log on GLM-5.1 reaches Datadog like this:

```json
{
  "level": "ERROR",
  "target": "services::completions",
  "fields": {
    "organization_id": "...",
    "model_id": "...",
    "message": "Failed to store chat signature",
    "error": "ProviderError(\"Failed to perform completion: error sending request for url (https://glm-5-1.completions.near.ai/v1/signature/<chat_id>?signing_algo=ecdsa)\")"
  }
}
```

The cause chain that would tell us whether this is GOAWAY, RST, h2 stream reset, TLS handshake failure, or a TCP timeout is gone by the time we log. That's blocking the GLM-5.1 attestation-error investigation in nearai/infra#120 — every existing hypothesis (KV-cache pressure, SPKI mismatch, cross-backend signature affinity) has been ruled out by Datadog evidence, but we can't move forward because the actual transport-level reason isn't in the logs.

## What

Tiny private helper `format_error_chain<E: std::error::Error>(&E) -> String` that walks `e.source()` and joins each level with `: caused by: `. Used at the four sites in `vllm/mod.rs` that previously dropped the chain:

- `send_streaming_request` (line ~681) — TTFB send
- `get_signature` send (line ~750) — **the GLM-5.1 signature-fetch site**
- `get_signature` JSON decode (line ~756)
- `chat_completion` `map_send_err` (line ~1013)

After this, the same DD record will look like (illustrative):

```
"error": "ProviderError(\"Failed to perform completion: error sending request for url (https://glm-5-1.completions.near.ai/v1/signature/<id>?signing_algo=ecdsa): caused by: connection closed before message completed: caused by: ...\")"
```

…and we'll know in one DD query whether the underlying cause is connection-close, RST, or something else, and proceed accordingly.

## Why this doesn't break `is_connection_error`

The keyword substring checks in `is_connection_error` (`"error sending request"`, `"connection closed"`, `"connection reset"`, `"broken pipe"`, etc.) keep matching: the outer wrapper text is still present, the chain just appends more text after it. If anything, transport failures that previously surfaced only as `"error sending request for url (...)"` will now also include `"connection closed"` / `"broken pipe"` etc. in the message, letting `clear_bucket` / re-verify fire more accurately on the completion path.

## Privacy

No customer data is added to logs. reqwest/hyper/h2/rustls error chains contain transport-level reasons only — never request headers or bodies. See CLAUDE.md "Privacy & Data Security" section; this change adheres to "log error types and categories", not content.

## Test plan

- [x] `cargo build -p inference_providers` — clean
- [x] `cargo test -p inference_providers --lib format_error_chain` — 2 new unit tests pass:
  - flat error (no source) renders as just `Display`
  - chained error (3 levels) renders as `outer: caused by: middle: caused by: inner`
- [x] `cargo clippy -p inference_providers --lib` — no new warnings
- [x] `cargo fmt --all --check` — clean
- [ ] After deploy, query DD `service:cloud-api env:prod @fields.message:"Failed to store chat signature"` and confirm `@fields.error` now contains a `: caused by: ` suffix with transport detail
- [ ] Use the surfaced cause to close out nearai/infra#120 with a real root cause (this PR is only the diagnostic enabler; not a fix to the underlying failure)

## Out of scope (separate PRs once we know the cause)

- The fallback-to-general-client loop in `get_signature` short-circuits on `?` for transport errors (line 750). Only HTTP 404 currently falls through.
- `get_signature` doesn't `clear_bucket()` on connection errors the way the completion paths do (lines 949, 1035), so a bucket with a dead H2 conn keeps serving signature fetches stale until the next completion routes through it.

Both above are real bugs but I want this diagnostic-enabler in first so we don't fix the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)