### PR TITLE
fix(completions): pass unknown chat tool types through to upstream

### DIFF
--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -555,22 +555,48 @@ impl CompletionServiceImpl {
         }
     }
 
-    /// Extract tools and tool_choice from extra HashMap if present.
-    /// This handles the case where the Responses API places tools in request.extra.
-    /// Returns (tools, tool_choice) and removes them from extra to avoid duplication.
+    /// Extract tools and tool_choice from the extra HashMap if present and
+    /// parseable as the typed `ToolDefinition` / `ToolChoice` shapes.
+    ///
+    /// Returns `(tools, tool_choice)` and only removes the corresponding
+    /// key from `extra` when parsing succeeds. If parsing fails — for
+    /// example because the client sent a non-standard tool type like
+    /// NEAR's `{"type":"web_context_search"}`, which the upstream
+    /// inference-proxy handles natively but doesn't fit the
+    /// function-tool shape — the original value is left in `extra` so it
+    /// flows through to the upstream request body verbatim via the
+    /// `#[serde(flatten)]` on `ChatCompletionParams.extra`. This means
+    /// cloud-api never silently drops tool definitions it doesn't
+    /// recognise; the upstream gets to decide.
     fn extract_tools_from_extra(
         extra: &mut std::collections::HashMap<String, serde_json::Value>,
     ) -> (
         Option<Vec<inference_providers::ToolDefinition>>,
         Option<inference_providers::ToolChoice>,
     ) {
-        let tools = extra.remove("tools").and_then(|v| {
-            serde_json::from_value::<Vec<inference_providers::ToolDefinition>>(v).ok()
-        });
+        let tools = match extra.get("tools").cloned() {
+            Some(raw) => {
+                match serde_json::from_value::<Vec<inference_providers::ToolDefinition>>(raw) {
+                    Ok(parsed) => {
+                        extra.remove("tools");
+                        Some(parsed)
+                    }
+                    Err(_) => None,
+                }
+            }
+            None => None,
+        };
 
-        let tool_choice = extra
-            .remove("tool_choice")
-            .and_then(|v| serde_json::from_value::<inference_providers::ToolChoice>(v).ok());
+        let tool_choice = match extra.get("tool_choice").cloned() {
+            Some(raw) => match serde_json::from_value::<inference_providers::ToolChoice>(raw) {
+                Ok(parsed) => {
+                    extra.remove("tool_choice");
+                    Some(parsed)
+                }
+                Err(_) => None,
+            },
+            None => None,
+        };
 
         (tools, tool_choice)
     }
@@ -2731,5 +2757,109 @@ mod tests {
             }
             other => panic!("Expected ProviderError with 504, got {:?}", other),
         }
+    }
+
+    // ── extract_tools_from_extra ───────────────────────────────────
+
+    #[test]
+    fn extract_tools_consumes_function_shaped_tools() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "tools".to_string(),
+            serde_json::json!([{
+                "type": "function",
+                "function": {
+                    "name": "calc",
+                    "description": "add",
+                    "parameters": {"type": "object", "properties": {}}
+                }
+            }]),
+        );
+        extra.insert("tool_choice".to_string(), serde_json::json!("auto"));
+
+        let (tools, tool_choice) = CompletionServiceImpl::extract_tools_from_extra(&mut extra);
+
+        assert!(tools.is_some(), "function tool should parse");
+        assert_eq!(tools.unwrap().len(), 1);
+        assert!(tool_choice.is_some(), "tool_choice 'auto' should parse");
+        // Successfully-parsed keys are consumed from extra so they aren't
+        // also serialized via the flatten — would otherwise produce
+        // duplicate keys in the upstream JSON.
+        assert!(!extra.contains_key("tools"));
+        assert!(!extra.contains_key("tool_choice"));
+    }
+
+    #[test]
+    fn extract_tools_passes_through_unknown_tool_types() {
+        // NEAR's `web_context_search` is a namespaced tool type handled
+        // natively by the inference-proxy inside the CVM. It has no
+        // `function` field, so it doesn't fit our typed `ToolDefinition`.
+        // The helper must NOT silently drop it — leaving it in `extra`
+        // lets it flow through to the upstream request body verbatim
+        // via the flattened serialization.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "tools".to_string(),
+            serde_json::json!([{"type": "web_context_search"}]),
+        );
+
+        let (tools, tool_choice) = CompletionServiceImpl::extract_tools_from_extra(&mut extra);
+
+        assert!(
+            tools.is_none(),
+            "non-function-shaped tools shouldn't bind the typed field"
+        );
+        assert!(tool_choice.is_none());
+        // The raw value MUST still be in extra so it survives serialization
+        // through to the upstream request body.
+        let preserved = extra.get("tools").expect("tools must remain in extra");
+        assert_eq!(
+            preserved,
+            &serde_json::json!([{"type": "web_context_search"}])
+        );
+    }
+
+    #[test]
+    fn extract_tools_passes_through_mixed_unknown_in_array() {
+        // If one of the tools in the array can't be parsed as a function
+        // tool, we conservatively leave the whole array in `extra` rather
+        // than silently dropping some entries — cloud-api isn't the right
+        // layer to decide which tools the upstream can handle.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "tools".to_string(),
+            serde_json::json!([
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "calc",
+                        "description": "add",
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                },
+                {"type": "web_context_search"}
+            ]),
+        );
+
+        let (tools, _) = CompletionServiceImpl::extract_tools_from_extra(&mut extra);
+
+        assert!(tools.is_none());
+        assert!(extra.contains_key("tools"));
+    }
+
+    #[test]
+    fn extract_tools_passes_through_unknown_tool_choice() {
+        // Symmetric to tools: a non-standard tool_choice string survives
+        // for upstream interpretation.
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "tool_choice".to_string(),
+            serde_json::json!({"weird": "shape"}),
+        );
+
+        let (_, tool_choice) = CompletionServiceImpl::extract_tools_from_extra(&mut extra);
+
+        assert!(tool_choice.is_none());
+        assert!(extra.contains_key("tool_choice"));
     }
 }


### PR DESCRIPTION
## Problem

`extract_tools_from_extra` in `crates/services/src/completions/mod.rs` had two interacting bugs:

```rust
let tools = extra.remove("tools").and_then(|v| {
    serde_json::from_value::<Vec<inference_providers::ToolDefinition>>(v).ok()
});
```

1. `extra.remove(\"tools\")` happens **unconditionally**, before parsing.
2. `.ok()` swallows parse errors silently.

Net effect: any chat-completions request whose `tools` array doesn't fit our typed `ToolDefinition` shape (i.e. anything other than `{type:\"function\", function:{name,description,parameters}}`) is silently dropped — removed from `extra` and parsed to `None`. The upstream never sees the tool, and the model never knows it could call it.

This blocked the `web_context_search` agent loop (nearai/inference-proxy#144) from running end-to-end through cloud-api. The inference-proxy expands `{\"type\":\"web_context_search\"}` into a proper function tool inside the CVM, but cloud-api was stripping it before the request ever got there.

Empirical evidence: `POST /v1/chat/completions` with `tools:[{\"type\":\"web_context_search\"}]` against GLM-5.1 returns `prompt_tokens=19` (just the user message). The tool schema alone would add ~100 tokens — so cloud-api forwarded the request without it.

## Fix

Only consume from `extra` on **successful** parse. If parsing fails, the raw value stays in `extra` and flows through to the upstream request body verbatim via the existing `#[serde(flatten)]` on `ChatCompletionParams.extra`. Same treatment for `tool_choice` for symmetry.

This is a permissive-passthrough change at the cloud-api layer: deciding whether a tool type is supported is the upstream's job (vLLM/SGLang via inference-proxy for our models, the provider for Gemini/Anthropic). External providers already only consume typed tools, so they're unaffected — non-function tools simply don't reach them.

## Tests

`cargo test -p services --lib extract_tools` (4 new tests, all pass):

- `extract_tools_consumes_function_shaped_tools` — regression cover for the existing path: standard function tools parse, get consumed from `extra` (so we don't end up with both the typed `tools` field and a flattened `extra.tools`, which would be a duplicate key in the upstream JSON).
- `extract_tools_passes_through_unknown_tool_types` — the `web_context_search` regression: array remains in `extra`.
- `extract_tools_passes_through_mixed_unknown_in_array` — an array mixing function and unknown stays fully opaque. Conservative: don't strip some entries; cloud-api isn't the right layer to half-parse arrays.
- `extract_tools_passes_through_unknown_tool_choice` — symmetric guard for `tool_choice`.

Full suite: `cargo test -p services --lib` → 315 existing + 4 new pass. `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Test plan after deploy

- [ ] Plain (no-E2EE) `POST /v1/chat/completions` to `cloud-api.near.ai` with `tools:[{\"type\":\"web_context_search\"}]` against a GLM-5.1 deployment that has `WEB_CONTEXT_SEARCH_*` env set (gpu23/04/03/26 — done in cvm-conf v0.0.191). Expect: `nearai_tool_result` chunk + `data: [DONE]`.
- [ ] Same request with E2EE headers (`X-Signing-Algo`, `X-Client-Pub-Key`). Expect: encrypted `nearai_tool_result.output` on the wire, decryptable with the client key.
- [ ] Existing chat completion + standard `function`-typed tool — should be byte-identical to today (the regression test covers this in code).

## Related

- nearai/inference-proxy#144 — server-side `web_context_search` loop in the inference-proxy.
- nearai/cvm-compose-files: digest bump + Brave env wiring to all 4 GLM-5.1 hosts (gpu23, gpu04, gpu03, gpu26).