### PR TITLE
fix(completions): accept chat `stop` as string or array (OpenAI-spec / OpenRouter)

### DIFF
--- a/crates/api/src/conversions.rs
+++ b/crates/api/src/conversions.rs
@@ -96,7 +96,7 @@ impl From<ChatCompletionRequest> for ChatCompletionParams {
             max_tokens: req.max_tokens,
             temperature: req.temperature,
             top_p: req.top_p,
-            stop: req.stop,
+            stop: req.stop.map(|s| s.into_vec()),
             stream: req.stream,
             tools,
             max_completion_tokens: req.max_tokens,
@@ -828,7 +828,7 @@ mod tests {
             top_p: Some(1.0),
             n: Some(1),
             stream: None,
-            stop: Some(vec!["\\n".to_string()]),
+            stop: Some(crate::models::StopSequences::Many(vec!["\\n".to_string()])),
             presence_penalty: None,
             frequency_penalty: None,
             extra: HashMap::new(),
@@ -840,5 +840,20 @@ mod tests {
         assert_eq!(domain_params.max_tokens, Some(100));
         assert_eq!(domain_params.temperature, Some(0.7));
         assert_eq!(domain_params.stop, Some(vec!["\\n".to_string()]));
+    }
+
+    #[test]
+    fn test_chat_completion_stop_accepts_string_or_array() {
+        // OpenAI `stop` may be a bare string; it must convert to a single-element Vec.
+        let single: ChatCompletionRequest =
+            serde_json::from_str(r#"{"model":"m","messages":[],"stop":"STOP"}"#).unwrap();
+        let domain: ChatCompletionParams = single.into();
+        assert_eq!(domain.stop, Some(vec!["STOP".to_string()]));
+
+        // Array form keeps working.
+        let many: ChatCompletionRequest =
+            serde_json::from_str(r#"{"model":"m","messages":[],"stop":["a","b"]}"#).unwrap();
+        let domain: ChatCompletionParams = many.into();
+        assert_eq!(domain.stop, Some(vec!["a".to_string(), "b".to_string()]));
     }
 }

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -48,7 +48,8 @@ pub struct ChatCompletionRequest {
     #[serde(default = "default_n")]
     pub n: Option<i64>,
     pub stream: Option<bool>,
-    pub stop: Option<Vec<String>>,
+    /// OpenAI `stop` accepts either a single string or an array of strings.
+    pub stop: Option<StopSequences>,
     pub presence_penalty: Option<f32>,
     pub frequency_penalty: Option<f32>,
 
@@ -204,7 +205,7 @@ impl CompletionPrompt {
 }
 
 /// OpenAI `stop`: either a single string or an array of strings.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(untagged)]
 pub enum StopSequences {
     Single(String),

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -309,7 +309,7 @@ fn convert_chat_request_to_service(
         max_tokens: request.max_tokens,
         temperature: request.temperature,
         top_p: request.top_p,
-        stop: request.stop.clone(),
+        stop: request.stop.clone().map(|s| s.into_vec()),
         stream: request.stream,
         user_id: user_id.into(),
         n: request.n,


### PR DESCRIPTION
## Summary

OpenAI's chat-completions spec allows `stop` to be **either a single string or an array of strings**. `ChatCompletionRequest.stop` was typed `Option<Vec<String>>`, so a bare-string `"stop": "foo"` failed serde deserialization with **HTTP 422**:

```
Failed to deserialize the JSON body into the target type:
stop: invalid type: string "foo", expected a sequence
```

The array form (`"stop": ["foo"]`) worked fine. OpenRouter and the OpenAI SDK both send the **bare-string** form, so this surfaces as spurious 422s — found during OpenRouter-listing verification.

## Fix

The legacy `/v1/completions` (`CompletionRequest`) struct already uses the flexible `StopSequences` untagged enum (`Single(String) | Many(Vec<String>)`). This PR reuses it for the chat struct too:

- `ChatCompletionRequest.stop`: `Option<Vec<String>>` → `Option<StopSequences>`
- Flatten to `Vec<String>` at the domain boundary via `into_vec()` (conversions.rs + completions.rs), so nothing downstream changes — the domain `ChatCompletionParams.stop` stays `Option<Vec<String>>`.
- Derive `Serialize` on `StopSequences` (the request struct is serialized elsewhere). Untagged serialization round-trips correctly: `Single` → string, `Many` → array.

## Verification

```bash
# Before: HTTP 422.  After: HTTP 200.
curl -s -w '%{http_code}\n' https://cloud-api.near.ai/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-30B-A3B-Instruct-2507","messages":[{"role":"user","content":"count 1 to 9"}],"max_tokens":40,"stop":"5"}'
```

Unit tests added (`cargo test -p api --lib stop`, both pass):
- `conversions::tests::test_chat_completion_stop_accepts_string_or_array` — string → `["STOP"]`, array → `["a","b"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
