### PR TITLE
[codex] add feature request API

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,6 +22,9 @@ use crate::{
             models, privacy_classify, rerank, score,
         },
         conversations,
+        feature_requests::{
+            list_admin_feature_requests, submit_feature_request, FeatureRequestsRouteState,
+        },
         health::health_check,
         models::{get_model_by_name, list_models, ModelsAppState},
         responses,
@@ -883,6 +886,11 @@ pub fn build_app_with_config(
     let files_routes =
         build_files_routes(app_state.clone(), &auth_components.auth_state_middleware);
 
+    let feature_request_routes = build_feature_request_routes(
+        database.pool().clone(),
+        &auth_components.auth_state_middleware,
+    );
+
     let billing_routes = build_billing_routes(
         domain_services.usage_service.clone(),
         &auth_components.auth_state_middleware,
@@ -936,6 +944,7 @@ pub fn build_app_with_config(
                 .merge(invitation_routes)
                 .merge(auth_vpc_routes)
                 .merge(files_routes)
+                .merge(feature_request_routes)
                 .merge(billing_routes)
                 .merge(usage_recording_routes)
                 .merge(gateway_routes)
@@ -1317,6 +1326,36 @@ pub fn build_files_routes(app_state: AppState, auth_state_middleware: &AuthState
             auth_state_middleware.clone(),
             auth_middleware_with_api_key,
         ))
+}
+
+/// Build feature request routes for user submissions and admin aggregation.
+pub fn build_feature_request_routes(
+    pool: database::DbPool,
+    auth_state_middleware: &AuthState,
+) -> Router {
+    use crate::middleware::{admin_middleware, auth_middleware};
+
+    let state = FeatureRequestsRouteState {
+        repository: Arc::new(database::repositories::FeatureRequestRepository::new(pool)),
+    };
+
+    let user_routes = Router::new()
+        .route("/feature-requests", post(submit_feature_request))
+        .with_state(state.clone())
+        .layer(from_fn_with_state(
+            auth_state_middleware.clone(),
+            auth_middleware,
+        ));
+
+    let admin_routes = Router::new()
+        .route("/admin/feature-requests", get(list_admin_feature_requests))
+        .with_state(state)
+        .layer(from_fn_with_state(
+            auth_state_middleware.clone(),
+            admin_middleware,
+        ));
+
+    Router::new().merge(user_routes).merge(admin_routes)
 }
 
 /// Build billing routes with API key auth (HuggingFace billing integration)

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -122,6 +122,9 @@ use utoipa::{Modify, OpenApi};
         crate::routes::usage::record_usage,
         crate::routes::usage::get_user_organization_metrics,
         crate::routes::usage::get_user_organization_timeseries,
+        // Feature request endpoints
+        crate::routes::feature_requests::submit_feature_request,
+        crate::routes::feature_requests::list_admin_feature_requests,
         // Gateway endpoints (model gateway integration)
         crate::routes::gateway::check_api_key,
         // Billing endpoints (HuggingFace integration)
@@ -245,6 +248,14 @@ use utoipa::{Modify, OpenApi};
             crate::routes::usage::UserWorkspaceMetrics,
             crate::routes::usage::UserTimeSeriesMetrics,
             crate::routes::usage::UserTimeSeriesPoint,
+            // Feature request models
+            crate::routes::feature_requests::FeatureRequestKind,
+            crate::routes::feature_requests::SubmitFeatureRequest,
+            crate::routes::feature_requests::SubmitFeatureRequestResponse,
+            crate::routes::feature_requests::FeatureRequestTargetResponse,
+            crate::routes::feature_requests::FeatureRequestVoteResponse,
+            crate::routes::feature_requests::AdminFeatureRequestSummaryResponse,
+            crate::routes::feature_requests::AdminFeatureRequestListResponse,
             // Gateway models
             crate::routes::gateway::CheckApiKeyResponse,
             // Billing models (HuggingFace integration)

--- a/crates/api/src/routes/feature_requests.rs
+++ b/crates/api/src/routes/feature_requests.rs
@@ -1,0 +1,359 @@
+use crate::middleware::{AdminUser, AuthenticatedUser};
+use crate::models::ErrorResponse;
+use crate::routes::common::{validate_limit_offset, validate_max_length, validate_non_empty_field};
+use axum::{
+    extract::{Json, Query, State},
+    http::StatusCode,
+    response::Json as ResponseJson,
+    Extension,
+};
+use database::repositories::{
+    FeatureRequestRepository, FeatureRequestSummary, FeatureRequestTarget,
+    FeatureRequestVoteSummary, SubmitFeatureRequestParams,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::error;
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+const MAX_KEY_LENGTH: usize = 255;
+const MAX_TITLE_LENGTH: usize = 255;
+const MAX_NOTE_LENGTH: usize = 2000;
+const MAX_SOURCE_LENGTH: usize = 100;
+
+#[derive(Clone)]
+pub struct FeatureRequestsRouteState {
+    pub repository: Arc<FeatureRequestRepository>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FeatureRequestKind {
+    Model,
+    Feature,
+}
+
+impl FeatureRequestKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FeatureRequestKind::Model => "model",
+            FeatureRequestKind::Feature => "feature",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "model" => Some(FeatureRequestKind::Model),
+            "feature" => Some(FeatureRequestKind::Feature),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitFeatureRequest {
+    pub kind: String,
+    pub key: String,
+    pub title: Option<String>,
+    pub note: Option<String>,
+    pub organization_id: Option<Uuid>,
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureRequestTargetResponse {
+    pub id: Uuid,
+    pub kind: String,
+    pub key: String,
+    pub title: String,
+    pub status: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitFeatureRequestResponse {
+    pub target: FeatureRequestTargetResponse,
+    pub unique_user_count: i64,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureRequestVoteResponse {
+    pub user_id: Uuid,
+    pub user_email: String,
+    pub user_display_name: Option<String>,
+    pub organization_id: Option<Uuid>,
+    pub organization_name: Option<String>,
+    pub note: Option<String>,
+    pub source: Option<String>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminFeatureRequestSummaryResponse {
+    pub target: FeatureRequestTargetResponse,
+    pub unique_user_count: i64,
+    pub unique_organization_count: i64,
+    pub latest_requested_at: chrono::DateTime<chrono::Utc>,
+    pub recent_votes: Vec<FeatureRequestVoteResponse>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminFeatureRequestListResponse {
+    pub requests: Vec<AdminFeatureRequestSummaryResponse>,
+    pub limit: i64,
+    pub offset: i64,
+    pub total: i64,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct AdminFeatureRequestListQuery {
+    pub kind: Option<String>,
+    #[serde(default = "crate::routes::common::default_limit")]
+    pub limit: i64,
+    #[serde(default)]
+    pub offset: i64,
+}
+
+/// Submit or update the current user's interest in a feature request target.
+#[utoipa::path(
+    post,
+    path = "/v1/feature-requests",
+    tag = "Feature Requests",
+    request_body = SubmitFeatureRequest,
+    responses(
+        (status = 200, description = "Feature request recorded", body = SubmitFeatureRequestResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Organization membership required", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn submit_feature_request(
+    State(state): State<FeatureRequestsRouteState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Json(request): Json<SubmitFeatureRequest>,
+) -> Result<ResponseJson<SubmitFeatureRequestResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
+    let kind = parse_kind(&request.kind)?;
+    let key = normalize_key(&request.key);
+    let title = request
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| request.key.trim())
+        .to_string();
+    let note = request
+        .note
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let source = request
+        .source
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    validate_input(&key, &title, note.as_deref(), source.as_deref())?;
+
+    if let Some(org_id) = request.organization_id {
+        let belongs = state
+            .repository
+            .user_belongs_to_organization(user.0.id, org_id)
+            .await
+            .map_err(internal_error)?;
+        if !belongs {
+            return Err((
+                StatusCode::FORBIDDEN,
+                ResponseJson(ErrorResponse::new(
+                    "User does not belong to the specified organization".to_string(),
+                    "forbidden".to_string(),
+                )),
+            ));
+        }
+    }
+
+    let result = state
+        .repository
+        .submit(SubmitFeatureRequestParams {
+            kind: kind.as_str().to_string(),
+            key,
+            title,
+            user_id: user.0.id,
+            organization_id: request.organization_id,
+            note,
+            source,
+        })
+        .await
+        .map_err(internal_error)?;
+
+    Ok(ResponseJson(SubmitFeatureRequestResponse {
+        target: target_to_response(result.target),
+        unique_user_count: result.unique_user_count,
+    }))
+}
+
+/// List aggregated feature requests for admins.
+#[utoipa::path(
+    get,
+    path = "/v1/admin/feature-requests",
+    tag = "Admin",
+    params(AdminFeatureRequestListQuery),
+    responses(
+        (status = 200, description = "Aggregated feature requests", body = AdminFeatureRequestListResponse),
+        (status = 400, description = "Invalid parameters", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn list_admin_feature_requests(
+    State(state): State<FeatureRequestsRouteState>,
+    Extension(_admin_user): Extension<AdminUser>,
+    Query(params): Query<AdminFeatureRequestListQuery>,
+) -> Result<ResponseJson<AdminFeatureRequestListResponse>, (StatusCode, ResponseJson<ErrorResponse>)>
+{
+    validate_limit_offset(params.limit, params.offset)?;
+
+    let kind = match params
+        .kind
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) => {
+            let normalized = value.to_ascii_lowercase();
+            if FeatureRequestKind::parse(&normalized).is_none() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    ResponseJson(ErrorResponse::new(
+                        "kind must be 'model' or 'feature'".to_string(),
+                        "invalid_parameter".to_string(),
+                    )),
+                ));
+            }
+            Some(normalized)
+        }
+        None => None,
+    };
+
+    let (requests, total) = state
+        .repository
+        .list_admin(kind.as_deref(), params.limit, params.offset)
+        .await
+        .map_err(internal_error)?;
+
+    Ok(ResponseJson(AdminFeatureRequestListResponse {
+        requests: requests.into_iter().map(summary_to_response).collect(),
+        limit: params.limit,
+        offset: params.offset,
+        total,
+    }))
+}
+
+fn normalize_key(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn parse_kind(
+    value: &str,
+) -> Result<FeatureRequestKind, (StatusCode, ResponseJson<ErrorResponse>)> {
+    let normalized = value.trim().to_ascii_lowercase();
+    FeatureRequestKind::parse(&normalized).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                "kind must be 'model' or 'feature'".to_string(),
+                "invalid_request".to_string(),
+            )),
+        )
+    })
+}
+
+fn validate_input(
+    key: &str,
+    title: &str,
+    note: Option<&str>,
+    source: Option<&str>,
+) -> Result<(), (StatusCode, ResponseJson<ErrorResponse>)> {
+    let validation = || -> Result<(), String> {
+        validate_non_empty_field(key, "key")?;
+        validate_max_length(key, "key", MAX_KEY_LENGTH)?;
+        validate_non_empty_field(title, "title")?;
+        validate_max_length(title, "title", MAX_TITLE_LENGTH)?;
+        if let Some(note) = note {
+            validate_max_length(note, "note", MAX_NOTE_LENGTH)?;
+        }
+        if let Some(source) = source {
+            validate_max_length(source, "source", MAX_SOURCE_LENGTH)?;
+        }
+        Ok(())
+    };
+
+    validation().map_err(|message| {
+        (
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(message, "invalid_request".to_string())),
+        )
+    })
+}
+
+fn target_to_response(target: FeatureRequestTarget) -> FeatureRequestTargetResponse {
+    FeatureRequestTargetResponse {
+        id: target.id,
+        kind: target.kind,
+        key: target.key,
+        title: target.title,
+        status: target.status,
+        created_at: target.created_at,
+        updated_at: target.updated_at,
+    }
+}
+
+fn vote_to_response(vote: FeatureRequestVoteSummary) -> FeatureRequestVoteResponse {
+    FeatureRequestVoteResponse {
+        user_id: vote.user_id,
+        user_email: vote.user_email,
+        user_display_name: vote.user_display_name,
+        organization_id: vote.organization_id,
+        organization_name: vote.organization_name,
+        note: vote.note,
+        source: vote.source,
+        updated_at: vote.updated_at,
+    }
+}
+
+fn summary_to_response(summary: FeatureRequestSummary) -> AdminFeatureRequestSummaryResponse {
+    AdminFeatureRequestSummaryResponse {
+        target: target_to_response(summary.target),
+        unique_user_count: summary.unique_user_count,
+        unique_organization_count: summary.unique_organization_count,
+        latest_requested_at: summary.latest_requested_at,
+        recent_votes: summary
+            .recent_votes
+            .into_iter()
+            .map(vote_to_response)
+            .collect(),
+    }
+}
+
+fn internal_error(error: anyhow::Error) -> (StatusCode, ResponseJson<ErrorResponse>) {
+    error!("Feature request operation failed: {:?}", error);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        ResponseJson(ErrorResponse::new(
+            "Internal server error".to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
+}

--- a/crates/api/src/routes/feature_requests.rs
+++ b/crates/api/src/routes/feature_requests.rs
@@ -205,7 +205,7 @@ pub async fn submit_feature_request(
 #[utoipa::path(
     get,
     path = "/v1/admin/feature-requests",
-    tag = "Admin",
+    tag = "Feature Requests",
     params(AdminFeatureRequestListQuery),
     responses(
         (status = 200, description = "Aggregated feature requests", body = AdminFeatureRequestListResponse),
@@ -348,6 +348,7 @@ fn summary_to_response(summary: FeatureRequestSummary) -> AdminFeatureRequestSum
 }
 
 fn internal_error(error: anyhow::Error) -> (StatusCode, ResponseJson<ErrorResponse>) {
+    // PRIVACY: keep context here generic; request titles, notes, and sources can contain user data.
     error!("Feature request operation failed: {:?}", error);
     (
         StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -7,6 +7,7 @@ pub mod billing;
 pub mod common;
 pub mod completions;
 pub mod conversations;
+pub mod feature_requests;
 pub mod files;
 pub mod gateway;
 pub mod health;

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -495,10 +495,11 @@ pub async fn setup_unique_test_session(database: &Arc<Database>) -> (String, Str
     // Session ID format: rt_{uuid} (with dashes so it can be parsed by MockAuthService)
     let session_id = format!("rt_{user_id_str}");
     let email = format!("test-{user_id_str}@test.com");
+    let provider_user_id = format!("mock_user-{user_id_str}");
 
     let pool = database.pool();
     let client = pool.get().await.expect("Failed to get database connection");
-    let _ = client.execute(
+    client.execute(
         "INSERT INTO users (id, email, username, display_name, avatar_url, auth_provider, provider_user_id, created_at, updated_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
          ON CONFLICT (id) DO NOTHING",
@@ -509,9 +510,9 @@ pub async fn setup_unique_test_session(database: &Arc<Database>) -> (String, Str
             &Some("Test User".to_string()),
             &Some("https://example.com/avatar.jpg".to_string()),
             &"mock",
-            &"mock_user",
+            &provider_user_id,
         ],
-    ).await;
+    ).await.expect("Failed to create unique test user");
 
     (session_id, email)
 }

--- a/crates/api/tests/e2e_all/feature_requests.rs
+++ b/crates/api/tests/e2e_all/feature_requests.rs
@@ -1,0 +1,122 @@
+use crate::common::*;
+
+#[tokio::test]
+async fn test_feature_request_submit_dedupes_by_user_and_admin_lists() {
+    let (server, database) = setup_test_server_with_database().await;
+    let request_key = format!("missing-model-{}", uuid::Uuid::new_v4());
+
+    let first = server
+        .post("/v1/feature-requests")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "kind": "model",
+            "key": request_key,
+            "title": request_key,
+            "note": "Need it for evals",
+            "source": "models_page"
+        }))
+        .await;
+    assert_eq!(first.status_code(), 200);
+    let first_body: serde_json::Value = first.json();
+    assert_eq!(first_body["uniqueUserCount"], 1);
+
+    let duplicate = server
+        .post("/v1/feature-requests")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "kind": "model",
+            "key": request_key,
+            "title": request_key,
+            "note": "Updated use case",
+            "source": "models_page"
+        }))
+        .await;
+    assert_eq!(duplicate.status_code(), 200);
+    let duplicate_body: serde_json::Value = duplicate.json();
+    assert_eq!(duplicate_body["uniqueUserCount"], 1);
+
+    let (second_session, _) = setup_unique_test_session(&database).await;
+    let second = server
+        .post("/v1/feature-requests")
+        .add_header("Authorization", format!("Bearer {second_session}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "kind": "model",
+            "key": request_key,
+            "title": request_key,
+            "note": "Another user also needs this",
+            "source": "models_page"
+        }))
+        .await;
+    assert_eq!(second.status_code(), 200);
+    let second_body: serde_json::Value = second.json();
+    assert_eq!(second_body["uniqueUserCount"], 2);
+
+    let admin_list = server
+        .get("/v1/admin/feature-requests?kind=model&limit=100&offset=0")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(admin_list.status_code(), 200);
+    let admin_body: serde_json::Value = admin_list.json();
+    let requests = admin_body["requests"]
+        .as_array()
+        .expect("requests should be an array");
+    let found = requests
+        .iter()
+        .find(|item| item["target"]["key"] == request_key.to_ascii_lowercase())
+        .expect("submitted request should be listed");
+    assert_eq!(found["uniqueUserCount"], 2);
+    assert_eq!(found["recentVotes"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_feature_request_validation_and_auth() {
+    let server = setup_test_server().await;
+
+    let unauthenticated = server
+        .get("/v1/admin/feature-requests?limit=10&offset=0")
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(unauthenticated.status_code(), 401);
+
+    let empty_key = server
+        .post("/v1/feature-requests")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "kind": "model",
+            "key": "",
+            "title": "Missing model"
+        }))
+        .await;
+    assert_eq!(empty_key.status_code(), 400);
+
+    let invalid_kind = server
+        .post("/v1/feature-requests")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "kind": "integration",
+            "key": "some-model",
+            "title": "Some Model"
+        }))
+        .await;
+    assert_eq!(invalid_kind.status_code(), 400);
+
+    let long_note = "x".repeat(2001);
+    let oversized_note = server
+        .post("/v1/feature-requests")
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "kind": "model",
+            "key": "some-model",
+            "title": "Some Model",
+            "note": long_note
+        }))
+        .await;
+    assert_eq!(oversized_note.status_code(), 400);
+}

--- a/crates/api/tests/e2e_all/feature_requests.rs
+++ b/crates/api/tests/e2e_all/feature_requests.rs
@@ -4,6 +4,7 @@ use crate::common::*;
 async fn test_feature_request_submit_dedupes_by_user_and_admin_lists() {
     let (server, database) = setup_test_server_with_database().await;
     let request_key = format!("missing-model-{}", uuid::Uuid::new_v4());
+    let request_title = format!("Missing Model {}", uuid::Uuid::new_v4());
 
     let first = server
         .post("/v1/feature-requests")
@@ -12,7 +13,7 @@ async fn test_feature_request_submit_dedupes_by_user_and_admin_lists() {
         .json(&serde_json::json!({
             "kind": "model",
             "key": request_key,
-            "title": request_key,
+            "title": request_title,
             "note": "Need it for evals",
             "source": "models_page"
         }))
@@ -28,7 +29,7 @@ async fn test_feature_request_submit_dedupes_by_user_and_admin_lists() {
         .json(&serde_json::json!({
             "kind": "model",
             "key": request_key,
-            "title": request_key,
+            "title": "A later voter should not replace the title",
             "note": "Updated use case",
             "source": "models_page"
         }))
@@ -45,7 +46,7 @@ async fn test_feature_request_submit_dedupes_by_user_and_admin_lists() {
         .json(&serde_json::json!({
             "kind": "model",
             "key": request_key,
-            "title": request_key,
+            "title": "Another later voter should not replace the title",
             "note": "Another user also needs this",
             "source": "models_page"
         }))
@@ -68,6 +69,7 @@ async fn test_feature_request_submit_dedupes_by_user_and_admin_lists() {
         .iter()
         .find(|item| item["target"]["key"] == request_key.to_ascii_lowercase())
         .expect("submitted request should be listed");
+    assert_eq!(found["target"]["title"], request_title);
     assert_eq!(found["uniqueUserCount"], 2);
     assert_eq!(found["recentVotes"].as_array().unwrap().len(), 2);
 }

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -26,6 +26,7 @@ mod duplicate_names;
 mod embeddings;
 mod error_msg;
 mod external_providers;
+mod feature_requests;
 mod files;
 mod function_tools;
 mod general;

--- a/crates/database/src/migrations/sql/V0050__add_feature_requests.sql
+++ b/crates/database/src/migrations/sql/V0050__add_feature_requests.sql
@@ -1,0 +1,35 @@
+CREATE TABLE feature_request_targets (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    kind VARCHAR(50) NOT NULL CHECK (kind IN ('model', 'feature')),
+    key VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'open'
+        CHECK (status IN ('open', 'planned', 'in_progress', 'shipped', 'closed')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (kind, key)
+);
+
+CREATE INDEX idx_feature_request_targets_kind ON feature_request_targets(kind);
+CREATE INDEX idx_feature_request_targets_status ON feature_request_targets(status);
+CREATE INDEX idx_feature_request_targets_updated ON feature_request_targets(updated_at DESC);
+
+CREATE TABLE feature_request_votes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    target_id UUID NOT NULL REFERENCES feature_request_targets(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    organization_id UUID REFERENCES organizations(id) ON DELETE SET NULL,
+    note TEXT,
+    source VARCHAR(100),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (target_id, user_id)
+);
+
+CREATE INDEX idx_feature_request_votes_target ON feature_request_votes(target_id);
+CREATE INDEX idx_feature_request_votes_user ON feature_request_votes(user_id);
+CREATE INDEX idx_feature_request_votes_org ON feature_request_votes(organization_id);
+CREATE INDEX idx_feature_request_votes_updated ON feature_request_votes(updated_at DESC);
+
+COMMENT ON TABLE feature_request_targets IS 'Reusable feature-interest targets, including missing model requests and future feature demand signals.';
+COMMENT ON TABLE feature_request_votes IS 'Unique user interest signals for feature_request_targets. Repeat submissions update context without inflating demand.';

--- a/crates/database/src/repositories/feature_request.rs
+++ b/crates/database/src/repositories/feature_request.rs
@@ -4,6 +4,7 @@ use crate::retry_db;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use services::common::RepositoryError;
+use std::collections::HashMap;
 use tokio_postgres::Row;
 use uuid::Uuid;
 
@@ -121,7 +122,11 @@ impl FeatureRequestRepository {
                     VALUES ($1, $2, $3)
                     ON CONFLICT (kind, key) DO UPDATE
                     SET title = EXCLUDED.title,
-                        updated_at = NOW()
+                        updated_at = CASE
+                            WHEN feature_request_targets.title IS DISTINCT FROM EXCLUDED.title
+                            THEN NOW()
+                            ELSE feature_request_targets.updated_at
+                        END
                     RETURNING id, kind, key, title, status, created_at, updated_at
                     "#,
                     &[&params.kind, &params.key, &params.title],
@@ -238,10 +243,18 @@ impl FeatureRequestRepository {
             Ok::<_, RepositoryError>((rows, total))
         })?;
 
+        let target_ids = rows
+            .iter()
+            .map(|row| row.get::<_, Uuid>("id"))
+            .collect::<Vec<_>>();
+        let mut recent_votes_by_target = self.list_recent_votes_for_targets(&target_ids, 3).await?;
+
         let mut summaries = Vec::with_capacity(rows.len());
         for row in rows {
             let target = Self::row_to_target(&row);
-            let recent_votes = self.list_recent_votes(target.id, 3).await?;
+            let recent_votes = recent_votes_by_target
+                .remove(&target.id)
+                .unwrap_or_default();
             summaries.push(FeatureRequestSummary {
                 target,
                 unique_user_count: row.get("unique_user_count"),
@@ -254,11 +267,15 @@ impl FeatureRequestRepository {
         Ok((summaries, total))
     }
 
-    async fn list_recent_votes(
+    async fn list_recent_votes_for_targets(
         &self,
-        target_id: Uuid,
+        target_ids: &[Uuid],
         limit: i64,
-    ) -> Result<Vec<FeatureRequestVoteSummary>> {
+    ) -> Result<HashMap<Uuid, Vec<FeatureRequestVoteSummary>>> {
+        if target_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
         let rows = retry_db!("list_recent_feature_request_votes", {
             let client = self
                 .pool
@@ -270,41 +287,65 @@ impl FeatureRequestRepository {
             client
                 .query(
                     r#"
+                    WITH ranked_votes AS (
+                        SELECT
+                            v.target_id,
+                            v.user_id,
+                            u.email AS user_email,
+                            u.display_name AS user_display_name,
+                            v.organization_id,
+                            o.name AS organization_name,
+                            v.note,
+                            v.source,
+                            v.updated_at,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY v.target_id
+                                ORDER BY v.updated_at DESC
+                            ) AS row_number
+                        FROM feature_request_votes v
+                        JOIN users u ON u.id = v.user_id
+                        LEFT JOIN organizations o ON o.id = v.organization_id
+                        WHERE v.target_id = ANY($1::UUID[])
+                    )
                     SELECT
-                        v.user_id,
-                        u.email AS user_email,
-                        u.display_name AS user_display_name,
-                        v.organization_id,
-                        o.name AS organization_name,
-                        v.note,
-                        v.source,
-                        v.updated_at
-                    FROM feature_request_votes v
-                    JOIN users u ON u.id = v.user_id
-                    LEFT JOIN organizations o ON o.id = v.organization_id
-                    WHERE v.target_id = $1
-                    ORDER BY v.updated_at DESC
-                    LIMIT $2
+                        target_id,
+                        user_id,
+                        user_email,
+                        user_display_name,
+                        organization_id,
+                        organization_name,
+                        note,
+                        source,
+                        updated_at
+                    FROM ranked_votes
+                    WHERE row_number <= $2
+                    ORDER BY target_id, updated_at DESC
                     "#,
-                    &[&target_id, &limit],
+                    &[&target_ids, &limit],
                 )
                 .await
                 .map_err(map_db_error)
         })?;
 
-        Ok(rows
-            .iter()
-            .map(|row| FeatureRequestVoteSummary {
-                user_id: row.get("user_id"),
-                user_email: row.get("user_email"),
-                user_display_name: row.get("user_display_name"),
-                organization_id: row.get("organization_id"),
-                organization_name: row.get("organization_name"),
-                note: row.get("note"),
-                source: row.get("source"),
-                updated_at: row.get("updated_at"),
-            })
-            .collect())
+        let mut recent_votes_by_target: HashMap<Uuid, Vec<FeatureRequestVoteSummary>> =
+            HashMap::new();
+        for row in rows {
+            recent_votes_by_target
+                .entry(row.get("target_id"))
+                .or_default()
+                .push(FeatureRequestVoteSummary {
+                    user_id: row.get("user_id"),
+                    user_email: row.get("user_email"),
+                    user_display_name: row.get("user_display_name"),
+                    organization_id: row.get("organization_id"),
+                    organization_name: row.get("organization_name"),
+                    note: row.get("note"),
+                    source: row.get("source"),
+                    updated_at: row.get("updated_at"),
+                });
+        }
+
+        Ok(recent_votes_by_target)
     }
 
     fn row_to_target(row: &Row) -> FeatureRequestTarget {

--- a/crates/database/src/repositories/feature_request.rs
+++ b/crates/database/src/repositories/feature_request.rs
@@ -121,12 +121,7 @@ impl FeatureRequestRepository {
                     INSERT INTO feature_request_targets (kind, key, title)
                     VALUES ($1, $2, $3)
                     ON CONFLICT (kind, key) DO UPDATE
-                    SET title = EXCLUDED.title,
-                        updated_at = CASE
-                            WHEN feature_request_targets.title IS DISTINCT FROM EXCLUDED.title
-                            THEN NOW()
-                            ELSE feature_request_targets.updated_at
-                        END
+                    SET title = feature_request_targets.title
                     RETURNING id, kind, key, title, status, created_at, updated_at
                     "#,
                     &[&params.kind, &params.key, &params.title],

--- a/crates/database/src/repositories/feature_request.rs
+++ b/crates/database/src/repositories/feature_request.rs
@@ -1,0 +1,321 @@
+use crate::pool::DbPool;
+use crate::repositories::utils::map_db_error;
+use crate::retry_db;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use services::common::RepositoryError;
+use tokio_postgres::Row;
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct FeatureRequestTarget {
+    pub id: Uuid,
+    pub kind: String,
+    pub key: String,
+    pub title: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeatureRequestSummary {
+    pub target: FeatureRequestTarget,
+    pub unique_user_count: i64,
+    pub unique_organization_count: i64,
+    pub latest_requested_at: DateTime<Utc>,
+    pub recent_votes: Vec<FeatureRequestVoteSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeatureRequestVoteSummary {
+    pub user_id: Uuid,
+    pub user_email: String,
+    pub user_display_name: Option<String>,
+    pub organization_id: Option<Uuid>,
+    pub organization_name: Option<String>,
+    pub note: Option<String>,
+    pub source: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmitFeatureRequestParams {
+    pub kind: String,
+    pub key: String,
+    pub title: String,
+    pub user_id: Uuid,
+    pub organization_id: Option<Uuid>,
+    pub note: Option<String>,
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmitFeatureRequestResult {
+    pub target: FeatureRequestTarget,
+    pub unique_user_count: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeatureRequestRepository {
+    pool: DbPool,
+}
+
+impl FeatureRequestRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn user_belongs_to_organization(
+        &self,
+        user_id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<bool> {
+        let row = retry_db!("feature_request_user_belongs_to_organization", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_opt(
+                    r#"
+                    SELECT 1
+                    FROM organization_members
+                    WHERE user_id = $1 AND organization_id = $2
+                    LIMIT 1
+                    "#,
+                    &[&user_id, &organization_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(row.is_some())
+    }
+
+    pub async fn submit(
+        &self,
+        params: SubmitFeatureRequestParams,
+    ) -> Result<SubmitFeatureRequestResult> {
+        let (target_row, unique_user_count) = retry_db!("submit_feature_request", {
+            let mut client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let transaction = client
+                .transaction()
+                .await
+                .context("Failed to start transaction")
+                .map_err(RepositoryError::DatabaseError)?;
+
+            let target_row = transaction
+                .query_one(
+                    r#"
+                    INSERT INTO feature_request_targets (kind, key, title)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (kind, key) DO UPDATE
+                    SET title = EXCLUDED.title,
+                        updated_at = NOW()
+                    RETURNING id, kind, key, title, status, created_at, updated_at
+                    "#,
+                    &[&params.kind, &params.key, &params.title],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let target_id: Uuid = target_row.get("id");
+
+            transaction
+                .execute(
+                    r#"
+                    INSERT INTO feature_request_votes (
+                        target_id, user_id, organization_id, note, source
+                    )
+                    VALUES ($1, $2, $3, $4, $5)
+                    ON CONFLICT (target_id, user_id) DO UPDATE
+                    SET organization_id = EXCLUDED.organization_id,
+                        note = EXCLUDED.note,
+                        source = EXCLUDED.source,
+                        updated_at = NOW()
+                    "#,
+                    &[
+                        &target_id,
+                        &params.user_id,
+                        &params.organization_id,
+                        &params.note,
+                        &params.source,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let count_row = transaction
+                .query_one(
+                    r#"
+                    SELECT COUNT(DISTINCT user_id)::BIGINT AS unique_user_count
+                    FROM feature_request_votes
+                    WHERE target_id = $1
+                    "#,
+                    &[&target_id],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            transaction
+                .commit()
+                .await
+                .context("Failed to commit feature request transaction")
+                .map_err(RepositoryError::DatabaseError)?;
+
+            Ok::<_, RepositoryError>((target_row, count_row.get::<_, i64>("unique_user_count")))
+        })?;
+
+        Ok(SubmitFeatureRequestResult {
+            target: Self::row_to_target(&target_row),
+            unique_user_count,
+        })
+    }
+
+    pub async fn list_admin(
+        &self,
+        kind: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<(Vec<FeatureRequestSummary>, i64)> {
+        let (rows, total) = retry_db!("list_feature_requests_admin", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let total: i64 = client
+                .query_one(
+                    r#"
+                    SELECT COUNT(*)::BIGINT
+                    FROM feature_request_targets
+                    WHERE ($1::TEXT IS NULL OR kind = $1)
+                    "#,
+                    &[&kind],
+                )
+                .await
+                .map_err(map_db_error)?
+                .get(0);
+
+            let rows = client
+                .query(
+                    r#"
+                    SELECT
+                        t.id,
+                        t.kind,
+                        t.key,
+                        t.title,
+                        t.status,
+                        t.created_at,
+                        t.updated_at,
+                        COUNT(DISTINCT v.user_id)::BIGINT AS unique_user_count,
+                        COUNT(DISTINCT v.organization_id)::BIGINT AS unique_organization_count,
+                        COALESCE(MAX(v.updated_at), t.updated_at) AS latest_requested_at
+                    FROM feature_request_targets t
+                    LEFT JOIN feature_request_votes v ON v.target_id = t.id
+                    WHERE ($1::TEXT IS NULL OR t.kind = $1)
+                    GROUP BY t.id
+                    ORDER BY unique_user_count DESC, latest_requested_at DESC, t.title ASC
+                    LIMIT $2 OFFSET $3
+                    "#,
+                    &[&kind, &limit, &offset],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok::<_, RepositoryError>((rows, total))
+        })?;
+
+        let mut summaries = Vec::with_capacity(rows.len());
+        for row in rows {
+            let target = Self::row_to_target(&row);
+            let recent_votes = self.list_recent_votes(target.id, 3).await?;
+            summaries.push(FeatureRequestSummary {
+                target,
+                unique_user_count: row.get("unique_user_count"),
+                unique_organization_count: row.get("unique_organization_count"),
+                latest_requested_at: row.get("latest_requested_at"),
+                recent_votes,
+            });
+        }
+
+        Ok((summaries, total))
+    }
+
+    async fn list_recent_votes(
+        &self,
+        target_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<FeatureRequestVoteSummary>> {
+        let rows = retry_db!("list_recent_feature_request_votes", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT
+                        v.user_id,
+                        u.email AS user_email,
+                        u.display_name AS user_display_name,
+                        v.organization_id,
+                        o.name AS organization_name,
+                        v.note,
+                        v.source,
+                        v.updated_at
+                    FROM feature_request_votes v
+                    JOIN users u ON u.id = v.user_id
+                    LEFT JOIN organizations o ON o.id = v.organization_id
+                    WHERE v.target_id = $1
+                    ORDER BY v.updated_at DESC
+                    LIMIT $2
+                    "#,
+                    &[&target_id, &limit],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows
+            .iter()
+            .map(|row| FeatureRequestVoteSummary {
+                user_id: row.get("user_id"),
+                user_email: row.get("user_email"),
+                user_display_name: row.get("user_display_name"),
+                organization_id: row.get("organization_id"),
+                organization_name: row.get("organization_name"),
+                note: row.get("note"),
+                source: row.get("source"),
+                updated_at: row.get("updated_at"),
+            })
+            .collect())
+    }
+
+    fn row_to_target(row: &Row) -> FeatureRequestTarget {
+        FeatureRequestTarget {
+            id: row.get("id"),
+            kind: row.get("kind"),
+            key: row.get("key"),
+            title: row.get("title"),
+            status: row.get("status"),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        }
+    }
+}

--- a/crates/database/src/repositories/mod.rs
+++ b/crates/database/src/repositories/mod.rs
@@ -4,6 +4,7 @@ pub mod analytics;
 pub mod api_key;
 pub mod attestation;
 pub mod conversation;
+pub mod feature_request;
 pub mod file;
 pub mod mcp_connector;
 pub mod model;
@@ -34,6 +35,10 @@ pub use analytics::PgAnalyticsRepository;
 pub use api_key::ApiKeyRepository;
 pub use attestation::PgAttestationRepository;
 pub use conversation::PgConversationRepository;
+pub use feature_request::{
+    FeatureRequestRepository, FeatureRequestSummary, FeatureRequestTarget,
+    FeatureRequestVoteSummary, SubmitFeatureRequestParams, SubmitFeatureRequestResult,
+};
 pub use file::FileRepository;
 pub use mcp_connector::McpConnectorRepository;
 pub use model::ModelRepository;


### PR DESCRIPTION
## Summary

Adds reusable feature-interest infrastructure for missing model requests and future feature demand tracking.

## Changes

- Add `feature_request_targets` and `feature_request_votes` tables with unique per-user votes.
- Add authenticated `POST /v1/feature-requests` for user submissions.
- Add admin `GET /v1/admin/feature-requests` for aggregated counts, recent notes, and requester context.
- Wire routes into the API, OpenAPI schemas, and database repository exports.
- Add focused e2e tests for dedupe, second-user counting, validation, auth, and admin aggregation.

## Validation

- `cargo fmt`
- `cargo check -p api`
- `cargo test -p api --test e2e_all feature_request -- --nocapture` builds, but local execution is blocked because Postgres bootstrap cannot connect: `Connection refused` at `common/db_setup.rs:57`.