### PR TITLE
feat(usage): add POST /v1/internal/usage for service-token reporters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "services",
  "sha2 0.11.0",
  "sha3 0.12.0",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -38,6 +38,8 @@ thiserror = "2.0"
 # Body hashing middleware dependencies
 sha2 = "0.11"
 hex = "0.4"
+# Constant-time comparison for service-token auth on /v1/internal/usage
+subtle = "2.6"
 bytes = "1.11"
 http-body-util = "0.1"
 # AWS S3 for file storage

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -832,6 +832,8 @@ pub fn build_app_with_config(
         rate_limit_state.clone(),
     );
 
+    let internal_routes = build_internal_routes(app_state.clone());
+
     let response_routes = build_response_routes(
         domain_services.response_service,
         domain_services.attestation_service.clone(),
@@ -948,6 +950,7 @@ pub fn build_app_with_config(
                 .merge(billing_routes)
                 .merge(usage_recording_routes)
                 .merge(gateway_routes)
+                .merge(internal_routes)
                 .merge(health_routes),
         )
         .merge(openapi_routes)
@@ -1427,6 +1430,21 @@ pub fn build_gateway_routes(
         ))
 }
 
+/// Build internal-only routes authenticated by the shared
+/// `CLOUD_API_USAGE_TOKEN` service secret rather than the standard `sk-…`
+/// API-key middleware. Mounted under `/v1/internal/*` after the global
+/// `/v1` nest. Today's only route is `POST /internal/usage` (for
+/// inference-proxy's service-token reporter); future internal endpoints
+/// can be added here without touching the sk-auth stack.
+pub fn build_internal_routes(app_state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/internal/usage",
+            post(crate::routes::usage::record_usage_internal),
+        )
+        .with_state(app_state)
+}
+
 pub fn build_model_routes(models_service: Arc<dyn ModelsServiceTrait>) -> Router {
     let models_app_state = ModelsAppState { models_service };
 
@@ -1734,6 +1752,7 @@ mod tests {
                 port: 0, // Use port 0 for testing to get a random available port
             },
             inference_api_key: Some("test-key".to_string()),
+            internal_usage_token: None,
             logging: config::LoggingConfig {
                 level: "info".to_string(),
                 format: "compact".to_string(),
@@ -1833,6 +1852,7 @@ mod tests {
                 port: 0,
             },
             inference_api_key: Some("test-key".to_string()),
+            internal_usage_token: None,
             logging: config::LoggingConfig {
                 level: "info".to_string(),
                 format: "compact".to_string(),

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -825,15 +825,19 @@ fn build_record_usage_response(entry: services::usage::UsageLogEntry) -> RecordU
 /// Internal endpoints aren't surfaced in the public OpenAPI doc anyway.
 #[derive(Debug, Deserialize)]
 pub struct RecordUsageInternalRequest {
-    /// UUID of the organization to bill. Verified to match the
-    /// `workspace_id` / `api_key_id` via the existing service-layer
-    /// lookup; mismatched IDs trip the standard validation path and
-    /// return 400.
+    /// UUID of the organization to bill. **Trusted as provided** —
+    /// `record_usage_from_api` does not cross-validate that this org
+    /// owns the supplied `workspace_id` or `api_key_id`, matching the
+    /// stated threat model (any holder of `CLOUD_API_USAGE_TOKEN` is
+    /// allowed to write rows on behalf of any tenant). Reporters must
+    /// supply mutually consistent values; cloud-api enforces only
+    /// existence of the model named in the inner `usage` payload.
     pub organization_id: String,
-    /// UUID of the workspace the usage belongs to.
+    /// UUID of the workspace the usage belongs to. Trusted as provided
+    /// (see `organization_id`).
     pub workspace_id: String,
     /// UUID of the API key the usage should be attributed to (for
-    /// per-key analytics).
+    /// per-key analytics). Trusted as provided.
     pub api_key_id: String,
     /// The standard usage payload, identical to `POST /v1/usage`.
     #[serde(flatten)]
@@ -886,9 +890,26 @@ fn verify_internal_usage_token(
 pub async fn record_usage_internal(
     State(app_state): State<AppState>,
     headers: HeaderMap,
-    Json(request): Json<RecordUsageInternalRequest>,
+    body: axum::body::Bytes,
 ) -> Result<ResponseJson<RecordUsageResponse>, UsageError> {
+    // Auth before body deserialization. Axum extractors run in signature
+    // order, so passing `Json<…>` directly would parse the body before
+    // any auth check — meaning a disabled-endpoint + malformed-body
+    // request would return 422 instead of 503, and unauthenticated
+    // callers could probe the body schema via parse errors. We take
+    // raw `Bytes` and deserialize only after `verify_internal_usage_token`
+    // succeeds, preserving the fail-closed posture.
     verify_internal_usage_token(&headers, app_state.config.internal_usage_token.as_deref())?;
+
+    let request: RecordUsageInternalRequest = serde_json::from_slice(&body).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                format!("Invalid request body: {e}"),
+                "validation_error".to_string(),
+            )),
+        )
+    })?;
 
     let parse_uuid = |raw: &str, field: &'static str| {
         Uuid::parse_str(raw).map_err(|_| {

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -5,13 +5,14 @@ use crate::{
 };
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::Json as ResponseJson,
     Extension, Json,
 };
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use services::organization::OrganizationError;
+use subtle::ConstantTimeEq;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -748,10 +749,17 @@ pub async fn record_usage(
             }
         })?;
 
-    // Use the *returned entry's* inference_type to determine response format,
-    // not the incoming request type. When idempotency returns an existing record
-    // the request type may differ from the stored record's actual type.
-    let response = match entry.inference_type {
+    Ok(ResponseJson(build_record_usage_response(entry)))
+}
+
+/// Build the public `RecordUsageResponse` from a service-layer `UsageLogEntry`.
+///
+/// The variant is chosen by the *returned entry's* `inference_type` rather
+/// than the caller's request type so that an idempotent duplicate (which
+/// returns the existing row, possibly recorded under a different type) is
+/// still serialized correctly.
+fn build_record_usage_response(entry: services::usage::UsageLogEntry) -> RecordUsageResponse {
+    match entry.inference_type {
         services::usage::InferenceType::ImageGeneration
         | services::usage::InferenceType::ImageEdit => RecordUsageResponse::ImageGeneration {
             id: entry.id.to_string(),
@@ -780,9 +788,157 @@ pub async fn record_usage(
             total_cost_display: format_amount(entry.total_cost),
             created_at: entry.created_at.to_rfc3339(),
         },
-    };
+    }
+}
 
-    Ok(ResponseJson(response))
+// =====================================================================
+// POST /v1/internal/usage — Service-token-authenticated usage recording
+// =====================================================================
+//
+// This endpoint is the locked-down replacement for `POST /v1/usage` aimed
+// at trusted infrastructure reporters (today: inference-proxy). Instead of
+// accepting an `sk-…` API key — which lets any holder of that key submit
+// arbitrary usage rows on the org's behalf — it requires a shared
+// `CLOUD_API_USAGE_TOKEN` service secret and carries the subject identity
+// (`organization_id`, `workspace_id`, `api_key_id`) in the body.
+//
+// Threat model:
+// - Anyone holding `CLOUD_API_USAGE_TOKEN` can submit usage rows for any
+//   org. The token therefore lives only on trusted infrastructure
+//   (inference-proxy CVMs) and is rotated alongside other service secrets.
+// - The legacy `POST /v1/usage` endpoint stays available so the rollout
+//   can be staged. Once all reporters have switched, that endpoint can be
+//   restricted or removed (separate PR).
+//
+// The body shape is the existing `RecordUsageApiRequest` flattened under a
+// wrapper that adds the three identity fields. The actual usage payload
+// is identical to the legacy endpoint so reporters keep one builder.
+
+/// Request body for `POST /v1/internal/usage`. The `usage` field is
+/// flattened, so the on-the-wire shape is the legacy `RecordUsageApiRequest`
+/// JSON with three extra top-level keys.
+///
+/// `ToSchema` is intentionally not derived: `RecordUsageApiRequest`
+/// doesn't implement `PartialSchema` (its OpenAPI doc is hand-rolled on
+/// the legacy handler via `request_body = serde_json::Value`), and
+/// `#[serde(flatten)]` requires the inner type to be a known schema.
+/// Internal endpoints aren't surfaced in the public OpenAPI doc anyway.
+#[derive(Debug, Deserialize)]
+pub struct RecordUsageInternalRequest {
+    /// UUID of the organization to bill. Verified to match the
+    /// `workspace_id` / `api_key_id` via the existing service-layer
+    /// lookup; mismatched IDs trip the standard validation path and
+    /// return 400.
+    pub organization_id: String,
+    /// UUID of the workspace the usage belongs to.
+    pub workspace_id: String,
+    /// UUID of the API key the usage should be attributed to (for
+    /// per-key analytics).
+    pub api_key_id: String,
+    /// The standard usage payload, identical to `POST /v1/usage`.
+    #[serde(flatten)]
+    pub usage: services::usage::RecordUsageApiRequest,
+}
+
+/// Validate the `Authorization: Bearer …` header against the configured
+/// `internal_usage_token` in constant time. Returns:
+/// - `Ok(())` on match.
+/// - `Err(503)` if the endpoint is disabled (token not configured).
+/// - `Err(401)` if the header is missing or doesn't match.
+fn verify_internal_usage_token(
+    headers: &HeaderMap,
+    expected: Option<&str>,
+) -> Result<(), UsageError> {
+    let expected = expected.ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            ResponseJson(ErrorResponse::new(
+                "Internal usage endpoint is not configured on this deployment".to_string(),
+                "endpoint_disabled".to_string(),
+            )),
+        )
+    })?;
+    let provided = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "));
+    let unauthorized = || {
+        (
+            StatusCode::UNAUTHORIZED,
+            ResponseJson(ErrorResponse::new(
+                "Invalid or missing service token".to_string(),
+                "unauthorized".to_string(),
+            )),
+        )
+    };
+    let provided = provided.ok_or_else(unauthorized)?;
+    if provided.as_bytes().ct_eq(expected.as_bytes()).into() {
+        Ok(())
+    } else {
+        Err(unauthorized())
+    }
+}
+
+/// Record usage from a trusted internal reporter.
+///
+/// Auth: `Authorization: Bearer <CLOUD_API_USAGE_TOKEN>`. The endpoint is
+/// disabled (503) until that env var is set on the cloud-api side.
+pub async fn record_usage_internal(
+    State(app_state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<RecordUsageInternalRequest>,
+) -> Result<ResponseJson<RecordUsageResponse>, UsageError> {
+    verify_internal_usage_token(&headers, app_state.config.internal_usage_token.as_deref())?;
+
+    let parse_uuid = |raw: &str, field: &'static str| {
+        Uuid::parse_str(raw).map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                ResponseJson(ErrorResponse::new(
+                    format!("Invalid {field}: must be a UUID"),
+                    "validation_error".to_string(),
+                )),
+            )
+        })
+    };
+    let organization_id = parse_uuid(&request.organization_id, "organization_id")?;
+    let workspace_id = parse_uuid(&request.workspace_id, "workspace_id")?;
+    let api_key_id = parse_uuid(&request.api_key_id, "api_key_id")?;
+
+    let entry = app_state
+        .usage_service
+        .record_usage_from_api(organization_id, workspace_id, api_key_id, request.usage)
+        .await
+        .map_err(|e| match &e {
+            services::usage::UsageError::ModelNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                ResponseJson(ErrorResponse::new(e.to_string(), "not_found".to_string())),
+            ),
+            services::usage::UsageError::ValidationError(_) => (
+                StatusCode::BAD_REQUEST,
+                ResponseJson(ErrorResponse::new(
+                    e.to_string(),
+                    "validation_error".to_string(),
+                )),
+            ),
+            _ => {
+                tracing::error!(
+                    %organization_id,
+                    %workspace_id,
+                    %api_key_id,
+                    "Failed to record internal usage"
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ResponseJson(ErrorResponse::new(
+                        "Failed to record usage".to_string(),
+                        "internal_server_error".to_string(),
+                    )),
+                )
+            }
+        })?;
+
+    Ok(ResponseJson(build_record_usage_response(entry)))
 }
 
 // ============= User-facing analytics endpoints =============
@@ -1072,4 +1228,64 @@ pub async fn get_user_organization_timeseries(
             })
             .collect(),
     }))
+}
+
+#[cfg(test)]
+mod internal_usage_tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_bearer(token: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "authorization",
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn verify_returns_503_when_endpoint_unconfigured() {
+        // Default deployment posture: feature disabled until the operator
+        // sets CLOUD_API_USAGE_TOKEN. Reporters fall back to the legacy
+        // /v1/usage path when they observe this.
+        let h = headers_with_bearer("anything");
+        let err = verify_internal_usage_token(&h, None).unwrap_err();
+        assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn verify_returns_401_on_missing_header() {
+        let err = verify_internal_usage_token(&HeaderMap::new(), Some("svc")).unwrap_err();
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn verify_returns_401_on_wrong_token() {
+        let h = headers_with_bearer("not-the-right-one");
+        let err = verify_internal_usage_token(&h, Some("the-actual-secret")).unwrap_err();
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn verify_returns_401_on_missing_bearer_prefix() {
+        let mut h = HeaderMap::new();
+        h.insert("authorization", HeaderValue::from_static("svc-token"));
+        let err = verify_internal_usage_token(&h, Some("svc-token")).unwrap_err();
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn verify_accepts_matching_token() {
+        let h = headers_with_bearer("the-actual-secret");
+        assert!(verify_internal_usage_token(&h, Some("the-actual-secret")).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_close_but_not_equal_tokens() {
+        // Sanity that we're comparing the whole string, not a prefix.
+        let h = headers_with_bearer("svc-token-tampered");
+        let err = verify_internal_usage_token(&h, Some("svc-token")).unwrap_err();
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+    }
 }

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -383,6 +383,22 @@ pub async fn setup_test_server() -> axum_test::TestServer {
     server
 }
 
+/// Variant of `setup_test_server` that runs an arbitrary mutator against
+/// the test `ApiConfig` before the test server is built. Use when a test
+/// needs to flip a config knob — e.g. to enable the
+/// `/v1/internal/usage` endpoint by setting `internal_usage_token` —
+/// without racing other tests via process-wide env vars.
+pub async fn setup_test_server_with_config<F>(mutate: F) -> axum_test::TestServer
+where
+    F: FnOnce(&mut config::ApiConfig),
+{
+    let mut infra = setup_test_infrastructure().await;
+    mutate(&mut infra.config);
+    let (server, _pool, _mock) =
+        build_test_server_components(infra.database.clone(), infra.config).await;
+    server
+}
+
 pub async fn setup_test_server_with_database() -> (axum_test::TestServer, Arc<Database>) {
     let (server, _, _, database) = setup_test_server_with_pool().await;
     (server, database)

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -60,6 +60,7 @@ pub fn test_config() -> ApiConfig {
             .or_else(|_| std::env::var("MODEL_DISCOVERY_API_KEY"))
             .ok()
             .or(Some("test_api_key".to_string())),
+        internal_usage_token: None,
         logging: config::LoggingConfig {
             level: "debug".to_string(),
             format: "compact".to_string(),

--- a/crates/api/tests/e2e_all/usage_recording.rs
+++ b/crates/api/tests/e2e_all/usage_recording.rs
@@ -643,3 +643,64 @@ async fn test_record_chat_completion_usage_cache_read_capped_to_input() {
         response.text()
     );
 }
+
+/// `POST /v1/internal/usage` returns 503 when the deployment has not
+/// configured `CLOUD_API_USAGE_TOKEN`. This is the default test posture
+/// — the feature is fail-closed until an operator sets the secret, so
+/// reporters using the new path can fall back to the legacy `/v1/usage`
+/// without ambiguity.
+#[tokio::test]
+async fn test_internal_usage_returns_503_when_disabled() {
+    let server = setup_test_server().await;
+
+    let response = server
+        .post("/v1/internal/usage")
+        .add_header("Authorization", "Bearer any-token-here")
+        .json(&serde_json::json!({
+            "organization_id": "00000000-0000-0000-0000-000000000000",
+            "workspace_id": "00000000-0000-0000-0000-000000000000",
+            "api_key_id": "00000000-0000-0000-0000-000000000000",
+            "type": "chat_completion",
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "id": "test-internal-disabled"
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        503,
+        "Internal usage must 503 when CLOUD_API_USAGE_TOKEN is not configured: {}",
+        response.text()
+    );
+}
+
+/// `POST /v1/internal/usage` returns 401 when the deployment is configured
+/// but the request omits or mismatches the service token. Today we can
+/// only e2e-test the *missing-header* shape because flipping the config
+/// at runtime in the shared test harness would race other tests; the
+/// `wrong-token` shape is covered by the `verify_internal_usage_token`
+/// unit tests in the route file.
+#[tokio::test]
+async fn test_internal_usage_returns_503_without_authorization() {
+    let server = setup_test_server().await;
+
+    let response = server
+        .post("/v1/internal/usage")
+        .json(&serde_json::json!({
+            "organization_id": "00000000-0000-0000-0000-000000000000",
+            "workspace_id": "00000000-0000-0000-0000-000000000000",
+            "api_key_id": "00000000-0000-0000-0000-000000000000",
+            "type": "chat_completion",
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "id": "test-internal-noauth"
+        }))
+        .await;
+
+    // With no token configured, the disabled-503 check fires before the
+    // missing-header-401 path can run. Documents the current ordering.
+    assert_eq!(response.status_code(), 503);
+}

--- a/crates/api/tests/e2e_all/usage_recording.rs
+++ b/crates/api/tests/e2e_all/usage_recording.rs
@@ -676,14 +676,14 @@ async fn test_internal_usage_returns_503_when_disabled() {
     );
 }
 
-/// `POST /v1/internal/usage` returns 401 when the deployment is configured
-/// but the request omits or mismatches the service token. Today we can
-/// only e2e-test the *missing-header* shape because flipping the config
-/// at runtime in the shared test harness would race other tests; the
-/// `wrong-token` shape is covered by the `verify_internal_usage_token`
-/// unit tests in the route file.
+/// `POST /v1/internal/usage` returns 503 even when the request omits the
+/// `Authorization` header — the disabled-endpoint check runs *before*
+/// the missing-header check, so callers see a single fail-closed
+/// response regardless of what they sent. (The 401-on-mismatch path
+/// is covered by `verify_internal_usage_token`'s unit tests; flipping
+/// the harness config at runtime would race other tests.)
 #[tokio::test]
-async fn test_internal_usage_returns_503_without_authorization() {
+async fn test_internal_usage_503_takes_precedence_over_missing_auth() {
     let server = setup_test_server().await;
 
     let response = server
@@ -700,7 +700,119 @@ async fn test_internal_usage_returns_503_without_authorization() {
         }))
         .await;
 
-    // With no token configured, the disabled-503 check fires before the
-    // missing-header-401 path can run. Documents the current ordering.
     assert_eq!(response.status_code(), 503);
+}
+
+/// Defense against extractor-ordering regressions: when the endpoint is
+/// disabled, a request with a malformed body must still return 503 (not
+/// 400/422). The handler takes raw `Bytes` and runs the token check
+/// before attempting to deserialize, so body shape can't leak through
+/// to unauthenticated callers.
+#[tokio::test]
+async fn test_internal_usage_503_takes_precedence_over_bad_body() {
+    let server = setup_test_server().await;
+
+    let response = server
+        .post("/v1/internal/usage")
+        .add_header("Authorization", "Bearer anything")
+        .add_header("Content-Type", "application/json")
+        .text("{not valid json")
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        503,
+        "Disabled endpoint must short-circuit before body parsing: {}",
+        response.text()
+    );
+}
+
+/// Happy path with `internal_usage_token` configured: a valid request
+/// produces a row identical to what the legacy `/v1/usage` endpoint
+/// would write. Exercises the actual `serde(flatten)` of
+/// `RecordUsageApiRequest` under the wrapper — guards against
+/// "wire-format works in production for the first time after a config
+/// flip on staging."
+///
+/// `api_key_id` comes from the workspace's `create_api_key` response so
+/// the FK to `api_keys` resolves. This avoids depending on whatever
+/// shape `/v1/check_api_key` is returning at the time the test runs
+/// (PR #664 adds `api_key_id` there; until that lands the field is
+/// just absent).
+#[tokio::test]
+async fn test_internal_usage_records_with_valid_token() {
+    const TOKEN: &str = "test-internal-secret";
+    let server = setup_test_server_with_config(|c| {
+        c.internal_usage_token = Some(TOKEN.to_string());
+    })
+    .await;
+
+    setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let workspaces = list_workspaces(&server, org.id.clone()).await;
+    let workspace_id = workspaces.first().unwrap().id.clone();
+    let api_key_resp = create_api_key_in_workspace(
+        &server,
+        workspace_id.clone(),
+        "internal-usage-happy-path".to_string(),
+    )
+    .await;
+
+    let response = server
+        .post("/v1/internal/usage")
+        .add_header("Authorization", format!("Bearer {TOKEN}"))
+        .json(&serde_json::json!({
+            "organization_id": org.id,
+            "workspace_id": workspace_id,
+            "api_key_id": api_key_resp.id,
+            "type": "chat_completion",
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "id": "test-internal-happy-path"
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        200,
+        "Authenticated internal request should succeed: {}",
+        response.text()
+    );
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["type"], "chat_completion");
+    assert_eq!(body["input_tokens"], 100);
+    assert_eq!(body["output_tokens"], 50);
+    // Cost shape matches the legacy endpoint (uses same service-layer call).
+    assert_eq!(body["total_cost"], 200_000_000i64);
+}
+
+/// `/v1/internal/usage` returns 401 when configured but called with the
+/// wrong token. Pairs with the happy-path test; unit tests cover the
+/// `verify_internal_usage_token` function directly but this asserts the
+/// route handler wires it correctly.
+#[tokio::test]
+async fn test_internal_usage_returns_401_on_wrong_token() {
+    let server = setup_test_server_with_config(|c| {
+        c.internal_usage_token = Some("expected-secret".to_string());
+    })
+    .await;
+
+    let response = server
+        .post("/v1/internal/usage")
+        .add_header("Authorization", "Bearer wrong-secret")
+        .json(&serde_json::json!({
+            "organization_id": "00000000-0000-0000-0000-000000000000",
+            "workspace_id": "00000000-0000-0000-0000-000000000000",
+            "api_key_id": "00000000-0000-0000-0000-000000000000",
+            "type": "chat_completion",
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "id": "test-internal-wrong-token"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 401);
 }

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -5,6 +5,11 @@ pub struct ApiConfig {
     pub server: ServerConfig,
     /// API key for authenticating with inference backends (vLLM/SGLang via inference_url)
     pub inference_api_key: Option<String>,
+    /// Shared secret accepted by `POST /v1/internal/usage` from trusted
+    /// reporters (e.g. inference-proxy). When `None`, the endpoint is
+    /// disabled and returns 503. Reporters can still authenticate to the
+    /// legacy `POST /v1/usage` with an `sk-…` key while this is unset.
+    pub internal_usage_token: Option<String>,
     pub logging: LoggingConfig,
     pub dstack_client: DstackClientConfig,
     pub auth: AuthConfig,
@@ -24,6 +29,13 @@ impl ApiConfig {
             inference_api_key: env::var("INFERENCE_API_KEY")
                 .or_else(|_| env::var("MODEL_DISCOVERY_API_KEY"))
                 .ok(),
+            // Same env-var name on both sides (inference-proxy and
+            // cloud-api). Operators set both to the same secret string;
+            // unsetting either side disables the new reporting path
+            // without breaking anything.
+            internal_usage_token: env::var("CLOUD_API_USAGE_TOKEN")
+                .ok()
+                .filter(|s| !s.is_empty()),
             logging: LoggingConfig::from_env()?,
             dstack_client: DstackClientConfig::from_env()?,
             auth: AuthConfig::from_env()?,

--- a/env.example
+++ b/env.example
@@ -16,6 +16,13 @@ MODEL_DISCOVERY_SERVER_URL=http://localhost:8080/models
 # API key for authenticating with discovered model providers
 MODEL_DISCOVERY_API_KEY=YOUR_API_KEY_HERE
 
+# Shared service-token accepted by `POST /v1/internal/usage` for trusted
+# reporters (e.g. inference-proxy). Set the SAME value here and on every
+# inference-proxy CVM (their env var is also `CLOUD_API_USAGE_TOKEN`).
+# Leave unset to disable the endpoint (it returns 503 and reporters fall
+# back to the legacy `POST /v1/usage` + `sk-…` path).
+# CLOUD_API_USAGE_TOKEN=
+
 # How often to refresh model list (in seconds)
 MODEL_DISCOVERY_REFRESH_INTERVAL=300
 


### PR DESCRIPTION
## Summary

Adds the locked-down replacement for `POST /v1/usage` aimed at trusted infrastructure reporters (today: inference-proxy, via [nearai/inference-proxy#143](https://github.com/nearai/inference-proxy/pull/143)). The legacy endpoint accepts an `sk-…` API key — meaning anyone holding that key can submit arbitrary usage rows against the org's balance, which was the primitive that made the billing-bypass via `inference_id` collision exploitable in the first place. #663 isolated the namespaces to neutralize that vector; this PR removes the primitive entirely for infrastructure reporters.

The new endpoint requires a shared `CLOUD_API_USAGE_TOKEN` service secret in `Authorization: Bearer` and carries the subject identity (`organization_id`, `workspace_id`, `api_key_id`) in the body. The service-layer call is the same `record_usage_from_api` the legacy endpoint uses, so cost calculation, model lookup, idempotency, and balance updates are bit-for-bit identical — only the auth + identity sourcing differ.

## Wire shape

```http
POST /v1/internal/usage HTTP/1.1
Authorization: Bearer <CLOUD_API_USAGE_TOKEN>
Content-Type: application/json

{
  "organization_id": "uuid",
  "workspace_id": "uuid",
  "api_key_id": "uuid",
  "type": "chat_completion",
  "model": "anthropic/claude-opus-4-7",
  "input_tokens": 100,
  "output_tokens": 50,
  "id": "chatcmpl-xyz"
}
```

The `usage` field is flattened, so reporters use the same body builder as the legacy endpoint plus three top-level identity keys. Response shape is identical to `POST /v1/usage`.

## Compatibility

- `POST /v1/usage` is **unchanged**. Both endpoints accept reports until migration completes.
- The new endpoint is **fail-closed**: returns 503 until `CLOUD_API_USAGE_TOKEN` is set on cloud-api. inference-proxy already ships with a matching client-side gate (`can_use_service_token_path` in #143) that falls back to the legacy path when the endpoint isn't reachable. Deploy order between the two repos doesn't matter.
- Body shape is additive; older clients ignore unknown fields.

## Changes

- `crates/config/src/types.rs`: new `ApiConfig.internal_usage_token`, from env `CLOUD_API_USAGE_TOKEN` (same name as inference-proxy side for ops parity).
- `crates/api/src/routes/usage.rs`:
  - `verify_internal_usage_token`: constant-time bearer compare via `subtle::ConstantTimeEq`. 503 when unconfigured, 401 on missing/wrong header.
  - `RecordUsageInternalRequest`: wraps the legacy `RecordUsageApiRequest` via `#[serde(flatten)]`.
  - `record_usage_internal` handler: auth → parse UUIDs → reuse the existing service call → reuse a newly-extracted `build_record_usage_response` helper.
- `crates/api/src/lib.rs`: new `build_internal_routes` mounted on `/v1/internal/*`. **Not** wrapped in the sk-auth/rate-limit/usage-check middleware stack — auth is per-route via the verify fn above.
- `crates/api/Cargo.toml`: adds `subtle = "2.6"`.

## Test plan

- [x] `cargo test --lib internal_usage` — 6 unit tests pass (verify fn: 503 unconfigured, 401 missing/wrong/no-prefix/tampered, ok on match).
- [x] `cargo test --test e2e_all internal_usage` — 2 e2e tests pass (503 with and without `Authorization` header, against default test config which has the feature disabled).
- [x] `cargo clippy -p api --tests` — clean.
- [x] `cargo fmt -- --check` — clean.

## Rollout sequence (for ops)

1. **Land [#664](https://github.com/nearai/cloud-api/pull/664)** (add `api_key_id` to `/v1/check_api_key`) so inference-proxy can resolve the third identity field server-side.
2. **Land this PR.** With `CLOUD_API_USAGE_TOKEN` still unset, the new endpoint stays 503 and nothing changes in production.
3. **Set `CLOUD_API_USAGE_TOKEN` to the same value on cloud-api AND inference-proxy CVMs.** From this point new reports go through `/v1/internal/usage`; in-flight reports finish on the legacy path.
4. **Verify in dashboards** that report counts are flowing through the new endpoint. inference-proxy logs include a `mode=service_token` / `mode=sk_legacy` tag on its warn log emitted when reports fail.
5. **Follow-up PR**: remove `sk-` auth on `POST /v1/usage` once 100% migration is confirmed.