### PR TITLE
completions: return 400 (not 502) for client media fetch/decode errors

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -205,6 +205,7 @@ fn completion_stream_error_category(e: &inference_providers::CompletionError) ->
         inference_providers::CompletionError::InvalidResponse(_) => "invalid_response",
         inference_providers::CompletionError::NoPubKeyProvider(_) => "stale_pubkey",
         inference_providers::CompletionError::Unknown(_) => "unknown",
+        inference_providers::CompletionError::ClientMediaError(_) => "client_media_error",
         inference_providers::CompletionError::Timeout { .. } => "timeout",
     }
 }
@@ -222,6 +223,10 @@ fn completion_stream_error_openai_type(e: &inference_providers::CompletionError)
             400..=499 => "invalid_request_error",
             _ => "server_error",
         },
+        // Client supplied an unfetchable/undecodable image or video: a 400-class
+        // bad-input error, surfaced to the client as invalid_request_error to
+        // match the non-stream path (map_provider_error -> InvalidParams -> 400).
+        inference_providers::CompletionError::ClientMediaError(_) => "invalid_request_error",
         inference_providers::CompletionError::CompletionError(_)
         | inference_providers::CompletionError::InvalidResponse(_)
         | inference_providers::CompletionError::Unknown(_)

--- a/crates/inference_providers/src/models.rs
+++ b/crates/inference_providers/src/models.rs
@@ -732,6 +732,14 @@ pub enum CompletionError {
     InvalidResponse(String),
     #[error("Unknown error")]
     Unknown(String),
+    /// The engine could not fetch or decode a client-supplied image/video
+    /// (unreachable URL, non-image bytes, "cannot identify image file"). This is
+    /// a permanent client-input error: it is classified here on the RAW upstream
+    /// body (before URL redaction) and carried as a typed variant so the status
+    /// mapping doesn't have to re-derive it from the sanitized message.
+    /// Non-retryable; surfaced to the client as a 400.
+    #[error("Client media fetch/decode error: {0}")]
+    ClientMediaError(String),
     /// No provider found matching the requested E2EE public key.
     /// Client should refresh their attestation report and retry.
     #[error("No provider found for encryption key: {0}")]

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -2684,7 +2684,10 @@ mod tests {
                     out
                 );
             }
-            other => panic!("ClientMediaError should map to InvalidParams, got {:?}", other),
+            other => panic!(
+                "ClientMediaError should map to InvalidParams, got {:?}",
+                other
+            ),
         }
     }
 

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -782,33 +782,6 @@ impl CompletionServiceImpl {
                         message: "The request timed out waiting for the model to respond. Please try again.".to_string(),
                     }
                 }
-                // 5xx whose body shows the engine failed to FETCH or DECODE a
-                // client-supplied image/video (e.g. unreachable URL, non-image
-                // bytes, "cannot identify image file"). These are permanent
-                // bad-input errors — the same payload can't succeed on retry —
-                // so surface a 400 instead of a 502. This gives the client a
-                // correct, non-retryable signal and mirrors the pool's
-                // `non_retryable_client_media_error` retry decision (#688).
-                // Use a generic message: the provider body carries the user's
-                // URL and internal paths, which must not be echoed/logged.
-                (500..=599, _)
-                    if crate::inference_provider_pool::InferenceProviderPool::is_client_media_fetch_error(
-                        message,
-                    ) =>
-                {
-                    tracing::warn!(
-                        %organization_id,
-                        model,
-                        status_code,
-                        "Client media fetch/decode error during {}",
-                        operation
-                    );
-                    ports::CompletionError::InvalidParams(
-                        "One or more image or video inputs could not be fetched or decoded. \
-                         Ensure each URL is reachable and points to a valid image."
-                            .to_string(),
-                    )
-                }
                 // 5xx = provider error, use generic message
                 (500..=599, _) => {
                     tracing::error!(
@@ -850,6 +823,24 @@ impl CompletionServiceImpl {
                     }
                 }
             },
+            // The pool already determined (on the RAW upstream body, before URL
+            // redaction) that the engine couldn't fetch/decode a client-supplied
+            // image/video. Surface a 400 (non-retryable) — not a 502 — and use a
+            // generic message: the carried body holds the user's URL and internal
+            // paths, which must not be echoed to the client or logged here.
+            inference_providers::CompletionError::ClientMediaError(_) => {
+                tracing::warn!(
+                    %organization_id,
+                    model,
+                    "Client media fetch/decode error during {}",
+                    operation
+                );
+                ports::CompletionError::InvalidParams(
+                    "One or more image or video inputs could not be fetched or decoded. \
+                     Ensure each URL is reachable and resolves to a valid image or video."
+                        .to_string(),
+                )
+            }
             inference_providers::CompletionError::NoPubKeyProvider(msg) => {
                 tracing::warn!(
                     model,
@@ -2670,37 +2661,30 @@ mod tests {
     }
 
     #[test]
-    fn test_map_provider_error_500_client_media_becomes_invalid_params() {
-        // Engines return 500 when they can't fetch/decode a client-supplied
-        // image. That's a permanent bad-input error and must surface as a
-        // non-retryable 400, not a 502, and must not echo the provider body
-        // (which carries the user's URL / internal paths).
-        for msg in [
-            "Internal server error: An exception occurred while loading IMAGE data at index 0: \
-             Error while loading data ImageData(url='https://x/y.jpg'): cannot identify image file <_io.BytesIO>",
-            "Error while loading data: failed to open input buffer",
-        ] {
-            let error = inference_providers::CompletionError::HttpError {
-                status_code: 500,
-                message: msg.to_string(),
-                is_external: false,
-            };
-            let result = CompletionServiceImpl::map_provider_error(
-                "test-model",
-                &error,
-                "test",
-                Uuid::nil(),
-            );
-            match result {
-                ports::CompletionError::InvalidParams(out) => {
-                    assert!(
-                        !out.contains("BytesIO") && !out.contains("http"),
-                        "must not echo provider body, got: {}",
-                        out
-                    );
-                }
-                other => panic!("client media 500 should map to InvalidParams, got {:?}", other),
+    fn test_map_provider_error_client_media_becomes_invalid_params() {
+        // The pool classifies media fetch/decode failures on the RAW upstream
+        // body and carries the verdict as ClientMediaError, so the status
+        // mapping is a simple variant match — independent of the (sanitized)
+        // message content. Must be a non-retryable 400 with a GENERIC message
+        // that never echoes the carried body (URL / internal paths). Using a
+        // URL-bearing body here proves the status no longer depends on markers
+        // that URL-redaction would strip.
+        let error = inference_providers::CompletionError::ClientMediaError(
+            "HTTP error 500: 404, message='Not Found', url='https://x/y.jpg': \
+             cannot identify image file <_io.BytesIO>"
+                .to_string(),
+        );
+        let result =
+            CompletionServiceImpl::map_provider_error("test-model", &error, "test", Uuid::nil());
+        match result {
+            ports::CompletionError::InvalidParams(out) => {
+                assert!(
+                    !out.contains("BytesIO") && !out.contains("http") && !out.contains("y.jpg"),
+                    "must not echo carried provider body, got: {}",
+                    out
+                );
             }
+            other => panic!("ClientMediaError should map to InvalidParams, got {:?}", other),
         }
     }
 

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -782,6 +782,33 @@ impl CompletionServiceImpl {
                         message: "The request timed out waiting for the model to respond. Please try again.".to_string(),
                     }
                 }
+                // 5xx whose body shows the engine failed to FETCH or DECODE a
+                // client-supplied image/video (e.g. unreachable URL, non-image
+                // bytes, "cannot identify image file"). These are permanent
+                // bad-input errors — the same payload can't succeed on retry —
+                // so surface a 400 instead of a 502. This gives the client a
+                // correct, non-retryable signal and mirrors the pool's
+                // `non_retryable_client_media_error` retry decision (#688).
+                // Use a generic message: the provider body carries the user's
+                // URL and internal paths, which must not be echoed/logged.
+                (500..=599, _)
+                    if crate::inference_provider_pool::InferenceProviderPool::is_client_media_fetch_error(
+                        message,
+                    ) =>
+                {
+                    tracing::warn!(
+                        %organization_id,
+                        model,
+                        status_code,
+                        "Client media fetch/decode error during {}",
+                        operation
+                    );
+                    ports::CompletionError::InvalidParams(
+                        "One or more image or video inputs could not be fetched or decoded. \
+                         Ensure each URL is reachable and points to a valid image."
+                            .to_string(),
+                    )
+                }
                 // 5xx = provider error, use generic message
                 (500..=599, _) => {
                     tracing::error!(
@@ -2639,6 +2666,41 @@ mod tests {
                 assert_eq!(status_code, 502, "External 500 should map to 502");
             }
             other => panic!("Expected ProviderError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_map_provider_error_500_client_media_becomes_invalid_params() {
+        // Engines return 500 when they can't fetch/decode a client-supplied
+        // image. That's a permanent bad-input error and must surface as a
+        // non-retryable 400, not a 502, and must not echo the provider body
+        // (which carries the user's URL / internal paths).
+        for msg in [
+            "Internal server error: An exception occurred while loading IMAGE data at index 0: \
+             Error while loading data ImageData(url='https://x/y.jpg'): cannot identify image file <_io.BytesIO>",
+            "Error while loading data: failed to open input buffer",
+        ] {
+            let error = inference_providers::CompletionError::HttpError {
+                status_code: 500,
+                message: msg.to_string(),
+                is_external: false,
+            };
+            let result = CompletionServiceImpl::map_provider_error(
+                "test-model",
+                &error,
+                "test",
+                Uuid::nil(),
+            );
+            match result {
+                ports::CompletionError::InvalidParams(out) => {
+                    assert!(
+                        !out.contains("BytesIO") && !out.contains("http"),
+                        "must not echo provider body, got: {}",
+                        out
+                    );
+                }
+                other => panic!("client media 500 should map to InvalidParams, got {:?}", other),
+            }
         }
     }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -3767,7 +3767,10 @@ mod tests {
         match carried {
             // Verdict preserved → map_provider_error maps it to 400 directly.
             CompletionError::ClientMediaError(msg) => {
-                assert!(msg.contains("[URL_REDACTED]"), "URL must be redacted: {msg}");
+                assert!(
+                    msg.contains("[URL_REDACTED]"),
+                    "URL must be redacted: {msg}"
+                );
                 assert!(!msg.contains("https://"), "raw URL must not survive: {msg}");
             }
             other => panic!("expected ClientMediaError to survive sanitize, got {other:?}"),

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1341,6 +1341,9 @@ impl InferenceProviderPool {
                 CompletionError::InvalidResponse(sanitize_and_format(&msg))
             }
             CompletionError::Unknown(msg) => CompletionError::Unknown(sanitize_and_format(&msg)),
+            CompletionError::ClientMediaError(msg) => {
+                CompletionError::ClientMediaError(sanitize_and_format(&msg))
+            }
             CompletionError::NoPubKeyProvider(msg) => {
                 CompletionError::NoPubKeyProvider(sanitize_and_format(&msg))
             }
@@ -1371,6 +1374,7 @@ impl InferenceProviderPool {
             },
             CompletionError::InvalidResponse(_) => "invalid_response",
             CompletionError::Unknown(_) => "unknown",
+            CompletionError::ClientMediaError(_) => "client_media_error",
             CompletionError::NoPubKeyProvider(_) => "no_pubkey_provider",
             CompletionError::Timeout { .. } => "timeout",
         }
@@ -1382,7 +1386,7 @@ impl InferenceProviderPool {
     /// error — retrying the same payload re-runs the same fetch and produces
     /// the same failure. Treat these as non-retryable so one broken URL
     /// from a client doesn't get amplified into 4x backend work.
-    pub(crate) fn is_client_media_fetch_error(message: &str) -> bool {
+    fn is_client_media_fetch_error(message: &str) -> bool {
         // ASCII-only lowercase: the markers are all ASCII and this path can
         // run at high volume during a malformed-media incident.
         let lower = message.to_ascii_lowercase();
@@ -1460,6 +1464,7 @@ impl InferenceProviderPool {
                 }
             }
             CompletionError::Timeout { .. } => "non_retryable_explicit_timeout",
+            CompletionError::ClientMediaError(_) => "non_retryable_client_media_error",
             CompletionError::NoPubKeyProvider(_) => "non_retryable_no_pubkey_provider",
             CompletionError::InvalidResponse(_) => "non_retryable_invalid_response",
             CompletionError::Unknown(_) => "non_retryable_unknown",
@@ -1712,7 +1717,16 @@ impl InferenceProviderPool {
                                 operation = operation_name,
                                 "Client media-fetch failure, not retrying or trying other providers"
                             );
-                            return Err(Self::sanitize_completion_error(e, model_id));
+                            // Carry the decision as a typed variant (classified
+                            // here on the RAW body) so the status mapping maps it
+                            // to 400 directly, instead of re-deriving it from the
+                            // sanitized, URL-redacted message (which would miss
+                            // the URL-bearing forms). sanitize redacts the carried
+                            // diagnostic text for safe logging.
+                            return Err(Self::sanitize_completion_error(
+                                CompletionError::ClientMediaError(e.to_string()),
+                                model_id,
+                            ));
                         }
 
                         // Increment failure counter only for retryable errors —
@@ -3728,6 +3742,46 @@ mod tests {
     }
 
     #[test]
+    fn test_client_media_error_verdict_survives_sanitize() {
+        // The media short-circuit classifies on the RAW body, then carries the
+        // verdict as a typed ClientMediaError so the status mapping doesn't have
+        // to re-derive it from the sanitized message. Using the URL-bearing
+        // aiohttp form (which the regex can't match once the URL is redacted)
+        // proves the verdict no longer depends on markers surviving redaction.
+        let raw = CompletionError::HttpError {
+            status_code: 500,
+            message: "HTTP error 500: 404, message='Not Found', url='https://example.test/img.jpg'"
+                .to_string(),
+            is_external: false,
+        };
+        // Detected as a client-media error on the raw body.
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&raw),
+            "non_retryable_client_media_error",
+        );
+        // What the short-circuit returns: ClientMediaError(raw), sanitized.
+        let carried = InferenceProviderPool::sanitize_completion_error(
+            CompletionError::ClientMediaError(raw.to_string()),
+            "test-model",
+        );
+        match carried {
+            // Verdict preserved → map_provider_error maps it to 400 directly.
+            CompletionError::ClientMediaError(msg) => {
+                assert!(msg.contains("[URL_REDACTED]"), "URL must be redacted: {msg}");
+                assert!(!msg.contains("https://"), "raw URL must not survive: {msg}");
+            }
+            other => panic!("expected ClientMediaError to survive sanitize, got {other:?}"),
+        }
+        // And it still classifies non-retryable as a typed variant.
+        assert_eq!(
+            InferenceProviderPool::classify_retry_decision(&CompletionError::ClientMediaError(
+                "x".to_string()
+            )),
+            "non_retryable_client_media_error",
+        );
+    }
+
+    #[test]
     fn test_sanitize_error_message() {
         // Test URL sanitization
         let error = "Failed to perform completion: error sending request for url (http://192.168.0.1:8000/v1/chat/completions)";
@@ -4376,11 +4430,12 @@ mod tests {
             "client-media 5xx from the first provider must short-circuit immediately; \
              the second provider must not be tried and the round must not retry"
         );
-        // And the returned error must preserve the original 500 status (post-sanitize),
-        // not a 502 from a later provider.
+        // And the returned error must be the typed client-media verdict from the
+        // first provider (classified on its raw 500 body, carried so the status
+        // layer maps it to 400) — not a 502 from a later provider.
         match result.err().expect("err") {
-            CompletionError::HttpError { status_code, .. } => assert_eq!(status_code, 500),
-            other => panic!("Expected HttpError(500), got: {:?}", other),
+            CompletionError::ClientMediaError(_) => {}
+            other => panic!("Expected ClientMediaError, got: {:?}", other),
         }
     }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1382,7 +1382,7 @@ impl InferenceProviderPool {
     /// error — retrying the same payload re-runs the same fetch and produces
     /// the same failure. Treat these as non-retryable so one broken URL
     /// from a client doesn't get amplified into 4x backend work.
-    fn is_client_media_fetch_error(message: &str) -> bool {
+    pub(crate) fn is_client_media_fetch_error(message: &str) -> bool {
         // ASCII-only lowercase: the markers are all ASCII and this path can
         // run at high volume during a malformed-media incident.
         let lower = message.to_ascii_lowercase();

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -173,6 +173,10 @@ impl StopReason {
             inference_providers::CompletionError::InvalidResponse(_) => StopReason::ProviderError,
             inference_providers::CompletionError::NoPubKeyProvider(_) => StopReason::ProviderError,
             inference_providers::CompletionError::Unknown(_) => StopReason::ProviderError,
+            // Internal stop-reason label only (not the client-facing status,
+            // which is a 400). Grouped with the other non-timeout/non-ratelimit
+            // error variants, matching the siblings above.
+            inference_providers::CompletionError::ClientMediaError(_) => StopReason::ProviderError,
             inference_providers::CompletionError::Timeout { .. } => StopReason::Timeout,
         }
     }


### PR DESCRIPTION
## Problem
When the inference engine (SGLang/vLLM) can't fetch or decode a client-supplied image — unreachable URL, non-image bytes, `cannot identify image file` — it returns **500**. `map_provider_error` mapped that to a generic **502**, so the client saw a *retryable server error* for permanent bad input. Observed on gemma-4-31B-it at ~146 undecodable-image failures/hour (scraped-ad URLs returning non-image content, malformed `data:image` URLs). Affects all VL models. Tracking: **nearai/infra#159**.

## Approach (revised after review)
The pool (#688) already classifies these on the **raw** body — deliberately *before* `sanitize_completion_error` redacts URLs, because the URL-bearing aiohttp form (`HTTP error 500: 4xx … url='https://…'`) stops matching once the URL becomes `[URL_REDACTED]`. An earlier version of this PR re-ran that string heuristic in `map_provider_error` on the **sanitized** message, which silently missed those URL-bearing forms (retry-suppressed by #688 but still returned 502 — the two decisions diverged).

Fix: **carry the verdict instead of re-deriving it.**
- Add `CompletionError::ClientMediaError`, constructed at the pool's media short-circuit (where classification already runs on the raw body) and preserved through sanitization.
- `map_provider_error` maps that variant → **400 (`InvalidParams`, non-retryable)** with a **generic** message — no message re-inspection, so redaction can't defeat it, and the provider body (user URL / internal paths) is never echoed or logged.
- Reverted the temporary `pub(crate)` on `is_client_media_fetch_error` (pool-only again).

Complements #688: #688 stopped the *retries*; this makes the *status* correct end-to-end, from the same single (raw-body) verdict.

## Tests
- `ClientMediaError` → 400 generic, asserts the carried body (URL/`BytesIO`) is not echoed.
- Raw URL-bearing body → `non_retryable_client_media_error` **and** survives `sanitize_completion_error` as the typed variant (locks in the aiohttp-form fix).
- Updated the #688 short-circuit test to assert the variant.
- 503 unit tests pass (`-p services -p inference_providers`); `clippy` + `fmt` clean.

## Note
#688 itself is merged but **not yet in the prod image** (prod cloud-api dated 2026-05-28); both should ship together to fully resolve #159.