### PR TITLE
fix(vllm): raise control_timeout default from 90s to 300s

### DIFF
--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -124,8 +124,13 @@ impl VLlmConfig {
     /// on a single non-streaming request; 600s is a comfortable ceiling that
     /// still surfaces genuinely stuck requests.
     pub const DEFAULT_COMPLETION_TIMEOUT_SECS: i64 = 600;
-    /// Default control timeout. Metadata/TTFB ops should resolve quickly.
-    pub const DEFAULT_CONTROL_TIMEOUT_SECS: i64 = 90;
+    /// Default control timeout. Covers TTFB on streaming requests, attestation
+    /// report fetches, models-list and signature lookups. Reasoning models
+    /// (GLM-5.1, Qwen3.5) can delay TTFB by minutes when the backend queues a
+    /// request behind a long thinking phase, and attestation TDX-quote + GPU
+    /// evidence collection can also cross 90s under load. 300s gives enough
+    /// headroom for those without masking a sustained backend stall.
+    pub const DEFAULT_CONTROL_TIMEOUT_SECS: i64 = 300;
 
     /// Construct a config. The `timeout_seconds` parameter, when supplied, sets
     /// the **completion** timeout only (control stays at its default / env value).

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -199,9 +199,10 @@ pub struct VLlmProvider {
     backend_verifier: Option<Arc<dyn crate::BackendVerifier>>,
     /// Fallback client used when inline bucket verification exhausts all retries.
     /// Has completion-timeout read settings so long-running inference requests
-    /// don't hit the 90s control-plane idle timeout. Does not pin TLS to a
-    /// specific backend — requests are served without prefix-cache routing but
-    /// are not dropped, ensuring inline verification failures degrade gracefully.
+    /// don't hit the shorter control_timeout (read budget) used by the general
+    /// client. Does not pin TLS to a specific backend — requests are served
+    /// without prefix-cache routing but are not dropped, ensuring inline
+    /// verification failures degrade gracefully.
     fallback_client: Client,
     /// Bounds concurrent inline verifications to prevent thundering-herd pressure
     /// on inference-proxy GPU evidence collection at startup (when all buckets are
@@ -539,8 +540,8 @@ impl VLlmProvider {
         //
         // Note on worst-case wait time: the permit is held for the entire retry
         // loop (INLINE_VERIFY_RETRIES + 1 attempts × control_timeout each). With
-        // default values that is 3 × 90s = 270s per slot. Requests queueing behind
-        // a saturated semaphore of size N can wait up to (queue_depth / N) × 270s.
+        // default values that is 3 × 300s = 900s per slot. Requests queueing behind
+        // a saturated semaphore of size N can wait up to (queue_depth / N) × 900s.
         // In practice the first successful verification fills the bucket and all
         // subsequent waiters take the fast path (re-check after acquiring permit).
         let _permit = self


### PR DESCRIPTION
## Summary

Bump `VLlmConfig::DEFAULT_CONTROL_TIMEOUT_SECS` from **90s** to **300s**.

The control timeout in `inference_providers/src/vllm/mod.rs` gates three call paths:

1. **TTFB on streaming chat completions** (`send_streaming_request`, around line 793) — wraps `client.post(...).send()` so the timeout applies only to receiving response headers, not body streaming.
2. **`/v1/attestation/report` fetches** (`get_attestation_report`, around line 1343) — full request timeout.
3. Models-list, signature lookups, and other control-plane operations.

### Why bump

- **GLM-5.1, Qwen3.5** are reasoning models. Under load, vLLM/sglang can queue a request behind a long thinking phase and delay HTTP response headers by minutes. The 90s control_timeout fires as `CompletionError::Timeout` before the model emits anything — surfaces to clients as a 504 / failure even though the backend is healthy.
- **Attestation fetches** trigger TDX quote generation + GPU evidence collection (NVIDIA `cc_admin.collect_gpu_evidence_remote` via Python subprocess, serialized behind a host-level mutex in `inference-proxy`). Under contention this regularly crosses 90s. We've been seeing intermittent `503 Service Unavailable` on `/v1/attestation/report?model=zai-org/GLM-5.1-FP8` with body:
  > `"error sending request for url (https://glm-5-1.completions.near.ai/v1/attestation/report?...)"`
- **300s** matches `cloud_api_helpers.TIMEOUT` used by `infra-tests`, and is the value reasoning tests already cite (`nearai/infra#121`). It sits well below the 600s `completion_timeout` cap so a sustained backend stall still surfaces, just no longer at 90s.

### Backward compat

- The constant remains overridable per-deployment via `VLLM_PROVIDER_CONTROL_TIMEOUT`.
- Existing unit tests reference `VLlmConfig::DEFAULT_CONTROL_TIMEOUT_SECS` symbolically (not the hard-coded 90), so they automatically track the new default. `cargo check -p inference_providers` is clean.

## Test plan

- [x] `cargo check -p inference_providers`
- [ ] CI: full `cargo test` and clippy
- [ ] Post-deploy: re-run the attestation burst probe against `cloud-api.near.ai/v1/attestation/report?model=zai-org/GLM-5.1-FP8` and confirm no transient 503s under the prior reproduction (4/500 fails at conc=8 cold-start)