### PR TITLE
feat(usage): add per-model spend breakdown endpoint

### DIFF
--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -119,6 +119,7 @@ use utoipa::{Modify, OpenApi};
         // Usage endpoints
         crate::routes::usage::get_organization_balance,
         crate::routes::usage::get_organization_usage_history,
+        crate::routes::usage::get_organization_usage_by_model,
         crate::routes::usage::get_api_key_usage_history,
         crate::routes::usage::record_usage,
         crate::routes::usage::get_user_organization_metrics,
@@ -240,6 +241,8 @@ use utoipa::{Modify, OpenApi};
             crate::routes::usage::OrganizationBalanceResponse,
             crate::routes::usage::UsageHistoryResponse,
             crate::routes::usage::UsageHistoryEntryResponse,
+            crate::routes::usage::UsageByModelResponse,
+            crate::routes::usage::UsageByModelEntryResponse,
             crate::routes::usage::ServiceUsageHistoryResponse,
             crate::routes::usage::ServiceUsageEntryResponse,
             crate::routes::usage::RecordUsageResponse,

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -114,6 +114,10 @@ pub fn build_management_router(app_state: AppState, auth_state: AuthState) -> Ro
             get(crate::routes::usage::get_organization_usage_history),
         )
         .route(
+            "/{id}/usage/by-model",
+            get(crate::routes::usage::get_organization_usage_by_model),
+        )
+        .route(
             "/{id}/service-usage/history",
             get(crate::routes::usage::get_service_usage_history),
         )

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -1312,15 +1312,17 @@ pub struct UsageByModelResponse {
 
 /// Get organization usage broken down by model.
 ///
-/// Returns one row per model, summed over the selected time window (`day`, `week`, or `month`).
-/// Used by the dashboard pie chart to show which models drive spend.
+/// Returns one row per model, summed over a rolling window ending now:
+/// `day` = last 24h, `week` = last 7 days, `month` = last 30 days (NOT calendar
+/// day/week/month-to-date). Used by the dashboard pie chart to show which models
+/// drive spend.
 #[utoipa::path(
     get,
     path = "/v1/organizations/{org_id}/usage/by-model",
     tag = "Usage",
     params(
         ("org_id" = String, Path, description = "Organization ID"),
-        ("period" = Option<String>, Query, description = "`day`, `week`, or `month` (default: `month`)")
+        ("period" = Option<String>, Query, description = "Rolling window: `day` (last 24h), `week` (last 7d), or `month` (last 30d). Default: `month`")
     ),
     responses(
         (status = 200, description = "Per-model usage breakdown", body = UsageByModelResponse),
@@ -1345,8 +1347,8 @@ pub async fn get_organization_usage_by_model(
         .usage_service
         .get_usage_by_model(organization_id, start_date)
         .await
-        .map_err(|_| {
-            tracing::error!("Failed to get usage by model");
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to get usage by model");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ResponseJson(ErrorResponse::new(

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -1251,6 +1251,131 @@ pub async fn get_user_organization_timeseries(
     }))
 }
 
+/// Period selector for the by-model usage breakdown.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UsageByModelPeriod {
+    Day,
+    Week,
+    Month,
+}
+
+impl UsageByModelPeriod {
+    fn since(self) -> chrono::DateTime<Utc> {
+        let now = Utc::now();
+        match self {
+            UsageByModelPeriod::Day => now - Duration::days(1),
+            UsageByModelPeriod::Week => now - Duration::days(7),
+            UsageByModelPeriod::Month => now - Duration::days(30),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            UsageByModelPeriod::Day => "day",
+            UsageByModelPeriod::Week => "week",
+            UsageByModelPeriod::Month => "month",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UsageByModelQuery {
+    /// `day` (last 24h), `week` (last 7d), or `month` (last 30d). Defaults to `month`.
+    #[serde(default = "default_period")]
+    pub period: UsageByModelPeriod,
+}
+
+fn default_period() -> UsageByModelPeriod {
+    UsageByModelPeriod::Month
+}
+
+/// Per-model usage aggregation entry
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UsageByModelEntryResponse {
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost: i64,            // In nano-dollars (scale 9)
+    pub total_cost_display: String, // Human readable, e.g., "$0.00123"
+    pub request_count: i64,
+}
+
+/// Per-model usage breakdown response
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UsageByModelResponse {
+    pub period: String,
+    pub start_date: String,
+    pub data: Vec<UsageByModelEntryResponse>,
+}
+
+/// Get organization usage broken down by model.
+///
+/// Returns one row per model, summed over the selected time window (`day`, `week`, or `month`).
+/// Used by the dashboard pie chart to show which models drive spend.
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/usage/by-model",
+    tag = "Usage",
+    params(
+        ("org_id" = String, Path, description = "Organization ID"),
+        ("period" = Option<String>, Query, description = "`day`, `week`, or `month` (default: `month`)")
+    ),
+    responses(
+        (status = 200, description = "Per-model usage breakdown", body = UsageByModelResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn get_organization_usage_by_model(
+    State(app_state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(org_id): Path<String>,
+    Query(query): Query<UsageByModelQuery>,
+) -> Result<ResponseJson<UsageByModelResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
+    let organization_id = check_org_membership(&app_state, user, &org_id).await?;
+    let start_date = query.period.since();
+
+    let entries = app_state
+        .usage_service
+        .get_usage_by_model(organization_id, start_date)
+        .await
+        .map_err(|_| {
+            tracing::error!("Failed to get usage by model");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    "Failed to retrieve usage breakdown".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    let data = entries
+        .into_iter()
+        .map(|e| UsageByModelEntryResponse {
+            model: e.model,
+            input_tokens: e.input_tokens,
+            output_tokens: e.output_tokens,
+            total_tokens: e.total_tokens,
+            total_cost: e.total_cost,
+            total_cost_display: format_amount(e.total_cost),
+            request_count: e.request_count,
+        })
+        .collect();
+
+    Ok(ResponseJson(UsageByModelResponse {
+        period: query.period.as_str().to_string(),
+        start_date: start_date.to_rfc3339(),
+        data,
+    }))
+}
+
 #[cfg(test)]
 mod internal_usage_tests {
     use super::*;

--- a/crates/database/src/repositories/organization_usage.rs
+++ b/crates/database/src/repositories/organization_usage.rs
@@ -385,6 +385,55 @@ impl OrganizationUsageRepository {
         })
     }
 
+    /// Aggregate usage by model for an organization since `start_date`.
+    pub async fn get_usage_by_model_since(
+        &self,
+        organization_id: Uuid,
+        start_date: chrono::DateTime<Utc>,
+    ) -> Result<Vec<UsageByModel>> {
+        let rows = retry_db!("get_organization_usage_by_model", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT
+                        model_name,
+                        COALESCE(SUM(input_tokens), 0)::BIGINT  AS input_tokens,
+                        COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens,
+                        COALESCE(SUM(total_tokens), 0)::BIGINT  AS total_tokens,
+                        COALESCE(SUM(total_cost), 0)::BIGINT    AS total_cost,
+                        COUNT(*)::BIGINT                        AS request_count
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND created_at >= $2
+                    GROUP BY model_name
+                    ORDER BY total_cost DESC
+                    "#,
+                    &[&organization_id, &start_date],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| UsageByModel {
+                model: row.get("model_name"),
+                input_tokens: row.get("input_tokens"),
+                output_tokens: row.get("output_tokens"),
+                total_tokens: row.get("total_tokens"),
+                total_cost: row.get("total_cost"),
+                request_count: row.get("request_count"),
+            })
+            .collect())
+    }
+
     fn row_to_usage_log(&self, row: &Row, was_inserted: bool) -> Result<OrganizationUsageLog> {
         // Parse stop_reason from string to enum
         let stop_reason_str: Option<String> = row.get("stop_reason");
@@ -552,4 +601,14 @@ pub struct UsageStats {
     pub request_count: i64,
     pub total_tokens: i64,
     pub total_cost: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct UsageByModel {
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost: i64,
+    pub request_count: i64,
 }

--- a/crates/database/src/repositories/usage_repository_impl.rs
+++ b/crates/database/src/repositories/usage_repository_impl.rs
@@ -1,6 +1,9 @@
 use crate::models::RecordUsageRequest;
 use crate::repositories::OrganizationUsageRepository;
-use services::usage::ports::{InferenceCost, OrganizationBalanceInfo, UsageLogEntry};
+use chrono::{DateTime, Utc};
+use services::usage::ports::{
+    InferenceCost, OrganizationBalanceInfo, UsageByModelEntry, UsageLogEntry,
+};
 use uuid::Uuid;
 
 /// Trait implementation adapter for UsageRepository
@@ -200,5 +203,27 @@ impl services::usage::ports::UsageRepository for OrganizationUsageRepository {
     ) -> anyhow::Result<Option<services::usage::StopReason>> {
         self.get_stop_reason_by_provider_request_id(provider_request_id)
             .await
+    }
+
+    async fn get_usage_by_model(
+        &self,
+        organization_id: Uuid,
+        start_date: DateTime<Utc>,
+    ) -> anyhow::Result<Vec<UsageByModelEntry>> {
+        let rows = self
+            .get_usage_by_model_since(organization_id, start_date)
+            .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| UsageByModelEntry {
+                model: r.model,
+                input_tokens: r.input_tokens,
+                output_tokens: r.output_tokens,
+                total_tokens: r.total_tokens,
+                total_cost: r.total_cost,
+                request_count: r.request_count,
+            })
+            .collect())
     }
 }

--- a/crates/services/src/test_utils.rs
+++ b/crates/services/src/test_utils.rs
@@ -230,6 +230,14 @@ impl UsageServiceTrait for MockUsageService {
     ) -> Result<Vec<crate::usage::InferenceCost>, UsageError> {
         Ok(vec![])
     }
+
+    async fn get_usage_by_model(
+        &self,
+        _organization_id: Uuid,
+        _start_date: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<crate::usage::UsageByModelEntry>, UsageError> {
+        Ok(vec![])
+    }
 }
 
 /// A usage service that captures requests for testing
@@ -411,6 +419,14 @@ impl UsageServiceTrait for CapturingUsageService {
         _organization_id: Uuid,
         _inference_ids: Vec<Uuid>,
     ) -> Result<Vec<crate::usage::InferenceCost>, UsageError> {
+        Ok(vec![])
+    }
+
+    async fn get_usage_by_model(
+        &self,
+        _organization_id: Uuid,
+        _start_date: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<crate::usage::UsageByModelEntry>, UsageError> {
         Ok(vec![])
     }
 }

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -627,6 +627,17 @@ impl UsageServiceTrait for UsageServiceImpl {
 
         Ok(results)
     }
+
+    async fn get_usage_by_model(
+        &self,
+        organization_id: Uuid,
+        start_date: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<UsageByModelEntry>, UsageError> {
+        self.usage_repository
+            .get_usage_by_model(organization_id, start_date)
+            .await
+            .map_err(|e| UsageError::InternalError(format!("Failed to get usage by model: {e}")))
+    }
 }
 
 #[cfg(test)]

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -276,6 +276,14 @@ pub trait UsageServiceTrait: Send + Sync {
         organization_id: Uuid,
         inference_ids: Vec<Uuid>,
     ) -> Result<Vec<InferenceCost>, UsageError>;
+
+    /// Get per-model usage aggregation for an organization since `start_date`.
+    /// Returns one row per model: summed tokens, summed cost (nano-dollars), and request count.
+    async fn get_usage_by_model(
+        &self,
+        organization_id: Uuid,
+        start_date: DateTime<Utc>,
+    ) -> Result<Vec<UsageByModelEntry>, UsageError>;
 }
 
 // ============================================
@@ -335,6 +343,13 @@ pub trait UsageRepository: Send + Sync {
         &self,
         provider_request_id: &str,
     ) -> anyhow::Result<Option<StopReason>>;
+
+    /// Get per-model usage aggregation for an organization since `start_date`.
+    async fn get_usage_by_model(
+        &self,
+        organization_id: Uuid,
+        start_date: DateTime<Utc>,
+    ) -> anyhow::Result<Vec<UsageByModelEntry>>;
 }
 
 #[async_trait::async_trait]
@@ -513,6 +528,18 @@ pub struct OrganizationBalanceInfo {
     pub total_requests: i64,
     pub total_tokens: i64,
     pub updated_at: DateTime<Utc>,
+}
+
+/// Per-model usage aggregation over a time window.
+/// Cost is in nano-dollars (scale 9).
+#[derive(Debug, Clone)]
+pub struct UsageByModelEntry {
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost: i64,
+    pub request_count: i64,
 }
 
 /// Usage log entry


### PR DESCRIPTION
## Summary
- New endpoint: `GET /v1/organizations/{org_id}/usage/by-model?period=day|week|month`
- Aggregates `organization_usage_log` by `model_name` since the period start: summed input/output/total tokens, summed cost (nano-USD, scale 9), and request count per model.
- Ordered by `total_cost DESC` so the highest-spend models come first.

Powers the new pie chart on the dashboard usage page (`/dashboard/organizations/<id>/usage`) in [nearai-cloud-ui](https://github.com/nearai/nearai-cloud-ui) so org owners can see at a glance which models drive their spend.

## Wiring
- `crates/services/src/usage/ports.rs` — `UsageByModelEntry` + `UsageServiceTrait::get_usage_by_model` + `UsageRepository::get_usage_by_model`
- `crates/services/src/usage/mod.rs` — service impl
- `crates/services/src/test_utils.rs` — mock impls for `MockUsageService` and `CapturingUsageService`
- `crates/database/src/repositories/organization_usage.rs` — `UsageByModel` struct + `get_usage_by_model_since` SQL
- `crates/database/src/repositories/usage_repository_impl.rs` — trait adapter
- `crates/api/src/routes/usage.rs` — route handler + `UsageByModelPeriod` enum (day=24h, week=7d, month=30d)
- `crates/api/src/routes/api.rs`, `openapi.rs` — wiring

## Test plan
- [ ] `cargo check -p api` (already green locally)
- [ ] After deploy: hit `/v1/organizations/<id>/usage/by-model?period=month` with a session cookie and confirm the response shape
- [ ] Verify orgs with no usage in the period return `{ "data": [] }` rather than an error