### PR TITLE
Show organization names in invitations

### DIFF
--- a/crates/api/src/conversions.rs
+++ b/crates/api/src/conversions.rs
@@ -669,6 +669,17 @@ pub fn services_invitation_to_api(
     }
 }
 
+/// Convert services OrganizationInvitationWithDetails to API OrganizationInvitationWithOrgResponse
+pub fn services_invitation_to_api_with_org(
+    invitation: services::organization::OrganizationInvitationWithDetails,
+) -> crate::models::OrganizationInvitationWithOrgResponse {
+    crate::models::OrganizationInvitationWithOrgResponse {
+        organization_name: invitation.organization_name,
+        invited_by_display_name: invitation.invited_by_display_name,
+        invitation: services_invitation_to_api(invitation.invitation),
+    }
+}
+
 /// Convert database::User to AdminUserResponse (for owners/admins only)  
 pub fn db_user_to_admin_user(user: &database::User) -> AdminUserResponse {
     AdminUserResponse {

--- a/crates/api/src/routes/users.rs
+++ b/crates/api/src/routes/users.rs
@@ -1,6 +1,7 @@
 use crate::{
     conversions::{
-        authenticated_user_to_user_id, services_invitation_to_api, services_member_to_api_member,
+        authenticated_user_to_user_id, services_invitation_to_api,
+        services_invitation_to_api_with_org, services_member_to_api_member,
         services_user_to_api_user,
     },
     middleware::AuthenticatedUser,
@@ -473,7 +474,7 @@ pub async fn create_access_token(
     path = "/v1/users/me/invitations",
     tag = "Users",
     responses(
-        (status = 200, description = "List of pending invitations", body = Vec<crate::models::OrganizationInvitationResponse>),
+        (status = 200, description = "List of pending invitations", body = Vec<crate::models::OrganizationInvitationWithOrgResponse>),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -485,7 +486,7 @@ pub async fn list_user_invitations(
     State(app_state): State<AppState>,
     Extension(user): Extension<AuthenticatedUser>,
 ) -> Result<
-    Json<Vec<crate::models::OrganizationInvitationResponse>>,
+    Json<Vec<crate::models::OrganizationInvitationWithOrgResponse>>,
     (StatusCode, Json<ErrorResponse>),
 > {
     debug!("Listing invitations for user: {}", user.0.email);
@@ -496,9 +497,9 @@ pub async fn list_user_invitations(
         .await
     {
         Ok(invitations) => {
-            let responses: Vec<crate::models::OrganizationInvitationResponse> = invitations
+            let responses = invitations
                 .into_iter()
-                .map(services_invitation_to_api)
+                .map(services_invitation_to_api_with_org)
                 .collect();
             Ok(Json(responses))
         }

--- a/crates/api/tests/e2e_all/invitations.rs
+++ b/crates/api/tests/e2e_all/invitations.rs
@@ -1,0 +1,77 @@
+use crate::common::*;
+
+#[tokio::test]
+async fn test_user_invitations_include_organization_name() {
+    let (server, database) = setup_test_server_with_database().await;
+    let org_name = format!("Invitation Org {}", uuid::Uuid::new_v4());
+
+    let create_response = server
+        .post("/v1/organizations")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&api::models::CreateOrganizationRequest {
+            name: org_name.clone(),
+            description: Some("Organization used for invitation name tests".to_string()),
+        })
+        .await;
+
+    assert_eq!(create_response.status_code(), 200);
+    let org = create_response.json::<api::models::OrganizationResponse>();
+    assert_eq!(org.name, org_name);
+
+    let invitation_id = uuid::Uuid::new_v4();
+    let organization_id = uuid::Uuid::parse_str(&org.id).expect("org id should be a uuid");
+    let invited_by_user_id =
+        uuid::Uuid::parse_str(MOCK_USER_ID).expect("mock user id should be a uuid");
+    let token = format!("test-token-{}", uuid::Uuid::new_v4());
+    let pool = database.pool();
+    let client = pool.get().await.expect("Failed to get database connection");
+    client
+        .execute(
+            "INSERT INTO organization_invitations (
+                id,
+                organization_id,
+                email,
+                role,
+                invited_by_user_id,
+                status,
+                token,
+                created_at,
+                expires_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW() + INTERVAL '7 days')",
+            &[
+                &invitation_id,
+                &organization_id,
+                &"admin@test.com",
+                &"member",
+                &invited_by_user_id,
+                &"pending",
+                &token,
+            ],
+        )
+        .await
+        .expect("Failed to create invitation fixture");
+    drop(client);
+
+    let list_response = server
+        .get("/v1/users/me/invitations")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    assert_eq!(list_response.status_code(), 200);
+    let invitations =
+        list_response.json::<Vec<api::models::OrganizationInvitationWithOrgResponse>>();
+    let invitation = invitations
+        .iter()
+        .find(|inv| inv.invitation.id == invitation_id.to_string())
+        .expect("authenticated user should have a pending invitation for the created organization");
+
+    assert_eq!(invitation.organization_name, org.name);
+    assert_eq!(invitation.invitation.email, "admin@test.com");
+    assert_eq!(
+        invitation.invited_by_display_name,
+        Some("Test User".to_string())
+    );
+}

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -29,6 +29,7 @@ mod external_providers;
 mod files;
 mod function_tools;
 mod general;
+mod invitations;
 mod mcp;
 mod mcp_server;
 mod message_metadata;

--- a/crates/database/src/repositories/organization_invitation.rs
+++ b/crates/database/src/repositories/organization_invitation.rs
@@ -12,6 +12,7 @@ use services::organization::ports::{
     CreateInvitationRequest, InvitationEmailStatus as ServicesInvitationEmailStatus,
     InvitationStatus as ServicesInvitationStatus, OrganizationInvitation as ServicesInvitation,
     OrganizationInvitationRepository,
+    OrganizationInvitationWithDetails as ServicesInvitationWithDetails,
 };
 use tracing::debug;
 use uuid::Uuid;
@@ -72,6 +73,19 @@ impl PgOrganizationInvitationRepository {
             email_sent_at: row.get("email_sent_at"),
             email_last_error: row.get("email_last_error"),
             email_message_id: row.get("email_message_id"),
+        })
+    }
+
+    fn row_to_domain_invitation_with_details(
+        &self,
+        row: &tokio_postgres::Row,
+    ) -> Result<ServicesInvitationWithDetails> {
+        let db_inv = self.row_to_db_invitation(row)?;
+
+        Ok(ServicesInvitationWithDetails {
+            invitation: self.db_to_domain(db_inv)?,
+            organization_name: row.get("organization_name"),
+            invited_by_display_name: row.get("invited_by_display_name"),
         })
     }
 
@@ -356,6 +370,66 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
         for r in rows {
             let db_inv = self.row_to_db_invitation(&r)?;
             invitations.push(self.db_to_domain(db_inv)?);
+        }
+
+        Ok(invitations)
+    }
+
+    async fn list_by_email_with_details(
+        &self,
+        email: &str,
+        status: Option<ServicesInvitationStatus>,
+    ) -> Result<Vec<ServicesInvitationWithDetails>> {
+        let db_status = status.map(|s| self.domain_to_db_status(s));
+
+        let rows = retry_db!("list_organization_invitations_by_email_with_details", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            if let Some(ref db_status) = db_status {
+                client
+                    .query(
+                        "SELECT i.id, i.organization_id, i.email, i.role, i.invited_by_user_id,
+                            i.status, i.token, i.created_at, i.expires_at, i.responded_at,
+                            i.email_status, i.email_sent_at, i.email_last_error,
+                            i.email_message_id, o.name AS organization_name,
+                            u.display_name AS invited_by_display_name
+                         FROM organization_invitations i
+                         JOIN organizations o ON o.id = i.organization_id
+                         LEFT JOIN users u ON u.id = i.invited_by_user_id
+                         WHERE i.email = $1 AND i.status = $2
+                         ORDER BY i.created_at DESC",
+                        &[&email, &db_status.to_string()],
+                    )
+                    .await
+                    .map_err(map_db_error)
+            } else {
+                client
+                    .query(
+                        "SELECT i.id, i.organization_id, i.email, i.role, i.invited_by_user_id,
+                            i.status, i.token, i.created_at, i.expires_at, i.responded_at,
+                            i.email_status, i.email_sent_at, i.email_last_error,
+                            i.email_message_id, o.name AS organization_name,
+                            u.display_name AS invited_by_display_name
+                         FROM organization_invitations i
+                         JOIN organizations o ON o.id = i.organization_id
+                         LEFT JOIN users u ON u.id = i.invited_by_user_id
+                         WHERE i.email = $1
+                         ORDER BY i.created_at DESC",
+                        &[&email],
+                    )
+                    .await
+                    .map_err(map_db_error)
+            }
+        })?;
+
+        let mut invitations = Vec::new();
+        for r in rows {
+            invitations.push(self.row_to_domain_invitation_with_details(&r)?);
         }
 
         Ok(invitations)

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -558,10 +558,10 @@ mod tests {
     use crate::organization::{
         AddOrganizationMemberRequest, BatchInvitationResponse, CreateOrganizationRequest,
         InvitationStatus, MemberRole, Organization, OrganizationError, OrganizationId,
-        OrganizationInvitation, OrganizationMember, OrganizationMemberWithUser,
-        OrganizationOrderBy, OrganizationOrderDirection, OrganizationRepository,
-        OrganizationServiceTrait, OrganizationWithRole, UpdateOrganizationMemberRequest,
-        UpdateOrganizationRequest,
+        OrganizationInvitation, OrganizationInvitationWithDetails, OrganizationMember,
+        OrganizationMemberWithUser, OrganizationOrderBy, OrganizationOrderDirection,
+        OrganizationRepository, OrganizationServiceTrait, OrganizationWithRole,
+        UpdateOrganizationMemberRequest, UpdateOrganizationRequest,
     };
     use crate::workspace::{
         ApiKey, ApiKeyId, ApiKeyRepository, CreateApiKeyRequest, Workspace, WorkspaceId,
@@ -1094,7 +1094,7 @@ mod tests {
         async fn list_user_invitations(
             &self,
             _: &str,
-        ) -> Result<Vec<OrganizationInvitation>, OrganizationError> {
+        ) -> Result<Vec<OrganizationInvitationWithDetails>, OrganizationError> {
             unimplemented!()
         }
         async fn get_invitation_by_token(

--- a/crates/services/src/organization/mod.rs
+++ b/crates/services/src/organization/mod.rs
@@ -945,9 +945,9 @@ impl OrganizationServiceImpl {
     async fn list_user_invitations_impl(
         &self,
         email: &str,
-    ) -> Result<Vec<ports::OrganizationInvitation>, OrganizationError> {
+    ) -> Result<Vec<ports::OrganizationInvitationWithDetails>, OrganizationError> {
         self.invitation_repository
-            .list_by_email(email, Some(ports::InvitationStatus::Pending))
+            .list_by_email_with_details(email, Some(ports::InvitationStatus::Pending))
             .await
             .map_err(|e| {
                 OrganizationError::InternalError(format!("Failed to list invitations: {e}"))
@@ -1384,7 +1384,7 @@ impl OrganizationServiceTrait for OrganizationServiceImpl {
     async fn list_user_invitations(
         &self,
         email: &str,
-    ) -> Result<Vec<OrganizationInvitation>, OrganizationError> {
+    ) -> Result<Vec<OrganizationInvitationWithDetails>, OrganizationError> {
         self.list_user_invitations_impl(email).await
     }
 
@@ -1805,6 +1805,14 @@ mod tests {
             _: &str,
             _: Option<InvitationStatus>,
         ) -> anyhow::Result<Vec<OrganizationInvitation>> {
+            unimplemented!()
+        }
+
+        async fn list_by_email_with_details(
+            &self,
+            _: &str,
+            _: Option<InvitationStatus>,
+        ) -> anyhow::Result<Vec<OrganizationInvitationWithDetails>> {
             unimplemented!()
         }
 

--- a/crates/services/src/organization/ports.rs
+++ b/crates/services/src/organization/ports.rs
@@ -206,6 +206,14 @@ pub struct OrganizationInvitation {
     pub email_message_id: Option<String>,
 }
 
+/// Organization invitation with display details needed by invitees
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationInvitationWithDetails {
+    pub invitation: OrganizationInvitation,
+    pub organization_name: String,
+    pub invited_by_display_name: Option<String>,
+}
+
 /// Create invitation request
 #[derive(Debug, Clone)]
 pub struct CreateInvitationRequest {
@@ -329,6 +337,13 @@ pub trait OrganizationInvitationRepository: Send + Sync {
         email: &str,
         status: Option<InvitationStatus>,
     ) -> Result<Vec<OrganizationInvitation>>;
+
+    /// List invitations for a user by email, enriched with organization and inviter details
+    async fn list_by_email_with_details(
+        &self,
+        email: &str,
+        status: Option<InvitationStatus>,
+    ) -> Result<Vec<OrganizationInvitationWithDetails>>;
 
     /// Update invitation status
     async fn update_status(
@@ -522,7 +537,7 @@ pub trait OrganizationServiceTrait: Send + Sync {
     async fn list_user_invitations(
         &self,
         email: &str,
-    ) -> Result<Vec<OrganizationInvitation>, OrganizationError>;
+    ) -> Result<Vec<OrganizationInvitationWithDetails>, OrganizationError>;
 
     /// Get invitation by token (public, for viewing before auth)
     async fn get_invitation_by_token(


### PR DESCRIPTION
## Summary
- enrich `/v1/users/me/invitations` responses with `organization_name`
- add a converter for `OrganizationInvitationWithOrgResponse`
- add e2e coverage for the invited-user inbox response

## Tests
- `cargo fmt --all --check`
- `cargo test -p api --test e2e_all test_user_invitations_include_organization_name` (compiled, but local run could not bootstrap because Postgres was not listening on localhost:5432)