### PR TITLE
feat(admin): fire GitHub dispatch on model PATCH (infra#153)

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1582,6 +1582,9 @@ pub fn build_admin_routes(
             as Arc<dyn services::completions::CompletionServiceTrait>,
     )) as Arc<dyn services::admin::AdminService + Send + Sync>;
 
+    let github_dispatcher =
+        services::github_dispatch::dispatcher_from_config(&config.github_dispatch);
+
     let admin_app_state = AdminAppState {
         admin_service,
         analytics_service: services.analytics_service,
@@ -1590,6 +1593,7 @@ pub fn build_admin_routes(
         config,
         admin_access_token_repository,
         inference_provider_pool: services.inference_provider_pool,
+        github_dispatcher,
     };
 
     Router::new()
@@ -1828,6 +1832,7 @@ mod tests {
             },
             cors: config::CorsConfig::default(),
             external_providers: config::ExternalProvidersConfig::default(),
+            github_dispatch: config::GitHubDispatchConfig::default(),
         };
 
         // Initialize services
@@ -1928,6 +1933,7 @@ mod tests {
             },
             cors: config::CorsConfig::default(),
             external_providers: config::ExternalProvidersConfig::default(),
+            github_dispatch: config::GitHubDispatchConfig::default(),
         };
 
         let auth_components = init_auth_services(database.clone(), &config);

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -344,22 +344,34 @@ pub async fn batch_upsert_models(
         }
     }
 
-    // Fire GitHub repository_dispatch for each upserted model. Downstream
-    // automation (validate / promote workflows in cvm-ansible-playbooks)
-    // listens for the configured event_type and reacts. Fire-and-forget:
-    // a GitHub outage does not block the PATCH. Only enabled on staging
-    // cloud-api via ENABLE_GITHUB_DISPATCH; production keeps it off so
-    // promote-driven prod PATCHes do not recursively re-fire the chain.
-    for model_id in batch_request.keys() {
+    // Fire GitHub repository_dispatch for each model this PATCH (re)loaded.
+    // Downstream automation (validate / promote workflows in
+    // cvm-ansible-playbooks) listens for the configured event_type and reacts.
+    // Fire-and-forget: a GitHub outage does not block the PATCH. Only enabled
+    // on staging cloud-api via ENABLE_GITHUB_DISPATCH; production keeps it off
+    // so promote-driven prod PATCHes do not recursively re-fire the chain.
+    //
+    // Skip deactivations: a PATCH that sets is_active=false is an unload, not a
+    // load, and must not trigger validate/promote of a model being taken
+    // offline. Dispatch the whole set from a single background task so a large
+    // batch does not burst N concurrent requests at GitHub's dispatch API
+    // (which would trip secondary rate limits and silently drop events).
+    let dispatch_model_ids: Vec<String> = batch_request
+        .iter()
+        .filter(|(_, request)| request.is_active != Some(false))
+        .map(|(model_id, _)| model_id.clone())
+        .collect();
+    if !dispatch_model_ids.is_empty() {
         let dispatcher = app_state.github_dispatcher.clone();
-        let model_id = model_id.clone();
         tokio::spawn(async move {
-            if let Err(e) = dispatcher.dispatch_model_loaded(&model_id).await {
-                tracing::warn!(
-                    error = %e,
-                    model_id = %model_id,
-                    "GitHub dispatch failed; manual workflow trigger may be required"
-                );
+            for model_id in dispatch_model_ids {
+                if let Err(e) = dispatcher.dispatch_model_loaded(&model_id).await {
+                    tracing::warn!(
+                        error = %e,
+                        model_id = %model_id,
+                        "GitHub dispatch failed; manual workflow trigger may be required"
+                    );
+                }
             }
         });
     }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -25,6 +25,7 @@ use chrono::{Duration, Utc};
 use config::ApiConfig;
 use services::admin::{AdminService, AnalyticsService, UpdateModelAdminRequest};
 use services::auth::AuthServiceTrait;
+use services::github_dispatch::GitHubDispatcher;
 use services::usage::UsageServiceTrait;
 use std::sync::Arc;
 use tracing::{debug, error};
@@ -38,6 +39,7 @@ pub struct AdminAppState {
     pub config: Arc<ApiConfig>,
     pub admin_access_token_repository: Arc<database::repositories::AdminAccessTokenRepository>,
     pub inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
+    pub github_dispatcher: Arc<dyn GitHubDispatcher>,
 }
 
 /// Batch upsert models metadata (Admin only)
@@ -340,6 +342,26 @@ pub async fn batch_upsert_models(
         {
             tracing::warn!(error = %e, "Failed to register some external providers at runtime");
         }
+    }
+
+    // Fire GitHub repository_dispatch for each upserted model. Downstream
+    // automation (validate / promote workflows in cvm-ansible-playbooks)
+    // listens for the configured event_type and reacts. Fire-and-forget:
+    // a GitHub outage does not block the PATCH. Only enabled on staging
+    // cloud-api via ENABLE_GITHUB_DISPATCH; production keeps it off so
+    // promote-driven prod PATCHes do not recursively re-fire the chain.
+    for model_id in batch_request.keys() {
+        let dispatcher = app_state.github_dispatcher.clone();
+        let model_id = model_id.clone();
+        tokio::spawn(async move {
+            if let Err(e) = dispatcher.dispatch_model_loaded(&model_id).await {
+                tracing::warn!(
+                    error = %e,
+                    model_id = %model_id,
+                    "GitHub dispatch failed; manual workflow trigger may be required"
+                );
+            }
+        });
     }
 
     // Convert to API response - map from HashMap to Vec

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -28,7 +28,7 @@ use services::auth::AuthServiceTrait;
 use services::github_dispatch::GitHubDispatcher;
 use services::usage::UsageServiceTrait;
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::{debug, error, Instrument};
 
 #[derive(Clone)]
 pub struct AdminAppState {
@@ -363,17 +363,23 @@ pub async fn batch_upsert_models(
         .collect();
     if !dispatch_model_ids.is_empty() {
         let dispatcher = app_state.github_dispatcher.clone();
-        tokio::spawn(async move {
-            for model_id in dispatch_model_ids {
-                if let Err(e) = dispatcher.dispatch_model_loaded(&model_id).await {
-                    tracing::warn!(
-                        error = %e,
-                        model_id = %model_id,
-                        "GitHub dispatch failed; manual workflow trigger may be required"
-                    );
+        // Carry the current tracing span into the fire-and-forget task;
+        // tokio::spawn does not inherit it, so dispatch-failure warnings would
+        // otherwise lose the request's log context.
+        tokio::spawn(
+            async move {
+                for model_id in dispatch_model_ids {
+                    if let Err(e) = dispatcher.dispatch_model_loaded(&model_id).await {
+                        tracing::warn!(
+                            error = %e,
+                            model_id = %model_id,
+                            "GitHub dispatch failed; manual workflow trigger may be required"
+                        );
+                    }
                 }
             }
-        });
+            .instrument(tracing::Span::current()),
+        );
     }
 
     // Convert to API response - map from HashMap to Vec

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -111,6 +111,7 @@ pub fn test_config() -> ApiConfig {
         },
         cors: config::CorsConfig::default(),
         external_providers: config::ExternalProvidersConfig::default(),
+        github_dispatch: config::GitHubDispatchConfig::default(),
     }
 }
 

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -51,11 +51,16 @@ impl ApiConfig {
     }
 }
 
+/// Default `event_type` when `GITHUB_DISPATCH_EVENT_TYPE` is unset. Shared
+/// between `from_env` and the `Default` impl so a `Default`-constructed config
+/// never dispatches with an empty type (which no workflow listens on).
+pub const DEFAULT_GITHUB_DISPATCH_EVENT_TYPE: &str = "stg_model_loaded";
+
 /// Configuration for triggering GitHub Actions workflows after admin PATCH on
 /// models. When `enabled`, a successful `PATCH /v1/admin/models` fires a
 /// `repository_dispatch` event so downstream automation (validate / promote
 /// pipelines) can react. Intended to be enabled only on staging cloud-api.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct GitHubDispatchConfig {
     pub enabled: bool,
     /// Target repo in `owner/name` form.
@@ -67,6 +72,17 @@ pub struct GitHubDispatchConfig {
     pub pat: Option<String>,
 }
 
+impl Default for GitHubDispatchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            repo: None,
+            event_type: DEFAULT_GITHUB_DISPATCH_EVENT_TYPE.to_string(),
+            pat: None,
+        }
+    }
+}
+
 impl GitHubDispatchConfig {
     pub fn from_env() -> Result<Self, String> {
         let enabled = env::var("ENABLE_GITHUB_DISPATCH")
@@ -76,14 +92,30 @@ impl GitHubDispatchConfig {
 
         let repo = non_empty_env("GITHUB_DISPATCH_REPO");
         let event_type = non_empty_env("GITHUB_DISPATCH_EVENT_TYPE")
-            .unwrap_or_else(|| "stg_model_loaded".to_string());
-        let pat = read_optional_secret_env("GITHUB_DISPATCH_PAT_FILE", "GITHUB_DISPATCH_PAT")?;
+            .unwrap_or_else(|| DEFAULT_GITHUB_DISPATCH_EVENT_TYPE.to_string());
+        // Only read the PAT (which may touch the filesystem) when enabled. A
+        // disabled instance must not fail to boot just because GITHUB_DISPATCH_PAT_FILE
+        // is set in a shared env template but the secret is not mounted.
+        let pat = if enabled {
+            read_optional_secret_env("GITHUB_DISPATCH_PAT_FILE", "GITHUB_DISPATCH_PAT")?
+        } else {
+            None
+        };
 
         if enabled {
-            if repo.is_none() {
-                return Err(
-                    "GITHUB_DISPATCH_REPO must be set when ENABLE_GITHUB_DISPATCH=true".to_string(),
-                );
+            match repo.as_deref() {
+                None => {
+                    return Err(
+                        "GITHUB_DISPATCH_REPO must be set when ENABLE_GITHUB_DISPATCH=true"
+                            .to_string(),
+                    );
+                }
+                Some(r) if !is_owner_name(r) => {
+                    return Err(format!(
+                        "GITHUB_DISPATCH_REPO must be in 'owner/name' form, got '{r}'"
+                    ));
+                }
+                _ => {}
             }
             if pat.is_none() {
                 return Err(
@@ -100,6 +132,15 @@ impl GitHubDispatchConfig {
             pat,
         })
     }
+}
+
+/// `true` when `s` is `owner/name`: exactly one `/` with both sides non-empty.
+fn is_owner_name(s: &str) -> bool {
+    let mut parts = s.split('/');
+    matches!(
+        (parts.next(), parts.next(), parts.next()),
+        (Some(owner), Some(name), None) if !owner.is_empty() && !name.is_empty()
+    )
 }
 
 /// Database configuration
@@ -599,6 +640,106 @@ mod tests {
 
         // Should return false when no admin domains configured
         assert!(!config.is_admin_email("admin@near.ai"));
+    }
+
+    fn clear_github_dispatch_env() {
+        for key in [
+            "ENABLE_GITHUB_DISPATCH",
+            "GITHUB_DISPATCH_REPO",
+            "GITHUB_DISPATCH_EVENT_TYPE",
+            "GITHUB_DISPATCH_PAT",
+            "GITHUB_DISPATCH_PAT_FILE",
+        ] {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn github_dispatch_disabled_by_default() {
+        clear_github_dispatch_env();
+        let config = GitHubDispatchConfig::from_env().unwrap();
+        assert!(!config.enabled);
+        assert!(config.repo.is_none());
+        assert!(config.pat.is_none());
+        assert_eq!(config.event_type, DEFAULT_GITHUB_DISPATCH_EVENT_TYPE);
+    }
+
+    #[test]
+    #[serial]
+    fn github_dispatch_default_matches_from_env_event_type() {
+        // The Default impl must agree with from_env's fallback so a
+        // Default-constructed config never carries an empty event_type.
+        assert_eq!(
+            GitHubDispatchConfig::default().event_type,
+            DEFAULT_GITHUB_DISPATCH_EVENT_TYPE
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn github_dispatch_disabled_ignores_unreadable_pat_file() {
+        // Regression: a disabled instance must boot even when PAT_FILE points
+        // at a missing secret (e.g. left in a shared env template).
+        clear_github_dispatch_env();
+        std::env::set_var("ENABLE_GITHUB_DISPATCH", "false");
+        std::env::set_var(
+            "GITHUB_DISPATCH_PAT_FILE",
+            "/nonexistent/github_dispatch_pat",
+        );
+        let config = GitHubDispatchConfig::from_env().unwrap();
+        assert!(!config.enabled);
+        assert!(config.pat.is_none());
+        clear_github_dispatch_env();
+    }
+
+    #[test]
+    #[serial]
+    fn github_dispatch_enabled_requires_repo() {
+        clear_github_dispatch_env();
+        std::env::set_var("ENABLE_GITHUB_DISPATCH", "true");
+        std::env::set_var("GITHUB_DISPATCH_PAT", "ghp_test");
+        let err = GitHubDispatchConfig::from_env().unwrap_err();
+        assert!(err.contains("GITHUB_DISPATCH_REPO"));
+        clear_github_dispatch_env();
+    }
+
+    #[test]
+    #[serial]
+    fn github_dispatch_enabled_requires_pat() {
+        clear_github_dispatch_env();
+        std::env::set_var("ENABLE_GITHUB_DISPATCH", "true");
+        std::env::set_var("GITHUB_DISPATCH_REPO", "nearai/cvm-ansible-playbooks");
+        let err = GitHubDispatchConfig::from_env().unwrap_err();
+        assert!(err.contains("PAT"));
+        clear_github_dispatch_env();
+    }
+
+    #[test]
+    #[serial]
+    fn github_dispatch_enabled_rejects_malformed_repo() {
+        clear_github_dispatch_env();
+        std::env::set_var("ENABLE_GITHUB_DISPATCH", "true");
+        std::env::set_var("GITHUB_DISPATCH_REPO", "noslash");
+        std::env::set_var("GITHUB_DISPATCH_PAT", "ghp_test");
+        let err = GitHubDispatchConfig::from_env().unwrap_err();
+        assert!(err.contains("owner/name"));
+        clear_github_dispatch_env();
+    }
+
+    #[test]
+    #[serial]
+    fn github_dispatch_enabled_ok_with_inline_pat() {
+        clear_github_dispatch_env();
+        std::env::set_var("ENABLE_GITHUB_DISPATCH", "true");
+        std::env::set_var("GITHUB_DISPATCH_REPO", "nearai/cvm-ansible-playbooks");
+        std::env::set_var("GITHUB_DISPATCH_PAT", "ghp_test");
+        let config = GitHubDispatchConfig::from_env().unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.repo.as_deref(), Some("nearai/cvm-ansible-playbooks"));
+        assert_eq!(config.pat.as_deref(), Some("ghp_test"));
+        assert_eq!(config.event_type, DEFAULT_GITHUB_DISPATCH_EVENT_TYPE);
+        clear_github_dispatch_env();
     }
 
     #[test]

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -19,6 +19,7 @@ pub struct ApiConfig {
     pub otlp: OtlpConfig,
     pub cors: CorsConfig,
     pub external_providers: ExternalProvidersConfig,
+    pub github_dispatch: GitHubDispatchConfig,
 }
 
 impl ApiConfig {
@@ -45,6 +46,58 @@ impl ApiConfig {
             otlp: OtlpConfig::from_env()?,
             cors: CorsConfig::default(),
             external_providers: ExternalProvidersConfig::from_env(),
+            github_dispatch: GitHubDispatchConfig::from_env()?,
+        })
+    }
+}
+
+/// Configuration for triggering GitHub Actions workflows after admin PATCH on
+/// models. When `enabled`, a successful `PATCH /v1/admin/models` fires a
+/// `repository_dispatch` event so downstream automation (validate / promote
+/// pipelines) can react. Intended to be enabled only on staging cloud-api.
+#[derive(Debug, Clone, Default)]
+pub struct GitHubDispatchConfig {
+    pub enabled: bool,
+    /// Target repo in `owner/name` form.
+    pub repo: Option<String>,
+    /// `event_type` field in the dispatch payload. Workflows listen on
+    /// `on: repository_dispatch: types: [<event_type>]`.
+    pub event_type: String,
+    /// Fine-grained PAT with `actions: write` scoped to `repo` only.
+    pub pat: Option<String>,
+}
+
+impl GitHubDispatchConfig {
+    pub fn from_env() -> Result<Self, String> {
+        let enabled = env::var("ENABLE_GITHUB_DISPATCH")
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false);
+
+        let repo = non_empty_env("GITHUB_DISPATCH_REPO");
+        let event_type = non_empty_env("GITHUB_DISPATCH_EVENT_TYPE")
+            .unwrap_or_else(|| "stg_model_loaded".to_string());
+        let pat = read_optional_secret_env("GITHUB_DISPATCH_PAT_FILE", "GITHUB_DISPATCH_PAT")?;
+
+        if enabled {
+            if repo.is_none() {
+                return Err(
+                    "GITHUB_DISPATCH_REPO must be set when ENABLE_GITHUB_DISPATCH=true".to_string(),
+                );
+            }
+            if pat.is_none() {
+                return Err(
+                    "GITHUB_DISPATCH_PAT or GITHUB_DISPATCH_PAT_FILE must be set when ENABLE_GITHUB_DISPATCH=true"
+                        .to_string(),
+                );
+            }
+        }
+
+        Ok(Self {
+            enabled,
+            repo,
+            event_type,
+            pat,
         })
     }
 }

--- a/crates/services/src/github_dispatch/mod.rs
+++ b/crates/services/src/github_dispatch/mod.rs
@@ -7,7 +7,7 @@
 //! the configured `event_type` and react to the loaded model.
 //!
 //! Failures are intentionally non-fatal: GitHub being unreachable must not
-//! block model registration. Errors are logged and surfaced via metrics so
+//! block model registration. Errors are logged at WARN by the caller so
 //! operators can fall back to a manual `gh workflow run` trigger.
 
 use async_trait::async_trait;
@@ -91,38 +91,44 @@ impl DispatchTransport for ReqwestDispatchTransport {
         pat: &str,
         request: DispatchRequest,
     ) -> Result<(), GitHubDispatchError> {
-        let response = tokio::time::timeout(
-            DISPATCH_TIMEOUT,
-            self.client
+        // Wrap the whole exchange — send AND error-body read — in one timeout.
+        // reqwest has no client-level timeout configured, so reading the body
+        // of a stalled error response would otherwise hang the spawned task.
+        let exchange = async {
+            let response = self
+                .client
                 .post(endpoint)
                 .bearer_auth(pat)
                 .header("Accept", "application/vnd.github+json")
                 .header("X-GitHub-Api-Version", "2022-11-28")
                 .header("User-Agent", USER_AGENT)
                 .json(&request)
-                .send(),
-        )
-        .await
-        .map_err(|_| {
-            GitHubDispatchError::new(format!(
-                "GitHub dispatch timed out after {}s",
-                DISPATCH_TIMEOUT.as_secs()
-            ))
-        })?
-        .map_err(|err| {
-            GitHubDispatchError::new(format!("GitHub dispatch request failed: {err}"))
-        })?;
+                .send()
+                .await
+                .map_err(|err| {
+                    GitHubDispatchError::new(format!("GitHub dispatch request failed: {err}"))
+                })?;
 
-        let status = response.status();
-        if status.is_success() {
-            return Ok(());
-        }
+            let status = response.status();
+            if status.is_success() {
+                return Ok(());
+            }
 
-        let body = response.text().await.unwrap_or_default();
-        Err(GitHubDispatchError::new(format!(
-            "GitHub dispatch returned HTTP {status}: {}",
-            truncate(&body, 200)
-        )))
+            let body = response.text().await.unwrap_or_default();
+            Err(GitHubDispatchError::new(format!(
+                "GitHub dispatch returned HTTP {status}: {}",
+                crate::email::sanitize_error(&body)
+            )))
+        };
+
+        tokio::time::timeout(DISPATCH_TIMEOUT, exchange)
+            .await
+            .map_err(|_| {
+                GitHubDispatchError::new(format!(
+                    "GitHub dispatch timed out after {}s",
+                    DISPATCH_TIMEOUT.as_secs()
+                ))
+            })?
     }
 }
 
@@ -183,16 +189,6 @@ pub fn dispatcher_from_config(config: &GitHubDispatchConfig) -> Arc<dyn GitHubDi
         GITHUB_API_BASE.to_string(),
         Arc::new(ReqwestDispatchTransport::default()),
     ))
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let mut truncated = s.chars().take(max).collect::<String>();
-        truncated.push('…');
-        truncated
-    }
 }
 
 #[cfg(test)]

--- a/crates/services/src/github_dispatch/mod.rs
+++ b/crates/services/src/github_dispatch/mod.rs
@@ -1,0 +1,310 @@
+//! GitHub `repository_dispatch` notifier.
+//!
+//! When a successful `PATCH /v1/admin/models` lands on a cloud-api with
+//! `ENABLE_GITHUB_DISPATCH=true`, the admin handler spawns a fire-and-forget
+//! task here that POSTs to GitHub's `repos/{owner}/{name}/dispatches` API.
+//! Downstream GH Actions workflows (validate / promote / rollback) listen on
+//! the configured `event_type` and react to the loaded model.
+//!
+//! Failures are intentionally non-fatal: GitHub being unreachable must not
+//! block model registration. Errors are logged and surfaced via metrics so
+//! operators can fall back to a manual `gh workflow run` trigger.
+
+use async_trait::async_trait;
+use config::GitHubDispatchConfig;
+use serde::Serialize;
+use std::{sync::Arc, time::Duration};
+
+const GITHUB_API_BASE: &str = "https://api.github.com";
+const DISPATCH_TIMEOUT: Duration = Duration::from_secs(10);
+const USER_AGENT: &str = "nearai-cloud-api/github-dispatch";
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
+pub struct GitHubDispatchError {
+    message: String,
+}
+
+impl GitHubDispatchError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+#[async_trait]
+pub trait GitHubDispatcher: Send + Sync {
+    /// Fire a `repository_dispatch` event for the given model id. Returns
+    /// `Ok(())` for both the disabled-noop case and a successful POST.
+    async fn dispatch_model_loaded(&self, model_id: &str) -> Result<(), GitHubDispatchError>;
+}
+
+pub struct NoopGitHubDispatcher;
+
+#[async_trait]
+impl GitHubDispatcher for NoopGitHubDispatcher {
+    async fn dispatch_model_loaded(&self, _model_id: &str) -> Result<(), GitHubDispatchError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DispatchRequest {
+    event_type: String,
+    client_payload: DispatchPayload,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DispatchPayload {
+    model_id: String,
+}
+
+#[async_trait]
+trait DispatchTransport: Send + Sync {
+    async fn dispatch(
+        &self,
+        endpoint: &str,
+        pat: &str,
+        request: DispatchRequest,
+    ) -> Result<(), GitHubDispatchError>;
+}
+
+#[derive(Clone)]
+struct ReqwestDispatchTransport {
+    client: reqwest::Client,
+}
+
+impl Default for ReqwestDispatchTransport {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl DispatchTransport for ReqwestDispatchTransport {
+    async fn dispatch(
+        &self,
+        endpoint: &str,
+        pat: &str,
+        request: DispatchRequest,
+    ) -> Result<(), GitHubDispatchError> {
+        let response = tokio::time::timeout(
+            DISPATCH_TIMEOUT,
+            self.client
+                .post(endpoint)
+                .bearer_auth(pat)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .header("User-Agent", USER_AGENT)
+                .json(&request)
+                .send(),
+        )
+        .await
+        .map_err(|_| {
+            GitHubDispatchError::new(format!(
+                "GitHub dispatch timed out after {}s",
+                DISPATCH_TIMEOUT.as_secs()
+            ))
+        })?
+        .map_err(|err| {
+            GitHubDispatchError::new(format!("GitHub dispatch request failed: {err}"))
+        })?;
+
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        Err(GitHubDispatchError::new(format!(
+            "GitHub dispatch returned HTTP {status}: {}",
+            truncate(&body, 200)
+        )))
+    }
+}
+
+pub struct HttpGitHubDispatcher {
+    repo: String,
+    event_type: String,
+    pat: String,
+    base_url: String,
+    transport: Arc<dyn DispatchTransport>,
+}
+
+impl HttpGitHubDispatcher {
+    fn new(
+        repo: String,
+        event_type: String,
+        pat: String,
+        base_url: String,
+        transport: Arc<dyn DispatchTransport>,
+    ) -> Self {
+        Self {
+            repo,
+            event_type,
+            pat,
+            base_url,
+            transport,
+        }
+    }
+}
+
+#[async_trait]
+impl GitHubDispatcher for HttpGitHubDispatcher {
+    async fn dispatch_model_loaded(&self, model_id: &str) -> Result<(), GitHubDispatchError> {
+        let endpoint = format!("{}/repos/{}/dispatches", self.base_url, self.repo);
+        let request = DispatchRequest {
+            event_type: self.event_type.clone(),
+            client_payload: DispatchPayload {
+                model_id: model_id.to_string(),
+            },
+        };
+        self.transport.dispatch(&endpoint, &self.pat, request).await
+    }
+}
+
+/// Build a dispatcher from config. Returns `NoopGitHubDispatcher` when the
+/// feature flag is off or when required fields are missing (config validation
+/// already enforces this when enabled, so the noop fallback here is defensive).
+pub fn dispatcher_from_config(config: &GitHubDispatchConfig) -> Arc<dyn GitHubDispatcher> {
+    if !config.enabled {
+        return Arc::new(NoopGitHubDispatcher);
+    }
+    let (Some(repo), Some(pat)) = (config.repo.clone(), config.pat.clone()) else {
+        return Arc::new(NoopGitHubDispatcher);
+    };
+    Arc::new(HttpGitHubDispatcher::new(
+        repo,
+        config.event_type.clone(),
+        pat,
+        GITHUB_API_BASE.to_string(),
+        Arc::new(ReqwestDispatchTransport::default()),
+    ))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut truncated = s.chars().take(max).collect::<String>();
+        truncated.push('…');
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct StubTransport {
+        outcome: Mutex<Result<(), GitHubDispatchError>>,
+        calls: Mutex<Vec<(String, String, DispatchRequest)>>,
+    }
+
+    impl StubTransport {
+        fn new(outcome: Result<(), GitHubDispatchError>) -> Self {
+            Self {
+                outcome: Mutex::new(outcome),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl DispatchTransport for StubTransport {
+        async fn dispatch(
+            &self,
+            endpoint: &str,
+            pat: &str,
+            request: DispatchRequest,
+        ) -> Result<(), GitHubDispatchError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((endpoint.to_string(), pat.to_string(), request));
+            self.outcome.lock().unwrap().clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn noop_dispatcher_returns_ok() {
+        let dispatcher = NoopGitHubDispatcher;
+        let result = dispatcher.dispatch_model_loaded("glm-5.1").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn http_dispatcher_posts_expected_payload() {
+        let transport = Arc::new(StubTransport::new(Ok(())));
+        let dispatcher = HttpGitHubDispatcher::new(
+            "nearai/cvm-ansible-playbooks".to_string(),
+            "stg_model_loaded".to_string(),
+            "ghp_test".to_string(),
+            "https://api.example.test".to_string(),
+            transport.clone(),
+        );
+
+        dispatcher.dispatch_model_loaded("glm-5.1").await.unwrap();
+
+        let calls = transport.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let (endpoint, pat, request) = &calls[0];
+        assert_eq!(
+            endpoint,
+            "https://api.example.test/repos/nearai/cvm-ansible-playbooks/dispatches"
+        );
+        assert_eq!(pat, "ghp_test");
+        assert_eq!(request.event_type, "stg_model_loaded");
+        assert_eq!(request.client_payload.model_id, "glm-5.1");
+    }
+
+    #[tokio::test]
+    async fn http_dispatcher_propagates_transport_error() {
+        let transport = Arc::new(StubTransport::new(Err(GitHubDispatchError::new("boom"))));
+        let dispatcher = HttpGitHubDispatcher::new(
+            "nearai/cvm-ansible-playbooks".to_string(),
+            "stg_model_loaded".to_string(),
+            "ghp_test".to_string(),
+            "https://api.example.test".to_string(),
+            transport,
+        );
+
+        let err = dispatcher
+            .dispatch_model_loaded("glm-5.1")
+            .await
+            .unwrap_err();
+        assert_eq!(format!("{err}"), "boom");
+    }
+
+    #[tokio::test]
+    async fn factory_returns_noop_when_disabled() {
+        let config = GitHubDispatchConfig {
+            enabled: false,
+            repo: Some("nearai/cvm-ansible-playbooks".to_string()),
+            event_type: "stg_model_loaded".to_string(),
+            pat: Some("ghp_test".to_string()),
+        };
+
+        let dispatcher = dispatcher_from_config(&config);
+        // Verify by calling — noop returns Ok regardless of repo/pat presence.
+        dispatcher.dispatch_model_loaded("glm-5.1").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn factory_returns_noop_when_enabled_but_fields_missing() {
+        let config = GitHubDispatchConfig {
+            enabled: true,
+            repo: None,
+            event_type: "stg_model_loaded".to_string(),
+            pat: None,
+        };
+
+        let dispatcher = dispatcher_from_config(&config);
+        // Defensive fallback: missing fields downgrade to noop instead of panicking.
+        dispatcher.dispatch_model_loaded("glm-5.1").await.unwrap();
+    }
+}

--- a/crates/services/src/github_dispatch/mod.rs
+++ b/crates/services/src/github_dispatch/mod.rs
@@ -180,6 +180,10 @@ pub fn dispatcher_from_config(config: &GitHubDispatchConfig) -> Arc<dyn GitHubDi
         return Arc::new(NoopGitHubDispatcher);
     }
     let (Some(repo), Some(pat)) = (config.repo.clone(), config.pat.clone()) else {
+        tracing::error!(
+            "GitHub dispatch enabled but repo/PAT missing; falling back to noop. \
+             Config validation should reject this — the chain is now silently disabled."
+        );
         return Arc::new(NoopGitHubDispatcher);
     };
     Arc::new(HttpGitHubDispatcher::new(

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -7,6 +7,7 @@ pub mod completions;
 pub mod conversations;
 pub mod email;
 pub mod files;
+pub mod github_dispatch;
 pub mod id_prefixes;
 pub mod inference_provider_pool;
 pub mod mcp;

--- a/env.example
+++ b/env.example
@@ -202,3 +202,18 @@ ENVIRONMENT=local
 BRAVE_SEARCH_PRO_API_KEY=MY_KEY
 # Optional. Falls back to BRAVE_SEARCH_PRO_API_KEY when unset.
 # BRAVE_LLM_CONTEXT_API_KEY=MY_KEY
+
+# =============================================================================
+# GitHub repository_dispatch on admin model PATCH
+# =============================================================================
+# When enabled, a successful PATCH /v1/admin/models fires a GitHub
+# repository_dispatch event so downstream automation (model onboarding
+# pipelines in cvm-ansible-playbooks) can react. Only enable on staging
+# cloud-api; production keeps it off to avoid recursion when promote
+# workflows PATCH prod.
+# ENABLE_GITHUB_DISPATCH=false
+# GITHUB_DISPATCH_REPO=nearai/cvm-ansible-playbooks
+# GITHUB_DISPATCH_EVENT_TYPE=stg_model_loaded
+# Provide PAT either inline or via file path (file pattern matches other secrets)
+# GITHUB_DISPATCH_PAT=ghp_...
+# GITHUB_DISPATCH_PAT_FILE=/run/secrets/github_dispatch_pat


### PR DESCRIPTION
## Summary

After a successful `PATCH /v1/admin/models`, cloud-api now spawns a fire-and-forget GitHub `repository_dispatch` event per upserted model id. Downstream automation in `nearai/cvm-ansible-playbooks` listens for the configured `event_type` and kicks off the validate-model-staging workflow.

Part of [infra#153](https://github.com/nearai/infra/issues/153) — the trigger mechanism for the model onboarding chain.

## How it works

- New `services::github_dispatch` module mirrors the `email` service pattern: trait + noop impl + reqwest impl + factory + mockable transport.
- `AdminAppState` gets an `Arc<dyn GitHubDispatcher>` field. Built once at startup from `config.github_dispatch`.
- `batch_upsert_models` handler loops over upserted model ids after registration completes and `tokio::spawn`s the dispatch. Errors are logged at WARN; the PATCH response is unaffected.

## Configuration

Off by default. Enable on **staging cloud-api only** (production keeps it off so promote-driven prod PATCHes don't recursively re-fire the chain):

```
ENABLE_GITHUB_DISPATCH=true
GITHUB_DISPATCH_REPO=nearai/cvm-ansible-playbooks
GITHUB_DISPATCH_EVENT_TYPE=stg_model_loaded
GITHUB_DISPATCH_PAT_FILE=/run/secrets/github_dispatch_pat
```

PAT scope: fine-grained, `actions: write` on cvm-ansible-playbooks only. Rotate every 90 days. Eventual goal: replace with a GitHub App.

When enabled, missing `GITHUB_DISPATCH_REPO` or PAT will fail config validation at startup (not silently degrade). When disabled, the dispatcher is a noop and consumes no resources.

## Test plan

- [x] `cargo test --lib --bins` — 321 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] After merge + deploy to cloud-stg-api: PATCH a test model, verify `repository_dispatch` event arrives at cvm-ansible-playbooks (will land in a no-op workflow until the validate workflow is built in the follow-up PR)
- [ ] Verify failure path: revoke PAT, PATCH a model, confirm PATCH still succeeds with a WARN log entry

## Out of scope (follow-up work)

- `validate-model-staging.yml` workflow in cvm-ansible-playbooks (consumer of this dispatch)
- `promote-model-prod.yml`, `rollback-model-prod.yml`
- New generic tests in `infra-tests` (tool_call_generic, e2ee, signature_retrieval, load_smoke)