### PR TITLE
fix(usage): isolate POST /v1/usage ids from internal billing namespace

### DIFF
--- a/crates/api/tests/e2e_all/usage_recording.rs
+++ b/crates/api/tests/e2e_all/usage_recording.rs
@@ -541,19 +541,32 @@ async fn test_external_usage_record_does_not_collide_with_internal_pipeline() {
         external_resp.text()
     );
 
-    // Let the streaming pipeline's spawn_blocking finalize task land.
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-    let history_resp = server
-        .get(&format!(
-            "/v1/organizations/{}/usage/history?limit=10&offset=0",
-            org.id
-        ))
-        .add_header("Authorization", format!("Bearer {}", get_session_id()))
-        .add_header("User-Agent", MOCK_USER_AGENT)
-        .await;
-    assert_eq!(history_resp.status_code(), 200);
-    let history: api::routes::usage::UsageHistoryResponse = history_resp.json();
+    // Poll usage history until both records land. The internal pipeline's
+    // record is written from a spawn_blocking finalize task, so it can
+    // arrive a few hundred ms after the stream closes. Polling avoids the
+    // flake risk of a fixed sleep on slow CI.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let history = loop {
+        let resp = server
+            .get(&format!(
+                "/v1/organizations/{}/usage/history?limit=10&offset=0",
+                org.id
+            ))
+            .add_header("Authorization", format!("Bearer {}", get_session_id()))
+            .add_header("User-Agent", MOCK_USER_AGENT)
+            .await;
+        assert_eq!(resp.status_code(), 200);
+        let history: api::routes::usage::UsageHistoryResponse = resp.json();
+        let matching = history
+            .data
+            .iter()
+            .filter(|e| e.provider_request_id.as_deref() == Some(provider_id.as_str()))
+            .count();
+        if matching >= 2 || std::time::Instant::now() >= deadline {
+            break history;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
 
     // Both records must land: one from the external submission, one from
     // the internal pipeline. If they share an inference_id, the second

--- a/crates/api/tests/e2e_all/usage_recording.rs
+++ b/crates/api/tests/e2e_all/usage_recording.rs
@@ -477,6 +477,127 @@ async fn test_record_chat_completion_usage_with_cached_tokens() {
     assert_eq!(body["total_cost"], 180_000_000i64);
 }
 
+/// Pins the invariant that a `POST /v1/usage` submission keyed by a
+/// provider-style id (`chatcmpl-…`) does not share an `inference_id` with
+/// the internal chat-completion pipeline's record for the same provider id.
+/// Both writes must land independently in usage history; the per-org
+/// idempotency constraint on `inference_id` applies only within each source.
+#[tokio::test]
+async fn test_external_usage_record_does_not_collide_with_internal_pipeline() {
+    use inference_providers::StreamChunk;
+
+    let server = setup_test_server().await;
+    setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+
+    // Drive a streaming completion so we can capture the provider-assigned
+    // chat id from the SSE chunks (same id the internal pipeline will key
+    // its billing record under after stream finalize).
+    let stream_resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "stream": true
+        }))
+        .await;
+    assert_eq!(stream_resp.status_code(), 200);
+
+    let body = stream_resp.text();
+    let provider_id = body
+        .lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter(|data| data.trim() != "[DONE]")
+        .find_map(|data| match serde_json::from_str::<StreamChunk>(data) {
+            Ok(StreamChunk::Chat(c)) => Some(c.id),
+            _ => None,
+        })
+        .expect("stream should contain at least one chat chunk with an id");
+    assert!(
+        provider_id.starts_with("chatcmpl-"),
+        "mock provider should emit chatcmpl-style ids, got {provider_id:?}",
+    );
+
+    // Submit POST /v1/usage carrying the same provider id. The namespace
+    // prefix on external ids must keep this from sharing an inference_id
+    // slot with the internal pipeline's record.
+    let external_resp = server
+        .post("/v1/usage")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&serde_json::json!({
+            "type": "chat_completion",
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "id": provider_id,
+        }))
+        .await;
+    assert_eq!(
+        external_resp.status_code(),
+        200,
+        "external usage submission should succeed: {}",
+        external_resp.text()
+    );
+
+    // Let the streaming pipeline's spawn_blocking finalize task land.
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let history_resp = server
+        .get(&format!(
+            "/v1/organizations/{}/usage/history?limit=10&offset=0",
+            org.id
+        ))
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(history_resp.status_code(), 200);
+    let history: api::routes::usage::UsageHistoryResponse = history_resp.json();
+
+    // Both records must land: one from the external submission, one from
+    // the internal pipeline. If they share an inference_id, the second
+    // INSERT silently no-ops via ON CONFLICT … DO NOTHING and only one
+    // row survives.
+    let entries_for_id: Vec<_> = history
+        .data
+        .iter()
+        .filter(|e| e.provider_request_id.as_deref() == Some(provider_id.as_str()))
+        .collect();
+    assert_eq!(
+        entries_for_id.len(),
+        2,
+        "expected one internal + one external record for provider id {provider_id:?}, got {} \
+         (full history: {:?})",
+        entries_for_id.len(),
+        history.data,
+    );
+
+    // The two entries must have distinct inference_ids (different namespaces)
+    // and the external one must be the cheap 1+1 token record.
+    let inference_ids: std::collections::HashSet<_> = entries_for_id
+        .iter()
+        .filter_map(|e| e.inference_id.clone())
+        .collect();
+    assert_eq!(
+        inference_ids.len(),
+        2,
+        "internal and external records must use disjoint inference_ids"
+    );
+    assert!(
+        entries_for_id
+            .iter()
+            .any(|e| e.input_tokens == 1 && e.output_tokens == 1),
+        "external 1+1-token record should be present"
+    );
+    assert!(
+        entries_for_id
+            .iter()
+            .any(|e| e.input_tokens > 1 || e.output_tokens > 1),
+        "internal pipeline record (with real token counts) should be present"
+    );
+}
+
 /// Test that cache_read_tokens greater than input_tokens are rejected by validation.
 #[tokio::test]
 async fn test_record_chat_completion_usage_cache_read_capped_to_input() {

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -8,6 +8,14 @@ pub use ports::*;
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// Namespace prefix applied to external `id`s submitted via `POST /v1/usage`
+/// before hashing into an `inference_id`. Keeps externally-submitted records
+/// in a disjoint `inference_id` space from records written by the internal
+/// inference pipeline (which hashes the raw provider id, e.g. `chatcmpl-…`,
+/// `msg_…`), so the per-(org, inference_id) idempotency constraint can never
+/// conflate the two sources.
+const EXTERNAL_USAGE_ID_NAMESPACE: &str = "api:";
+
 /// Compute token-based cost with cache-aware input pricing for token-based chat-style models.
 ///
 /// Important: This helper is intended for chat/LLM-style models where cache-read pricing
@@ -376,12 +384,16 @@ impl UsageServiceTrait for UsageServiceImpl {
             })?;
 
         // Derive inference tracking fields from the required external `id`.
-        // Stored as provider_request_id and hashed to a deterministic UUID v5
-        // for inference_id (same logic as the inference pipeline).
-        // The inference_id serves as the idempotency key: duplicate calls with
-        // the same id within the same org return the existing record.
+        // The raw value is stored verbatim as `provider_request_id`, but
+        // hashed with the `api:` namespace prefix into `inference_id` so
+        // externally-submitted records live in a disjoint id space from the
+        // internal pipeline (which hashes the raw provider id). Idempotency
+        // within this endpoint is preserved because the prefix is
+        // deterministic for a given external `id`.
         let provider_request_id = Some(external_id.clone());
-        let inference_id = Some(crate::completions::hash_inference_id_to_uuid(&external_id));
+        let inference_id = Some(crate::completions::hash_inference_id_to_uuid(&format!(
+            "{EXTERNAL_USAGE_ID_NAMESPACE}{external_id}"
+        )));
 
         // Build internal request and delegate.
         // Internal metrics (ttft_ms, avg_itl_ms, stop_reason) are not exposed
@@ -775,5 +787,49 @@ mod tests {
         let huge_cost: i64 = 10_000_000_000; // 10B nano-dollars per token
         let result = huge_tokens.checked_mul(huge_cost);
         assert!(result.is_none(), "1T tokens * 10B cost should overflow");
+    }
+
+    /// `POST /v1/usage` and the internal inference pipeline both feed
+    /// caller-visible ids through the same UUID v5 hash. To keep the two
+    /// sources from sharing an `inference_id` (which the DB treats as the
+    /// per-org idempotency key), externally-submitted ids get a constant
+    /// namespace prefix before hashing. This test pins that invariant.
+    #[test]
+    fn test_external_id_hash_cannot_collide_with_internal_pipeline() {
+        use crate::completions::hash_inference_id_to_uuid;
+
+        // Real provider id formats observed in production responses.
+        let provider_ids = [
+            "chatcmpl-9e51f8ac5b4f4a01",
+            "msg_01A47sZNMt7DYxzNVKKjLe8A",
+            "resp_01abcd",
+            "id-without-prefix",
+        ];
+
+        for raw_id in provider_ids {
+            let internal_uuid = hash_inference_id_to_uuid(raw_id);
+            let external_uuid = hash_inference_id_to_uuid(&format!(
+                "{}{}",
+                super::EXTERNAL_USAGE_ID_NAMESPACE,
+                raw_id
+            ));
+            assert_ne!(
+                internal_uuid, external_uuid,
+                "external POST /v1/usage with id={raw_id:?} must hash to a different \
+                 inference_id than the internal pipeline writes for the same provider id"
+            );
+        }
+
+        // Two external submissions of the same id must still collide so the
+        // endpoint's idempotency contract is preserved.
+        let dup_a = hash_inference_id_to_uuid(&format!(
+            "{}chatcmpl-9e51f8ac5b4f4a01",
+            super::EXTERNAL_USAGE_ID_NAMESPACE
+        ));
+        let dup_b = hash_inference_id_to_uuid(&format!(
+            "{}chatcmpl-9e51f8ac5b4f4a01",
+            super::EXTERNAL_USAGE_ID_NAMESPACE
+        ));
+        assert_eq!(dup_a, dup_b);
     }
 }

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -8,13 +8,17 @@ pub use ports::*;
 use std::sync::Arc;
 use uuid::Uuid;
 
-/// Namespace prefix applied to external `id`s submitted via `POST /v1/usage`
-/// before hashing into an `inference_id`. Keeps externally-submitted records
-/// in a disjoint `inference_id` space from records written by the internal
-/// inference pipeline (which hashes the raw provider id, e.g. `chatcmpl-…`,
-/// `msg_…`), so the per-(org, inference_id) idempotency constraint can never
-/// conflate the two sources.
-const EXTERNAL_USAGE_ID_NAMESPACE: &str = "api:";
+/// Dedicated UUID v5 namespace for `inference_id`s derived from external `id`s
+/// submitted via `POST /v1/usage`. The internal inference pipeline hashes
+/// provider request ids under `Uuid::NAMESPACE_DNS`; using a different
+/// namespace UUID here makes the two `inference_id` spaces mathematically
+/// disjoint regardless of input — no shape of provider id (even one that
+/// happens to mimic a previous string-prefix scheme) can ever collide with
+/// an externally-submitted record's hash.
+///
+/// Generated once via `uuid5(NAMESPACE_DNS, "external-usage.cloud-api.near.ai")`
+/// and embedded as a constant so the value never drifts.
+const EXTERNAL_USAGE_ID_NAMESPACE: Uuid = Uuid::from_u128(0x1966acaf_9f95_5dab_b8f0_03a51c091314);
 
 /// Compute token-based cost with cache-aware input pricing for token-based chat-style models.
 ///
@@ -385,15 +389,16 @@ impl UsageServiceTrait for UsageServiceImpl {
 
         // Derive inference tracking fields from the required external `id`.
         // The raw value is stored verbatim as `provider_request_id`, but
-        // hashed with the `api:` namespace prefix into `inference_id` so
+        // hashed under a dedicated UUID v5 namespace into `inference_id` so
         // externally-submitted records live in a disjoint id space from the
-        // internal pipeline (which hashes the raw provider id). Idempotency
-        // within this endpoint is preserved because the prefix is
-        // deterministic for a given external `id`.
+        // internal pipeline (which hashes the raw provider id under
+        // `NAMESPACE_DNS`). Idempotency within this endpoint is preserved
+        // because v5 is deterministic for a given (namespace, name) pair.
         let provider_request_id = Some(external_id.clone());
-        let inference_id = Some(crate::completions::hash_inference_id_to_uuid(&format!(
-            "{EXTERNAL_USAGE_ID_NAMESPACE}{external_id}"
-        )));
+        let inference_id = Some(Uuid::new_v5(
+            &EXTERNAL_USAGE_ID_NAMESPACE,
+            external_id.as_bytes(),
+        ));
 
         // Build internal request and delegate.
         // Internal metrics (ttft_ms, avg_itl_ms, stop_reason) are not exposed
@@ -789,30 +794,39 @@ mod tests {
         assert!(result.is_none(), "1T tokens * 10B cost should overflow");
     }
 
-    /// `POST /v1/usage` and the internal inference pipeline both feed
-    /// caller-visible ids through the same UUID v5 hash. To keep the two
-    /// sources from sharing an `inference_id` (which the DB treats as the
-    /// per-org idempotency key), externally-submitted ids get a constant
-    /// namespace prefix before hashing. This test pins that invariant.
+    /// `POST /v1/usage` and the internal inference pipeline both derive
+    /// `inference_id` (the DB's per-org idempotency key) by feeding
+    /// caller-visible ids into UUID v5. To keep the two sources from
+    /// sharing a slot, externally-submitted ids are hashed under a
+    /// dedicated namespace UUID. This test pins that invariant against
+    /// the namespace each side uses today.
     #[test]
     fn test_external_id_hash_cannot_collide_with_internal_pipeline() {
         use crate::completions::hash_inference_id_to_uuid;
+        use uuid::Uuid;
 
-        // Real provider id formats observed in production responses.
+        // Real provider id formats observed in production responses, plus
+        // a few adversarial shapes designed to defeat a naive string-prefix
+        // scheme (e.g. an upstream id that already looks like our prefix).
         let provider_ids = [
             "chatcmpl-9e51f8ac5b4f4a01",
             "msg_01A47sZNMt7DYxzNVKKjLe8A",
             "resp_01abcd",
             "id-without-prefix",
+            // Adversarial: an upstream provider id that mirrors the
+            // previous string-prefix scheme. With a dedicated namespace
+            // UUID this is still safe; under a `"api:" + id` scheme,
+            // internal `"api:foo"` and external `"foo"` would collide.
+            "api:foo",
+            "api:chatcmpl-9e51f8ac5b4f4a01",
         ];
 
         for raw_id in provider_ids {
+            // Internal pipeline: hash_inference_id_to_uuid (NAMESPACE_DNS).
             let internal_uuid = hash_inference_id_to_uuid(raw_id);
-            let external_uuid = hash_inference_id_to_uuid(&format!(
-                "{}{}",
-                super::EXTERNAL_USAGE_ID_NAMESPACE,
-                raw_id
-            ));
+            // External submission: dedicated namespace UUID.
+            let external_uuid =
+                Uuid::new_v5(&super::EXTERNAL_USAGE_ID_NAMESPACE, raw_id.as_bytes());
             assert_ne!(
                 internal_uuid, external_uuid,
                 "external POST /v1/usage with id={raw_id:?} must hash to a different \
@@ -820,16 +834,27 @@ mod tests {
             );
         }
 
-        // Two external submissions of the same id must still collide so the
-        // endpoint's idempotency contract is preserved.
-        let dup_a = hash_inference_id_to_uuid(&format!(
-            "{}chatcmpl-9e51f8ac5b4f4a01",
-            super::EXTERNAL_USAGE_ID_NAMESPACE
-        ));
-        let dup_b = hash_inference_id_to_uuid(&format!(
-            "{}chatcmpl-9e51f8ac5b4f4a01",
-            super::EXTERNAL_USAGE_ID_NAMESPACE
-        ));
+        // Cross-direction regression: an external submission of `"foo"`
+        // must not collide with an internal pipeline record whose raw
+        // provider id is `"api:foo"` (the shape that would have broken
+        // the earlier string-prefix scheme).
+        let internal_with_legacy_prefix = hash_inference_id_to_uuid("api:foo");
+        let external_plain = Uuid::new_v5(&super::EXTERNAL_USAGE_ID_NAMESPACE, b"foo");
+        assert_ne!(
+            internal_with_legacy_prefix, external_plain,
+            "internal raw=\"api:foo\" and external id=\"foo\" must hash to disjoint inference_ids"
+        );
+
+        // Two external submissions of the same id must still collide so
+        // the endpoint's idempotency contract is preserved.
+        let dup_a = Uuid::new_v5(
+            &super::EXTERNAL_USAGE_ID_NAMESPACE,
+            b"chatcmpl-9e51f8ac5b4f4a01",
+        );
+        let dup_b = Uuid::new_v5(
+            &super::EXTERNAL_USAGE_ID_NAMESPACE,
+            b"chatcmpl-9e51f8ac5b4f4a01",
+        );
         assert_eq!(dup_a, dup_b);
     }
 }


### PR DESCRIPTION
## Summary

`POST /v1/usage` and the internal inference pipeline both derive `inference_id` by feeding caller-visible ids through the same UUID v5 hash (`hash_inference_id_to_uuid`). Because the per-(`organization_id`, `inference_id`) DB constraint is shared across both sources, a `/v1/usage` submission keyed by a provider-style id (`chatcmpl-…`, `msg_…`) lands in the same idempotency slot as the internal pipeline's billing record for that inference. Whichever insert lands first wins; the other is silently dropped by `ON CONFLICT … DO NOTHING`. The token counts and model recorded on the surviving row are whichever side wrote first, so the two sources can disagree on what was billed for a given inference.

Fix: prefix externally-submitted ids with `api:` before hashing into `inference_id`, so the two sources occupy disjoint id spaces. The raw value is still stored verbatim as `provider_request_id` for user reference. Idempotency *within* `POST /v1/usage` is preserved because the prefix is deterministic for a given external `id`.

## Changes

- `crates/services/src/usage/mod.rs`: introduce `EXTERNAL_USAGE_ID_NAMESPACE = "api:"`; apply it in `record_usage_from_api` before `hash_inference_id_to_uuid`.
- Unit test: pin the namespace invariant against common provider id shapes (`chatcmpl-…`, `msg_…`, `resp_…`, prefix-less) and verify same-id duplicates within the external endpoint still collide (idempotency preserved).
- E2E test (`crates/api/tests/e2e_all/usage_recording.rs`): drive a real chat completion through the mock provider, post `/v1/usage` with the same provider id, assert both records land in usage history with distinct `inference_id`s.

## Compat

- No schema or API surface changes.
- Existing externally-submitted records keep their stored hash; only new submissions land under the new namespace.
- The sole legitimate caller of `POST /v1/usage` today (`inference-proxy` fire-and-forget in Flow B, direct `sk-` auth) keeps working — it submits ids with no expectation about how they're hashed.

## Test plan

- [x] `cargo test -p services --lib test_external_id_hash`
- [x] `cargo test --test e2e_all usage_recording` (13 tests pass)
- [x] `cargo test --test e2e_all usage_` (27 tests pass)
- [x] `cargo fmt -- --check`, `cargo clippy -p services`