### PR TITLE
feat(vllm): rotation-SNI fallback on 5xx + recognize in-stream error chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3812,6 +3812,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tracing",
+ "url",
  "uuid",
  "x509-parser 0.18.1",
 ]

--- a/crates/inference_providers/Cargo.toml
+++ b/crates/inference_providers/Cargo.toml
@@ -29,6 +29,7 @@ dstack-sdk-types = "0.1.2"
 serde_urlencoded = "0.7.1"
 regex = "1"
 sha2 = "0.11"
+url = "2.5"
 
 # Dev dependencies for testing and examples
 [dev-dependencies]

--- a/crates/inference_providers/src/external/openai_compatible.rs
+++ b/crates/inference_providers/src/external/openai_compatible.rs
@@ -11,7 +11,7 @@
 
 use super::backend::{BackendConfig, ExternalBackend};
 use crate::{
-    models::StreamOptions, sse_parser::new_sse_parser, AudioTranscriptionError,
+    models::StreamOptions, sse_parser::new_external_sse_parser, AudioTranscriptionError,
     AudioTranscriptionParams, AudioTranscriptionResponse, ChatCompletionParams,
     ChatCompletionResponse, ChatCompletionResponseWithBytes, CompletionError, ImageGenerationError,
     ImageGenerationParams, ImageGenerationResponse, ImageGenerationResponseWithBytes,
@@ -129,8 +129,11 @@ impl ExternalBackend for OpenAiCompatibleBackend {
             });
         }
 
-        // Use the SSE parser to handle the stream
-        let sse_stream = new_sse_parser(response.bytes_stream(), true);
+        // Use the SSE parser to handle the stream. External upstream → any
+        // in-stream `{"error":{...}}` frame surfaces as
+        // `HttpError { is_external: true }` so `map_provider_error` applies
+        // the third-party taxonomy (e.g. 404 → `ProviderError 502`).
+        let sse_stream = new_external_sse_parser(response.bytes_stream(), true);
         Ok(Box::pin(sse_stream))
     }
 

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -87,7 +87,9 @@ pub use models::{
     ScoreError, ScoreParams, ScoreResponse, ScoreResult, ScoreUsage, StreamChunk, StreamOptions,
     TokenUsage, ToolChoice, ToolDefinition, TranscriptionSegment, TranscriptionWord,
 };
-pub use sse_parser::{new_sse_parser, BufferedSSEParser, SSEEvent, SSEEventParser, SSEParser};
+pub use sse_parser::{
+    new_external_sse_parser, new_sse_parser, BufferedSSEParser, SSEEvent, SSEEventParser, SSEParser,
+};
 pub use vllm::{VLlmConfig, VLlmProvider};
 
 // Chunk builder for external provider parsers

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -60,6 +60,7 @@ pub mod chunk_builder;
 pub mod external;
 pub mod mock;
 pub mod models;
+pub mod rotation;
 pub mod spki_verifier;
 pub mod sse_parser;
 pub mod vllm;
@@ -262,6 +263,13 @@ pub trait InferenceProvider {
 
     /// Clean up the dedicated client for a chat_id after signature fetching.
     fn unpin_chat_connection(&self, _chat_id: &str) {}
+
+    /// Update the provider's view of how many healthy backends sit behind its
+    /// canonical SNI. Discovery calls this after each cycle so the traffic-
+    /// time fallback path knows how many rotation-SNI indices to iterate when
+    /// the sticky backend returns a 5xx. Default is a no-op — only providers
+    /// that participate in model-proxy rotation (vLLM) override it.
+    fn set_backend_count(&self, _count: usize) {}
 
     async fn get_attestation_report(
         &self,

--- a/crates/inference_providers/src/rotation.rs
+++ b/crates/inference_providers/src/rotation.rs
@@ -16,6 +16,14 @@ use serde::Deserialize;
 use tracing::debug;
 use url::Url;
 
+/// Hard cap on rotation fan-out, shared between the discovery cycle (which
+/// caps `/backends/count` before issuing per-index attestation probes) and
+/// the traffic-time fallback path (which caps how many indices we walk on a
+/// 5xx). Far above any realistic backend pool; hitting it means a registry
+/// reading is bogus and we're defending against unbounded fresh-TCP
+/// handshakes per request.
+pub const MAX_FANOUT: usize = 256;
+
 /// Pieces of an inference URL that the rotation path needs.
 ///
 /// `host` is the original SNI/Host the provider was registered with

--- a/crates/inference_providers/src/rotation.rs
+++ b/crates/inference_providers/src/rotation.rs
@@ -1,11 +1,12 @@
-//! Rotation-SNI helpers for backend-deterministic attestation discovery.
+//! Rotation-SNI helpers for backend-deterministic routing.
 //!
 //! Model-proxy publishes a synthetic SNI scheme `<canonical>-i<N>.<base>` that
 //! routes a fresh-TCP connection to backend `N % healthy_count`, bypassing the
 //! least-connections LB that otherwise collapses our probes onto a stable
-//! subset. Cloud-api combines this with `GET /backends/count?domain=<host>` to
-//! learn the live healthy count per cycle and iterate every backend in one
-//! pass.
+//! subset. Combined with `GET /backends/count?domain=<host>` to learn the live
+//! healthy count, callers can iterate every backend in one pass — used by both
+//! attestation discovery (deterministic per-backend probing) and traffic-time
+//! fallback (retry on a different backend when the sticky one returns 5xx).
 //!
 //! See model-proxy PR #27.
 
@@ -22,7 +23,7 @@ use url::Url;
 /// DNS label (`glm-5-1`), and `base` is everything after that
 /// (`completions.near.ai`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct UrlParts {
+pub struct UrlParts {
     pub host: String,
     pub canonical_label: String,
     pub base: String,
@@ -36,10 +37,8 @@ pub(super) struct UrlParts {
 ///
 /// Returns `None` when the URL's host doesn't look like a child of a single
 /// base domain (one-label hostnames, IP literals, missing host). Callers
-/// treat that as "skip rotation for this URL" — there is no other path in
-/// this PR, so the discovery cycle records zero observations and the
-/// existing fail-closed eviction logic runs.
-pub(super) fn split_inference_url(url: &Url) -> Option<UrlParts> {
+/// treat that as "skip rotation for this URL".
+pub fn split_inference_url(url: &Url) -> Option<UrlParts> {
     let host = url.host_str()?;
     // IP literals (`url::Host::Ipv4` / `Ipv6`) parse into `host_str` too, so
     // gate on the URL host *type*: only Domain is meaningful for SNI rotation.
@@ -64,13 +63,13 @@ pub(super) fn split_inference_url(url: &Url) -> Option<UrlParts> {
 }
 
 /// Build the rotation URL for index `i`:
-/// `https://<canonical>-i<i>.<base>/v1/attestation/report?...`
+/// `https://<canonical>-i<i>.<base>/`
 ///
-/// The caller appends the query string itself; this helper only builds the
-/// authority part. Returns `None` only if URL construction fails (which
-/// requires a malformed `UrlParts`, an unreachable state given that
+/// The caller appends path + query themselves; this helper builds the
+/// authority. Returns `None` only if URL construction fails (which requires
+/// a malformed `UrlParts`, an unreachable state given that
 /// `split_inference_url` validated the inputs).
-pub(super) fn rotation_base_url(parts: &UrlParts, index: u64) -> Option<Url> {
+pub fn rotation_base_url(parts: &UrlParts, index: u64) -> Option<Url> {
     let host = format!("{}-i{}.{}", parts.canonical_label, index, parts.base);
     let authority = match parts.port {
         Some(p) => format!("{}://{}:{}", parts.scheme, host, p),
@@ -81,7 +80,7 @@ pub(super) fn rotation_base_url(parts: &UrlParts, index: u64) -> Option<Url> {
 
 /// Build the count endpoint URL for this provider's base:
 /// `https://<base>/backends/count?domain=<host>`
-pub(super) fn count_url(parts: &UrlParts) -> Option<Url> {
+pub fn count_url(parts: &UrlParts) -> Option<Url> {
     let authority = match parts.port {
         Some(p) => format!("{}://{}:{}", parts.scheme, parts.base, p),
         None => format!("{}://{}", parts.scheme, parts.base),
@@ -104,15 +103,14 @@ struct CountResponse {
 ///
 /// `Ok(healthy)` means model-proxy authoritatively reported the live healthy
 /// count for this domain. `Err(reason)` means we couldn't get a count and
-/// must skip the rotation cycle; the reason is recorded in
-/// `DiscoveryOutcome::failure_reasons` for observability and the cycle ends
-/// with zero observations.
-pub(super) enum CountFetch {
+/// the caller should skip this cycle; the reason is suitable for low-
+/// cardinality observability ingestion.
+pub enum CountFetch {
     Ok(usize),
     Err(String),
 }
 
-pub(super) async fn fetch_backend_count(
+pub async fn fetch_backend_count(
     client: &reqwest::Client,
     parts: &UrlParts,
     timeout: Duration,

--- a/crates/inference_providers/src/sse_parser.rs
+++ b/crates/inference_providers/src/sse_parser.rs
@@ -197,11 +197,28 @@ where
 #[derive(Default)]
 pub struct OpenAIParserState {
     pub(crate) is_chat: bool,
+    /// Tags `HttpError` events surfaced from in-stream `{"error":{...}}`
+    /// frames so `map_provider_error` can distinguish our own vLLM/SGLang
+    /// (`false`) from a third-party OpenAI-compatible upstream (`true`).
+    /// The (status, external) tuple drives different user-facing messages
+    /// — e.g. a 404 from a third-party provider is a `ProviderError 502`,
+    /// while a 404 from our own vLLM is `InvalidModel`.
+    pub(crate) is_external: bool,
 }
 
 impl OpenAIParserState {
     pub fn new(is_chat: bool) -> Self {
-        Self { is_chat }
+        Self {
+            is_chat,
+            is_external: false,
+        }
+    }
+
+    pub fn new_with_external(is_chat: bool, is_external: bool) -> Self {
+        Self {
+            is_chat,
+            is_external,
+        }
     }
 }
 
@@ -249,7 +266,7 @@ impl SSEEventParser for OpenAIEventParser {
                     return Err(CompletionError::HttpError {
                         status_code,
                         message,
-                        is_external: false,
+                        is_external: state.is_external,
                     });
                 }
                 let chunk = if state.is_chat {
@@ -293,12 +310,25 @@ impl SSEEventParser for OpenAIEventParser {
 /// Type alias for backward compatibility.
 pub type SSEParser<S> = BufferedSSEParser<S, OpenAIEventParser>;
 
-/// Create a new SSE parser for OpenAI/vLLM format
+/// Create a new SSE parser for OpenAI/vLLM format (our own vLLM/SGLang).
+/// In-stream error frames are tagged `is_external: false`.
 pub fn new_sse_parser<S>(stream: S, is_chat: bool) -> SSEParser<S>
 where
     S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin,
 {
     BufferedSSEParser::new(stream, OpenAIParserState::new(is_chat))
+}
+
+/// Create a new SSE parser for a third-party OpenAI-compatible upstream
+/// (the `external::openai_compatible` provider). In-stream error frames
+/// surface as `HttpError { is_external: true }` so `map_provider_error`
+/// applies the external-provider taxonomy (e.g. 404 → `ProviderError 502`
+/// rather than `InvalidModel`).
+pub fn new_external_sse_parser<S>(stream: S, is_chat: bool) -> SSEParser<S>
+where
+    S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin,
+{
+    BufferedSSEParser::new(stream, OpenAIParserState::new_with_external(is_chat, true))
 }
 
 #[cfg(test)]
@@ -598,6 +628,35 @@ mod tests {
                 assert_eq!(*status_code, 502, "Missing code should default to 502");
             }
             other => panic!("Expected HttpError 502, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_external_sse_parser_tags_error_chunks_as_external() {
+        // External (third-party OpenAI-compatible) providers route through
+        // `new_external_sse_parser` so their in-stream error chunks surface
+        // with `is_external: true`. This matters for `map_provider_error`:
+        // a 404 from a third-party provider should map to `ProviderError
+        // 502` (their model is unavailable), not `InvalidModel` (which is
+        // the meaning of 404 from our own vLLM infrastructure).
+        let packet = "data: {\"error\":{\"message\":\"model not found\",\"type\":\"not_found\",\"code\":404}}\n\n";
+        let mock_stream =
+            futures_util::stream::iter(vec![Ok::<_, reqwest::Error>(bytes::Bytes::from(packet))]);
+        let parser = new_external_sse_parser(mock_stream, true);
+        let events: Vec<_> = parser.collect().await;
+        match &events[0] {
+            Err(CompletionError::HttpError {
+                status_code,
+                is_external,
+                ..
+            }) => {
+                assert_eq!(*status_code, 404);
+                assert!(
+                    *is_external,
+                    "External provider error chunks must be tagged is_external: true"
+                );
+            }
+            other => panic!("Expected HttpError 404 with is_external: true, got: {other:?}"),
         }
     }
 

--- a/crates/inference_providers/src/sse_parser.rs
+++ b/crates/inference_providers/src/sse_parser.rs
@@ -225,6 +225,33 @@ impl SSEEventParser for OpenAIEventParser {
         // Parse JSON data
         match serde_json::from_str::<serde_json::Value>(data) {
             Ok(json) => {
+                // SGLang / vLLM emit an in-stream error frame when an abort
+                // fires AFTER the HTTP 200 headers were sent (queue-full,
+                // priority-disabled, waiting timeout, etc.):
+                //   data: {"error":{"message":"...","type":"...","code":503}}
+                // Surface it as a typed `HttpError` so VLlmProvider's
+                // rotation-SNI fallback can classify by upstream status
+                // (5xx → try a different backend) instead of treating it as
+                // a generic `InvalidResponse`, which would terminate the
+                // stream silently with a `server_error` SSE frame.
+                if let Some(err_obj) = json.get("error").and_then(|v| v.as_object()) {
+                    let status_code = err_obj
+                        .get("code")
+                        .and_then(|v| v.as_u64())
+                        .and_then(|n| u16::try_from(n).ok())
+                        .filter(|&n| (100..=599).contains(&n))
+                        .unwrap_or(502);
+                    let message = err_obj
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Upstream stream emitted an error event")
+                        .to_string();
+                    return Err(CompletionError::HttpError {
+                        status_code,
+                        message,
+                        is_external: false,
+                    });
+                }
                 let chunk = if state.is_chat {
                     match serde_json::from_value::<ChatCompletionChunk>(json) {
                         Ok(chunk) => StreamChunk::Chat(chunk),
@@ -514,5 +541,84 @@ mod tests {
         // correctly reassembled é since bytes are buffered until newline.
         assert_eq!(events.len(), 1, "Expected 1 event, got {}", events.len());
         assert!(events[0].is_ok(), "The event should be parsed successfully");
+    }
+
+    #[tokio::test]
+    async fn test_sse_parser_propagates_error_chunk_as_http_error() {
+        // SGLang `--max-queued-requests` abort emits an in-stream error frame
+        // *after* HTTP 200 headers. Previously the parser couldn't classify
+        // this and surfaced `InvalidResponse("Failed to parse event")`, which
+        // hid the upstream status from VLlmProvider's rotation fallback.
+        // The fix promotes any `{"error":{"code":N,...}}` chunk to a typed
+        // `HttpError { status_code: N }` so the rotation path can recognize
+        // it as 5xx and walk to a different backend.
+        let packet = "data: {\"error\":{\"object\":\"error\",\"message\":\"The request queue is full.\",\"type\":\"SERVICE_UNAVAILABLE\",\"code\":503}}\n\ndata: [DONE]\n\n";
+        let mock_stream =
+            futures_util::stream::iter(vec![Ok::<_, reqwest::Error>(bytes::Bytes::from(packet))]);
+        let parser = new_sse_parser(mock_stream, true);
+        let events: Vec<_> = parser.collect().await;
+        assert_eq!(
+            events.len(),
+            1,
+            "Expected exactly one error event before stream termination, got {}",
+            events.len()
+        );
+        match &events[0] {
+            Err(CompletionError::HttpError {
+                status_code,
+                message,
+                is_external,
+            }) => {
+                assert_eq!(*status_code, 503);
+                assert!(
+                    message.contains("queue is full"),
+                    "Expected upstream message to round-trip, got: {message}"
+                );
+                assert!(
+                    !*is_external,
+                    "Internal vLLM/SGLang errors must not leak as external"
+                );
+            }
+            other => panic!("Expected HttpError 503, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sse_parser_error_chunk_without_numeric_code_falls_back_to_502() {
+        // Defensive: not every upstream emits `code`. A `{"error":{...}}` with
+        // no `code` field still indicates an upstream problem — surface it as
+        // 502 so rotation fallback considers it retryable (5xx).
+        let packet = "data: {\"error\":{\"message\":\"something went wrong\",\"type\":\"server_error\"}}\n\n";
+        let mock_stream =
+            futures_util::stream::iter(vec![Ok::<_, reqwest::Error>(bytes::Bytes::from(packet))]);
+        let parser = new_sse_parser(mock_stream, true);
+        let events: Vec<_> = parser.collect().await;
+        match &events[0] {
+            Err(CompletionError::HttpError { status_code, .. }) => {
+                assert_eq!(*status_code, 502, "Missing code should default to 502");
+            }
+            other => panic!("Expected HttpError 502, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sse_parser_ignores_non_object_error_field() {
+        // A chunk like `{"id":..., "error": null}` would historically have
+        // failed `ChatCompletionChunk` deserialization and surfaced as
+        // `InvalidResponse`. With the new branch we MUST only intercept on
+        // `error` being an *object* — otherwise a legitimate streaming
+        // response with a null/missing-error semantic would be misclassified
+        // as 502.
+        let packet = "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}],\"error\":null}\n\n";
+        let mock_stream =
+            futures_util::stream::iter(vec![Ok::<_, reqwest::Error>(bytes::Bytes::from(packet))]);
+        let parser = new_sse_parser(mock_stream, true);
+        let events: Vec<_> = parser.collect().await;
+        assert_eq!(events.len(), 1);
+        assert!(
+            events[0].is_ok(),
+            "null `error` field must not trigger the error path: got {:?}",
+            events[0]
+        );
     }
 }

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -966,18 +966,32 @@ impl VLlmProvider {
             {
                 Ok(r) => r,
                 Err(e) => match &e {
+                    // 4xx other than 429 is a real client error (bad request,
+                    // invalid params) — every backend would reject it the
+                    // same way, so surface immediately rather than burn the
+                    // remaining indices on a doomed request.
                     CompletionError::HttpError { status_code, .. }
-                        if Self::is_rotation_retryable_status(*status_code) =>
+                        if !Self::is_rotation_retryable_status(*status_code) =>
                     {
+                        return Err(e);
+                    }
+                    // Everything else (retryable HttpError 5xx/429,
+                    // `Timeout` from `send_streaming_request`'s TTFB guard,
+                    // generic `CompletionError` for TLS/TCP/transport
+                    // failures) is per-backend by construction: model-proxy
+                    // PR #27 pins each `-iN` SNI to one backend, so the
+                    // failure at index N tells us nothing about index N+1.
+                    // Mirror the non-streaming sibling and try the next
+                    // index instead of giving up.
+                    _ => {
                         tracing::debug!(
                             index,
-                            status_code = *status_code,
-                            "Rotation-SNI stream attempt returned 5xx/429, trying next backend"
+                            error = %e,
+                            "Rotation-SNI stream attempt failed, trying next backend"
                         );
                         last_error = e;
                         continue;
                     }
-                    _ => return Err(e),
                 },
             };
             let parser = new_sse_parser(response.bytes_stream(), true);
@@ -1360,7 +1374,24 @@ impl InferenceProvider for VLlmProvider {
         //     forwards verbatim): peek catches it via the parser's typed
         //     `HttpError` and we route to the same rotation fallback.
         //   - Otherwise: pin bucket, return peekable as the live stream.
+        //
+        // We only peek when rotation is actually possible
+        // (`rotation_count() > 0`): the peek blocks until the first SSE
+        // chunk arrives, so on the happy path it adds first-byte latency
+        // to every streaming request. When rotation can't help (cold-start
+        // before discovery's first cycle, or non-rotation URLs like
+        // `localhost`), skip the peek so a first-chunk error still surfaces
+        // through the route layer's `sse_error_frame` path (PR #629) and
+        // happy-path streams return HTTP 200 as soon as the headers arrive.
         match canonical_send {
+            Ok(response) if self.rotation_count() == 0 => {
+                self.pending_buckets
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(request_hash, bucket_id);
+                let sse_stream = new_sse_parser(response.bytes_stream(), true);
+                Ok(Box::pin(sse_stream))
+            }
             Ok(response) => {
                 let parser = new_sse_parser(response.bytes_stream(), true);
                 let stream: StreamingResult = Box::pin(parser);
@@ -1386,14 +1417,10 @@ impl InferenceProvider for VLlmProvider {
                         Ok(Box::pin(peekable))
                     }
                     Some(status_code) => {
+                        // rotation_count() > 0 is guaranteed by the arm
+                        // guard above, so the fallback will actually iterate
+                        // at least one alternative backend.
                         drop(peekable);
-                        if self.rotation_count() == 0 {
-                            return Err(CompletionError::HttpError {
-                                status_code,
-                                message: "Upstream stream emitted an error event".to_string(),
-                                is_external: false,
-                            });
-                        }
                         self.try_chat_completion_stream_rotation(
                             &streaming_params,
                             &headers,

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -758,18 +758,16 @@ impl VLlmProvider {
         Ok(response)
     }
 
-    /// Hard cap on rotation fan-out. Mirrors `MAX_ROTATION_FANOUT` in the
-    /// discovery path: a bogus `/backends/count` reading shouldn't let one
-    /// 5xx burn an unbounded number of fresh-TCP handshakes.
-    const MAX_ROTATION_FANOUT: usize = 256;
-
     /// Status codes that warrant a rotation-SNI retry. Mirrors the pool's
-    /// `classify_retry_decision` ("retryable_http_5xx" + 429), but evaluated
-    /// here so the rotation fallback fires *before* the canonical 5xx
-    /// escapes to the pool's same-provider backoff loop (which would only
-    /// re-hit the sticky bucket → same overloaded backend).
+    /// `classify_retry_decision` ("retryable_http_5xx" + 429 + 408), but
+    /// evaluated here so the rotation fallback fires *before* the canonical
+    /// 5xx escapes to the pool's same-provider backoff loop (which would
+    /// only re-hit the sticky bucket → same overloaded backend). 408 is
+    /// included because the pool already treats it as "next-provider-
+    /// worthy" — keeping the gates in sync avoids a taxonomy mismatch
+    /// where the pool would retry on 408 but rotation wouldn't.
     fn is_rotation_retryable_status(status_code: u16) -> bool {
-        status_code == 429 || (500..=599).contains(&status_code)
+        status_code == 408 || status_code == 429 || (500..=599).contains(&status_code)
     }
 
     /// Healthy backend count clamped to the rotation fan-out cap. Returns 0
@@ -782,7 +780,7 @@ impl VLlmProvider {
         }
         self.last_backend_count
             .load(Ordering::Relaxed)
-            .min(Self::MAX_ROTATION_FANOUT)
+            .min(crate::rotation::MAX_FANOUT)
     }
 
     /// Build the absolute URL `https://<canonical>-i<index>.<base><path>` for
@@ -831,6 +829,15 @@ impl VLlmProvider {
         canonical_err: CompletionError,
     ) -> Result<ChatCompletionResponseWithBytes, CompletionError> {
         let count = self.rotation_count();
+        // `last_error` tracks only HttpError-shaped failures so the pool's
+        // `classify_retry_decision` sees a typed `retryable_http_5xx` (or
+        // 429) at the end. Transport-level failures from the rotation loop
+        // (Timeout, generic CompletionError) are logged but never overwrite
+        // `last_error`: if every rotation index produced only transport
+        // errors, we fall back to `canonical_err` (always an HttpError 5xx/
+        // 429 by call-site construction) instead of returning a misleading
+        // `CompletionError(...)` that would classify as
+        // `retryable_connection_keyword`.
         let mut last_error = canonical_err;
         for index in 0..count as u64 {
             let url = match self.rotation_url(index, "/v1/chat/completions") {
@@ -840,7 +847,10 @@ impl VLlmProvider {
             let client = match self.build_rotation_client() {
                 Ok(c) => c,
                 Err(e) => {
-                    last_error = e;
+                    tracing::debug!(
+                        index, error = %e,
+                        "Rotation-SNI chat_completion client build failed, trying next backend"
+                    );
                     continue;
                 }
             };
@@ -854,20 +864,16 @@ impl VLlmProvider {
             let response = match send_res {
                 Ok(r) => r,
                 Err(e) => {
-                    // Connect / network errors against this index — try the
-                    // next backend; treat as retryable since the rotation
-                    // listener pins to one backend by design (model-proxy
-                    // PR #27).
-                    last_error = if e.is_timeout() && !e.is_connect() {
-                        CompletionError::Timeout {
-                            operation: "chat_completion".to_string(),
-                            timeout_seconds: timeout.as_secs(),
-                        }
-                    } else {
-                        CompletionError::CompletionError(format_error_chain(&e))
-                    };
+                    // Connect / network / TTFB-timeout errors against this
+                    // index — try the next backend. The rotation listener
+                    // pins to one backend by design (model-proxy PR #27),
+                    // so failure at index N tells us nothing about N+1.
+                    // We log the error but DON'T overwrite `last_error`:
+                    // see the field comment above.
                     tracing::debug!(
-                        index, error = %last_error,
+                        index, error = %format_error_chain(&e),
+                        is_timeout = e.is_timeout(),
+                        is_connect = e.is_connect(),
                         "Rotation-SNI chat_completion attempt errored, trying next backend"
                     );
                     continue;
@@ -888,12 +894,12 @@ impl VLlmProvider {
                     tracing::debug!(
                         index,
                         status_code,
-                        "Rotation-SNI chat_completion backend still 5xx, trying next"
+                        "Rotation-SNI chat_completion backend still 5xx/429/408, trying next"
                     );
                     last_error = err;
                     continue;
                 }
-                // 4xx (other than 429) means the request itself is bad —
+                // 4xx (other than 408/429) means the request itself is bad —
                 // surface immediately rather than burn the rest of the
                 // rotation set on the same client error.
                 return Err(err);
@@ -947,6 +953,14 @@ impl VLlmProvider {
         canonical_err: CompletionError,
     ) -> Result<StreamingResult, CompletionError> {
         let count = self.rotation_count();
+        // See the non-streaming sibling for the design: `last_error` only
+        // tracks HttpError-shaped failures from rotation indices, so the
+        // pool's `classify_retry_decision` sees the right `retryable_http_*`
+        // label at the end. Transport-level failures (Timeout, generic
+        // CompletionError) are logged but never overwrite `last_error`;
+        // if rotation produces only transport errors, we fall back to
+        // `canonical_err` (always HttpError 5xx/429 by call-site
+        // construction).
         let mut last_error = canonical_err;
         for index in 0..count as u64 {
             let url = match self.rotation_url(index, "/v1/chat/completions") {
@@ -956,7 +970,10 @@ impl VLlmProvider {
             let client = match self.build_rotation_client() {
                 Ok(c) => c,
                 Err(e) => {
-                    last_error = e;
+                    tracing::debug!(
+                        index, error = %e,
+                        "Rotation-SNI stream client build failed, trying next backend"
+                    );
                     continue;
                 }
             };
@@ -966,30 +983,37 @@ impl VLlmProvider {
             {
                 Ok(r) => r,
                 Err(e) => match &e {
-                    // 4xx other than 429 is a real client error (bad request,
-                    // invalid params) — every backend would reject it the
-                    // same way, so surface immediately rather than burn the
-                    // remaining indices on a doomed request.
+                    // 4xx other than 408/429 is a real client error (bad
+                    // request, invalid params) — every backend would reject
+                    // it the same way, so surface immediately rather than
+                    // burn the remaining indices on a doomed request.
                     CompletionError::HttpError { status_code, .. }
                         if !Self::is_rotation_retryable_status(*status_code) =>
                     {
                         return Err(e);
                     }
-                    // Everything else (retryable HttpError 5xx/429,
-                    // `Timeout` from `send_streaming_request`'s TTFB guard,
-                    // generic `CompletionError` for TLS/TCP/transport
-                    // failures) is per-backend by construction: model-proxy
-                    // PR #27 pins each `-iN` SNI to one backend, so the
-                    // failure at index N tells us nothing about index N+1.
-                    // Mirror the non-streaming sibling and try the next
-                    // index instead of giving up.
+                    // Retryable HttpError (5xx/429/408) — update last_error
+                    // so the trace label stays accurate at end-of-rotation.
+                    CompletionError::HttpError { .. } => {
+                        tracing::debug!(
+                            index, error = %e,
+                            "Rotation-SNI stream attempt returned 5xx/429/408, trying next backend"
+                        );
+                        last_error = e;
+                        continue;
+                    }
+                    // Transport-level failures (`Timeout` from
+                    // `send_streaming_request`'s TTFB guard, generic
+                    // `CompletionError` for TLS/TCP). Per-backend by
+                    // construction: model-proxy PR #27 pins each `-iN` SNI
+                    // to one backend, so failure at index N tells us nothing
+                    // about index N+1. Log but DON'T overwrite last_error.
                     _ => {
                         tracing::debug!(
                             index,
                             error = %e,
-                            "Rotation-SNI stream attempt failed, trying next backend"
+                            "Rotation-SNI stream attempt failed transport, trying next backend"
                         );
-                        last_error = e;
                         continue;
                     }
                 },
@@ -3033,20 +3057,25 @@ mod tests {
     }
 
     #[test]
-    fn rotation_retryable_status_covers_5xx_and_429() {
+    fn rotation_retryable_status_covers_5xx_429_and_408() {
         // Mirrors `classify_retry_decision` in the pool ("retryable_http_5xx"
-        // + 429). Keeping these in sync is load-bearing: if the rotation
-        // gate diverges, a 503 that the pool considers retryable could
-        // bypass rotation and burn the pool's 3-round backoff against the
-        // same overloaded bucket.
+        // + 429 + 408). Keeping these in sync is load-bearing: if the
+        // rotation gate diverges, a 503 that the pool considers retryable
+        // could bypass rotation and burn the pool's 3-round backoff against
+        // the same overloaded bucket. 408 is included because the pool
+        // already treats it as next-provider-worthy in the chat_completion
+        // closure — and other indices may succeed where the sticky bucket
+        // timed out.
+        assert!(VLlmProvider::is_rotation_retryable_status(408));
         assert!(VLlmProvider::is_rotation_retryable_status(429));
         assert!(VLlmProvider::is_rotation_retryable_status(500));
         assert!(VLlmProvider::is_rotation_retryable_status(503));
         assert!(VLlmProvider::is_rotation_retryable_status(599));
         assert!(!VLlmProvider::is_rotation_retryable_status(200));
         assert!(!VLlmProvider::is_rotation_retryable_status(400));
+        assert!(!VLlmProvider::is_rotation_retryable_status(401));
         assert!(!VLlmProvider::is_rotation_retryable_status(404));
-        assert!(!VLlmProvider::is_rotation_retryable_status(408));
+        assert!(!VLlmProvider::is_rotation_retryable_status(422));
     }
 
     #[test]
@@ -3103,7 +3132,7 @@ mod tests {
             control_timeout_seconds: 30,
         });
         provider.set_backend_count(10_000);
-        assert_eq!(provider.rotation_count(), VLlmProvider::MAX_ROTATION_FANOUT);
+        assert_eq!(provider.rotation_count(), crate::rotation::MAX_FANOUT);
     }
 
     #[test]

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -10,6 +10,7 @@ use prefix_router::PrefixRouter;
 use reqwest::{header::HeaderValue, Client};
 use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Semaphore;
@@ -181,6 +182,33 @@ pub struct VLlmProvider {
     /// empty and many requests arrive simultaneously). Configurable via the
     /// `INLINE_VERIFY_CONCURRENCY` environment variable (default: 4).
     verification_semaphore: Arc<Semaphore>,
+    /// Cached TLS roots for building per-attempt rotation clients. Reused for
+    /// the rotation-SNI fallback path so the fingerprint pin set stays
+    /// consistent with the bucket clients.
+    tls_roots: SharedTlsRoots,
+    /// Most recent healthy backend count reported by discovery. Used by the
+    /// rotation-SNI retry path to bound the number of distinct backends to
+    /// fan out to when the sticky bucket returns 5xx. Discovery writes via
+    /// `set_backend_count`; the chat paths read with `Ordering::Relaxed`
+    /// (best-effort — a stale read just means we try one too few or one too
+    /// many indices, both safe because the proxy wraps `index % healthy`).
+    last_backend_count: AtomicUsize,
+    /// Pre-parsed rotation parts derived from `config.base_url` at
+    /// construction time, so we don't reparse on every retry. `None` for
+    /// URLs that don't fit the rotation scheme (one-label host, IP literal,
+    /// etc.) — in that case the rotation fallback is a no-op and the
+    /// canonical-SNI error propagates as before.
+    rotation_parts: Option<crate::rotation::UrlParts>,
+    /// Maps request_hash → rotation index when the streaming canonical attempt
+    /// fell over and a rotation-SNI attempt served the response instead.
+    /// `pin_chat_connection` promotes this to `signature_rotation` once the
+    /// chat_id is known, so `get_signature` can reuse the same rotation SNI.
+    pending_rotation: Arc<std::sync::Mutex<HashMap<String, u64>>>,
+    /// Maps chat_id → rotation index for the signature fetch path. Populated
+    /// either by the non-streaming chat_completion (chat_id known at send
+    /// time) or by `pin_chat_connection` once the stream's first chunk
+    /// yields a chat_id.
+    signature_rotation: Arc<std::sync::Mutex<HashMap<String, u64>>>,
 }
 
 impl VLlmProvider {
@@ -317,6 +345,15 @@ impl VLlmProvider {
                 .collect()
         };
 
+        // Pre-parse the base URL into rotation parts once. URLs that don't fit
+        // the rotation scheme (one-label host, IP literal, etc.) yield `None`,
+        // disabling rotation fallback for that provider — the canonical-SNI
+        // attempt's error simply propagates as it did before.
+        let rotation_parts = url::Url::parse(&config.base_url)
+            .ok()
+            .as_ref()
+            .and_then(crate::rotation::split_inference_url);
+
         Self {
             config,
             client,
@@ -328,6 +365,11 @@ impl VLlmProvider {
             signature_buckets: Arc::new(std::sync::Mutex::new(HashMap::new())),
             fingerprint_state,
             backend_verifier,
+            tls_roots,
+            last_backend_count: AtomicUsize::new(0),
+            rotation_parts,
+            pending_rotation: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            signature_rotation: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -715,6 +757,270 @@ impl VLlmProvider {
 
         Ok(response)
     }
+
+    /// Hard cap on rotation fan-out. Mirrors `MAX_ROTATION_FANOUT` in the
+    /// discovery path: a bogus `/backends/count` reading shouldn't let one
+    /// 5xx burn an unbounded number of fresh-TCP handshakes.
+    const MAX_ROTATION_FANOUT: usize = 256;
+
+    /// Status codes that warrant a rotation-SNI retry. Mirrors the pool's
+    /// `classify_retry_decision` ("retryable_http_5xx" + 429), but evaluated
+    /// here so the rotation fallback fires *before* the canonical 5xx
+    /// escapes to the pool's same-provider backoff loop (which would only
+    /// re-hit the sticky bucket → same overloaded backend).
+    fn is_rotation_retryable_status(status_code: u16) -> bool {
+        status_code == 429 || (500..=599).contains(&status_code)
+    }
+
+    /// Healthy backend count clamped to the rotation fan-out cap. Returns 0
+    /// when rotation is disabled (URL doesn't fit the rotation scheme, or
+    /// discovery hasn't reported a count yet) — callers use that as the
+    /// signal to skip the rotation fallback and propagate the original error.
+    fn rotation_count(&self) -> usize {
+        if self.rotation_parts.is_none() {
+            return 0;
+        }
+        self.last_backend_count
+            .load(Ordering::Relaxed)
+            .min(Self::MAX_ROTATION_FANOUT)
+    }
+
+    /// Build the absolute URL `https://<canonical>-i<index>.<base><path>` for
+    /// a rotation attempt at the given backend index. Returns `None` only if
+    /// rotation parts are missing — callers should already have filtered via
+    /// `rotation_count() > 0`.
+    fn rotation_url(&self, index: u64, path: &str) -> Option<String> {
+        let parts = self.rotation_parts.as_ref()?;
+        let mut url = crate::rotation::rotation_base_url(parts, index)?;
+        url.set_path(path);
+        Some(url.to_string())
+    }
+
+    /// Build a one-shot reqwest client used for a single rotation-SNI
+    /// attempt. We disable connection pooling (`pool_max_idle_per_host(0)`)
+    /// so a follow-up attempt at index N+1 can't accidentally reuse the
+    /// TLS/H2 connection that landed on index N — defeating the whole point
+    /// of the rotation. Shares the per-provider fingerprint state so the
+    /// same pinned SPKI set is enforced for every backend.
+    fn build_rotation_client(&self) -> Result<Client, CompletionError> {
+        Client::builder()
+            .use_preconfigured_tls(self.tls_roots.build_config(self.fingerprint_state.clone()))
+            .pool_max_idle_per_host(0)
+            .http2_adaptive_window(true)
+            .connect_timeout(Duration::from_secs(5))
+            .read_timeout(self.config.completion_timeout())
+            .build()
+            .map_err(|e| CompletionError::CompletionError(format!("rotation_client_build: {e}")))
+    }
+
+    /// Iterate every healthy backend by index until one returns a 2xx (or
+    /// every backend has been exhausted). Called by `chat_completion` after
+    /// the sticky bucket's canonical-SNI attempt returns 5xx/429: with H2
+    /// pooling disabled on each per-index client, every attempt lands on a
+    /// distinct backend, so a single overloaded SGLang can't poison the
+    /// whole request.
+    ///
+    /// `canonical_err` is the error that triggered the fallback; if all
+    /// rotation indices return retryable failures it surfaces as the final
+    /// error to preserve the original `status_code` for `map_provider_error`.
+    async fn try_chat_completion_rotation(
+        &self,
+        params: &ChatCompletionParams,
+        headers: &reqwest::header::HeaderMap,
+        timeout: Duration,
+        canonical_err: CompletionError,
+    ) -> Result<ChatCompletionResponseWithBytes, CompletionError> {
+        let count = self.rotation_count();
+        let mut last_error = canonical_err;
+        for index in 0..count as u64 {
+            let url = match self.rotation_url(index, "/v1/chat/completions") {
+                Some(u) => u,
+                None => continue,
+            };
+            let client = match self.build_rotation_client() {
+                Ok(c) => c,
+                Err(e) => {
+                    last_error = e;
+                    continue;
+                }
+            };
+            let send_res = client
+                .post(&url)
+                .headers(headers.clone())
+                .json(params)
+                .timeout(timeout)
+                .send()
+                .await;
+            let response = match send_res {
+                Ok(r) => r,
+                Err(e) => {
+                    // Connect / network errors against this index — try the
+                    // next backend; treat as retryable since the rotation
+                    // listener pins to one backend by design (model-proxy
+                    // PR #27).
+                    last_error = if e.is_timeout() && !e.is_connect() {
+                        CompletionError::Timeout {
+                            operation: "chat_completion".to_string(),
+                            timeout_seconds: timeout.as_secs(),
+                        }
+                    } else {
+                        CompletionError::CompletionError(format_error_chain(&e))
+                    };
+                    tracing::debug!(
+                        index, error = %last_error,
+                        "Rotation-SNI chat_completion attempt errored, trying next backend"
+                    );
+                    continue;
+                }
+            };
+            if !response.status().is_success() {
+                let status_code = response.status().as_u16();
+                let error_text = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|e| format!("Failed to read error response body: {e}"));
+                let err = CompletionError::HttpError {
+                    status_code,
+                    message: crate::extract_error_message(&error_text),
+                    is_external: false,
+                };
+                if Self::is_rotation_retryable_status(status_code) {
+                    tracing::debug!(
+                        index,
+                        status_code,
+                        "Rotation-SNI chat_completion backend still 5xx, trying next"
+                    );
+                    last_error = err;
+                    continue;
+                }
+                // 4xx (other than 429) means the request itself is bad —
+                // surface immediately rather than burn the rest of the
+                // rotation set on the same client error.
+                return Err(err);
+            }
+
+            let raw_bytes = response
+                .bytes()
+                .await
+                .map_err(|e| CompletionError::CompletionError(format_error_chain(&e)))?
+                .to_vec();
+            let chat_completion_response: ChatCompletionResponse =
+                serde_json::from_slice(&raw_bytes).map_err(|e| {
+                    CompletionError::CompletionError(format!("Failed to parse response: {e}"))
+                })?;
+
+            let chat_id = chat_completion_response.id.clone();
+            self.signature_rotation
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(chat_id, index);
+            tracing::info!(
+                index,
+                "Rotation-SNI chat_completion served by alternative backend"
+            );
+            return Ok(ChatCompletionResponseWithBytes {
+                response: chat_completion_response,
+                raw_bytes,
+            });
+        }
+        Err(last_error)
+    }
+
+    /// Streaming sibling of `try_chat_completion_rotation`. Two failure modes
+    /// land here:
+    ///   - The canonical send returned HTTP 5xx/429 outright (e.g. nginx 502
+    ///     when the inference-proxy container is restarting).
+    ///   - The canonical send returned HTTP 200 but the first SSE chunk was
+    ///     a `{"error":{"code":...}}` frame, which the parser now surfaces as
+    ///     a typed `HttpError` (the SGLang queue-full path that inference-
+    ///     proxy's SseTransformer forwards verbatim).
+    ///
+    /// We iterate every backend by rotation index until one returns a 200
+    /// whose first SSE chunk is a real content event. Bytes already sent to
+    /// the client are zero (peek happens before any chunk forwarding), so
+    /// retrying the whole stream is safe.
+    async fn try_chat_completion_stream_rotation(
+        &self,
+        params: &ChatCompletionParams,
+        headers: &reqwest::header::HeaderMap,
+        request_hash: &str,
+        canonical_err: CompletionError,
+    ) -> Result<StreamingResult, CompletionError> {
+        let count = self.rotation_count();
+        let mut last_error = canonical_err;
+        for index in 0..count as u64 {
+            let url = match self.rotation_url(index, "/v1/chat/completions") {
+                Some(u) => u,
+                None => continue,
+            };
+            let client = match self.build_rotation_client() {
+                Ok(c) => c,
+                Err(e) => {
+                    last_error = e;
+                    continue;
+                }
+            };
+            let response = match self
+                .send_streaming_request(&url, headers.clone(), params, Some(&client))
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => match &e {
+                    CompletionError::HttpError { status_code, .. }
+                        if Self::is_rotation_retryable_status(*status_code) =>
+                    {
+                        tracing::debug!(
+                            index,
+                            status_code = *status_code,
+                            "Rotation-SNI stream attempt returned 5xx/429, trying next backend"
+                        );
+                        last_error = e;
+                        continue;
+                    }
+                    _ => return Err(e),
+                },
+            };
+            let parser = new_sse_parser(response.bytes_stream(), true);
+            let stream: StreamingResult = Box::pin(parser);
+            let mut peekable = StreamingResultExt::peekable(stream);
+            let first_chunk_status =
+                if let Some(Err(CompletionError::HttpError { status_code, .. })) =
+                    peekable.peek().await
+                {
+                    if Self::is_rotation_retryable_status(*status_code) {
+                        Some(*status_code)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+            if let Some(status_code) = first_chunk_status {
+                tracing::debug!(
+                    index,
+                    status_code,
+                    "Rotation-SNI stream attempt: first chunk was an error, trying next backend"
+                );
+                last_error = CompletionError::HttpError {
+                    status_code,
+                    message: "Upstream stream emitted an error event".to_string(),
+                    is_external: false,
+                };
+                drop(peekable);
+                continue;
+            }
+            self.pending_rotation
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(request_hash.to_string(), index);
+            tracing::info!(
+                index,
+                "Rotation-SNI chat_completion_stream served by alternative backend"
+            );
+            return Ok(Box::pin(peekable));
+        }
+        Err(last_error)
+    }
 }
 
 #[async_trait]
@@ -724,15 +1030,62 @@ impl InferenceProvider for VLlmProvider {
         chat_id: &str,
         signing_algo: Option<String>,
     ) -> Result<ChatSignature, CompletionError> {
-        let url = format!(
-            "{}/v1/signature/{}?signing_algo={}",
-            self.config.base_url,
-            chat_id,
-            signing_algo.unwrap_or_else(|| "ecdsa".to_string())
-        );
+        let signing_algo = signing_algo.unwrap_or_else(|| "ecdsa".to_string());
+        let path_and_query = format!("/v1/signature/{chat_id}?signing_algo={signing_algo}");
+        let canonical_url = format!("{}{}", self.config.base_url, path_and_query);
         let headers = self
             .build_headers()
             .map_err(CompletionError::CompletionError)?;
+        let timeout = self.config.control_timeout();
+
+        // If this chat_id was served by a rotation-SNI fallback (sticky bucket
+        // returned 5xx, so we walked backends by index until one took the
+        // request), the signature lives on that *specific* backend — neither
+        // the bucket-pinned client nor the general LB client can find it. We
+        // build a one-shot rotation client targeting the same index and use
+        // it FIRST; the existing bucket/general fallback runs only if that
+        // attempt also misses.
+        let rotation_index = self
+            .signature_rotation
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(chat_id)
+            .copied();
+        if let Some(index) = rotation_index {
+            if let Some(rotation_url) = self.rotation_url(index, "") {
+                let rotation_url =
+                    format!("{}{}", rotation_url.trim_end_matches('/'), path_and_query);
+                if let Ok(client) = self.build_rotation_client() {
+                    match client
+                        .get(&rotation_url)
+                        .headers(headers.clone())
+                        .timeout(timeout)
+                        .send()
+                        .await
+                    {
+                        Ok(response) if response.status().is_success() => {
+                            return response.json().await.map_err(|e| {
+                                CompletionError::CompletionError(format_error_chain(&e))
+                            });
+                        }
+                        Ok(response) => {
+                            tracing::debug!(
+                                index,
+                                status = response.status().as_u16(),
+                                "Rotation-SNI signature fetch did not return 2xx, falling back to bucket/general"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                index,
+                                error = %format_error_chain(&e),
+                                "Rotation-SNI signature fetch errored, falling back to bucket/general"
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         // Use the bucket client for this chat_id to hit the same backend.
         // With HTTP/2 (ALPN-negotiated), all requests multiplex on one connection.
@@ -752,7 +1105,6 @@ impl InferenceProvider for VLlmProvider {
                 .clone()
         });
 
-        let timeout = self.config.control_timeout();
         let mut clients_to_try: Vec<&Client> = Vec::new();
         if let Some(ref bc) = bucket_client {
             clients_to_try.push(bc);
@@ -762,7 +1114,7 @@ impl InferenceProvider for VLlmProvider {
         let mut last_error = None;
         for client in clients_to_try {
             let response = client
-                .get(&url)
+                .get(&canonical_url)
                 .headers(headers.clone())
                 .timeout(timeout)
                 .send()
@@ -809,6 +1161,24 @@ impl InferenceProvider for VLlmProvider {
                 .unwrap_or_else(|e| e.into_inner())
                 .insert(chat_id.to_string(), bucket_id);
         }
+        // Streaming attempts that fell over to a rotation index left the
+        // index in `pending_rotation` keyed by request_hash; promote it
+        // alongside the bucket-side mapping so `get_signature` knows which
+        // SNI to use. Empty chat_id (orphan-cleanup case) only clears the
+        // pending entry without writing into signature_rotation.
+        if let Some(index) = self
+            .pending_rotation
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(request_hash)
+        {
+            if !chat_id.is_empty() {
+                self.signature_rotation
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(chat_id.to_string(), index);
+            }
+        }
     }
 
     fn unpin_chat_connection(&self, chat_id: &str) {
@@ -816,6 +1186,14 @@ impl InferenceProvider for VLlmProvider {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(chat_id);
+        self.signature_rotation
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(chat_id);
+    }
+
+    fn set_backend_count(&self, count: usize) {
+        self.last_backend_count.store(count, Ordering::Relaxed);
     }
 
     async fn get_attestation_report(
@@ -953,7 +1331,7 @@ impl InferenceProvider for VLlmProvider {
         // pins the client.
         let bucket_id = self.prefix_router.route(&streaming_params.messages);
         let bucket_client = self.get_or_verify_bucket_client(bucket_id).await?;
-        let response = match self
+        let canonical_send = match self
             .send_streaming_request(
                 &url,
                 headers.clone(),
@@ -962,26 +1340,90 @@ impl InferenceProvider for VLlmProvider {
             )
             .await
         {
-            Ok(r) => r,
+            Ok(r) => Ok(r),
             Err(ref e) if Self::is_connection_error(e) => {
                 // Connection dropped or fingerprint mismatch on reconnect —
                 // clear bucket and re-verify with a fresh attestation.
                 self.clear_bucket(bucket_id);
                 let fresh = self.get_or_verify_bucket_client(bucket_id).await?;
-                self.send_streaming_request(&url, headers, &streaming_params, Some(&fresh))
-                    .await?
+                self.send_streaming_request(&url, headers.clone(), &streaming_params, Some(&fresh))
+                    .await
             }
-            Err(e) => return Err(e),
+            Err(e) => Err(e),
         };
 
-        // Store the bucket ID for signature fetching.
-        self.pending_buckets
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(request_hash, bucket_id);
-
-        let sse_stream = new_sse_parser(response.bytes_stream(), true);
-        Ok(Box::pin(sse_stream))
+        // Decision tree before exposing the stream:
+        //   - HTTP-level 5xx/429 (status arrived in response headers): try
+        //     rotation-SNI backends in order.
+        //   - HTTP 200 + first SSE chunk is `{"error":{"code":N,...}}`
+        //     (SGLang queue-full path, which inference-proxy's SseTransformer
+        //     forwards verbatim): peek catches it via the parser's typed
+        //     `HttpError` and we route to the same rotation fallback.
+        //   - Otherwise: pin bucket, return peekable as the live stream.
+        match canonical_send {
+            Ok(response) => {
+                let parser = new_sse_parser(response.bytes_stream(), true);
+                let stream: StreamingResult = Box::pin(parser);
+                let mut peekable = StreamingResultExt::peekable(stream);
+                let first_chunk_status =
+                    if let Some(Err(CompletionError::HttpError { status_code, .. })) =
+                        peekable.peek().await
+                    {
+                        if Self::is_rotation_retryable_status(*status_code) {
+                            Some(*status_code)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                match first_chunk_status {
+                    None => {
+                        self.pending_buckets
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .insert(request_hash, bucket_id);
+                        Ok(Box::pin(peekable))
+                    }
+                    Some(status_code) => {
+                        drop(peekable);
+                        if self.rotation_count() == 0 {
+                            return Err(CompletionError::HttpError {
+                                status_code,
+                                message: "Upstream stream emitted an error event".to_string(),
+                                is_external: false,
+                            });
+                        }
+                        self.try_chat_completion_stream_rotation(
+                            &streaming_params,
+                            &headers,
+                            &request_hash,
+                            CompletionError::HttpError {
+                                status_code,
+                                message: "Upstream stream emitted an error event".to_string(),
+                                is_external: false,
+                            },
+                        )
+                        .await
+                    }
+                }
+            }
+            Err(canonical_err) => match &canonical_err {
+                CompletionError::HttpError { status_code, .. }
+                    if Self::is_rotation_retryable_status(*status_code)
+                        && self.rotation_count() > 0 =>
+                {
+                    self.try_chat_completion_stream_rotation(
+                        &streaming_params,
+                        &headers,
+                        &request_hash,
+                        canonical_err,
+                    )
+                    .await
+                }
+                _ => Err(canonical_err),
+            },
+        }
     }
 
     /// Performs a chat completion request
@@ -1054,7 +1496,7 @@ impl InferenceProvider for VLlmProvider {
             {
                 self.clear_bucket(bucket_id);
                 let fresh = self.get_or_verify_bucket_client(bucket_id).await?;
-                send(&fresh, headers).await.map_err(map_send_err)?
+                send(&fresh, headers.clone()).await.map_err(map_send_err)?
             }
             Err(e) => return Err(map_send_err(e)),
         };
@@ -1066,11 +1508,28 @@ impl InferenceProvider for VLlmProvider {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("Failed to read error response body: {e}"));
-            return Err(CompletionError::HttpError {
+            let canonical_err = CompletionError::HttpError {
                 status_code,
                 message: crate::extract_error_message(&error_text),
                 is_external: false,
-            });
+            };
+            // The sticky bucket landed on a backend whose queue is full (or
+            // is otherwise reporting 5xx/429). Walk each backend by index via
+            // model-proxy's rotation SNI before surfacing the error: with H2
+            // pooling disabled on the rotation client, every attempt lands
+            // on a distinct backend. If one is healthy, the request succeeds
+            // and we record the index for signature retrieval.
+            if Self::is_rotation_retryable_status(status_code) && self.rotation_count() > 0 {
+                return self
+                    .try_chat_completion_rotation(
+                        &non_streaming_params,
+                        &headers,
+                        timeout,
+                        canonical_err,
+                    )
+                    .await;
+            }
+            return Err(canonical_err);
         }
 
         // Get the raw bytes first for exact hash verification
@@ -2544,5 +3003,150 @@ mod tests {
                 "pre_warm should not fill any buckets in Bootstrap/Blocked state"
             );
         }
+    }
+
+    #[test]
+    fn rotation_retryable_status_covers_5xx_and_429() {
+        // Mirrors `classify_retry_decision` in the pool ("retryable_http_5xx"
+        // + 429). Keeping these in sync is load-bearing: if the rotation
+        // gate diverges, a 503 that the pool considers retryable could
+        // bypass rotation and burn the pool's 3-round backoff against the
+        // same overloaded bucket.
+        assert!(VLlmProvider::is_rotation_retryable_status(429));
+        assert!(VLlmProvider::is_rotation_retryable_status(500));
+        assert!(VLlmProvider::is_rotation_retryable_status(503));
+        assert!(VLlmProvider::is_rotation_retryable_status(599));
+        assert!(!VLlmProvider::is_rotation_retryable_status(200));
+        assert!(!VLlmProvider::is_rotation_retryable_status(400));
+        assert!(!VLlmProvider::is_rotation_retryable_status(404));
+        assert!(!VLlmProvider::is_rotation_retryable_status(408));
+    }
+
+    #[test]
+    fn rotation_disabled_for_non_rotation_url() {
+        // `localhost` is one-label → `split_inference_url` returns `None`, so
+        // `rotation_parts` stays `None`, `rotation_count()` is forced to 0
+        // even if discovery somehow wrote a non-zero count, and the
+        // canonical-SNI 5xx propagates unchanged.
+        let provider = create_test_provider();
+        provider.set_backend_count(5);
+        assert_eq!(
+            provider.rotation_count(),
+            0,
+            "rotation must stay disabled for URLs that don't fit the <canonical>.<multi-label-base> shape"
+        );
+        assert!(provider.rotation_url(0, "/v1/chat/completions").is_none());
+    }
+
+    #[test]
+    fn rotation_url_uses_canonical_label_and_index() {
+        let provider = VLlmProvider::new(VLlmConfig {
+            base_url: "https://glm-5-1.completions.near.ai".to_string(),
+            api_key: None,
+            completion_timeout_seconds: 30,
+            control_timeout_seconds: 30,
+        });
+        provider.set_backend_count(3);
+        assert_eq!(provider.rotation_count(), 3);
+        let url0 = provider
+            .rotation_url(0, "/v1/chat/completions")
+            .expect("rotation URL build");
+        let url2 = provider
+            .rotation_url(2, "/v1/chat/completions")
+            .expect("rotation URL build");
+        assert_eq!(
+            url0,
+            "https://glm-5-1-i0.completions.near.ai/v1/chat/completions"
+        );
+        assert_eq!(
+            url2,
+            "https://glm-5-1-i2.completions.near.ai/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn rotation_count_clamps_to_max_fanout() {
+        // Defensive: a bogus `/backends/count` reading (race during deploy,
+        // partial registry split) shouldn't let one 5xx burn unbounded
+        // fresh-TCP handshakes. Mirrors the discovery path's cap.
+        let provider = VLlmProvider::new(VLlmConfig {
+            base_url: "https://glm-5-1.completions.near.ai".to_string(),
+            api_key: None,
+            completion_timeout_seconds: 30,
+            control_timeout_seconds: 30,
+        });
+        provider.set_backend_count(10_000);
+        assert_eq!(provider.rotation_count(), VLlmProvider::MAX_ROTATION_FANOUT);
+    }
+
+    #[test]
+    fn rotation_count_returns_zero_when_discovery_has_not_run() {
+        // First request after startup, before discovery's first cycle: count
+        // is 0, so rotation is skipped and the canonical 5xx propagates
+        // as it did pre-this-PR. No false positives.
+        let provider = VLlmProvider::new(VLlmConfig {
+            base_url: "https://glm-5-1.completions.near.ai".to_string(),
+            api_key: None,
+            completion_timeout_seconds: 30,
+            control_timeout_seconds: 30,
+        });
+        assert_eq!(provider.rotation_count(), 0);
+    }
+
+    #[test]
+    fn pin_chat_connection_promotes_pending_rotation_to_signature_rotation() {
+        // The streaming fallback stores `request_hash → index` in
+        // `pending_rotation` because the chat_id isn't known at send time.
+        // Once the first chunk yields a chat_id, `pin_chat_connection`
+        // must promote that mapping into `signature_rotation` so the
+        // signature fetch reuses the same rotation index. Without this
+        // promotion the signature endpoint would land on the LB-chosen
+        // backend and 404.
+        let provider = create_test_provider();
+        provider
+            .pending_rotation
+            .lock()
+            .unwrap()
+            .insert("req-hash-abc".to_string(), 2);
+        provider.pin_chat_connection("req-hash-abc", "chatcmpl-xyz");
+        let stored = provider
+            .signature_rotation
+            .lock()
+            .unwrap()
+            .get("chatcmpl-xyz")
+            .copied();
+        assert_eq!(stored, Some(2));
+        // Pending entry should be drained so a future `request_hash` reuse
+        // can't accidentally surface the stale index.
+        assert!(provider.pending_rotation.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pin_chat_connection_with_empty_chat_id_drains_pending_without_writing_signature() {
+        // The pool's orphan-cleanup path (`provider.pin_chat_connection(hash, "")`)
+        // must drop the pending mapping without leaking an entry under an
+        // empty chat_id key — otherwise every orphan request would
+        // collide on the same `""` signature_rotation slot.
+        let provider = create_test_provider();
+        provider
+            .pending_rotation
+            .lock()
+            .unwrap()
+            .insert("req-hash-orphan".to_string(), 1);
+        provider.pin_chat_connection("req-hash-orphan", "");
+        assert!(provider.pending_rotation.lock().unwrap().is_empty());
+        assert!(provider.signature_rotation.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn unpin_chat_connection_clears_signature_rotation() {
+        let provider = create_test_provider();
+        provider
+            .signature_rotation
+            .lock()
+            .unwrap()
+            .insert("chat-1".to_string(), 4);
+        provider.unpin_chat_connection("chat-1");
+        assert!(provider.signature_rotation.lock().unwrap().is_empty());
     }
 }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1,8 +1,7 @@
-mod rotation;
-
 use crate::attestation::AttestationVerifier;
 use crate::common::encryption_headers;
 use config::ExternalProvidersConfig;
+use inference_providers::rotation;
 use inference_providers::spki_verifier::{FingerprintState, SharedTlsRoots};
 use inference_providers::{
     models::{AttestationError, CompletionError},
@@ -2441,6 +2440,12 @@ impl InferenceProviderPool {
                             backend_verifier,
                         ));
 
+                    // Seed the provider's backend_count cache so traffic-time
+                    // rotation-SNI fallback knows how many indices to iterate
+                    // on the first 5xx — without this, the very first 5xx
+                    // before any refresh cycle would skip rotation entirely.
+                    serving_provider.set_backend_count(outcome.backend_count);
+
                     if outcome.total_pinned == 0 {
                         // Fail closed: reject all TLS until a future refresh's
                         // cumulative discovery pins at least one fingerprint.
@@ -2770,6 +2775,14 @@ impl InferenceProviderPool {
                         "Cumulative discovery cycle (no new fingerprints)"
                     );
                 }
+
+                // Refresh the provider's backend_count cache so the
+                // rotation-SNI traffic fallback uses the latest known healthy
+                // count. A `count_zero` cycle yields 0 — that's still a
+                // useful update because it disables rotation fallback for
+                // this provider until the next cycle proves at least one
+                // backend healthy again.
+                provider.set_backend_count(outcome.backend_count);
 
                 let ptr = Arc::as_ptr(&provider) as *const () as usize;
                 let provider_has_any_pubkey_mapping = mapped_ptrs.contains(&ptr);

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -925,22 +925,22 @@ impl InferenceProviderPool {
 
         // Defense-in-depth: cap the fan-out. A bogus registry reading (race
         // during a deploy, partial split) could otherwise spawn an unbounded
-        // number of fresh-TCP TLS handshakes per cycle per model. The cap is
-        // far above any realistic backend pool; hitting it is logged so it
-        // surfaces in ops without silently dropping coverage.
-        const MAX_ROTATION_FANOUT: usize = 256;
-        let backend_count = if backend_count > MAX_ROTATION_FANOUT {
+        // number of fresh-TCP TLS handshakes per cycle per model. Shared
+        // with VLlmProvider's traffic-time rotation gate so the cap is
+        // defined exactly once.
+        let backend_count = if backend_count > rotation::MAX_FANOUT {
             warn!(
                 model = %model_name,
                 url = %url,
                 reported = backend_count,
-                capped_at = MAX_ROTATION_FANOUT,
+                capped_at = rotation::MAX_FANOUT,
                 "backend count from proxy exceeds sanity cap, truncating fan-out"
             );
             failure_reasons.push(format!(
-                "count_capped: proxy reported {backend_count} > {MAX_ROTATION_FANOUT}"
+                "count_capped: proxy reported {backend_count} > {}",
+                rotation::MAX_FANOUT
             ));
-            MAX_ROTATION_FANOUT
+            rotation::MAX_FANOUT
         } else {
             backend_count
         };


### PR DESCRIPTION
## Summary

When the sticky bucket-client (H2-pinned to one backend) returns 5xx/429, the retry path used to hand the same request back to the same overloaded backend: `retry_with_fallback` only iterates over `model_to_providers[model_id]` (usually one URL per model), and `prefix_router.route(...)` is deterministic in the prompt hash. SGLang queue-full aborts thus produced 3 retries × 7.5s of backoff against the same SGLang and surfaced as **HTTP 529** to the client.

This PR walks every healthy backend by index via model-proxy's rotation SNI (`<canonical>-i<N>.<base>`, [model-proxy PR #27](https://github.com/nearai/model-proxy/pull/27)) before propagating the error. With H2 pooling disabled on the per-attempt client, every attempt lands on a distinct backend by construction.

## Failure chain (pre-PR)

Documented in the [#infra thread](https://jasnahworkspace.slack.com/archives/C0B25RF6HQE/p1779313724474859) and PR #131 / #620:

```
cloud-api  chat_completion (sticky bucket → backend X via H2)
  ↓ 503 from SGLang queue full
retry_with_fallback (1 provider, 3 retries, 7.5s backoff)
  ↓ same bucket → same H2 → same backend X → still 503
ServiceOverloaded → HTTP 529 to client
```

What we want:

```
cloud-api  chat_completion (sticky bucket → backend X via H2)
  ↓ 503
rotation-SNI fallback: try i=0..backend_count
  ↓ i=0: backend X (still 503)  → next
  ↓ i=1: backend Y (200 OK)     → return
```

## What changes

### `chat_completion` (non-streaming)

After the canonical bucket-client attempt returns 5xx/429, fall through to `try_chat_completion_rotation`. Iterates `0..rotation_count()`, builds a fresh single-shot reqwest::Client per index (no pool reuse, no H2 sharing), targets `https://<canonical>-i<N>.<base>/v1/chat/completions`. First 200 wins; the rotation index is recorded in `signature_rotation` so subsequent `get_signature` calls hit the same backend.

### `chat_completion_stream` (streaming)

inference-proxy's `SseTransformer` forwards the SGLang queue-full chunk verbatim (HTTP 200 + `data: {"error":{"code":503,...}}`). The OpenAI SSE parser previously surfaced this as `InvalidResponse("Failed to parse event")`, hiding the upstream status. Two changes:

- `OpenAIEventParser::parse_event` now promotes `{"error":{"code":N,...}}` chunks to typed `HttpError { status_code: N }`.
- The stream-completion path **peeks the first SSE event** before exposing the stream to the caller; if it's a retryable `HttpError`, the stream is dropped and `try_chat_completion_stream_rotation` runs. Because peek happens *before* any byte hits the client, retrying the whole stream is byte-safe.

### Plumbing

- `rotation` module moved from `services::inference_provider_pool` → `inference_providers` (pub). Both discovery and traffic-time fallback now need the URL helpers. Tests moved with the file.
- New `InferenceProvider::set_backend_count` trait method (default no-op, overridden by `VLlmProvider`). Discovery's new-provider path and cumulative refresh path both call it, so the cache is seeded on startup and kept fresh per refresh cycle.
- Rotation fan-out is clamped to `MAX_ROTATION_FANOUT = 256` (mirrors the discovery cap) so a bogus `/backends/count` reading can't burn unbounded fresh-TCP handshakes.

### Signature retrieval

`get_signature` checks `signature_rotation` first. If the chat was served by a rotation index, it builds a one-shot rotation client targeting that exact backend *before* the existing bucket/general fallback. Without this, the signature endpoint would 404 against every other backend.

## What's preserved

- **Prefix-cache stickiness**: the canonical bucket is still the first attempt — rotation only kicks in on 5xx/429. Cache-hit-friendly requests pay zero extra cost.
- **Connection-error fallback**: the existing `is_connection_error` → `clear_bucket` → retry path runs before the rotation gate, so transient TLS hiccups still benefit from the bucket-level refresh.
- **Non-rotation URLs unaffected**: for URLs that don't fit `<canonical>.<multi-label-base>` (`localhost`, IP literals), `rotation_parts` stays `None`, `rotation_count()` returns 0, and the canonical 5xx propagates as before.

## Related

- inference-proxy PR #131 — assembler-path queue-full → HTTP 503 (non-streaming).
- cloud-api PR #620 — `ServiceOverloaded` → HTTP 529 to the client.
- cloud-api PR #629 — SSE error frames are valid JSON for OpenAI clients.
- model-proxy PR #27 — rotation SNI + `/backends/count`.

## Test plan

- [x] 152 `inference_providers` lib tests (141 pre-existing + 11 new):
  - SSE parser: queue-full error chunk → `HttpError { status_code: 503 }`; missing `code` → 502; `error: null` not misclassified.
  - VLlmProvider: rotation gate matches the pool's `retryable_http_5xx` taxonomy; rotation disabled for one-label URLs; rotation URL shape & index; `MAX_ROTATION_FANOUT` clamp; `pending_rotation → signature_rotation` promotion; orphan cleanup with empty chat_id; `unpin_chat_connection` clears the rotation map.
- [x] 302 `services` lib tests (no regressions from moving the rotation module + adding the trait method).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Manual: drive GLM-5.1 above `--max-queued-requests`, confirm cloud-api now returns 200 from a non-saturated backend instead of 529.