### PR TITLE
test(privacy_redact): drop NaN case from threshold validation test

### DIFF
--- a/crates/api/tests/e2e_all/privacy_redact.rs
+++ b/crates/api/tests/e2e_all/privacy_redact.rs
@@ -247,7 +247,11 @@ async fn test_privacy_redact_rejects_out_of_range_threshold() {
     let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
     let api_key = get_api_key_for_org(&server, org.id).await;
 
-    for bad in [-0.1, 1.5, f64::NAN] {
+    // NaN intentionally excluded: standard JSON has no NaN token, and
+    // `serde_json::json!(f64::NAN)` collapses to `null`, which our handler
+    // treats as "threshold absent". The handler still range-checks for NaN
+    // defensively in case the field arrives via a non-standard path.
+    for bad in [-0.1, 1.5] {
         let response = server
             .post("/v1/privacy/redact")
             .add_header("Authorization", format!("Bearer {api_key}"))
@@ -261,7 +265,7 @@ async fn test_privacy_redact_rejects_out_of_range_threshold() {
         assert_eq!(
             response.status_code(),
             400,
-            "threshold={bad:?} should be rejected",
+            "threshold={bad} should be rejected",
         );
     }
 }


### PR DESCRIPTION
## Summary

\`test_privacy_redact_rejects_out_of_range_threshold\` from #623 fails on CI in #599:

\`\`\`
assertion \`left == right\` failed: threshold=NaN should be rejected
  left: \"200\"
 right: \"400\"
\`\`\`

[Failing run](https://github.com/nearai/cloud-api/actions/runs/26238139048/job/77216941734).

## Root cause

NaN isn't a valid JSON token. \`serde_json::json!(f64::NAN)\` collapses to \`Value::Null\`, so the body sent over the wire is:

\`\`\`json
{ \"model\": \"openai/privacy-filter\", \"input\": \"hi\", \"threshold\": null }
\`\`\`

The handler reads \`Option::<f64> = None\` and skips validation, returning 200. The test asserts 400 → failure.

## Fix

Drop the NaN entry from the test loop and document why. Keep the handler's \`is_nan\` guard as defense-in-depth — it costs nothing and protects any future code path that supplies threshold from a non-standard JSON source.

## Stacking

Targets \`feat/auto-redact-natural-placeholders\` (base of #599) so the unblock lands inside #599's diff and Test Suite goes green there.

## Test plan

- [x] \`cargo build --tests -p api\` — clean
- [x] \`cargo test -p api --test e2e_all privacy_redact::test_privacy_redact_rejects_out_of_range_threshold\` needs Postgres locally; CI on this PR will verify