### PR TITLE
inference_provider_pool: don't retry upstream 5xx caused by client media-fetch errors

### DIFF
--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1383,14 +1383,29 @@ impl InferenceProviderPool {
     /// the same failure. Treat these as non-retryable so one broken URL
     /// from a client doesn't get amplified into 4x backend work.
     fn is_client_media_fetch_error(message: &str) -> bool {
-        let lower = message.to_lowercase();
-        lower.contains("loading image data")
+        // ASCII-only lowercase: the markers are all ASCII and this path can
+        // run at high volume during a malformed-media incident.
+        let lower = message.to_ascii_lowercase();
+        if lower.contains("loading image data")
             || lower.contains("loading video data")
             || lower.contains("cannot identify image file")
             || lower.contains("failed to open input buffer")
-            // aiohttp wrapper format: "HTTP error 500: 4xx, message='...', url='http..."
-            // — the inference engine collapsed a client-fetch 4xx into a 500.
-            || (lower.contains(", url='http") && lower.contains(", message='"))
+        {
+            return true;
+        }
+        // aiohttp wrapper format observed when the inference engine collapses
+        // a client-fetch 4xx into a 500: `HTTP error 500: 4xx, message='...',
+        // url='http...'`. Constrain to a wrapped 4xx (\\d{2} after the leading
+        // "4") so genuinely retryable wrapped 5xx (e.g. "HTTP error 500: 503,
+        // message='Service Unavailable', url='...'") still retry as before.
+        static AIOHTTP_WRAPPED_4XX: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+        let re = AIOHTTP_WRAPPED_4XX.get_or_init(|| {
+            // (?i) is on the original message; lower is already ASCII-lowered,
+            // so an anchored lower-case literal is sufficient and faster.
+            Regex::new(r"http error 500:\s*4\d{2},\s*message='[^']*',\s*url='https?://")
+                .expect("static regex compiles")
+        });
+        re.is_match(&lower)
     }
 
     /// Single source of truth for the retry decision: the inner retry loop
@@ -3569,20 +3584,24 @@ mod tests {
 
         // Upstream 5xx caused by a broken client media URL — must NOT retry
         // (would otherwise amplify load 4x on every broken URL the client sends).
-        // SGLang gemma4 image-load failure (verbatim from prod logs):
+        // Test fixtures use dummy URLs; the matcher only depends on the marker
+        // substrings (`loading IMAGE/VIDEO data`, `cannot identify image file`,
+        // `Failed to open input buffer`, aiohttp wrapper shape).
+
+        // SGLang gemma4 image-load failure shape:
         assert_eq!(
             InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
                 status_code: 500,
-                message: "Internal server error: An exception occurred while loading IMAGE data at index 0: Error while loading data ImageData(url='https://external.fsyd15-2.fna.fbcdn.net/...'): 403 Client Error: Forbidden for url: ...".to_string(),
+                message: "Internal server error: An exception occurred while loading IMAGE data at index 0: Error while loading data ImageData(url='https://example.test/img.jpg'): 403 Client Error: Forbidden for url: ...".to_string(),
                 is_external: false,
             }),
             "non_retryable_client_media_error",
         );
-        // vLLM Qwen3.5-122B torchcodec video-load failure (verbatim from prod logs):
+        // vLLM Qwen3.5-122B torchcodec video-load failure shape:
         assert_eq!(
             InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
                 status_code: 500,
-                message: "Internal server error: An exception occurred while loading VIDEO data at index 0: Error while loading data https://www.youtube.com/watch?v=2w_pbUrVZHY: SingleStreamDecoder, Failed to open input buffer: Invalid data found when processing input".to_string(),
+                message: "Internal server error: An exception occurred while loading VIDEO data at index 0: Error while loading data https://example.test/vid: SingleStreamDecoder, Failed to open input buffer: Invalid data found when processing input".to_string(),
                 is_external: false,
             }),
             "non_retryable_client_media_error",
@@ -3596,20 +3615,41 @@ mod tests {
             }),
             "non_retryable_client_media_error",
         );
-        // aiohttp wrapper format: 500 wrapping a 4xx from a Facebook Graph URL fetch:
+        // aiohttp wrapper format: 500 wrapping a 4xx (client fetch failed):
         assert_eq!(
             InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
                 status_code: 500,
-                message: "HTTP error 500: 404, message='Not Found', url='https://www.facebook.com/v24.0/122181986942783109_1506385084189441'".to_string(),
+                message: "HTTP error 500: 404, message='Not Found', url='https://example.test/img'".to_string(),
                 is_external: false,
             }),
             "non_retryable_client_media_error",
+        );
+        // aiohttp wrapper format: 500 wrapping a 5xx (transient backend) — MUST
+        // remain retryable. The new check requires the wrapped status to be a
+        // 4xx; this guards against the regression PierreLeGuen flagged.
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: "HTTP error 500: 503, message='Service Unavailable', url='https://example.test/backend'".to_string(),
+                is_external: false,
+            }),
+            "retryable_http_5xx",
         );
         // 5xx WITHOUT the media-fetch markers — still retryable (real backend hiccup).
         assert_eq!(
             InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
                 status_code: 500,
                 message: "engine: KV cache full, retract".to_string(),
+                is_external: false,
+            }),
+            "retryable_http_5xx",
+        );
+        // Generic 5xx message that happens to contain a url=... but no
+        // wrapper-shape and no media markers — still retryable.
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: "internal: failed to dial postgres url='postgres://...' message='conn refused'".to_string(),
                 is_external: false,
             }),
             "retryable_http_5xx",

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1376,6 +1376,23 @@ impl InferenceProviderPool {
         }
     }
 
+    /// Inference engines (vLLM, SGLang) return HTTP 500 when they fail to
+    /// fetch or decode a multimodal media URL supplied by the client. The
+    /// upstream status is 5xx but the *cause* is a permanent client-input
+    /// error — retrying the same payload re-runs the same fetch and produces
+    /// the same failure. Treat these as non-retryable so one broken URL
+    /// from a client doesn't get amplified into 4x backend work.
+    fn is_client_media_fetch_error(message: &str) -> bool {
+        let lower = message.to_lowercase();
+        lower.contains("loading image data")
+            || lower.contains("loading video data")
+            || lower.contains("cannot identify image file")
+            || lower.contains("failed to open input buffer")
+            // aiohttp wrapper format: "HTTP error 500: 4xx, message='...', url='http..."
+            // — the inference engine collapsed a client-fetch 4xx into a 500.
+            || (lower.contains(", url='http") && lower.contains(", message='"))
+    }
+
     /// Single source of truth for the retry decision: the inner retry loop
     /// gates on `starts_with("retryable_")`, and the terminal error log emits
     /// the label directly so the rationale is visible in production logs.
@@ -1400,9 +1417,21 @@ impl InferenceProviderPool {
                     "non_retryable_no_keyword_match"
                 }
             }
-            CompletionError::HttpError { status_code, .. } => {
+            CompletionError::HttpError {
+                status_code,
+                message,
+                ..
+            } => {
                 if *status_code >= 500 {
-                    "retryable_http_5xx"
+                    // Engines (vLLM, SGLang) return 500 when they fail to fetch
+                    // or decode a client-supplied multimodal media URL. These
+                    // are permanent client-input errors — the same payload
+                    // can't succeed on retry. Don't amplify load by 4x.
+                    if Self::is_client_media_fetch_error(message) {
+                        "non_retryable_client_media_error"
+                    } else {
+                        "retryable_http_5xx"
+                    }
                 } else if *status_code == 429 {
                     "retryable_http_429"
                 } else if *status_code == 408 {
@@ -3536,6 +3565,54 @@ mod tests {
                 &CompletionError::Unknown(String::new())
             ),
             "non_retryable_unknown",
+        );
+
+        // Upstream 5xx caused by a broken client media URL — must NOT retry
+        // (would otherwise amplify load 4x on every broken URL the client sends).
+        // SGLang gemma4 image-load failure (verbatim from prod logs):
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: "Internal server error: An exception occurred while loading IMAGE data at index 0: Error while loading data ImageData(url='https://external.fsyd15-2.fna.fbcdn.net/...'): 403 Client Error: Forbidden for url: ...".to_string(),
+                is_external: false,
+            }),
+            "non_retryable_client_media_error",
+        );
+        // vLLM Qwen3.5-122B torchcodec video-load failure (verbatim from prod logs):
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: "Internal server error: An exception occurred while loading VIDEO data at index 0: Error while loading data https://www.youtube.com/watch?v=2w_pbUrVZHY: SingleStreamDecoder, Failed to open input buffer: Invalid data found when processing input".to_string(),
+                is_external: false,
+            }),
+            "non_retryable_client_media_error",
+        );
+        // PIL UnidentifiedImageError (client sent base64 mp4 as image_url):
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: "Internal server error: An exception occurred while loading IMAGE data at index 0: Error while loading data ...: cannot identify image file <_io.BytesIO object at 0x7f151d152b10>".to_string(),
+                is_external: false,
+            }),
+            "non_retryable_client_media_error",
+        );
+        // aiohttp wrapper format: 500 wrapping a 4xx from a Facebook Graph URL fetch:
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: "HTTP error 500: 404, message='Not Found', url='https://www.facebook.com/v24.0/122181986942783109_1506385084189441'".to_string(),
+                is_external: false,
+            }),
+            "non_retryable_client_media_error",
+        );
+        // 5xx WITHOUT the media-fetch markers — still retryable (real backend hiccup).
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: "engine: KV cache full, retract".to_string(),
+                is_external: false,
+            }),
+            "retryable_http_5xx",
         );
     }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1697,6 +1697,24 @@ impl InferenceProviderPool {
                         let retry_decision = Self::classify_retry_decision(&e);
                         let is_retryable_error = retry_decision.starts_with("retryable_");
 
+                        // Short-circuit on client-media-fetch failures the same
+                        // way as the 4xx fast-return above: the bad client URL
+                        // cannot succeed on any provider, so don't try the rest
+                        // — and don't let a later provider's retryable 5xx flip
+                        // the outer gate back to "retry the whole round," which
+                        // would re-hit this same payload on this same provider.
+                        if retry_decision == "non_retryable_client_media_error" {
+                            tracing::warn!(
+                                model_id = %model_id,
+                                attempt = attempt + 1,
+                                retry_decision,
+                                error_detail = %e,
+                                operation = operation_name,
+                                "Client media-fetch failure, not retrying or trying other providers"
+                            );
+                            return Err(Self::sanitize_completion_error(e, model_id));
+                        }
+
                         // Increment failure counter only for retryable errors —
                         // backend-health signals (5xx, timeouts, network errors).
                         // Non-retryable client-input causes (e.g. a 5xx whose body
@@ -4297,6 +4315,72 @@ mod tests {
                 assert_eq!(status_code, 400);
             }
             other => panic!("Expected HttpError, got: {:?}", other),
+        }
+    }
+
+    /// Multi-provider, alternating-error test pinning Pierre's blocker: provider
+    /// A returns a non-retryable client-media 5xx, provider B (if reached)
+    /// would return a retryable 5xx. Without the short-circuit, the for-loop
+    /// would walk through both providers; B's `retryable_*` decision would
+    /// then flip the outer gate to retry, and the round would loop hitting
+    /// provider A with the same bad payload again (~8 attempts across 4
+    /// rounds × 2 providers). With the short-circuit, provider A's media
+    /// failure returns immediately and B is never tried.
+    #[tokio::test(start_paused = true)]
+    async fn test_client_media_error_short_circuits_across_providers() {
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model_id = "Qwen/Qwen3-30B-A3B-Instruct-2507".to_string();
+        // Register two providers — Pierre's exact scenario shape.
+        for _ in 0..2 {
+            pool.register_provider(
+                model_id.clone(),
+                Arc::new(inference_providers::mock::MockProvider::new()),
+            )
+            .await;
+        }
+
+        let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_clone = attempt_count.clone();
+
+        let result: Result<((), _), _> = pool
+            .retry_with_fallback(&model_id, "test_op", None, move |_provider| {
+                let count = count_clone.clone();
+                async move {
+                    let n = count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if n == 0 {
+                        // Provider A: non-retryable client-media 5xx.
+                        Err(CompletionError::HttpError {
+                            status_code: 500,
+                            message: "Internal server error: An exception occurred \
+                                      while loading IMAGE data at index 0: cannot \
+                                      identify image file <_io.BytesIO ...>"
+                                .to_string(),
+                            is_external: false,
+                        })
+                    } else {
+                        // Provider B (and any further round) would be a transient 502.
+                        Err(CompletionError::HttpError {
+                            status_code: 502,
+                            message: "Bad gateway".to_string(),
+                            is_external: false,
+                        })
+                    }
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            attempt_count.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "client-media 5xx from the first provider must short-circuit immediately; \
+             the second provider must not be tried and the round must not retry"
+        );
+        // And the returned error must preserve the original 500 status (post-sanitize),
+        // not a 502 from a later provider.
+        match result.err().expect("err") {
+            CompletionError::HttpError { status_code, .. } => assert_eq!(status_code, 500),
+            other => panic!("Expected HttpError(500), got: {:?}", other),
         }
     }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1609,6 +1609,12 @@ impl InferenceProviderPool {
 
         // Track the last error (preserving its structure for proper status code mapping)
         let mut last_error: Option<CompletionError> = None;
+        // Retry decision computed from the RAW error before sanitization redacts
+        // URLs to `[URL_REDACTED]`. Sharing one decision across the retry gate,
+        // the failure-counter gate, and the terminal log keeps them consistent
+        // and prevents the regex matchers in classify_retry_decision from
+        // being defeated by sanitization.
+        let mut last_retry_decision: Option<&'static str> = None;
         let mut total_attempts: usize = 0;
         let mut retry_count: usize = 0;
         let started_at = std::time::Instant::now();
@@ -1684,9 +1690,20 @@ impl InferenceProviderPool {
                             }
                         }
 
-                        // Increment failure counter only for retryable errors
-                        // (5xx, timeouts, network errors — indicators of backend health issues)
-                        {
+                        // Classify the retry decision on the RAW error (before
+                        // sanitize_completion_error redacts URLs). Used for the
+                        // failure-counter gate below, the retry gate after this
+                        // loop, and the terminal "All providers failed" log.
+                        let retry_decision = Self::classify_retry_decision(&e);
+                        let is_retryable_error = retry_decision.starts_with("retryable_");
+
+                        // Increment failure counter only for retryable errors —
+                        // backend-health signals (5xx, timeouts, network errors).
+                        // Non-retryable client-input causes (e.g. a 5xx whose body
+                        // says "loading IMAGE data … cannot identify image file")
+                        // would otherwise demote a healthy backend on every broken
+                        // client URL.
+                        if is_retryable_error {
                             let mut counts = self
                                 .provider_failure_counts
                                 .write()
@@ -1703,13 +1720,17 @@ impl InferenceProviderPool {
                             attempt = attempt + 1,
                             retry = retry_count,
                             error_kind,
+                            retry_decision,
                             error_detail = %e,
                             operation = operation_name,
                             "Provider failed, will try next provider if available"
                         );
 
-                        // Sanitize and preserve the last error with its structure intact
+                        // Sanitize and preserve the last error with its structure intact.
+                        // Carry the raw-error retry decision so downstream gates and the
+                        // terminal log don't re-classify the sanitized form.
                         last_error = Some(Self::sanitize_completion_error(e, model_id));
+                        last_retry_decision = Some(retry_decision);
                     }
                 }
             }
@@ -1732,9 +1753,12 @@ impl InferenceProviderPool {
             //
             // The actual classification lives in `classify_retry_decision` (used
             // for both the retry gate and log labels) so the two can't drift.
-            let is_retryable = last_error
-                .as_ref()
-                .map(|e| Self::classify_retry_decision(e).starts_with("retryable_"))
+            // Use the decision computed from the *raw* error in the loop body —
+            // sanitize_completion_error has since redacted URLs to
+            // [URL_REDACTED], which would defeat the matcher's url='https?://
+            // anchor.
+            let is_retryable = last_retry_decision
+                .map(|d| d.starts_with("retryable_"))
                 .unwrap_or(false);
 
             if !is_retryable || retry_count >= MAX_RETRIES {
@@ -1776,10 +1800,10 @@ impl InferenceProviderPool {
             .as_ref()
             .map(Self::classify_error_kind)
             .unwrap_or("none");
-        let retry_decision = last_error
-            .as_ref()
-            .map(Self::classify_retry_decision)
-            .unwrap_or("none");
+        // Use the decision computed from the raw error in the loop body, not a
+        // re-classification of the sanitized last_error (URLs there are
+        // [URL_REDACTED] which would defeat the matcher's url-anchored regex).
+        let retry_decision = last_retry_decision.unwrap_or("none");
         let elapsed_ms = started_at.elapsed().as_millis();
         if let Some(pub_key) = model_pub_key {
             tracing::error!(
@@ -3619,7 +3643,8 @@ mod tests {
         assert_eq!(
             InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
                 status_code: 500,
-                message: "HTTP error 500: 404, message='Not Found', url='https://example.test/img'".to_string(),
+                message: "HTTP error 500: 404, message='Not Found', url='https://example.test/img'"
+                    .to_string(),
                 is_external: false,
             }),
             "non_retryable_client_media_error",
@@ -3649,10 +3674,38 @@ mod tests {
         assert_eq!(
             InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
                 status_code: 500,
-                message: "internal: failed to dial postgres url='postgres://...' message='conn refused'".to_string(),
+                message:
+                    "internal: failed to dial postgres url='postgres://...' message='conn refused'"
+                        .to_string(),
                 is_external: false,
             }),
             "retryable_http_5xx",
+        );
+
+        // Pin the sanitize-vs-classify ordering invariant:
+        // sanitize_error_message redacts URLs to `[URL_REDACTED]`, which defeats
+        // the aiohttp-wrapper regex (it anchors on `url='https?://`). The
+        // production retry loop therefore classifies BEFORE sanitization and
+        // stores the decision. If anyone later moves the classification to
+        // run on the sanitized error, this test combined with the assertions
+        // above will catch the regression: same payload, raw form classifies
+        // as non-retryable, sanitized form does not.
+        let raw_wrapped_4xx =
+            "HTTP error 500: 404, message='Not Found', url='https://example.test/img'".to_string();
+        let sanitized = InferenceProviderPool::sanitize_error_message(&raw_wrapped_4xx);
+        assert!(
+            sanitized.contains("[URL_REDACTED]"),
+            "sanitize_error_message should redact URLs (got: {sanitized})"
+        );
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::HttpError {
+                status_code: 500,
+                message: sanitized,
+                is_external: false,
+            }),
+            "retryable_http_5xx",
+            "sanitized aiohttp-wrapper must NOT match the regex — the production \
+             flow avoids this by classifying before sanitize_completion_error",
         );
     }
 


### PR DESCRIPTION
Fixes nearai/cloud-api#687.

## Summary

vLLM and SGLang return HTTP **500** when they can't fetch or decode a multimodal media URL the client supplied (broken Facebook CDN image URLs, geo-blocked YouTube videos, base64 mp4 sent as `image_url`, etc.). These are **permanent client-input errors** — the same payload re-runs the same fetch and produces the same failure. But `classify_retry_decision` treated every 5xx the same way → `retryable_http_5xx`, so each malformed request got **4 attempts** (1 + 3 retries) of identical work.

Under sustained bad-media load this 4× amplifies until the backends saturate. Observed twice:

- **2026-05-26 17:07 UTC** — `google/gemma-4-31B-it` + `Qwen/Qwen3.5-122B-A10B`, ~40 `All providers failed for model` events in 20 min, same `request_id` retried 4× each on identical broken URLs (`https://www.facebook.com/v24.0/...` returning 404, `https://www.youtube.com/watch?v=2w_pbUrVZHY` failing torchcodec).
- **2026-05-27 ~16:50 UTC** — gemma backends saturated (gpu11 queue grew to ~150) until the queue drained. cloud-api gemma went `0/5` then recovered.

## Fix

`is_client_media_fetch_error(message)` substring-matches the upstream `error_detail` body for high-confidence client-fetch markers:
- `loading image data` / `loading video data` (sglang + vLLM)
- `cannot identify image file` (PIL `UnidentifiedImageError`)
- `Failed to open input buffer` (torchcodec)
- `, url='http…` combined with `, message='…` (aiohttp wrapper format: `HTTP error 500: 404, message='Not Found', url='https://www.facebook.com/...'`)

In `classify_retry_decision`, the 5xx branch now consults this helper and returns `non_retryable_client_media_error` when it matches. The inner retry loop already gates on `starts_with("retryable_")`, so the label change is sufficient to stop the retry — no other plumbing needed.

Genuine backend 5xx (no media markers — KV-cache evictions, NCCL hiccups, OOM, etc.) still classify as `retryable_http_5xx` and retry as before.

## Same shape as #611

This is the `classify_provider_error` pattern from PR #611 (upstream auth-error masking), applied to the retry decision instead of the response classification. The two complement each other: #611 protects callers from seeing our backend-creds bugs; this protects backends from being retry-amplified by client-input bugs.

## What this does **not** do

- Doesn't change the **response status** the client sees (still 500 from the underlying upstream message). A followup could surface these as 422 with a cleaner message — out of scope to keep the diff minimal.
- Doesn't change `error_kind` (`http_5xx` stays accurate at the engine layer; only `retry_decision` flips).
- Doesn't address the root cause upstream (engines should return 4xx for media-fetch failures) — see referenced issue.

## Test plan

- [x] `cargo test -p services --lib test_classify_retry_decision` passes (added 5 new assertions: 4 verbatim from prod logs, 1 negative case to confirm non-media 500s still retry).
- [x] `cargo check -p services` clean.
- [ ] CI green.
- [ ] On rollout, watch the cloud-api `All providers failed for model` rate for `google/gemma-4-31B-it` and `Qwen/Qwen3.5-122B-A10B` — expect a significant drop in "4-attempts-same-error" patterns. Total RPS to inference backends should fall by ~3× of the malformed-media RPS.