### PR TITLE
Retry response body decode failures

### DIFF
--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1392,6 +1392,8 @@ impl InferenceProviderPool {
                     || lower.contains("connect")
                     || lower.contains("reset")
                     || lower.contains("broken pipe")
+                    || lower.contains("decoding response body")
+                    || lower.contains("body error")
                 {
                     "retryable_connection_keyword"
                 } else {
@@ -3465,6 +3467,12 @@ mod tests {
         assert_eq!(
             InferenceProviderPool::classify_retry_decision(&CompletionError::CompletionError(
                 "connection reset by peer".to_string()
+            )),
+            "retryable_connection_keyword",
+        );
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::CompletionError(
+                "error decoding response body".to_string()
             )),
             "retryable_connection_keyword",
         );


### PR DESCRIPTION
## Summary
- Treat provider body decode/body read failures as retryable transient errors.
- Add a unit assertion for the `error decoding response body` symptom seen during Kimi K2.6 testing.

## Why
A user reported Kimi K2.6 failing with `Failed to perform completion: error decoding response body`. Live smoke tests passed, but this class of reqwest body-read failure was classified as permanent, so a transient upstream issue could abort without retrying.

## Validation
- `cargo test -p services test_classify_retry_decision`
- `cargo fmt --check`