### PR TITLE
feat(responses): add budget guidance to web_context_search tool

### DIFF
--- a/crates/services/src/responses/tools/tool_config.rs
+++ b/crates/services/src/responses/tools/tool_config.rs
@@ -134,11 +134,15 @@ pub fn prepare_tools(request: &CreateResponseRequest) -> Vec<inference_providers
                             description: Some(
                                 "Search the web and return extracted source context optimized for grounding model answers. \
                                 Use this when deeper source passages are more useful than short search-result snippets. \
+                                \n\nBUDGET GUIDANCE — set 'maximum_number_of_tokens' based on query complexity:\
+                                \n- ~2048: simple factual lookups, single-answer questions\
+                                \n- ~4096: moderate queries needing context from several sources\
+                                \n- ~8192: complex research, multi-faceted or comparative topics\
                                 \n\nIMPORTANT PARAMETERS TO CONSIDER:\
                                 \n- Use 'freshness' for time-sensitive queries (news, recent events, current trends)\
                                 \n- Use 'country' for location-specific information\
                                 \n- Use 'count' and 'maximum_number_of_urls' to control breadth\
-                                \n- Use 'maximum_number_of_tokens', 'maximum_number_of_snippets', and per-URL limits to control context size\
+                                \n- Use 'maximum_number_of_snippets' and per-URL limits to control depth\
                                 \n- Use 'context_threshold_mode' as disabled, strict, balanced, or lenient".to_string()
                             ),
                             parameters: super::web_context_search_parameters_schema(),


### PR DESCRIPTION
## Summary
- Enriches the `web_context_search` tool description with budget guidance tiers so the LLM picks appropriate `maximum_number_of_tokens` values based on query complexity
- ~2048 for simple factual lookups, ~4096 for moderate queries, ~8192 for complex research
- No schema or logic changes — description-only update

## Context
Ali (Brave) suggested letting the LLM decide the context budget on the fly with presets. We already expose a continuous `maximum_number_of_tokens` parameter (1024–32768) but the tool description gave zero guidance on when to use lower vs higher values, so the model likely defaults to 8192 every time.

## Test plan
- [ ] `cargo check` compiles
- [ ] Deploy to staging, run Response API calls with `web_context_search` enabled
- [ ] Verify the model varies `maximum_number_of_tokens` across queries of different complexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)