### PR TITLE
feat(gateway): return api_key_id from /v1/check_api_key

### DIFF
--- a/crates/api/src/routes/gateway.rs
+++ b/crates/api/src/routes/gateway.rs
@@ -5,10 +5,12 @@ use utoipa::ToSchema;
 
 /// Response from the check_api_key endpoint.
 ///
-/// `organization_id` and `workspace_id` are returned so downstream gateways
-/// (e.g. inference-proxy) have a server-side authoritative tenant
-/// identifier and don't have to trust caller-supplied `X-Org-Id`
-/// headers when populating logs / usage records.
+/// `organization_id`, `workspace_id`, and `api_key_id` are returned so
+/// downstream gateways (e.g. inference-proxy) have a server-side
+/// authoritative subject identity and don't have to trust caller-supplied
+/// headers when populating logs / usage records / billing reports. In
+/// particular, this lets a trusted gateway report usage to cloud-api with
+/// a shared service token instead of forwarding the user's `sk-…`.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CheckApiKeyResponse {
     /// Whether the API key is valid and authorized
@@ -17,6 +19,9 @@ pub struct CheckApiKeyResponse {
     pub organization_id: String,
     /// Workspace the API key belongs to
     pub workspace_id: String,
+    /// UUID of the API key itself. Used by trusted gateways to attribute
+    /// per-key usage rows without holding the raw `sk-…` value.
+    pub api_key_id: String,
 }
 
 /// Check API key validity
@@ -48,5 +53,6 @@ pub async fn check_api_key(
         valid: true,
         organization_id: api_key.organization.id.to_string(),
         workspace_id: api_key.workspace.id.to_string(),
+        api_key_id: api_key.api_key.id.0.clone(),
     }))
 }

--- a/crates/api/src/routes/gateway.rs
+++ b/crates/api/src/routes/gateway.rs
@@ -53,6 +53,9 @@ pub async fn check_api_key(
         valid: true,
         organization_id: api_key.organization.id.to_string(),
         workspace_id: api_key.workspace.id.to_string(),
-        api_key_id: api_key.api_key.id.0.clone(),
+        // `ApiKeyId.0` is already a `String` and `api_key` is owned via
+        // `Extension`, so move it directly. The other two still need
+        // `to_string()` because they wrap `Uuid`.
+        api_key_id: api_key.api_key.id.0,
     }))
 }

--- a/crates/api/tests/e2e_all/check_api_key.rs
+++ b/crates/api/tests/e2e_all/check_api_key.rs
@@ -43,6 +43,15 @@ async fn test_check_api_key_valid() {
         expected_workspace_id,
         "response workspace_id must match the workspace the API key was created in"
     );
+    // `api_key_id` lets trusted gateways (inference-proxy) report usage
+    // with a shared service token without forwarding the user's `sk-…`.
+    let api_key_id = body["api_key_id"]
+        .as_str()
+        .expect("response must include api_key_id");
+    assert!(
+        uuid::Uuid::parse_str(api_key_id).is_ok(),
+        "api_key_id must be a UUID, got {api_key_id:?}"
+    );
 }
 
 /// Invalid API key returns 401.


### PR DESCRIPTION
## Summary

Extends \`CheckApiKeyResponse\` with \`api_key_id\` so trusted gateways have a server-side authoritative subject identity for billing/log attribution.

This is the smaller enabling change for the inference-proxy service-token usage-reporter path ([inference-proxy#143](https://github.com/nearai/inference-proxy/pull/143)). With \`organization_id\` + \`workspace_id\` + \`api_key_id\` all returned, inference-proxy can stop forwarding the user's \`sk-…\` to cloud-api when reporting usage and instead authenticate to a new shared-secret endpoint (separate cloud-api PR for that endpoint).

## Compatibility

- Body shape is **additive** — older deserializers that ignore unknown fields keep working.
- inference-proxy's deserializer is already lenient (\`#[serde(default)]\` on every field), so deploy order between repos doesn't matter. Until inference-proxy redeploys, the new field is just dropped on the floor.

## Test plan

- [x] \`cargo test --test e2e_all check_api_key\` — 4 tests pass (incl. the existing happy/invalid/missing-auth/no-credits cases).
- [x] Extended \`test_check_api_key_valid\` asserts \`api_key_id\` is present and parses as a UUID.

## Rollout

This is PR 1 of 2 for the usage-endpoint lockdown:
1. **This PR** — add \`api_key_id\` to \`/v1/check_api_key\`. Safe to merge whenever.
2. Next — add \`POST /v1/internal/usage\` accepting service-token auth + identity-in-body. Until then, inference-proxy stays on the legacy \`POST /v1/usage\` + \`sk-\` path even if its \`CLOUD_API_USAGE_TOKEN\` env var is set, because the identity gate (\`can_use_service_token_path\`) was already designed to fail closed.