### PR TITLE
feat(gateway): return org_id + workspace_id from /v1/check_api_key

### DIFF
--- a/crates/api/src/routes/gateway.rs
+++ b/crates/api/src/routes/gateway.rs
@@ -5,7 +5,7 @@ use utoipa::ToSchema;
 
 /// Response from the check_api_key endpoint.
 ///
-/// `org_id` and `workspace_id` are returned so downstream gateways
+/// `organization_id` and `workspace_id` are returned so downstream gateways
 /// (e.g. inference-proxy) have a server-side authoritative tenant
 /// identifier and don't have to trust caller-supplied `X-Org-Id`
 /// headers when populating logs / usage records.
@@ -14,7 +14,7 @@ pub struct CheckApiKeyResponse {
     /// Whether the API key is valid and authorized
     pub valid: bool,
     /// Organization the API key belongs to
-    pub org_id: String,
+    pub organization_id: String,
     /// Workspace the API key belongs to
     pub workspace_id: String,
 }
@@ -46,7 +46,7 @@ pub async fn check_api_key(
 ) -> Result<ResponseJson<CheckApiKeyResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
     Ok(ResponseJson(CheckApiKeyResponse {
         valid: true,
-        org_id: api_key.organization.id.to_string(),
+        organization_id: api_key.organization.id.to_string(),
         workspace_id: api_key.workspace.id.to_string(),
     }))
 }

--- a/crates/api/src/routes/gateway.rs
+++ b/crates/api/src/routes/gateway.rs
@@ -3,11 +3,20 @@ use axum::{http::StatusCode, response::Json as ResponseJson, Extension};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-/// Response from the check_api_key endpoint
+/// Response from the check_api_key endpoint.
+///
+/// `org_id` and `workspace_id` are returned so downstream gateways
+/// (e.g. inference-proxy) have a server-side authoritative tenant
+/// identifier and don't have to trust caller-supplied `X-Org-Id`
+/// headers when populating logs / usage records.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CheckApiKeyResponse {
     /// Whether the API key is valid and authorized
     pub valid: bool,
+    /// Organization the API key belongs to
+    pub org_id: String,
+    /// Workspace the API key belongs to
+    pub workspace_id: String,
 }
 
 /// Check API key validity
@@ -33,7 +42,11 @@ pub struct CheckApiKeyResponse {
     )
 )]
 pub async fn check_api_key(
-    Extension(_api_key): Extension<AuthenticatedApiKey>,
+    Extension(api_key): Extension<AuthenticatedApiKey>,
 ) -> Result<ResponseJson<CheckApiKeyResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
-    Ok(ResponseJson(CheckApiKeyResponse { valid: true }))
+    Ok(ResponseJson(CheckApiKeyResponse {
+        valid: true,
+        org_id: api_key.organization.id.to_string(),
+        workspace_id: api_key.workspace.id.to_string(),
+    }))
 }

--- a/crates/api/tests/e2e_all/check_api_key.rs
+++ b/crates/api/tests/e2e_all/check_api_key.rs
@@ -1,10 +1,13 @@
 use crate::common::*;
 
-/// Happy path: valid API key with credits returns 200.
+/// Happy path: valid API key with credits returns 200 and the body carries the
+/// authoritative `org_id` + `workspace_id` so downstream gateways don't have to
+/// trust caller-supplied tenant headers.
 #[tokio::test]
 async fn test_check_api_key_valid() {
     let server = setup_test_server().await;
     let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let org_id = org.id.clone();
     let api_key = get_api_key_for_org(&server, org.id).await;
 
     let response = server
@@ -21,6 +24,18 @@ async fn test_check_api_key_valid() {
 
     let body: serde_json::Value = response.json();
     assert_eq!(body["valid"], true);
+    assert_eq!(
+        body["org_id"].as_str().unwrap(),
+        org_id,
+        "response org_id must match the org the API key belongs to"
+    );
+    let workspace_id = body["workspace_id"]
+        .as_str()
+        .expect("response must include workspace_id");
+    assert!(
+        uuid::Uuid::parse_str(workspace_id).is_ok(),
+        "workspace_id must be a valid UUID, got {workspace_id}"
+    );
 }
 
 /// Invalid API key returns 401.

--- a/crates/api/tests/e2e_all/check_api_key.rs
+++ b/crates/api/tests/e2e_all/check_api_key.rs
@@ -1,13 +1,22 @@
 use crate::common::*;
 
 /// Happy path: valid API key with credits returns 200 and the body carries the
-/// authoritative `org_id` + `workspace_id` so downstream gateways don't have to
-/// trust caller-supplied tenant headers.
+/// authoritative `organization_id` + `workspace_id` so downstream gateways
+/// don't have to trust caller-supplied tenant headers.
 #[tokio::test]
 async fn test_check_api_key_valid() {
     let server = setup_test_server().await;
     let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
     let org_id = org.id.clone();
+    // `get_api_key_for_org` creates a key in the org's first workspace; capture
+    // that workspace id so we can assert the response surfaces *that* workspace,
+    // not just *some* UUID.
+    let expected_workspace_id = list_workspaces(&server, org_id.clone())
+        .await
+        .first()
+        .expect("org should have at least one workspace")
+        .id
+        .clone();
     let api_key = get_api_key_for_org(&server, org.id).await;
 
     let response = server
@@ -25,16 +34,14 @@ async fn test_check_api_key_valid() {
     let body: serde_json::Value = response.json();
     assert_eq!(body["valid"], true);
     assert_eq!(
-        body["org_id"].as_str().unwrap(),
+        body["organization_id"].as_str().unwrap(),
         org_id,
-        "response org_id must match the org the API key belongs to"
+        "response organization_id must match the org the API key belongs to"
     );
-    let workspace_id = body["workspace_id"]
-        .as_str()
-        .expect("response must include workspace_id");
-    assert!(
-        uuid::Uuid::parse_str(workspace_id).is_ok(),
-        "workspace_id must be a valid UUID, got {workspace_id}"
+    assert_eq!(
+        body["workspace_id"].as_str().unwrap(),
+        expected_workspace_id,
+        "response workspace_id must match the workspace the API key was created in"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds `org_id` and `workspace_id` to the success response of `POST /v1/check_api_key` so downstream gateways (notably **inference-proxy**) have a server-side authoritative tenant ID to attach to logs and usage records — instead of trusting a caller-supplied `X-Org-Id` header.

## Why

Per [nearai/inference-proxy#132](https://github.com/nearai/inference-proxy/issues/132): inference-proxy today reads `X-Org-Id` straight off the inbound request and (a) attaches it to the tracing span, (b) forwards it to the vLLM engine, (c) emits it on the per-request structured log line. That's safe only because inference-proxy is currently reachable solely via cloud-api / nginx — i.e. the trust boundary is the network ACL, not the API. If that ACL ever loosens, a caller can spoof an arbitrary `org_id` into the logs of another tenant.

`/v1/check_api_key` is the natural place to fix this: inference-proxy already calls it on every `sk-` key validation, and the API key uniquely identifies the org/workspace pair. Returning those IDs in the body lets inference-proxy stop trusting the inbound header.

## Changes

- `crates/api/src/routes/gateway.rs` — extend `CheckApiKeyResponse` with `org_id: String` + `workspace_id: String`. Both already available on the `AuthenticatedApiKey` extension, so the handler just serializes them.
- `crates/api/tests/e2e_all/check_api_key.rs` — happy-path test now asserts both fields are present and that `org_id` matches the org the key belongs to.

## Backwards compatibility

Additive on the 200 response shape only. Current inference-proxy drains the body without parsing (`auth.rs:84-180`), so it ignores the new fields gracefully — the inference-proxy PR that actually consumes them comes next, after this lands and deploys.

## Test plan

- [x] `cargo test --lib --bins` — 312 passed
- [x] `cargo test --test e2e_all check_api_key` — 4 passed against ephemeral Postgres
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets`
- [ ] CI passes
- [ ] Follow-up inference-proxy PR uses the returned `org_id` as source of truth

## Related

- Issue: nearai/inference-proxy#132
- Tracing PR that motivated this: nearai/inference-proxy#130