### PR TITLE
feat(external): support extra_request_body for OpenRouter provider preferences

### DIFF
--- a/crates/inference_providers/src/external/anthropic/mod.rs
+++ b/crates/inference_providers/src/external/anthropic/mod.rs
@@ -276,6 +276,7 @@ mod tests {
             api_key: "test-key".to_string(),
             timeout_seconds: 30,
             extra: std::collections::HashMap::new(),
+            extra_request_body: std::collections::HashMap::new(),
         };
 
         let headers = backend.build_headers(&config).unwrap();
@@ -301,6 +302,7 @@ mod tests {
             api_key: "test-key".to_string(),
             timeout_seconds: 30,
             extra,
+            extra_request_body: std::collections::HashMap::new(),
         };
 
         let headers = backend.build_headers(&config).unwrap();
@@ -414,6 +416,7 @@ mod tests {
             api_key: "test-key".to_string(),
             timeout_seconds: 30,
             extra: std::collections::HashMap::new(),
+            extra_request_body: std::collections::HashMap::new(),
         };
 
         let params = crate::ImageGenerationParams {

--- a/crates/inference_providers/src/external/backend.rs
+++ b/crates/inference_providers/src/external/backend.rs
@@ -26,7 +26,7 @@ pub struct BackendConfig {
     pub timeout_seconds: i64,
     /// Provider-specific extra configuration (e.g., organization_id, version)
     pub extra: HashMap<String, String>,
-    /// Extra fields injected into every outgoing request body (e.g., OpenRouter `provider` preferences)
+    /// Extra fields injected into outgoing JSON request bodies (e.g., OpenRouter `provider` preferences)
     pub extra_request_body: HashMap<String, serde_json::Value>,
 }
 

--- a/crates/inference_providers/src/external/backend.rs
+++ b/crates/inference_providers/src/external/backend.rs
@@ -26,6 +26,8 @@ pub struct BackendConfig {
     pub timeout_seconds: i64,
     /// Provider-specific extra configuration (e.g., organization_id, version)
     pub extra: HashMap<String, String>,
+    /// Extra fields injected into every outgoing request body (e.g., OpenRouter `provider` preferences)
+    pub extra_request_body: HashMap<String, serde_json::Value>,
 }
 
 impl Default for BackendConfig {
@@ -35,6 +37,7 @@ impl Default for BackendConfig {
             api_key: String::new(),
             timeout_seconds: 120,
             extra: HashMap::new(),
+            extra_request_body: HashMap::new(),
         }
     }
 }

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -69,7 +69,7 @@ fn strip_internal_tracing_keys(extra: &mut std::collections::HashMap<String, ser
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "backend")]
 pub enum ProviderConfig {
-    /// OpenAI-compatible providers (OpenAI, Azure, Together, Groq, Fireworks, etc.)
+    /// OpenAI-compatible providers (OpenAI, Azure, Together, Groq, Fireworks, OpenRouter, etc.)
     #[serde(rename = "openai_compatible")]
     OpenAiCompatible {
         /// Base URL for the API (e.g., "https://api.openai.com/v1")
@@ -80,6 +80,10 @@ pub enum ProviderConfig {
         /// Optional model name override (e.g., "gpt-5.2" when our model ID is "openai/gpt-5.2")
         #[serde(default)]
         model_name: Option<String>,
+        /// Extra fields injected into every outgoing request body.
+        /// Useful for provider-specific parameters like OpenRouter's `provider` preferences.
+        #[serde(default)]
+        extra_request_body: Option<std::collections::HashMap<String, serde_json::Value>>,
     },
 
     /// Anthropic provider
@@ -163,6 +167,7 @@ impl ExternalProvider {
                 base_url,
                 organization_id,
                 model_name: config_model_name,
+                extra_request_body,
             } => {
                 let mut extra = std::collections::HashMap::new();
                 if let Some(org_id) = organization_id {
@@ -176,6 +181,7 @@ impl ExternalProvider {
                         api_key,
                         timeout_seconds,
                         extra,
+                        extra_request_body: extra_request_body.unwrap_or_default(),
                     },
                     config_model_name,
                 )
@@ -195,6 +201,7 @@ impl ExternalProvider {
                         api_key,
                         timeout_seconds,
                         extra,
+                        extra_request_body: std::collections::HashMap::new(),
                     },
                     config_model_name,
                 )
@@ -209,6 +216,7 @@ impl ExternalProvider {
                     api_key,
                     timeout_seconds,
                     extra: std::collections::HashMap::new(),
+                    extra_request_body: std::collections::HashMap::new(),
                 },
                 config_model_name,
             ),
@@ -233,6 +241,17 @@ impl ExternalProvider {
     pub fn model_name(&self) -> &str {
         &self.model_name
     }
+
+    /// Inject provider-level default fields into the request body.
+    /// Per-request fields from the user take precedence over provider defaults.
+    fn inject_extra_request_body(&self, params: &mut ChatCompletionParams) {
+        for (key, value) in &self.config.extra_request_body {
+            params
+                .extra
+                .entry(key.clone())
+                .or_insert_with(|| value.clone());
+        }
+    }
 }
 
 #[async_trait]
@@ -253,9 +272,8 @@ impl InferenceProvider for ExternalProvider {
         mut params: ChatCompletionParams,
         _request_hash: String,
     ) -> Result<StreamingResult, CompletionError> {
-        // Strip cloud-api internal tracing keys — they must not be forwarded
-        // to external providers as JSON body fields (extra is #[serde(flatten)]).
         strip_internal_tracing_keys(&mut params.extra);
+        self.inject_extra_request_body(&mut params);
         self.backend
             .chat_completion_stream(&self.config, &self.model_name, params)
             .await
@@ -267,9 +285,8 @@ impl InferenceProvider for ExternalProvider {
         mut params: ChatCompletionParams,
         _request_hash: String,
     ) -> Result<ChatCompletionResponseWithBytes, CompletionError> {
-        // Strip cloud-api internal tracing keys — they must not be forwarded
-        // to external providers as JSON body fields (extra is #[serde(flatten)]).
         strip_internal_tracing_keys(&mut params.extra);
+        self.inject_extra_request_body(&mut params);
         self.backend
             .chat_completion(&self.config, &self.model_name, params)
             .await
@@ -412,6 +429,7 @@ mod tests {
                 base_url,
                 organization_id,
                 model_name,
+                ..
             } => {
                 assert_eq!(base_url, "https://api.openai.com/v1");
                 assert!(organization_id.is_none());
@@ -435,6 +453,7 @@ mod tests {
                 base_url,
                 organization_id,
                 model_name,
+                ..
             } => {
                 assert_eq!(base_url, "https://api.openai.com/v1");
                 assert_eq!(organization_id, Some("org-123".to_string()));
@@ -458,6 +477,7 @@ mod tests {
                 base_url,
                 organization_id,
                 model_name,
+                ..
             } => {
                 assert_eq!(base_url, "https://api.openai.com/v1");
                 assert!(organization_id.is_none());
@@ -550,6 +570,7 @@ mod tests {
                 base_url: "https://api.openai.com/v1".to_string(),
                 organization_id: Some("org-123".to_string()),
                 model_name: None,
+                extra_request_body: None,
             },
             api_key: "sk-test-key".to_string(),
             timeout_seconds: 60,
@@ -570,6 +591,7 @@ mod tests {
                 base_url: "https://api.openai.com/v1".to_string(),
                 organization_id: None,
                 model_name: Some("gpt-5.2".to_string()), // What OpenAI expects
+                extra_request_body: None,
             },
             api_key: "sk-test-key".to_string(),
             timeout_seconds: 60,
@@ -670,6 +692,7 @@ mod tests {
                 base_url: "https://api.openai.com/v1".to_string(),
                 organization_id: None,
                 model_name: None,
+                extra_request_body: None,
             },
             api_key: "test-key".to_string(),
             timeout_seconds: 30,
@@ -692,6 +715,7 @@ mod tests {
                 base_url: "https://api.openai.com/v1".to_string(),
                 organization_id: None,
                 model_name: None,
+                extra_request_body: None,
             },
             api_key: "test-key".to_string(),
             timeout_seconds: 30,
@@ -738,6 +762,7 @@ mod tests {
                 base_url: "https://api.openai.com/v1".to_string(),
                 organization_id: None,
                 model_name: None,
+                extra_request_body: None,
             },
             api_key: "test-key".to_string(),
             timeout_seconds: 30,
@@ -764,6 +789,7 @@ mod tests {
                 base_url: "https://api.openai.com/v1".to_string(),
                 organization_id: None,
                 model_name: None,
+                extra_request_body: None,
             },
             api_key: "test-key".to_string(),
             timeout_seconds: 30,
@@ -794,6 +820,7 @@ mod tests {
                 base_url: "https://example.com".to_string(),
                 organization_id: None,
                 model_name: None,
+                extra_request_body: None,
             },
             api_key: "key".to_string(),
             timeout_seconds: 30,
@@ -851,5 +878,152 @@ mod tests {
             }
             _ => panic!("Expected OpenAiCompatible variant"),
         }
+    }
+
+    #[test]
+    fn test_provider_config_extra_request_body_deserialization() {
+        let json = r#"{
+            "backend": "openai_compatible",
+            "base_url": "https://openrouter.ai/api/v1",
+            "model_name": "moonshotai/kimi-k2.6",
+            "extra_request_body": {
+                "provider": {
+                    "order": ["Chutes"],
+                    "allow_fallbacks": true
+                }
+            }
+        }"#;
+        let config: ProviderConfig = serde_json::from_str(json).unwrap();
+
+        match config {
+            ProviderConfig::OpenAiCompatible {
+                base_url,
+                extra_request_body,
+                ..
+            } => {
+                assert_eq!(base_url, "https://openrouter.ai/api/v1");
+                let extra = extra_request_body.unwrap();
+                let provider = extra.get("provider").unwrap();
+                assert_eq!(
+                    provider.get("order").unwrap().as_array().unwrap()[0],
+                    "Chutes"
+                );
+                assert_eq!(provider.get("allow_fallbacks").unwrap(), true);
+            }
+            _ => panic!("Expected OpenAiCompatible variant"),
+        }
+    }
+
+    #[test]
+    fn test_inject_extra_request_body() {
+        let config = ExternalProviderConfig {
+            model_name: "test-model".to_string(),
+            provider_config: ProviderConfig::OpenAiCompatible {
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                organization_id: None,
+                model_name: None,
+                extra_request_body: Some(std::collections::HashMap::from([(
+                    "provider".to_string(),
+                    serde_json::json!({"order": ["Chutes"], "allow_fallbacks": true}),
+                )])),
+            },
+            api_key: "test-key".to_string(),
+            timeout_seconds: 30,
+        };
+
+        let provider = ExternalProvider::new(config);
+
+        let mut params = ChatCompletionParams {
+            model: "test".to_string(),
+            messages: vec![],
+            max_completion_tokens: None,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            n: None,
+            stream: None,
+            stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            logit_bias: None,
+            logprobs: None,
+            top_logprobs: None,
+            user: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            metadata: None,
+            store: None,
+            stream_options: None,
+            modalities: None,
+            extra: std::collections::HashMap::new(),
+        };
+
+        provider.inject_extra_request_body(&mut params);
+        assert!(params.extra.contains_key("provider"));
+        let provider_val = params.extra.get("provider").unwrap();
+        assert_eq!(
+            provider_val.get("order").unwrap().as_array().unwrap()[0],
+            "Chutes"
+        );
+    }
+
+    #[test]
+    fn test_inject_extra_request_body_user_takes_precedence() {
+        let config = ExternalProviderConfig {
+            model_name: "test-model".to_string(),
+            provider_config: ProviderConfig::OpenAiCompatible {
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                organization_id: None,
+                model_name: None,
+                extra_request_body: Some(std::collections::HashMap::from([(
+                    "provider".to_string(),
+                    serde_json::json!({"order": ["Chutes"]}),
+                )])),
+            },
+            api_key: "test-key".to_string(),
+            timeout_seconds: 30,
+        };
+
+        let provider = ExternalProvider::new(config);
+
+        let mut params = ChatCompletionParams {
+            model: "test".to_string(),
+            messages: vec![],
+            max_completion_tokens: None,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            n: None,
+            stream: None,
+            stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            logit_bias: None,
+            logprobs: None,
+            top_logprobs: None,
+            user: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            metadata: None,
+            store: None,
+            stream_options: None,
+            modalities: None,
+            extra: std::collections::HashMap::from([(
+                "provider".to_string(),
+                serde_json::json!({"order": ["DeepInfra"]}),
+            )]),
+        };
+
+        provider.inject_extra_request_body(&mut params);
+        // User's value should take precedence over provider config default
+        let provider_val = params.extra.get("provider").unwrap();
+        assert_eq!(
+            provider_val.get("order").unwrap().as_array().unwrap()[0],
+            "DeepInfra"
+        );
     }
 }

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -62,6 +62,20 @@ fn strip_internal_tracing_keys(extra: &mut std::collections::HashMap<String, ser
     extra.remove(tracing_headers::WORKSPACE_ID);
 }
 
+fn merge_json_defaults(target: &mut serde_json::Value, defaults: &serde_json::Value) {
+    if let (serde_json::Value::Object(target), serde_json::Value::Object(defaults)) =
+        (target, defaults)
+    {
+        for (key, default_value) in defaults {
+            if let Some(target_value) = target.get_mut(key) {
+                merge_json_defaults(target_value, default_value);
+            } else {
+                target.insert(key.clone(), default_value.clone());
+            }
+        }
+    }
+}
+
 /// Provider configuration stored in database
 ///
 /// This enum represents the JSON configuration stored in the `provider_config`
@@ -80,7 +94,7 @@ pub enum ProviderConfig {
         /// Optional model name override (e.g., "gpt-5.2" when our model ID is "openai/gpt-5.2")
         #[serde(default)]
         model_name: Option<String>,
-        /// Extra fields injected into every outgoing request body.
+        /// Extra fields injected into outgoing JSON request bodies.
         /// Useful for provider-specific parameters like OpenRouter's `provider` preferences.
         #[serde(default)]
         extra_request_body: Option<std::collections::HashMap<String, serde_json::Value>>,
@@ -244,12 +258,16 @@ impl ExternalProvider {
 
     /// Inject provider-level default fields into the request body.
     /// Per-request fields from the user take precedence over provider defaults.
-    fn inject_extra_request_body(&self, params: &mut ChatCompletionParams) {
+    fn inject_extra_request_body(
+        &self,
+        extra: &mut std::collections::HashMap<String, serde_json::Value>,
+    ) {
         for (key, value) in &self.config.extra_request_body {
-            params
-                .extra
-                .entry(key.clone())
-                .or_insert_with(|| value.clone());
+            if let Some(target_value) = extra.get_mut(key) {
+                merge_json_defaults(target_value, value);
+            } else {
+                extra.insert(key.clone(), value.clone());
+            }
         }
     }
 }
@@ -273,7 +291,7 @@ impl InferenceProvider for ExternalProvider {
         _request_hash: String,
     ) -> Result<StreamingResult, CompletionError> {
         strip_internal_tracing_keys(&mut params.extra);
-        self.inject_extra_request_body(&mut params);
+        self.inject_extra_request_body(&mut params.extra);
         self.backend
             .chat_completion_stream(&self.config, &self.model_name, params)
             .await
@@ -286,7 +304,7 @@ impl InferenceProvider for ExternalProvider {
         _request_hash: String,
     ) -> Result<ChatCompletionResponseWithBytes, CompletionError> {
         strip_internal_tracing_keys(&mut params.extra);
-        self.inject_extra_request_body(&mut params);
+        self.inject_extra_request_body(&mut params.extra);
         self.backend
             .chat_completion(&self.config, &self.model_name, params)
             .await
@@ -344,9 +362,10 @@ impl InferenceProvider for ExternalProvider {
     /// - Not supported by Anthropic (will return error)
     async fn image_generation(
         &self,
-        params: ImageGenerationParams,
+        mut params: ImageGenerationParams,
         _request_hash: String,
     ) -> Result<ImageGenerationResponseWithBytes, ImageGenerationError> {
+        self.inject_extra_request_body(&mut params.extra);
         self.backend
             .image_generation(&self.config, &self.model_name, params)
             .await
@@ -380,15 +399,17 @@ impl InferenceProvider for ExternalProvider {
 
     async fn score(
         &self,
-        params: ScoreParams,
+        mut params: ScoreParams,
         _request_hash: String,
     ) -> Result<ScoreResponse, ScoreError> {
+        self.inject_extra_request_body(&mut params.extra);
         self.backend
             .score(&self.config, &self.model_name, params)
             .await
     }
 
-    async fn rerank(&self, params: RerankParams) -> Result<RerankResponse, RerankError> {
+    async fn rerank(&self, mut params: RerankParams) -> Result<RerankResponse, RerankError> {
+        self.inject_extra_request_body(&mut params.extra);
         self.backend
             .rerank(&self.config, &self.model_name, params)
             .await
@@ -397,16 +418,18 @@ impl InferenceProvider for ExternalProvider {
     async fn embeddings_raw(
         &self,
         body: bytes::Bytes,
-        extra: std::collections::HashMap<String, serde_json::Value>,
+        mut extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, EmbeddingError> {
+        self.inject_extra_request_body(&mut extra);
         self.backend.embeddings_raw(&self.config, body, extra).await
     }
 
     async fn privacy_classify_raw(
         &self,
         body: bytes::Bytes,
-        extra: std::collections::HashMap<String, serde_json::Value>,
+        mut extra: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bytes::Bytes, PrivacyClassifyError> {
+        self.inject_extra_request_body(&mut extra);
         self.backend
             .privacy_classify_raw(&self.config, body, extra)
             .await
@@ -416,6 +439,7 @@ impl InferenceProvider for ExternalProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     // ==================== ProviderConfig Deserialization Tests ====================
 
@@ -922,7 +946,7 @@ mod tests {
                 base_url: "https://openrouter.ai/api/v1".to_string(),
                 organization_id: None,
                 model_name: None,
-                extra_request_body: Some(std::collections::HashMap::from([(
+                extra_request_body: Some(HashMap::from([(
                     "provider".to_string(),
                     serde_json::json!({"order": ["Chutes"], "allow_fallbacks": true}),
                 )])),
@@ -933,36 +957,11 @@ mod tests {
 
         let provider = ExternalProvider::new(config);
 
-        let mut params = ChatCompletionParams {
-            model: "test".to_string(),
-            messages: vec![],
-            max_completion_tokens: None,
-            max_tokens: None,
-            temperature: None,
-            top_p: None,
-            n: None,
-            stream: None,
-            stop: None,
-            frequency_penalty: None,
-            presence_penalty: None,
-            logit_bias: None,
-            logprobs: None,
-            top_logprobs: None,
-            user: None,
-            seed: None,
-            tools: None,
-            tool_choice: None,
-            parallel_tool_calls: None,
-            metadata: None,
-            store: None,
-            stream_options: None,
-            modalities: None,
-            extra: std::collections::HashMap::new(),
-        };
+        let mut extra = HashMap::new();
 
-        provider.inject_extra_request_body(&mut params);
-        assert!(params.extra.contains_key("provider"));
-        let provider_val = params.extra.get("provider").unwrap();
+        provider.inject_extra_request_body(&mut extra);
+        assert!(extra.contains_key("provider"));
+        let provider_val = extra.get("provider").unwrap();
         assert_eq!(
             provider_val.get("order").unwrap().as_array().unwrap()[0],
             "Chutes"
@@ -977,9 +976,13 @@ mod tests {
                 base_url: "https://openrouter.ai/api/v1".to_string(),
                 organization_id: None,
                 model_name: None,
-                extra_request_body: Some(std::collections::HashMap::from([(
+                extra_request_body: Some(HashMap::from([(
                     "provider".to_string(),
-                    serde_json::json!({"order": ["Chutes"]}),
+                    serde_json::json!({
+                        "order": ["Chutes"],
+                        "allow_fallbacks": true,
+                        "data_collection": "deny"
+                    }),
                 )])),
             },
             api_key: "test-key".to_string(),
@@ -988,42 +991,65 @@ mod tests {
 
         let provider = ExternalProvider::new(config);
 
-        let mut params = ChatCompletionParams {
-            model: "test".to_string(),
-            messages: vec![],
-            max_completion_tokens: None,
-            max_tokens: None,
-            temperature: None,
-            top_p: None,
-            n: None,
-            stream: None,
-            stop: None,
-            frequency_penalty: None,
-            presence_penalty: None,
-            logit_bias: None,
-            logprobs: None,
-            top_logprobs: None,
-            user: None,
-            seed: None,
-            tools: None,
-            tool_choice: None,
-            parallel_tool_calls: None,
-            metadata: None,
-            store: None,
-            stream_options: None,
-            modalities: None,
-            extra: std::collections::HashMap::from([(
-                "provider".to_string(),
-                serde_json::json!({"order": ["DeepInfra"]}),
-            )]),
-        };
+        let mut extra = HashMap::from([(
+            "provider".to_string(),
+            serde_json::json!({"order": ["DeepInfra"]}),
+        )]);
 
-        provider.inject_extra_request_body(&mut params);
-        // User's value should take precedence over provider config default
-        let provider_val = params.extra.get("provider").unwrap();
+        provider.inject_extra_request_body(&mut extra);
+        // User's nested value should take precedence while missing defaults are preserved.
+        let provider_val = extra.get("provider").unwrap();
         assert_eq!(
             provider_val.get("order").unwrap().as_array().unwrap()[0],
             "DeepInfra"
         );
+        assert_eq!(provider_val.get("allow_fallbacks").unwrap(), true);
+        assert_eq!(provider_val.get("data_collection").unwrap(), "deny");
+    }
+
+    #[test]
+    fn test_inject_extra_request_body_deep_merges_nested_defaults() {
+        let config = ExternalProviderConfig {
+            model_name: "test-model".to_string(),
+            provider_config: ProviderConfig::OpenAiCompatible {
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                organization_id: None,
+                model_name: None,
+                extra_request_body: Some(HashMap::from([(
+                    "provider".to_string(),
+                    serde_json::json!({
+                        "preferences": {
+                            "privacy": {
+                                "data_collection": "deny",
+                                "training": false
+                            },
+                            "latency": "low"
+                        }
+                    }),
+                )])),
+            },
+            api_key: "test-key".to_string(),
+            timeout_seconds: 30,
+        };
+
+        let provider = ExternalProvider::new(config);
+        let mut extra = HashMap::from([(
+            "provider".to_string(),
+            serde_json::json!({
+                "preferences": {
+                    "privacy": {
+                        "training": true
+                    }
+                }
+            }),
+        )]);
+
+        provider.inject_extra_request_body(&mut extra);
+        let preferences = extra.get("provider").unwrap().get("preferences").unwrap();
+        let privacy = preferences.get("privacy").unwrap();
+
+        assert_eq!(privacy.get("data_collection").unwrap(), "deny");
+        assert_eq!(privacy.get("training").unwrap(), true);
+        assert_eq!(preferences.get("latency").unwrap(), "low");
     }
 }

--- a/crates/inference_providers/src/external/openai_compatible.rs
+++ b/crates/inference_providers/src/external/openai_compatible.rs
@@ -368,6 +368,7 @@ mod tests {
             api_key: "sk-test-key-123".to_string(),
             timeout_seconds: 30,
             extra: HashMap::new(),
+            extra_request_body: HashMap::new(),
         };
 
         let headers = backend.build_headers(&config).unwrap();
@@ -393,6 +394,7 @@ mod tests {
             api_key: "sk-test-key".to_string(),
             timeout_seconds: 30,
             extra,
+            extra_request_body: HashMap::new(),
         };
 
         let headers = backend.build_headers(&config).unwrap();
@@ -415,6 +417,7 @@ mod tests {
             api_key: "sk-test-key".to_string(),
             timeout_seconds: 30,
             extra: HashMap::new(),
+            extra_request_body: HashMap::new(),
         };
 
         let headers = backend.build_headers(&config).unwrap();


### PR DESCRIPTION
## Summary

- Adds `extra_request_body` field to `ProviderConfig::OpenAiCompatible` — a map of JSON fields injected into every outgoing request body
- Enables configuring OpenRouter-specific parameters (provider preferences, fallback behavior, data collection policies) at the model level via `PATCH /v1/admin/models`
- User-supplied request fields take precedence over provider defaults

Example `providerConfig` for an OpenRouter model with preferred provider:
```json
{
  "backend": "openai_compatible",
  "base_url": "https://openrouter.ai/api/v1",
  "model_name": "moonshotai/kimi-k2.6",
  "extra_request_body": {
    "provider": {
      "order": ["Chutes"],
      "allow_fallbacks": true,
      "data_collection": "deny"
    }
  }
}
```

## Test plan

- [x] Unit test: `extra_request_body` deserializes from JSON config
- [x] Unit test: fields injected into request params
- [x] Unit test: user-supplied fields take precedence over provider defaults
- [x] All 307 existing + new unit tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [ ] Staging: Kimi K2.6 and Qwen3.7 Max deployed via OpenRouter and tested