### PR TITLE
fix(responses): populate usage in non-streaming fallback path

### DIFF
--- a/crates/api/src/routes/responses.rs
+++ b/crates/api/src/routes/responses.rs
@@ -398,6 +398,7 @@ pub async fn create_response(
                 let mut content = String::new();
                 let mut status = ResponseStatus::InProgress;
                 let mut final_response: Option<ResponseObject> = None;
+                let mut tracked_usage: Option<Usage> = None;
 
                 let mut stream = Box::pin(stream);
                 let mut event_count = 0;
@@ -436,6 +437,9 @@ pub async fn create_response(
                         }
                         "response.completed" => {
                             status = ResponseStatus::Completed;
+                            if event.usage.is_some() {
+                                tracked_usage = event.usage.clone();
+                            }
                             tracing::debug!(
                                 "Non-streaming: response.completed event, accumulated_content_len={}",
                                 content.len()
@@ -479,6 +483,9 @@ pub async fn create_response(
                         }
                         "response.failed" => {
                             status = ResponseStatus::Failed;
+                            if event.usage.is_some() {
+                                tracked_usage = event.usage.clone();
+                            }
                         }
                         _ => {
                             // Handle other events as needed
@@ -557,7 +564,7 @@ pub async fn create_response(
                         top_logprobs: 0,
                         top_p: request.top_p.unwrap_or(1.0),
                         truncation: "disabled".to_string(),
-                        usage: Usage::new(0, 0), // TODO: Get actual usage from stream
+                        usage: tracked_usage.unwrap_or_else(|| Usage::new(0, 0)),
                         user: None,
                         metadata: request.metadata,
                     }

--- a/crates/services/src/responses/models.rs
+++ b/crates/services/src/responses/models.rs
@@ -991,6 +991,8 @@ pub struct ResponseStreamEvent {
     pub annotation: Option<TextAnnotation>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conversation_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
 }
 
 /// Input item list for responses

--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -246,6 +246,7 @@ impl ports::ResponseServiceTrait for ResponseServiceImpl {
                     annotation_index: None,
                     annotation: None,
                     conversation_title: None,
+                    usage: None,
                 };
                 let result = tx.send(error_event).await;
                 if let Err(e) = result {
@@ -3021,6 +3022,7 @@ impl ResponseServiceImpl {
             annotation_index: None,
             annotation: None,
             conversation_title: Some(title),
+            usage: None,
         };
 
         let _ = tx.send(event).await;
@@ -3178,6 +3180,7 @@ impl ResponseServiceImpl {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         use futures_util::SinkExt;
         let _ = emitter.tx.clone().send(event).await;
@@ -3207,6 +3210,7 @@ impl ResponseServiceImpl {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: Some(final_response.usage.clone()),
         };
         let _ = emitter.tx.clone().send(completion_event).await;
 

--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -202,6 +202,10 @@ impl ports::ResponseServiceTrait for ResponseServiceImpl {
             }
             // Note: MCP executor is added later after connecting to servers
 
+            // Shared tracker so the outer error handler can read accumulated
+            // usage after `ctx` is dropped on Err from process_response_stream.
+            let usage_tracker = crate::responses::service_helpers::UsageTracker::new();
+
             let context = ProcessStreamContext {
                 request,
                 user_id,
@@ -226,10 +230,20 @@ impl ports::ResponseServiceTrait for ResponseServiceImpl {
                 tool_registry,
             };
 
-            if let Err(e) = Self::process_response_stream(tx.clone(), context).await {
+            if let Err(e) =
+                Self::process_response_stream(tx.clone(), context, usage_tracker.clone()).await
+            {
                 tracing::error!("Error processing response stream: {:?}", e);
 
-                // Send error event
+                // Attach accumulated usage so downstream (e.g. non-streaming
+                // route fallback, billing) can bill for partial work done
+                // before the failure.
+                let usage = if usage_tracker.has_data() {
+                    Some(usage_tracker.snapshot())
+                } else {
+                    None
+                };
+
                 let error_event = models::ResponseStreamEvent {
                     event_type: "response.failed".to_string(),
                     sequence_number: None,
@@ -246,7 +260,7 @@ impl ports::ResponseServiceTrait for ResponseServiceImpl {
                     annotation_index: None,
                     annotation: None,
                     conversation_title: None,
-                    usage: None,
+                    usage,
                 };
                 let result = tx.send(error_event).await;
                 if let Err(e) = result {
@@ -883,6 +897,7 @@ impl ResponseServiceImpl {
     async fn process_response_stream(
         tx: futures::channel::mpsc::UnboundedSender<models::ResponseStreamEvent>,
         mut context: ProcessStreamContext,
+        usage_tracker: Arc<crate::responses::service_helpers::UsageTracker>,
     ) -> Result<(), errors::ResponseError> {
         tracing::info!("Starting response stream processing");
 
@@ -964,6 +979,7 @@ impl ResponseServiceImpl {
             initial_response.previous_response_id.clone(),
             initial_response.created_at,
             context.request.model.clone(),
+            usage_tracker,
         );
         let mut emitter = crate::responses::service_helpers::EventEmitter::new(tx);
 

--- a/crates/services/src/responses/service_helpers.rs
+++ b/crates/services/src/responses/service_helpers.rs
@@ -120,6 +120,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -146,6 +147,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -156,6 +158,7 @@ impl EventEmitter {
         ctx: &mut ResponseStreamContext,
         response: models::ResponseObject,
     ) -> Result<(), errors::ResponseError> {
+        let usage = response.usage.clone();
         let event = models::ResponseStreamEvent {
             event_type: "response.completed".to_string(),
             sequence_number: Some(ctx.next_sequence()),
@@ -172,6 +175,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: Some(usage),
         };
         self.send(event).await
     }
@@ -199,6 +203,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -226,6 +231,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -253,6 +259,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -280,6 +287,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -307,6 +315,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -334,6 +343,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -361,6 +371,7 @@ impl EventEmitter {
             annotation_index: Some(0), // Start with index 0 for first annotation
             annotation: Some(annotation),
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }
@@ -409,6 +420,7 @@ impl EventEmitter {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.send(event).await
     }

--- a/crates/services/src/responses/service_helpers.rs
+++ b/crates/services/src/responses/service_helpers.rs
@@ -6,7 +6,54 @@
 use crate::conversations::models::ConversationId;
 use crate::responses::{errors, models};
 use futures::channel::mpsc::UnboundedSender;
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Arc;
 use uuid::Uuid;
+
+/// Atomically-updated mirror of `ResponseStreamContext`'s token counters.
+///
+/// `process_response_stream` owns `ctx` and drops it when it returns. The outer
+/// `tokio::spawn` task that emits `response.failed` on error needs visibility
+/// into accumulated usage after `ctx` is gone, so `ctx` writes through this
+/// shared handle on every update; the outer scope reads it via `snapshot`.
+#[derive(Default)]
+pub struct UsageTracker {
+    input_tokens: AtomicI32,
+    output_tokens: AtomicI32,
+    cached_tokens: AtomicI32,
+    reasoning_tokens: AtomicI32,
+}
+
+impl UsageTracker {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn set_chunk_usage(&self, input: i32, output: i32, cached: i32) {
+        self.input_tokens.store(input, Ordering::Relaxed);
+        self.output_tokens.store(output, Ordering::Relaxed);
+        self.cached_tokens.store(cached, Ordering::Relaxed);
+    }
+
+    pub fn add_reasoning(&self, tokens: i32) {
+        self.reasoning_tokens.fetch_add(tokens, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> models::Usage {
+        models::Usage::new_with_reasoning_and_cache(
+            self.input_tokens.load(Ordering::Relaxed),
+            self.output_tokens.load(Ordering::Relaxed),
+            self.reasoning_tokens.load(Ordering::Relaxed),
+            self.cached_tokens.load(Ordering::Relaxed),
+        )
+    }
+
+    pub fn has_data(&self) -> bool {
+        self.input_tokens.load(Ordering::Relaxed) > 0
+            || self.output_tokens.load(Ordering::Relaxed) > 0
+            || self.reasoning_tokens.load(Ordering::Relaxed) > 0
+    }
+}
 
 /// Context for processing a response stream
 ///
@@ -29,9 +76,13 @@ pub struct ResponseStreamContext {
     pub previous_response_id: Option<String>,
     pub created_at: i64,
     pub model: String,
+    /// Shared mirror of token counters so the outer error handler can read
+    /// accumulated usage even after `ctx` is dropped.
+    pub usage_tracker: Arc<UsageTracker>,
 }
 
 impl ResponseStreamContext {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         response_id: models::ResponseId,
         api_key_id: Uuid,
@@ -40,6 +91,7 @@ impl ResponseStreamContext {
         previous_response_id: Option<String>,
         created_at: i64,
         model: String,
+        usage_tracker: Arc<UsageTracker>,
     ) -> Self {
         Self {
             response_id,
@@ -55,6 +107,7 @@ impl ResponseStreamContext {
             previous_response_id,
             model,
             created_at,
+            usage_tracker,
         }
     }
 
@@ -75,11 +128,14 @@ impl ResponseStreamContext {
         self.total_input_tokens = input_tokens;
         self.total_output_tokens = output_tokens;
         self.total_cached_tokens = cached_tokens;
+        self.usage_tracker
+            .set_chunk_usage(input_tokens, output_tokens, cached_tokens);
     }
 
     /// Add reasoning tokens from detected reasoning content
     pub fn add_reasoning_tokens(&mut self, tokens: i32) {
         self.reasoning_tokens += tokens;
+        self.usage_tracker.add_reasoning(tokens);
     }
 
     /// Estimate token count from text (rough approximation: chars / 4)
@@ -532,3 +588,86 @@ pub struct ToolCallAccumulatorEntry {
 /// Accumulator for streaming tool calls
 /// Maps tool call index -> accumulated entry data
 pub type ToolCallAccumulator = std::collections::HashMap<i64, ToolCallAccumulatorEntry>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ctx(tracker: Arc<UsageTracker>) -> ResponseStreamContext {
+        ResponseStreamContext::new(
+            models::ResponseId(uuid::Uuid::new_v4()),
+            uuid::Uuid::new_v4(),
+            None,
+            "resp_abc".to_string(),
+            None,
+            0,
+            "test-model".to_string(),
+            tracker,
+        )
+    }
+
+    #[test]
+    fn usage_tracker_starts_empty() {
+        let tracker = UsageTracker::new();
+        assert!(!tracker.has_data());
+        let snap = tracker.snapshot();
+        assert_eq!(snap.input_tokens, 0);
+        assert_eq!(snap.output_tokens, 0);
+        assert_eq!(snap.total_tokens, 0);
+    }
+
+    #[test]
+    fn ctx_update_usage_mirrors_to_tracker() {
+        let tracker = UsageTracker::new();
+        let mut ctx = make_ctx(tracker.clone());
+
+        ctx.update_usage(11, 22, 3);
+        ctx.add_reasoning_tokens(7);
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap.input_tokens, 11);
+        assert_eq!(snap.output_tokens, 22);
+        assert_eq!(snap.total_tokens, 33);
+        assert_eq!(
+            snap.output_tokens_details
+                .as_ref()
+                .unwrap()
+                .reasoning_tokens,
+            7
+        );
+        assert_eq!(snap.input_tokens_details.as_ref().unwrap().cached_tokens, 3);
+        assert!(tracker.has_data());
+    }
+
+    #[test]
+    fn ctx_update_usage_overwrites_per_chunk_in_tracker() {
+        let tracker = UsageTracker::new();
+        let mut ctx = make_ctx(tracker.clone());
+
+        ctx.update_usage(5, 5, 0);
+        ctx.update_usage(50, 100, 10); // last chunk wins, matching ctx semantics
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap.input_tokens, 50);
+        assert_eq!(snap.output_tokens, 100);
+    }
+
+    #[test]
+    fn ctx_add_reasoning_tokens_accumulates_in_tracker() {
+        let tracker = UsageTracker::new();
+        let mut ctx = make_ctx(tracker.clone());
+
+        ctx.add_reasoning_tokens(3);
+        ctx.add_reasoning_tokens(4);
+
+        let snap = tracker.snapshot();
+        assert_eq!(
+            snap.output_tokens_details
+                .as_ref()
+                .unwrap()
+                .reasoning_tokens,
+            7
+        );
+        assert!(tracker.has_data());
+    }
+}

--- a/crates/services/src/responses/tools/executor.rs
+++ b/crates/services/src/responses/tools/executor.rs
@@ -39,6 +39,7 @@ impl<'a> ToolEventContext<'a> {
             annotation_index: None,
             annotation: None,
             conversation_title: None,
+            usage: None,
         };
         self.emitter.send_raw(event).await
     }


### PR DESCRIPTION
## Problem

The non-streaming response fallback path always returns `Usage::new(0, 0)`, meaning token counts are always zero when the `response.completed` event does not contain a `ResponseObject`. This breaks billing and token visibility for those responses.

**Root cause**: Usage was only available inside the `ResponseObject` on terminal events, so when the fallback path ran (no `final_response`), there was no way to extract it — even though the service layer had correctly computed usage via `ResponseStreamContext`.

## Fix

### 1. Add `usage` field to `ResponseStreamEvent` (models.rs)
New optional field `usage: Option<Usage>` with `skip_serializing_if = "Option::is_none"`. Non-terminal events omit it from serialization. Terminal events (`response.completed`, image-gen completion) include it with the actual token counts.

### 2. Populate `usage` on terminal events (service_helpers.rs, service.rs)
- `emit_completed`: Extracts `usage` from the `ResponseObject` and includes it as `usage: Some(usage)` on the event.
- Image generation completion event in `service.rs`: Same pattern.
- All other events: `usage: None` (no change to serialized output).

### 3. Use `event.usage` in route handler (responses.rs)
- Track `tracked_usage: Option<Usage>` during stream collection.
- On `response.completed` and `response.failed` events, capture `event.usage` if present.
- In the fallback `ResponseObject` construction, use `tracked_usage.unwrap_or_else(|| Usage::new(0, 0))` instead of hardcoded `Usage::new(0, 0)`.

## Why this works even when `event.response` is `None`

The Claude review on the initial version correctly identified that the first approach (extracting usage from `event.response`) was dead code — when `final_response` is `None`, the `response.completed` event had `response: None` too. By adding `usage` as a top-level field on the event, it travels independently of the full `ResponseObject`, making it available even in the fallback case.

## Testing
- `cargo clippy -p api -p services` — passes
- `cargo fmt -p api -p services -- --check` — passes

Refs #372