### PR TITLE
[codex] Expose inactive admin users

### DIFF
--- a/crates/api/src/conversions.rs
+++ b/crates/api/src/conversions.rs
@@ -667,6 +667,8 @@ pub fn db_user_to_admin_user(user: &database::User) -> AdminUserResponse {
         created_at: user.created_at,
         last_login_at: user.last_login_at,
         is_active: user.is_active,
+        auth_provider: user.auth_provider.clone(),
+        provider_user_id: user.provider_user_id.clone(),
         organizations: None,
     }
 }

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -2370,6 +2370,8 @@ pub struct AdminUserResponse {
     pub created_at: DateTime<Utc>,
     pub last_login_at: Option<DateTime<Utc>>,
     pub is_active: bool,
+    pub auth_provider: String,
+    pub provider_user_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organizations: Option<Vec<AdminUserOrganizationDetails>>,
 }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -1174,7 +1174,9 @@ pub async fn deprecate_model(
         ("limit" = Option<i64>, Query, description = "Maximum number of users to return (default: 100)"),
         ("offset" = Option<i64>, Query, description = "Number of users to skip (default: 0)"),
         ("include_organizations" = Option<bool>, Query, description = "Whether to include organization information and spend limits for the first organization owned by each user (default: false)"),
-        ("search_by_name" = Option<String>, Query, description = "Filter users by organization name (case-insensitive match). Only effective when include_organizations=true; ignored otherwise.")
+        ("search" = Option<String>, Query, description = "Filter users by email, username, display name, user id, auth provider, or provider user id (case-insensitive partial match)."),
+        ("is_active" = Option<bool>, Query, description = "Filter users by active status. Omit to include active and inactive users."),
+        ("search_by_name" = Option<String>, Query, description = "Filter users by organization name (case-insensitive match). Only effective when include_organizations=true; separate from user search.")
     ),
     responses(
         (status = 200, description = "Users retrieved successfully", body = ListUsersResponse),
@@ -1193,15 +1195,26 @@ pub async fn list_users(
     crate::routes::common::validate_limit_offset(params.limit, params.offset)?;
 
     debug!(
-        "List users request with limit={}, offset={}, include_organizations={}, search_by_name={:?}",
-        params.limit, params.offset, params.include_organizations, params.search_by_name
+        "List users request with limit={}, offset={}, include_organizations={}, search={:?}, is_active={:?}, search_by_name={:?}",
+        params.limit,
+        params.offset,
+        params.include_organizations,
+        params.search,
+        params.is_active,
+        params.search_by_name
     );
 
     let (user_responses, total) = if params.include_organizations {
         // Fetch users with their default organization and spend limit
         let (users_with_orgs, total) = app_state
             .admin_service
-            .list_users_with_organizations(params.limit, params.offset, params.search_by_name)
+            .list_users_with_organizations(
+                params.limit,
+                params.offset,
+                params.search.clone(),
+                params.is_active,
+                params.search_by_name.clone(),
+            )
             .await
             .map_err(|e| {
                 error!("Failed to list users with organizations");
@@ -1253,6 +1266,8 @@ pub async fn list_users(
                     created_at: u.created_at,
                     last_login_at: u.last_login_at,
                     is_active: u.is_active,
+                    auth_provider: u.auth_provider,
+                    provider_user_id: u.provider_user_id,
                     organizations,
                 }
             })
@@ -1263,7 +1278,12 @@ pub async fn list_users(
         // Return users data only
         let (users, total) = app_state
             .admin_service
-            .list_users(params.limit, params.offset)
+            .list_users(
+                params.limit,
+                params.offset,
+                params.search.clone(),
+                params.is_active,
+            )
             .await
             .map_err(|e| {
                 error!("Failed to list users");
@@ -1293,6 +1313,8 @@ pub async fn list_users(
                 created_at: u.created_at,
                 last_login_at: u.last_login_at,
                 is_active: u.is_active,
+                auth_provider: u.auth_provider,
+                provider_user_id: u.provider_user_id,
                 organizations: None,
             })
             .collect();
@@ -1763,6 +1785,8 @@ pub struct ListUsersQueryParams {
     pub offset: i64,
     #[serde(default)]
     pub include_organizations: bool,
+    pub search: Option<String>,
+    pub is_active: Option<bool>,
     pub search_by_name: Option<String>,
 }
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -1195,13 +1195,21 @@ pub async fn list_users(
     crate::routes::common::validate_limit_offset(params.limit, params.offset)?;
 
     debug!(
-        "List users request with limit={}, offset={}, include_organizations={}, search={:?}, is_active={:?}, search_by_name={:?}",
+        "List users request with limit={}, offset={}, include_organizations={}, has_search={}, is_active={:?}, has_search_by_name={}",
         params.limit,
         params.offset,
         params.include_organizations,
-        params.search,
+        params
+            .search
+            .as_ref()
+            .map(|search| !search.is_empty())
+            .unwrap_or(false),
         params.is_active,
-        params.search_by_name
+        params
+            .search_by_name
+            .as_ref()
+            .map(|search| !search.is_empty())
+            .unwrap_or(false)
     );
 
     let (user_responses, total) = if params.include_organizations {

--- a/crates/api/tests/e2e_all/general.rs
+++ b/crates/api/tests/e2e_all/general.rs
@@ -2919,6 +2919,19 @@ async fn test_admin_list_users_finds_inactive_and_oauth_identity_fields() {
     assert!(!with_orgs.users[0].is_active);
     assert_eq!(with_orgs.users[0].auth_provider, "google");
     assert_eq!(with_orgs.users[0].provider_user_id, provider_user_id);
+
+    let unrelated_org_name = format!("missing-org-{suffix}");
+    let org_name_response = server
+        .get(&format!(
+            "/v1/admin/users?limit=10&offset=0&include_organizations=true&search_by_name={unrelated_org_name}"
+        ))
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await;
+
+    assert_eq!(org_name_response.status_code(), 200);
+    let org_name_search = org_name_response.json::<api::models::ListUsersResponse>();
+    assert_eq!(org_name_search.total, 0);
+    assert!(org_name_search.users.is_empty());
 }
 
 #[tokio::test]

--- a/crates/api/tests/e2e_all/general.rs
+++ b/crates/api/tests/e2e_all/general.rs
@@ -2828,6 +2828,100 @@ async fn test_admin_list_users_with_orgs() {
 }
 
 #[tokio::test]
+async fn test_admin_list_users_finds_inactive_and_oauth_identity_fields() {
+    let (server, database) = setup_test_server_with_database().await;
+    let access_token = get_access_token_from_refresh_token(&server, get_session_id()).await;
+
+    let user_id = uuid::Uuid::new_v4();
+    let suffix = user_id.simple();
+    let email = format!("inactive-admin-search-{suffix}@example.com");
+    let username = format!("inactive-search-{suffix}");
+    let display_name = format!("Inactive Search {suffix}");
+    let provider_user_id = format!("google-sub-{suffix}");
+
+    let client = database
+        .pool()
+        .get()
+        .await
+        .expect("Failed to get database connection");
+    client
+        .execute(
+            r#"
+            INSERT INTO users (
+                id, email, username, display_name, avatar_url,
+                created_at, updated_at, is_active,
+                auth_provider, provider_user_id
+            )
+            VALUES ($1, $2, $3, $4, NULL, NOW(), NOW(), false, 'google', $5)
+            "#,
+            &[
+                &user_id,
+                &email,
+                &username,
+                &display_name,
+                &provider_user_id,
+            ],
+        )
+        .await
+        .expect("Failed to insert inactive user");
+
+    let response = server
+        .get(&format!("/v1/admin/users?limit=10&offset=0&search={email}"))
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+    let users_response = response.json::<api::models::ListUsersResponse>();
+    assert_eq!(users_response.total, 1);
+    assert_eq!(users_response.users.len(), 1);
+    let user = users_response.users.first().unwrap();
+    assert_eq!(user.id, user_id.to_string());
+    assert_eq!(user.email, email);
+    assert!(!user.is_active);
+    assert_eq!(user.auth_provider, "google");
+    assert_eq!(user.provider_user_id, provider_user_id);
+
+    let active_only_response = server
+        .get(&format!(
+            "/v1/admin/users?limit=10&offset=0&search={email}&is_active=true"
+        ))
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await;
+
+    assert_eq!(active_only_response.status_code(), 200);
+    let active_only = active_only_response.json::<api::models::ListUsersResponse>();
+    assert_eq!(active_only.total, 0);
+    assert!(active_only.users.is_empty());
+
+    let provider_response = server
+        .get(&format!(
+            "/v1/admin/users?limit=10&offset=0&search={provider_user_id}&is_active=false"
+        ))
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await;
+
+    assert_eq!(provider_response.status_code(), 200);
+    let provider_search = provider_response.json::<api::models::ListUsersResponse>();
+    assert_eq!(provider_search.total, 1);
+    assert_eq!(provider_search.users[0].email, email);
+
+    let with_orgs_response = server
+        .get(&format!(
+            "/v1/admin/users?limit=10&offset=0&include_organizations=true&search={email}"
+        ))
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await;
+
+    assert_eq!(with_orgs_response.status_code(), 200);
+    let with_orgs = with_orgs_response.json::<api::models::ListUsersResponse>();
+    assert_eq!(with_orgs.total, 1);
+    assert_eq!(with_orgs.users[0].email, email);
+    assert!(!with_orgs.users[0].is_active);
+    assert_eq!(with_orgs.users[0].auth_provider, "google");
+    assert_eq!(with_orgs.users[0].provider_user_id, provider_user_id);
+}
+
+#[tokio::test]
 #[ignore = "skip the test as the user has created orgs in other tests"]
 async fn test_admin_list_users_with_organizations() {
     let server = setup_test_server().await;

--- a/crates/database/src/repositories/admin_composite.rs
+++ b/crates/database/src/repositories/admin_composite.rs
@@ -555,10 +555,19 @@ impl AdminRepository for AdminCompositeRepository {
             .collect())
     }
 
-    async fn list_users(&self, limit: i64, offset: i64) -> Result<Vec<UserInfo>> {
-        let users = self.user_repo.list(limit, offset).await?;
+    async fn list_users(
+        &self,
+        limit: i64,
+        offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
+    ) -> Result<(Vec<UserInfo>, i64)> {
+        let (users, total) = self
+            .user_repo
+            .list_admin(limit, offset, search, is_active)
+            .await?;
 
-        Ok(users
+        let users = users
             .into_iter()
             .map(|u| UserInfo {
                 id: u.id,
@@ -569,19 +578,25 @@ impl AdminRepository for AdminCompositeRepository {
                 created_at: u.created_at,
                 last_login_at: u.last_login_at,
                 is_active: u.is_active,
+                auth_provider: u.auth_provider,
+                provider_user_id: u.provider_user_id,
             })
-            .collect())
+            .collect();
+
+        Ok((users, total))
     }
 
     async fn list_users_with_organizations(
         &self,
         limit: i64,
         offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
         search_by_name: Option<String>,
     ) -> Result<(Vec<(UserInfo, Option<UserOrganizationInfo>)>, i64)> {
         let (users_with_orgs, total_count) = self
             .user_repo
-            .list_with_organizations(limit, offset, search_by_name)
+            .list_with_organizations(limit, offset, search, is_active, search_by_name)
             .await?;
 
         let result = users_with_orgs
@@ -596,16 +611,14 @@ impl AdminRepository for AdminCompositeRepository {
                     created_at: u.created_at,
                     last_login_at: u.last_login_at,
                     is_active: u.is_active,
+                    auth_provider: u.auth_provider,
+                    provider_user_id: u.provider_user_id,
                 };
                 (user_info, org_data)
             })
             .collect();
 
         Ok((result, total_count))
-    }
-
-    async fn get_active_user_count(&self) -> Result<i64> {
-        self.user_repo.get_active_user_count().await
     }
 
     async fn list_models(

--- a/crates/database/src/repositories/user.rs
+++ b/crates/database/src/repositories/user.rs
@@ -202,29 +202,6 @@ impl UserRepository {
         self.row_to_user(row)
     }
 
-    /// Get the number of active users
-    pub async fn get_active_user_count(&self) -> Result<i64> {
-        let row = retry_db!("get_number_of_active_users", {
-            let client = self
-                .pool
-                .get()
-                .await
-                .context("Failed to get database connection")
-                .map_err(RepositoryError::PoolError)?;
-
-            client
-                .query_one(
-                    r#"
-                SELECT COUNT(*) as count FROM users WHERE is_active = true
-                "#,
-                    &[],
-                )
-                .await
-                .map_err(map_db_error)
-        })?;
-        Ok(row.get::<_, i64>("count"))
-    }
-
     fn escape_like_query(query: &str) -> String {
         query
             .replace('\\', "\\\\")
@@ -373,8 +350,7 @@ impl UserRepository {
                    OR u.auth_provider ILIKE ('%' || $2 || '%') ESCAPE '\'
                    OR u.provider_user_id ILIKE ('%' || $2 || '%') ESCAPE '\')
               AND ($3::TEXT IS NULL
-                   OR o.name ILIKE ('%' || $3 || '%') ESCAPE '\'
-                   OR o.id IS NULL)
+                   OR o.name ILIKE ('%' || $3 || '%') ESCAPE '\')
             "#,
                     &[&is_active, &escaped_search, &escaped_org_search],
                 )
@@ -396,37 +372,41 @@ impl UserRepository {
             client
                 .query(
                     r#"
-            SELECT DISTINCT ON (u.id)
-                u.*,
-                o.id as organization_id,
-                o.name as organization_name,
-                o.description as organization_description,
-                olh.spend_limit as organization_spend_limit,
-                ob.total_spent as organization_total_spent,
-                ob.total_requests as organization_total_requests,
-                ob.total_tokens as organization_total_tokens
-            FROM users u
-            LEFT JOIN organization_members om ON u.id = om.user_id AND om.role = 'owner'
-            LEFT JOIN organizations o ON om.organization_id = o.id AND o.is_active = true
-            LEFT JOIN LATERAL (
-                SELECT SUM(spend_limit)::BIGINT AS spend_limit
-                FROM organization_limits_history
-                WHERE organization_id = o.id
-                  AND effective_until IS NULL
-            ) olh ON true
-            LEFT JOIN organization_balance ob ON o.id = ob.organization_id
-            WHERE ($3::BOOLEAN IS NULL OR u.is_active = $3)
-              AND ($4::TEXT IS NULL
-                   OR u.email ILIKE ('%' || $4 || '%') ESCAPE '\'
-                   OR u.username ILIKE ('%' || $4 || '%') ESCAPE '\'
-                   OR u.display_name ILIKE ('%' || $4 || '%') ESCAPE '\'
-                   OR u.id::TEXT ILIKE ('%' || $4 || '%') ESCAPE '\'
-                   OR u.auth_provider ILIKE ('%' || $4 || '%') ESCAPE '\'
-                   OR u.provider_user_id ILIKE ('%' || $4 || '%') ESCAPE '\')
-              AND ($5::TEXT IS NULL
-                   OR o.name ILIKE ('%' || $5 || '%') ESCAPE '\'
-                   OR o.id IS NULL)
-            ORDER BY u.id, o.created_at ASC NULLS LAST
+            WITH first_org_per_user AS (
+                SELECT DISTINCT ON (u.id)
+                    u.*,
+                    o.id as organization_id,
+                    o.name as organization_name,
+                    o.description as organization_description,
+                    olh.spend_limit as organization_spend_limit,
+                    ob.total_spent as organization_total_spent,
+                    ob.total_requests as organization_total_requests,
+                    ob.total_tokens as organization_total_tokens
+                FROM users u
+                LEFT JOIN organization_members om ON u.id = om.user_id AND om.role = 'owner'
+                LEFT JOIN organizations o ON om.organization_id = o.id AND o.is_active = true
+                LEFT JOIN LATERAL (
+                    SELECT SUM(spend_limit)::BIGINT AS spend_limit
+                    FROM organization_limits_history
+                    WHERE organization_id = o.id
+                      AND effective_until IS NULL
+                ) olh ON true
+                LEFT JOIN organization_balance ob ON o.id = ob.organization_id
+                WHERE ($3::BOOLEAN IS NULL OR u.is_active = $3)
+                  AND ($4::TEXT IS NULL
+                       OR u.email ILIKE ('%' || $4 || '%') ESCAPE '\'
+                       OR u.username ILIKE ('%' || $4 || '%') ESCAPE '\'
+                       OR u.display_name ILIKE ('%' || $4 || '%') ESCAPE '\'
+                       OR u.id::TEXT ILIKE ('%' || $4 || '%') ESCAPE '\'
+                       OR u.auth_provider ILIKE ('%' || $4 || '%') ESCAPE '\'
+                       OR u.provider_user_id ILIKE ('%' || $4 || '%') ESCAPE '\')
+                  AND ($5::TEXT IS NULL
+                       OR o.name ILIKE ('%' || $5 || '%') ESCAPE '\')
+                ORDER BY u.id, o.created_at ASC NULLS LAST
+            )
+            SELECT *
+            FROM first_org_per_user
+            ORDER BY created_at DESC
             LIMIT $1
             OFFSET $2
             "#,

--- a/crates/database/src/repositories/user.rs
+++ b/crates/database/src/repositories/user.rs
@@ -225,6 +225,13 @@ impl UserRepository {
         Ok(row.get::<_, i64>("count"))
     }
 
+    fn escape_like_query(query: &str) -> String {
+        query
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_")
+    }
+
     /// List all users (with pagination)
     pub async fn list(&self, limit: i64, offset: i64) -> Result<Vec<User>> {
         let rows = retry_db!("list_all_users_with_pagination", {
@@ -244,6 +251,85 @@ impl UserRepository {
         rows.into_iter().map(|row| self.row_to_user(row)).collect()
     }
 
+    /// List all users for admin views, including inactive users by default.
+    pub async fn list_admin(
+        &self,
+        limit: i64,
+        offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
+    ) -> Result<(Vec<User>, i64)> {
+        let escaped_search = search.as_ref().map(|s| Self::escape_like_query(s));
+
+        let total_count = retry_db!("count_admin_users", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let count_row = client
+                .query_one(
+                    r#"
+            SELECT COUNT(*) as total_count
+            FROM users
+            WHERE ($1::BOOLEAN IS NULL OR is_active = $1)
+              AND ($2::TEXT IS NULL
+                   OR email ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR username ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR display_name ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR id::TEXT ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR auth_provider ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR provider_user_id ILIKE ('%' || $2 || '%') ESCAPE '\')
+            "#,
+                    &[&is_active, &escaped_search],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok(count_row.get::<_, i64>("total_count"))
+        })?;
+
+        let rows = retry_db!("list_admin_users_with_pagination", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+            SELECT *
+            FROM users
+            WHERE ($3::BOOLEAN IS NULL OR is_active = $3)
+              AND ($4::TEXT IS NULL
+                   OR email ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR username ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR display_name ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR id::TEXT ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR auth_provider ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR provider_user_id ILIKE ('%' || $4 || '%') ESCAPE '\')
+            ORDER BY created_at DESC
+            LIMIT $1
+            OFFSET $2
+            "#,
+                    &[&limit, &offset, &is_active, &escaped_search],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        let users = rows
+            .into_iter()
+            .map(|row| self.row_to_user(row))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok((users, total_count))
+    }
+
     /// List all users with organizations (with pagination)
     /// Returns the earliest organization created by each user (owner role) with spend limit and usage
     /// Returns a tuple of (User, Option<UserOrganizationInfo>)
@@ -251,17 +337,16 @@ impl UserRepository {
         &self,
         limit: i64,
         offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
         search_by_name: Option<String>,
     ) -> Result<(
         Vec<(User, Option<services::admin::UserOrganizationInfo>)>,
         i64,
     )> {
         // Escape LIKE wildcard characters in user input to prevent injection
-        let escaped_search = search_by_name.as_ref().map(|s| {
-            s.replace('\\', "\\\\")
-                .replace('%', "\\%")
-                .replace('_', "\\_")
-        });
+        let escaped_search = search.as_ref().map(|s| Self::escape_like_query(s));
+        let escaped_org_search = search_by_name.as_ref().map(|s| Self::escape_like_query(s));
 
         // Get total count of matching users (independent of pagination)
         let total_count = retry_db!("count_users_with_organizations", {
@@ -279,12 +364,19 @@ impl UserRepository {
             FROM users u
             LEFT JOIN organization_members om ON u.id = om.user_id AND om.role = 'owner'
             LEFT JOIN organizations o ON om.organization_id = o.id AND o.is_active = true
-            WHERE u.is_active = true
-              AND ($1::TEXT IS NULL
-                   OR o.name ILIKE ('%' || $1 || '%') ESCAPE '\'
+            WHERE ($1::BOOLEAN IS NULL OR u.is_active = $1)
+              AND ($2::TEXT IS NULL
+                   OR u.email ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR u.username ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR u.display_name ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR u.id::TEXT ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR u.auth_provider ILIKE ('%' || $2 || '%') ESCAPE '\'
+                   OR u.provider_user_id ILIKE ('%' || $2 || '%') ESCAPE '\')
+              AND ($3::TEXT IS NULL
+                   OR o.name ILIKE ('%' || $3 || '%') ESCAPE '\'
                    OR o.id IS NULL)
             "#,
-                    &[&escaped_search],
+                    &[&is_active, &escaped_search, &escaped_org_search],
                 )
                 .await
                 .map_err(map_db_error)?;
@@ -323,15 +415,28 @@ impl UserRepository {
                   AND effective_until IS NULL
             ) olh ON true
             LEFT JOIN organization_balance ob ON o.id = ob.organization_id
-            WHERE u.is_active = true
-              AND ($3::TEXT IS NULL 
-                   OR o.name ILIKE ('%' || $3 || '%') ESCAPE '\'
+            WHERE ($3::BOOLEAN IS NULL OR u.is_active = $3)
+              AND ($4::TEXT IS NULL
+                   OR u.email ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR u.username ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR u.display_name ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR u.id::TEXT ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR u.auth_provider ILIKE ('%' || $4 || '%') ESCAPE '\'
+                   OR u.provider_user_id ILIKE ('%' || $4 || '%') ESCAPE '\')
+              AND ($5::TEXT IS NULL
+                   OR o.name ILIKE ('%' || $5 || '%') ESCAPE '\'
                    OR o.id IS NULL)
             ORDER BY u.id, o.created_at ASC NULLS LAST
             LIMIT $1
             OFFSET $2
             "#,
-                    &[&limit, &offset, &escaped_search],
+                    &[
+                        &limit,
+                        &offset,
+                        &is_active,
+                        &escaped_search,
+                        &escaped_org_search,
+                    ],
                 )
                 .await
                 .map_err(map_db_error)

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -243,16 +243,12 @@ impl AdminService for AdminServiceImpl {
         &self,
         limit: i64,
         offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
     ) -> Result<(Vec<UserInfo>, i64), AdminError> {
-        let users = self
+        let (users, total) = self
             .repository
-            .list_users(limit, offset)
-            .await
-            .map_err(|e| AdminError::InternalError(e.to_string()))?;
-
-        let total = self
-            .repository
-            .get_active_user_count()
+            .list_users(limit, offset, search, is_active)
             .await
             .map_err(|e| AdminError::InternalError(e.to_string()))?;
 
@@ -263,11 +259,13 @@ impl AdminService for AdminServiceImpl {
         &self,
         limit: i64,
         offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
         search_by_name: Option<String>,
     ) -> Result<(Vec<(UserInfo, Option<UserOrganizationInfo>)>, i64), AdminError> {
         let (users_with_orgs, total) = self
             .repository
-            .list_users_with_organizations(limit, offset, search_by_name)
+            .list_users_with_organizations(limit, offset, search, is_active, search_by_name)
             .await
             .map_err(|e| AdminError::InternalError(e.to_string()))?;
 

--- a/crates/services/src/admin/ports.rs
+++ b/crates/services/src/admin/ports.rs
@@ -171,6 +171,8 @@ pub struct UserInfo {
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub last_login_at: Option<chrono::DateTime<chrono::Utc>>,
     pub is_active: bool,
+    pub auth_provider: String,
+    pub provider_user_id: String,
 }
 
 /// Organization information for user listing (earliest organization with spend limit and usage)
@@ -355,7 +357,13 @@ pub trait AdminRepository: Send + Sync {
     ) -> Result<Vec<OrganizationLimitsHistoryEntry>, anyhow::Error>;
 
     /// List all users with pagination (admin only)
-    async fn list_users(&self, limit: i64, offset: i64) -> Result<Vec<UserInfo>, anyhow::Error>;
+    async fn list_users(
+        &self,
+        limit: i64,
+        offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
+    ) -> Result<(Vec<UserInfo>, i64), anyhow::Error>;
 
     /// List all users with their earliest organization and spend limit (admin only)
     /// If search_by_name is provided, filters users by organization name (case-insensitive partial match)
@@ -364,11 +372,10 @@ pub trait AdminRepository: Send + Sync {
         &self,
         limit: i64,
         offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
         search_by_name: Option<String>,
     ) -> Result<(Vec<(UserInfo, Option<UserOrganizationInfo>)>, i64), anyhow::Error>;
-
-    /// Get the count of active users (admin only)
-    async fn get_active_user_count(&self) -> Result<i64, anyhow::Error>;
 
     /// List all models with pagination (admin only)
     /// If include_inactive is true, includes disabled models
@@ -510,8 +517,13 @@ pub trait AdminService: Send + Sync {
     ) -> Result<(Vec<OrganizationLimitsHistoryEntry>, i64), AdminError>;
 
     /// List all users with pagination (admin only)
-    async fn list_users(&self, limit: i64, offset: i64)
-        -> Result<(Vec<UserInfo>, i64), AdminError>;
+    async fn list_users(
+        &self,
+        limit: i64,
+        offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
+    ) -> Result<(Vec<UserInfo>, i64), AdminError>;
 
     /// List all users with their earliest organization and spend limit (admin only)
     /// If search_by_name is provided, filters users by organization name (case-insensitive partial match)
@@ -519,6 +531,8 @@ pub trait AdminService: Send + Sync {
         &self,
         limit: i64,
         offset: i64,
+        search: Option<String>,
+        is_active: Option<bool>,
         search_by_name: Option<String>,
     ) -> Result<(Vec<(UserInfo, Option<UserOrganizationInfo>)>, i64), AdminError>;
 


### PR DESCRIPTION
## Summary

- Include inactive users by default in `/v1/admin/users`, including the `include_organizations=true` path.
- Add admin-only OAuth identity fields (`auth_provider`, `provider_user_id`) to admin user responses.
- Add server-side `search` and `is_active` filters with totals based on the exact filtered result set.
- Add e2e coverage for inactive user lookup and provider identity search.

## Why

Admins could not reliably diagnose login failures caused by hidden inactive user rows or OAuth identity collisions without direct production DB access. This makes those rows discoverable from admin tooling.

## Validation

- `cargo fmt`
- `cargo check -p api`
- `git diff --check`
- `cargo test -p api --test e2e_all test_admin_list_users_finds_inactive_and_oauth_identity_fields -- --nocapture` compiled, then failed during local test DB bootstrap because Postgres was not accepting connections (`Connection refused`).