### PR TITLE
[codex] make v1 models public

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1112,13 +1112,10 @@ pub fn build_completion_routes(
     let metadata_routes = Router::new()
         .route("/models", get(models))
         .with_state(app_state)
-        .layer(from_fn_with_state(
-            rate_limit_state.clone(),
-            middleware::api_key_rate_limit_middleware,
-        ))
-        .layer(from_fn_with_state(
-            auth_state_middleware.clone(),
-            auth_middleware_with_api_key,
+        // Public, OpenAI-compatible model catalog. The response is identical for
+        // all clients and changes only when an admin updates the catalog.
+        .layer(cache_control_layer(
+            "public, max-age=30, stale-while-revalidate=120",
         ));
 
     Router::new()

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1744,6 +1744,18 @@ mod tests {
         assert!(spec.servers.is_none() || spec.servers.as_ref().unwrap().is_empty());
     }
 
+    #[test]
+    fn test_openapi_models_endpoint_is_public() {
+        let spec = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let models_get = &spec["paths"]["/v1/models"]["get"];
+
+        assert_eq!(
+            models_get["security"],
+            serde_json::json!([{}]),
+            "/v1/models must explicitly override global OpenAPI security"
+        );
+    }
+
     /// Example of how to set up the application for E2E testing
     #[tokio::test]
     #[ignore] // Remove ignore to run with a real database and Patroni cluster

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1333,6 +1333,9 @@ pub async fn completions(
     responses(
         (status = 200, description = "List of available models", body = ModelsResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
+    ),
+    security(
+        ()
     )
 )]
 pub async fn models(

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1332,18 +1332,13 @@ pub async fn completions(
     tag = "Chat",
     responses(
         (status = 200, description = "List of available models", body = ModelsResponse),
-        (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
-    ),
-    security(
-        ("api_key" = [])
     )
 )]
 pub async fn models(
     State(app_state): State<AppState>,
-    Extension(api_key): Extension<services::workspace::ApiKey>,
 ) -> Result<ResponseJson<ModelsResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
-    debug!("Models list request from key: {:?}", api_key.id);
+    debug!("Models list request");
 
     let models = app_state
         .models_service

--- a/crates/api/tests/e2e_all/api_keys.rs
+++ b/crates/api/tests/e2e_all/api_keys.rs
@@ -241,7 +241,7 @@ async fn test_deleted_api_key_cannot_be_used() {
 
     // Verify key works before deletion
     let response = server
-        .get("/v1/models")
+        .get("/v1/files?limit=1")
         .add_header("Authorization", format!("Bearer {api_key}"))
         .await;
 
@@ -267,7 +267,7 @@ async fn test_deleted_api_key_cannot_be_used() {
 
     // Try to use the deleted API key - should fail
     let response = server
-        .get("/v1/models")
+        .get("/v1/files?limit=1")
         .add_header("Authorization", format!("Bearer {api_key}"))
         .await;
 
@@ -746,7 +746,7 @@ async fn test_api_key_authentication() {
 
     // Test valid API key
     let response = server
-        .get("/v1/models")
+        .get("/v1/files?limit=1")
         .add_header("Authorization", format!("Bearer {api_key}"))
         .await;
 
@@ -758,7 +758,7 @@ async fn test_api_key_authentication() {
 
     // Test invalid API key
     let response = server
-        .get("/v1/models")
+        .get("/v1/files?limit=1")
         .add_header("Authorization", "Bearer invalid_key_12345")
         .await;
 
@@ -769,7 +769,7 @@ async fn test_api_key_authentication() {
     );
 
     // Test missing API key
-    let response = server.get("/v1/models").await;
+    let response = server.get("/v1/files?limit=1").await;
 
     assert_eq!(
         response.status_code(),

--- a/crates/api/tests/e2e_all/error_msg.rs
+++ b/crates/api/tests/e2e_all/error_msg.rs
@@ -333,23 +333,22 @@ async fn test_create_api_key_duplicate_name_conflict_message() {
 }
 
 // ============================================
-// Models error message tests
+// Models public endpoint tests
 // ============================================
 
 #[tokio::test]
-async fn test_models_missing_auth_header_message() {
+async fn test_models_no_auth_required() {
     let server = setup_test_server().await;
 
     let response = server.get("/v1/models").await;
 
-    assert_eq!(response.status_code(), 401);
-    let err = response.json::<api::models::ErrorResponse>();
-    assert_eq!(err.error.r#type, "missing_auth_header");
-    assert_eq!(err.error.message, "Missing authorization header");
+    assert_eq!(response.status_code(), 200);
+    let models = response.json::<api::models::ModelsResponse>();
+    assert_eq!(models.object, "list");
 }
 
 #[tokio::test]
-async fn test_models_invalid_auth_header_format_message() {
+async fn test_models_invalid_auth_header_ignored() {
     let server = setup_test_server().await;
 
     let response = server
@@ -357,14 +356,13 @@ async fn test_models_invalid_auth_header_format_message() {
         .add_header("Authorization", "Token abc")
         .await;
 
-    assert_eq!(response.status_code(), 401);
-    let err = response.json::<api::models::ErrorResponse>();
-    assert_eq!(err.error.r#type, "invalid_auth_header");
-    assert_eq!(err.error.message, "Invalid authorization header format");
+    assert_eq!(response.status_code(), 200);
+    let models = response.json::<api::models::ModelsResponse>();
+    assert_eq!(models.object, "list");
 }
 
 #[tokio::test]
-async fn test_models_invalid_api_key_message() {
+async fn test_models_invalid_api_key_ignored() {
     let server = setup_test_server().await;
 
     let response = server
@@ -372,8 +370,7 @@ async fn test_models_invalid_api_key_message() {
         .add_header("Authorization", "Bearer invalid_key_123")
         .await;
 
-    assert_eq!(response.status_code(), 401);
-    let err = response.json::<api::models::ErrorResponse>();
-    assert_eq!(err.error.r#type, "invalid_api_key");
-    assert_eq!(err.error.message, "Invalid or expired API key");
+    assert_eq!(response.status_code(), 200);
+    let models = response.json::<api::models::ModelsResponse>();
+    assert_eq!(models.object, "list");
 }

--- a/crates/api/tests/e2e_all/vpc_login.rs
+++ b/crates/api/tests/e2e_all/vpc_login.rs
@@ -284,15 +284,15 @@ async fn test_vpc_login_api_key_works() {
 
     let body = response.json::<VpcLoginResponse>();
 
-    // Try to use the API key to list models
-    let models_response = server
-        .get("/v1/models")
+    // Try to use the API key on an authenticated endpoint
+    let auth_response = server
+        .get("/v1/files?limit=1")
         .add_header("Authorization", format!("Bearer {}", body.api_key))
         .add_header("User-Agent", MOCK_USER_AGENT)
         .await;
 
     assert_eq!(
-        models_response.status_code(),
+        auth_response.status_code(),
         200,
         "API key from VPC login should work for authenticated requests"
     );

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -41,7 +41,7 @@ on `http://localhost:3000`. Useful endpoints once it's up:
 | `GET  /health`                | Liveness probe                       |
 | `GET  /docs`                  | Scalar UI (interactive)              |
 | `GET  /api-docs/openapi.json` | Machine-readable OpenAPI spec        |
-| `GET  /v1/models`             | Model catalog (requires API key)     |
+| `GET  /v1/models`             | Public model catalog                 |
 | `POST /v1/chat/completions`   | OpenAI-compatible inference          |
 
 To pull down everything:
@@ -270,7 +270,7 @@ Provider refresh runs every 300s by default
 | `POST /v1/organizations`                    | session  | Body: `{"name": "...", "description": "..."}`               |
 | `POST /v1/organizations/{id}/workspaces`    | session  | Same body shape                                             |
 | `POST /v1/workspaces/{id}/api-keys`         | session  | Returns plaintext `key` — store it, it isn't shown again    |
-| `GET  /v1/models`                           | API key  | Catalog visible to the workspace                            |
+| `GET  /v1/models`                           | public   | OpenAI-compatible model catalog with pricing metadata       |
 | `POST /v1/chat/completions`                 | API key  | OpenAI-compatible. Add `"stream": true` for SSE             |
 | `POST /v1/responses`                        | API key  | Platform-specific event-streamed responses                  |
 | `POST /v1/conversations`                    | API key  | Conversation lifecycle                                      |


### PR DESCRIPTION
## Summary

- Make `GET /v1/models` public by removing API-key auth and API-key rate-limit middleware from the OpenAI-compatible model catalog route.
- Keep the endpoint cacheable with `Cache-Control: public, max-age=30, stale-while-revalidate=120`.
- Update OpenAPI metadata, tests, and local docs to treat `/v1/models` as public.
- Move API-key smoke checks to `GET /v1/files?limit=1`, which remains authenticated.

## Flooding / DB Load

The endpoint can still receive unauthenticated HTTP traffic, but DB load is protected by the existing model-service cache. `get_models_with_pricing()` uses a single-entry Moka cache with a 30-second TTL and `try_get_with`, so concurrent cold misses coalesce and only one caller loads from the repository per process. Admin model writes invalidate that cache. The new HTTP cache header also lets cooperating CDN/browser caches serve the public catalog without reaching the app during the fresh/SWR window.

This does not replace edge/WAF/IP-level rate limiting for generic HTTP flood protection; it just keeps the catalog DB query from being hit per request.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p api --test e2e_all test_models_` compiled successfully, then failed during test setup because local Postgres was not running: `Connection refused` in `common/db_setup.rs`.
