### PR TITLE
chore(usage): remove legacy POST /v1/usage; record only via /v1/internal/usage

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -818,13 +818,6 @@ pub fn build_app_with_config(
         rate_limit_state.clone(),
     );
 
-    let usage_recording_routes = build_usage_recording_routes(
-        app_state.clone(),
-        &auth_components.auth_state_middleware,
-        usage_state.clone(),
-        rate_limit_state.clone(),
-    );
-
     let gateway_routes = build_gateway_routes(
         app_state.clone(),
         &auth_components.auth_state_middleware,
@@ -952,7 +945,6 @@ pub fn build_app_with_config(
                 .merge(files_routes)
                 .merge(feature_request_routes)
                 .merge(billing_routes)
-                .merge(usage_recording_routes)
                 .merge(gateway_routes)
                 .merge(internal_routes)
                 .merge(health_routes),
@@ -1379,31 +1371,6 @@ pub fn build_billing_routes(
     Router::new()
         .route("/billing/costs", post(get_billing_costs))
         .with_state(billing_state)
-        .layer(from_fn_with_state(
-            auth_state_middleware.clone(),
-            middleware::auth::auth_middleware_with_workspace_context,
-        ))
-}
-
-/// Build usage recording routes with auth, rate limiting, and usage check.
-/// No body_hash_middleware — attestation/signing is not applicable to usage records.
-pub fn build_usage_recording_routes(
-    app_state: AppState,
-    auth_state_middleware: &AuthState,
-    usage_state: middleware::UsageState,
-    rate_limit_state: middleware::RateLimitState,
-) -> Router {
-    Router::new()
-        .route("/usage", post(crate::routes::usage::record_usage))
-        .with_state(app_state)
-        .layer(from_fn_with_state(
-            usage_state,
-            middleware::usage_check_middleware,
-        ))
-        .layer(from_fn_with_state(
-            rate_limit_state,
-            middleware::api_key_rate_limit_middleware,
-        ))
         .layer(from_fn_with_state(
             auth_state_middleware.clone(),
             middleware::auth::auth_middleware_with_workspace_context,

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -121,7 +121,6 @@ use utoipa::{Modify, OpenApi};
         crate::routes::usage::get_organization_usage_history,
         crate::routes::usage::get_organization_usage_by_model,
         crate::routes::usage::get_api_key_usage_history,
-        crate::routes::usage::record_usage,
         crate::routes::usage::get_user_organization_metrics,
         crate::routes::usage::get_user_organization_timeseries,
         // Feature request endpoints

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -1,5 +1,5 @@
 use crate::{
-    middleware::{auth::AuthenticatedApiKey, AuthenticatedUser},
+    middleware::AuthenticatedUser,
     models::ErrorResponse,
     routes::{api::AppState, common::format_amount},
 };
@@ -7,7 +7,7 @@ use axum::{
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     response::Json as ResponseJson,
-    Extension, Json,
+    Extension,
 };
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
@@ -606,11 +606,12 @@ pub async fn get_api_key_usage_history(
 }
 
 // ============================================
-// POST /v1/usage — Record usage
+// Usage recording response
 // ============================================
 
-/// POST /v1/usage response body — tagged union matching the request type.
-/// All costs use fixed scale of 9 (nano-dollars) and USD currency.
+/// Usage-recording response body — tagged union matching the request type.
+/// Returned by `POST /v1/internal/usage`. All costs use fixed scale of 9
+/// (nano-dollars) and USD currency.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RecordUsageResponse {
@@ -656,93 +657,6 @@ pub enum RecordUsageResponse {
     },
 }
 
-/// Record usage
-///
-/// Record a usage event. The server calculates costs based on the model's pricing.
-/// Uses a tagged union on the `type` field to distinguish usage kinds.
-///
-/// A required `id` field serves as an **idempotency key**. It is stored as
-/// `provider_request_id` and hashed to a deterministic UUID v5 for `inference_id`.
-/// If a record with the same `id` already exists within the same organization,
-/// the existing record is returned without double-charging.
-///
-/// ## Chat completion example
-/// ```json
-/// { "type": "chat_completion", "model": "Qwen/Qwen3-30B-A3B-Instruct-2507", "input_tokens": 100, "output_tokens": 50, "id": "req-abc-123" }
-/// ```
-///
-/// ## Image generation example
-/// ```json
-/// { "type": "image_generation", "model": "black-forest-labs/FLUX.1", "image_count": 2, "id": "req-img-456" }
-/// ```
-#[utoipa::path(
-    post,
-    path = "/v1/usage",
-    tag = "Usage",
-    request_body = serde_json::Value,
-    responses(
-        (status = 200, description = "Usage recorded successfully", body = RecordUsageResponse),
-        (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 401, description = "Unauthorized", body = ErrorResponse),
-        (status = 402, description = "Insufficient credits", body = ErrorResponse),
-        (status = 404, description = "Model not found", body = ErrorResponse),
-        (status = 500, description = "Internal server error", body = ErrorResponse)
-    ),
-    security(
-        ("api_key" = [])
-    )
-)]
-pub async fn record_usage(
-    State(app_state): State<AppState>,
-    Extension(api_key): Extension<AuthenticatedApiKey>,
-    Json(request): Json<services::usage::RecordUsageApiRequest>,
-) -> Result<ResponseJson<RecordUsageResponse>, (StatusCode, ResponseJson<ErrorResponse>)> {
-    let api_key_id = Uuid::parse_str(&api_key.api_key.id.0).map_err(|_| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            ResponseJson(ErrorResponse::new(
-                "Invalid API key ID".to_string(),
-                "internal_server_error".to_string(),
-            )),
-        )
-    })?;
-
-    let entry = app_state
-        .usage_service
-        .record_usage_from_api(
-            api_key.organization.id.0,
-            api_key.workspace.id.0,
-            api_key_id,
-            request,
-        )
-        .await
-        .map_err(|e| match &e {
-            services::usage::UsageError::ModelNotFound(_) => (
-                StatusCode::NOT_FOUND,
-                ResponseJson(ErrorResponse::new(e.to_string(), "not_found".to_string())),
-            ),
-            services::usage::UsageError::ValidationError(_) => (
-                StatusCode::BAD_REQUEST,
-                ResponseJson(ErrorResponse::new(
-                    e.to_string(),
-                    "validation_error".to_string(),
-                )),
-            ),
-            _ => {
-                tracing::error!("Failed to record usage");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    ResponseJson(ErrorResponse::new(
-                        "Failed to record usage".to_string(),
-                        "internal_server_error".to_string(),
-                    )),
-                )
-            }
-        })?;
-
-    Ok(ResponseJson(build_record_usage_response(entry)))
-}
-
 /// Build the public `RecordUsageResponse` from a service-layer `UsageLogEntry`.
 ///
 /// The variant is chosen by the *returned entry's* `inference_type` rather
@@ -786,34 +700,31 @@ fn build_record_usage_response(entry: services::usage::UsageLogEntry) -> RecordU
 // POST /v1/internal/usage — Service-token-authenticated usage recording
 // =====================================================================
 //
-// This endpoint is the locked-down replacement for `POST /v1/usage` aimed
-// at trusted infrastructure reporters (today: inference-proxy). Instead of
-// accepting an `sk-…` API key — which lets any holder of that key submit
-// arbitrary usage rows on the org's behalf — it requires a shared
-// `CLOUD_API_USAGE_TOKEN` service secret and carries the subject identity
-// (`organization_id`, `workspace_id`, `api_key_id`) in the body.
+// This endpoint is the sole usage-recording entry point for trusted
+// infrastructure reporters (today: inference-proxy). It replaced the
+// removed `sk-…`-authenticated `POST /v1/usage` — which let any holder of
+// that key submit arbitrary usage rows on the org's behalf — and instead
+// requires a shared `CLOUD_API_USAGE_TOKEN` service secret and carries the
+// subject identity (`organization_id`, `workspace_id`, `api_key_id`) in
+// the body.
 //
 // Threat model:
 // - Anyone holding `CLOUD_API_USAGE_TOKEN` can submit usage rows for any
 //   org. The token therefore lives only on trusted infrastructure
 //   (inference-proxy CVMs) and is rotated alongside other service secrets.
-// - The legacy `POST /v1/usage` endpoint stays available so the rollout
-//   can be staged. Once all reporters have switched, that endpoint can be
-//   restricted or removed (separate PR).
 //
 // The body shape is the existing `RecordUsageApiRequest` flattened under a
-// wrapper that adds the three identity fields. The actual usage payload
-// is identical to the legacy endpoint so reporters keep one builder.
+// wrapper that adds the three identity fields, so reporters keep one builder.
 
 /// Request body for `POST /v1/internal/usage`. The `usage` field is
-/// flattened, so the on-the-wire shape is the legacy `RecordUsageApiRequest`
-/// JSON with three extra top-level keys.
+/// flattened, so the on-the-wire shape is `RecordUsageApiRequest` JSON with
+/// three extra top-level keys.
 ///
 /// `ToSchema` is intentionally not derived: `RecordUsageApiRequest`
-/// doesn't implement `PartialSchema` (its OpenAPI doc is hand-rolled on
-/// the legacy handler via `request_body = serde_json::Value`), and
-/// `#[serde(flatten)]` requires the inner type to be a known schema.
-/// Internal endpoints aren't surfaced in the public OpenAPI doc anyway.
+/// doesn't implement `PartialSchema` (its OpenAPI doc was hand-rolled via
+/// `request_body = serde_json::Value`), and `#[serde(flatten)]` requires
+/// the inner type to be a known schema. Internal endpoints aren't surfaced
+/// in the public OpenAPI doc anyway.
 #[derive(Debug, Deserialize)]
 pub struct RecordUsageInternalRequest {
     /// UUID of the organization to bill. **Trusted as provided** —
@@ -830,7 +741,7 @@ pub struct RecordUsageInternalRequest {
     /// UUID of the API key the usage should be attributed to (for
     /// per-key analytics). Trusted as provided.
     pub api_key_id: String,
-    /// The standard usage payload, identical to `POST /v1/usage`.
+    /// The standard usage payload.
     #[serde(flatten)]
     pub usage: services::usage::RecordUsageApiRequest,
 }
@@ -1385,9 +1296,9 @@ mod internal_usage_tests {
 
     #[test]
     fn verify_returns_503_when_endpoint_unconfigured() {
-        // Default deployment posture: feature disabled until the operator
-        // sets CLOUD_API_USAGE_TOKEN. Reporters fall back to the legacy
-        // /v1/usage path when they observe this.
+        // Default deployment posture: usage recording is disabled until the
+        // operator sets CLOUD_API_USAGE_TOKEN. There is no longer a legacy
+        // fallback, so reporters simply cannot submit usage until then.
         let h = headers_with_bearer("anything");
         let err = verify_internal_usage_token(&h, None).unwrap_err();
         assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);

--- a/crates/api/tests/e2e_all/usage_chat_completions.rs
+++ b/crates/api/tests/e2e_all/usage_chat_completions.rs
@@ -1,6 +1,6 @@
 //! E2E tests: call /v1/chat/completions and verify usage in the response and that it was
 //! recorded into the usage history table (including cache_read_tokens when present).
-//! Does not use the manual POST /v1/usage endpoint.
+//! Does not use the manual usage-recording endpoint (`/v1/internal/usage`).
 
 use crate::common::*;
 use inference_providers::StreamChunk;

--- a/crates/api/tests/e2e_all/usage_recording.rs
+++ b/crates/api/tests/e2e_all/usage_recording.rs
@@ -1,30 +1,98 @@
 use crate::common::*;
 
-/// Happy-path test for POST /v1/usage with type=chat_completion.
+/// Shared service token used by every test in this module to authenticate
+/// against `POST /v1/internal/usage`.
+const INTERNAL_USAGE_TOKEN: &str = "test-internal-secret";
+
+/// Identity triple (plus the raw `sk-…` secret) for a provisioned org +
+/// workspace + API key. The internal usage endpoint trusts these as-is in
+/// the request body; `api_key` is only needed by tests that also drive the
+/// inference pipeline directly.
+struct UsageIdentity {
+    org_id: String,
+    workspace_id: String,
+    api_key_id: String,
+    api_key: String,
+}
+
+/// Spin up a test server with the internal usage endpoint enabled. The
+/// legacy `sk-…`-authenticated `POST /v1/usage` has been removed; usage is
+/// recorded exclusively through the service-token `/v1/internal/usage`
+/// path, which shares the same `record_usage_from_api` service logic.
+async fn enable_internal_usage_server() -> axum_test::TestServer {
+    setup_test_server_with_config(|c| {
+        c.internal_usage_token = Some(INTERNAL_USAGE_TOKEN.to_string());
+    })
+    .await
+}
+
+/// Provision an org with $10 credits, grab its default workspace, and mint
+/// an API key — returning the identity the internal usage body requires.
+async fn provision_identity(server: &axum_test::TestServer) -> UsageIdentity {
+    let org = setup_org_with_credits(server, 10_000_000_000i64).await;
+    let workspaces = list_workspaces(server, org.id.clone()).await;
+    let workspace_id = workspaces.first().unwrap().id.clone();
+    let key =
+        create_api_key_in_workspace(server, workspace_id.clone(), "internal-usage".to_string())
+            .await;
+    UsageIdentity {
+        org_id: org.id,
+        workspace_id,
+        api_key_id: key.id,
+        api_key: key.key.expect("freshly created API key returns its secret"),
+    }
+}
+
+/// Merge the identity triple into a usage payload to form the
+/// `/v1/internal/usage` request body.
+fn internal_usage_body(id: &UsageIdentity, mut usage: serde_json::Value) -> serde_json::Value {
+    let obj = usage
+        .as_object_mut()
+        .expect("usage payload must be a JSON object");
+    obj.insert("organization_id".into(), serde_json::json!(id.org_id));
+    obj.insert("workspace_id".into(), serde_json::json!(id.workspace_id));
+    obj.insert("api_key_id".into(), serde_json::json!(id.api_key_id));
+    usage
+}
+
+/// POST a usage payload to `/v1/internal/usage` with the shared service token.
+async fn post_internal_usage(
+    server: &axum_test::TestServer,
+    id: &UsageIdentity,
+    usage: serde_json::Value,
+) -> axum_test::TestResponse {
+    server
+        .post("/v1/internal/usage")
+        .add_header("Authorization", format!("Bearer {INTERNAL_USAGE_TOKEN}"))
+        .json(&internal_usage_body(id, usage))
+        .await
+}
+
+/// Happy-path test for `POST /v1/internal/usage` with type=chat_completion.
 /// Sets up a model with pricing, creates an org with credits, and records usage.
 #[tokio::test]
 async fn test_record_chat_completion_usage() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     // Setup model with known pricing (input: 1_000_000, output: 2_000_000 nano-dollars per token)
     setup_qwen_model(&server).await;
 
-    // Setup org with $10 credits and get an API key
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    // Setup org with $10 credits and an API key identity
+    let id = provision_identity(&server).await;
 
     // Record chat completion usage
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 100,
             "output_tokens": 50,
             "id": "test-chat-completion-001"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response.status_code(),
@@ -70,29 +138,29 @@ async fn test_record_chat_completion_usage() {
     );
 }
 
-/// Happy-path test for POST /v1/usage with type=image_generation.
+/// Happy-path test for `POST /v1/internal/usage` with type=image_generation.
 #[tokio::test]
 async fn test_record_image_generation_usage() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     // Setup image model with cost_per_image pricing (40_000_000 nano-dollars per image)
     setup_qwen_image_model(&server).await;
 
-    // Setup org with $10 credits and get an API key
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    // Setup org with $10 credits and an API key identity
+    let id = provision_identity(&server).await;
 
     // Record image generation usage
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "image_generation",
             "model": "Qwen/Qwen-Image-2512",
             "image_count": 3,
             "id": "test-image-gen-001"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response.status_code(),
@@ -136,23 +204,23 @@ async fn test_record_image_generation_usage() {
 /// Test that the required `id` field is stored and does not affect the response shape.
 #[tokio::test]
 async fn test_record_usage_with_external_id() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     setup_qwen_model(&server).await;
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 10,
             "output_tokens": 20,
             "id": "chatcmpl-ext-12345"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response.status_code(),
@@ -174,22 +242,22 @@ async fn test_record_usage_with_external_id() {
 /// Test validation: model not found returns 404.
 #[tokio::test]
 async fn test_record_usage_model_not_found() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "nonexistent/model",
             "input_tokens": 100,
             "output_tokens": 50,
             "id": "test-not-found-001"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(response.status_code(), 404);
 }
@@ -197,52 +265,56 @@ async fn test_record_usage_model_not_found() {
 /// Test validation: zero tokens returns 400.
 #[tokio::test]
 async fn test_record_usage_zero_tokens() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     setup_qwen_model(&server).await;
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 0,
             "output_tokens": 0,
             "id": "test-zero-tokens-001"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(response.status_code(), 400);
 }
 
-/// Test validation: missing `id` field returns 422 (deserialization error).
+/// Test validation: missing `id` field returns 400 (deserialization error).
+///
+/// Unlike the removed `POST /v1/usage` (which used the `Json` extractor and
+/// returned 422 on a bad body), `/v1/internal/usage` deserializes raw bytes
+/// itself and maps any parse failure to 400/`validation_error`.
 #[tokio::test]
 async fn test_record_usage_missing_id_field() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     setup_qwen_model(&server).await;
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 100,
             "output_tokens": 50
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     // Missing required `id` field should fail deserialization
     assert_eq!(
         response.status_code(),
-        422,
-        "Missing id should return 422: {}",
+        400,
+        "Missing id should return 400: {}",
         response.text()
     );
 }
@@ -250,23 +322,23 @@ async fn test_record_usage_missing_id_field() {
 /// Test validation: empty `id` field returns 400.
 #[tokio::test]
 async fn test_record_usage_empty_id() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     setup_qwen_model(&server).await;
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 100,
             "output_tokens": 50,
             "id": ""
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response.status_code(),
@@ -276,15 +348,15 @@ async fn test_record_usage_empty_id() {
     );
 }
 
-/// Idempotency test: calling POST /v1/usage twice with the same `id` returns
-/// the same record both times and only charges the organization once.
+/// Idempotency test: calling `POST /v1/internal/usage` twice with the same
+/// `id` returns the same record both times and only charges the organization
+/// once.
 #[tokio::test]
 async fn test_record_usage_idempotent_duplicate() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     setup_qwen_model(&server).await;
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
     let payload = serde_json::json!({
         "type": "chat_completion",
@@ -295,11 +367,7 @@ async fn test_record_usage_idempotent_duplicate() {
     });
 
     // First call — creates the record
-    let response1 = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&payload)
-        .await;
+    let response1 = post_internal_usage(&server, &id, payload.clone()).await;
 
     assert_eq!(
         response1.status_code(),
@@ -310,11 +378,7 @@ async fn test_record_usage_idempotent_duplicate() {
     let body1: serde_json::Value = response1.json();
 
     // Second call — should return existing record (no double-charge)
-    let response2 = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&payload)
-        .await;
+    let response2 = post_internal_usage(&server, &id, payload).await;
 
     assert_eq!(
         response2.status_code(),
@@ -334,17 +398,18 @@ async fn test_record_usage_idempotent_duplicate() {
 
     // Verify the balance was only charged once (total_cost = 200_000_000)
     // by recording a second distinct usage and checking the combined balance
-    let response3 = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response3 = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 10,
             "output_tokens": 5,
             "id": "idempotency-test-different-id"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(response3.status_code(), 200);
 }
@@ -353,31 +418,29 @@ async fn test_record_usage_idempotent_duplicate() {
 /// without conflicting — the idempotency scope is per-organization.
 #[tokio::test]
 async fn test_record_usage_same_id_different_orgs() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     setup_qwen_model(&server).await;
 
-    // Setup two separate orgs
-    let org1 = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key1 = get_api_key_for_org(&server, org1.id.clone()).await;
-
-    let org2 = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key2 = get_api_key_for_org(&server, org2.id.clone()).await;
+    // Setup two separate org identities on the same server
+    let id1 = provision_identity(&server).await;
+    let id2 = provision_identity(&server).await;
 
     let shared_id = "shared-external-id-across-orgs";
 
     // Org1 records usage with the shared id
-    let response1 = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key1}"))
-        .json(&serde_json::json!({
+    let response1 = post_internal_usage(
+        &server,
+        &id1,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 100,
             "output_tokens": 50,
             "id": shared_id
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response1.status_code(),
@@ -387,17 +450,18 @@ async fn test_record_usage_same_id_different_orgs() {
     );
 
     // Org2 records usage with the same id — should NOT conflict
-    let response2 = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key2}"))
-        .json(&serde_json::json!({
+    let response2 = post_internal_usage(
+        &server,
+        &id2,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 200,
             "output_tokens": 100,
             "id": shared_id
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response2.status_code(),
@@ -424,29 +488,29 @@ async fn test_record_usage_same_id_different_orgs() {
 /// Verifies that cache hits reduce input cost according to cache_read_cost_per_token.
 #[tokio::test]
 async fn test_record_chat_completion_usage_with_cached_tokens() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     // Setup model with cache-read pricing:
     // input: 1_000_000, output: 2_000_000, cache_read: 500_000 nano-dollars per token
     setup_qwen_model_with_cache_pricing(&server).await;
 
-    // Setup org with $10 credits and get an API key
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    // Setup org with $10 credits and an API key identity
+    let id = provision_identity(&server).await;
 
     // Record chat completion usage with 40 cached prompt tokens out of 100
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 100,
             "output_tokens": 50,
             "cache_read_tokens": 40,
             "id": "test-chat-completion-with-cache"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response.status_code(),
@@ -477,26 +541,26 @@ async fn test_record_chat_completion_usage_with_cached_tokens() {
     assert_eq!(body["total_cost"], 180_000_000i64);
 }
 
-/// Pins the invariant that a `POST /v1/usage` submission keyed by a
-/// provider-style id (`chatcmpl-…`) does not share an `inference_id` with
-/// the internal chat-completion pipeline's record for the same provider id.
-/// Both writes must land independently in usage history; the per-org
-/// idempotency constraint on `inference_id` applies only within each source.
+/// Pins the invariant that an external usage submission (`/v1/internal/usage`)
+/// keyed by a provider-style id (`chatcmpl-…`) does not share an
+/// `inference_id` with the internal chat-completion pipeline's record for the
+/// same provider id. Both writes must land independently in usage history;
+/// the per-org idempotency constraint on `inference_id` applies only within
+/// each source.
 #[tokio::test]
 async fn test_external_usage_record_does_not_collide_with_internal_pipeline() {
     use inference_providers::StreamChunk;
 
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
     setup_qwen_model(&server).await;
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
     // Drive a streaming completion so we can capture the provider-assigned
     // chat id from the SSE chunks (same id the internal pipeline will key
     // its billing record under after stream finalize).
     let stream_resp = server
         .post("/v1/chat/completions")
-        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("Authorization", format!("Bearer {}", id.api_key))
         .json(&serde_json::json!({
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "messages": [{ "role": "user", "content": "hello" }],
@@ -520,20 +584,21 @@ async fn test_external_usage_record_does_not_collide_with_internal_pipeline() {
         "mock provider should emit chatcmpl-style ids, got {provider_id:?}",
     );
 
-    // Submit POST /v1/usage carrying the same provider id. The namespace
+    // Submit external usage carrying the same provider id. The namespace
     // prefix on external ids must keep this from sharing an inference_id
     // slot with the internal pipeline's record.
-    let external_resp = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let external_resp = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 1,
             "output_tokens": 1,
             "id": provider_id,
-        }))
-        .await;
+        }),
+    )
+    .await;
     assert_eq!(
         external_resp.status_code(),
         200,
@@ -550,7 +615,7 @@ async fn test_external_usage_record_does_not_collide_with_internal_pipeline() {
         let resp = server
             .get(&format!(
                 "/v1/organizations/{}/usage/history?limit=10&offset=0",
-                org.id
+                id.org_id
             ))
             .add_header("Authorization", format!("Bearer {}", get_session_id()))
             .add_header("User-Agent", MOCK_USER_AGENT)
@@ -614,27 +679,27 @@ async fn test_external_usage_record_does_not_collide_with_internal_pipeline() {
 /// Test that cache_read_tokens greater than input_tokens are rejected by validation.
 #[tokio::test]
 async fn test_record_chat_completion_usage_cache_read_capped_to_input() {
-    let server = setup_test_server().await;
+    let server = enable_internal_usage_server().await;
 
     // Setup model with cache-read pricing enabled
     setup_qwen_model_with_cache_pricing(&server).await;
 
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let id = provision_identity(&server).await;
 
     // cache_read_tokens (100) > input_tokens (30) should be rejected by the API
-    let response = server
-        .post("/v1/usage")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&serde_json::json!({
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 30,
             "output_tokens": 0,
             "cache_read_tokens": 100,
             "id": "test-chat-completion-cache-capped"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response.status_code(),
@@ -645,10 +710,8 @@ async fn test_record_chat_completion_usage_cache_read_capped_to_input() {
 }
 
 /// `POST /v1/internal/usage` returns 503 when the deployment has not
-/// configured `CLOUD_API_USAGE_TOKEN`. This is the default test posture
-/// — the feature is fail-closed until an operator sets the secret, so
-/// reporters using the new path can fall back to the legacy `/v1/usage`
-/// without ambiguity.
+/// configured `CLOUD_API_USAGE_TOKEN`. This is the fail-closed posture —
+/// the endpoint is disabled until an operator sets the secret.
 #[tokio::test]
 async fn test_internal_usage_returns_503_when_disabled() {
     let server = setup_test_server().await;
@@ -728,11 +791,10 @@ async fn test_internal_usage_503_takes_precedence_over_bad_body() {
 }
 
 /// Happy path with `internal_usage_token` configured: a valid request
-/// produces a row identical to what the legacy `/v1/usage` endpoint
-/// would write. Exercises the actual `serde(flatten)` of
-/// `RecordUsageApiRequest` under the wrapper — guards against
-/// "wire-format works in production for the first time after a config
-/// flip on staging."
+/// records usage and returns the standard tagged-union response. Exercises
+/// the actual `serde(flatten)` of `RecordUsageApiRequest` under the wrapper
+/// — guards against "wire-format works in production for the first time
+/// after a config flip on staging."
 ///
 /// `api_key_id` comes from the workspace's `create_api_key` response so
 /// the FK to `api_keys` resolves. This avoids depending on whatever
@@ -741,37 +803,23 @@ async fn test_internal_usage_503_takes_precedence_over_bad_body() {
 /// just absent).
 #[tokio::test]
 async fn test_internal_usage_records_with_valid_token() {
-    const TOKEN: &str = "test-internal-secret";
-    let server = setup_test_server_with_config(|c| {
-        c.internal_usage_token = Some(TOKEN.to_string());
-    })
-    .await;
+    let server = enable_internal_usage_server().await;
 
     setup_qwen_model(&server).await;
-    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
-    let workspaces = list_workspaces(&server, org.id.clone()).await;
-    let workspace_id = workspaces.first().unwrap().id.clone();
-    let api_key_resp = create_api_key_in_workspace(
-        &server,
-        workspace_id.clone(),
-        "internal-usage-happy-path".to_string(),
-    )
-    .await;
+    let id = provision_identity(&server).await;
 
-    let response = server
-        .post("/v1/internal/usage")
-        .add_header("Authorization", format!("Bearer {TOKEN}"))
-        .json(&serde_json::json!({
-            "organization_id": org.id,
-            "workspace_id": workspace_id,
-            "api_key_id": api_key_resp.id,
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
             "type": "chat_completion",
             "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
             "input_tokens": 100,
             "output_tokens": 50,
             "id": "test-internal-happy-path"
-        }))
-        .await;
+        }),
+    )
+    .await;
 
     assert_eq!(
         response.status_code(),
@@ -784,7 +832,7 @@ async fn test_internal_usage_records_with_valid_token() {
     assert_eq!(body["type"], "chat_completion");
     assert_eq!(body["input_tokens"], 100);
     assert_eq!(body["output_tokens"], 50);
-    // Cost shape matches the legacy endpoint (uses same service-layer call).
+    // input: 100 * 1_000_000 + output: 50 * 2_000_000 = 200_000_000
     assert_eq!(body["total_cost"], 200_000_000i64);
 }
 

--- a/crates/api/tests/e2e_all/usage_recording.rs
+++ b/crates/api/tests/e2e_all/usage_recording.rs
@@ -31,7 +31,11 @@ async fn enable_internal_usage_server() -> axum_test::TestServer {
 async fn provision_identity(server: &axum_test::TestServer) -> UsageIdentity {
     let org = setup_org_with_credits(server, 10_000_000_000i64).await;
     let workspaces = list_workspaces(server, org.id.clone()).await;
-    let workspace_id = workspaces.first().unwrap().id.clone();
+    let workspace_id = workspaces
+        .first()
+        .expect("org should have a default workspace")
+        .id
+        .clone();
     let key =
         create_api_key_in_workspace(server, workspace_id.clone(), "internal-usage".to_string())
             .await;

--- a/crates/api/tests/e2e_all/usage_responses.rs
+++ b/crates/api/tests/e2e_all/usage_responses.rs
@@ -1,6 +1,6 @@
 //! E2E tests: call /v1/responses (Responses API) and verify usage is recorded,
 //! including cache_read_tokens derived from provider-side cached_tokens.
-//! Does not use the manual POST /v1/usage endpoint.
+//! Does not use the manual usage-recording endpoint (`/v1/internal/usage`).
 
 use crate::common::*;
 use serde_json::json;

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -6,9 +6,9 @@ pub struct ApiConfig {
     /// API key for authenticating with inference backends (vLLM/SGLang via inference_url)
     pub inference_api_key: Option<String>,
     /// Shared secret accepted by `POST /v1/internal/usage` from trusted
-    /// reporters (e.g. inference-proxy). When `None`, the endpoint is
-    /// disabled and returns 503. Reporters can still authenticate to the
-    /// legacy `POST /v1/usage` with an `sk-…` key while this is unset.
+    /// reporters (e.g. inference-proxy). This is the only usage-recording
+    /// entry point; when `None`, the endpoint is disabled and returns 503,
+    /// so reporters cannot submit usage until an operator sets the secret.
     pub internal_usage_token: Option<String>,
     pub logging: LoggingConfig,
     pub dstack_client: DstackClientConfig,

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -6,9 +6,11 @@ pub struct ApiConfig {
     /// API key for authenticating with inference backends (vLLM/SGLang via inference_url)
     pub inference_api_key: Option<String>,
     /// Shared secret accepted by `POST /v1/internal/usage` from trusted
-    /// reporters (e.g. inference-proxy). This is the only usage-recording
-    /// entry point; when `None`, the endpoint is disabled and returns 503,
-    /// so reporters cannot submit usage until an operator sets the secret.
+    /// reporters (e.g. inference-proxy). This is the only *API endpoint* for
+    /// reporter-submitted usage (the internal inference pipeline records its
+    /// own usage directly, unaffected by this). When `None`, the
+    /// `/v1/internal/usage` endpoint is disabled and returns 503, so reporters
+    /// cannot submit usage until an operator sets the secret.
     pub internal_usage_token: Option<String>,
     pub logging: LoggingConfig,
     pub dstack_client: DstackClientConfig,

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 /// Dedicated UUID v5 namespace for `inference_id`s derived from external `id`s
-/// submitted via `POST /v1/usage`. The internal inference pipeline hashes
+/// submitted via `POST /v1/internal/usage`. The internal inference pipeline hashes
 /// provider request ids under `Uuid::NAMESPACE_DNS`; using a different
 /// namespace UUID here makes the two `inference_id` spaces mathematically
 /// disjoint regardless of input — no shape of provider id (even one that
@@ -805,7 +805,7 @@ mod tests {
         assert!(result.is_none(), "1T tokens * 10B cost should overflow");
     }
 
-    /// `POST /v1/usage` and the internal inference pipeline both derive
+    /// `POST /v1/internal/usage` and the internal inference pipeline both derive
     /// `inference_id` (the DB's per-org idempotency key) by feeding
     /// caller-visible ids into UUID v5. To keep the two sources from
     /// sharing a slot, externally-submitted ids are hashed under a
@@ -840,7 +840,7 @@ mod tests {
                 Uuid::new_v5(&super::EXTERNAL_USAGE_ID_NAMESPACE, raw_id.as_bytes());
             assert_ne!(
                 internal_uuid, external_uuid,
-                "external POST /v1/usage with id={raw_id:?} must hash to a different \
+                "external POST /v1/internal/usage with id={raw_id:?} must hash to a different \
                  inference_id than the internal pipeline writes for the same provider id"
             );
         }


### PR DESCRIPTION
## What

Removes the legacy `sk-…`-authenticated `POST /v1/usage` endpoint. Usage is now recorded exclusively through the service-token `POST /v1/internal/usage` path added in #665.

## Why

`POST /v1/usage` accepted a workspace API key (`Authorization: Bearer sk-…`) and let *any* holder of that key submit arbitrary usage/billing rows on the organization's behalf. #665 introduced `/v1/internal/usage`, which authenticates with the shared `CLOUD_API_USAGE_TOKEN` service secret (held only on trusted infra) and carries the subject identity in the body. The legacy endpoint was explicitly kept only to stage the rollout — its own source comment flagged removal as a follow-up PR. inference-proxy already prefers the internal path whenever `CLOUD_API_USAGE_TOKEN` is set (`src/proxy.rs`), so this is that follow-up.

## Changes

- **Delete** the `record_usage` handler, its route mount (`build_usage_recording_routes` + the `.merge(...)`/call wiring in `lib.rs`), and its OpenAPI path entry.
- **Keep** `RecordUsageResponse` and `build_record_usage_response` — they're shared with `record_usage_internal`.
- **Migrate** the usage-recording e2e tests from `/v1/usage` to `/v1/internal/usage`. They drive the *same* `record_usage_from_api` service path, so coverage is preserved: cost calculation, cache-read pricing, idempotency, per-org idempotency scoping, validation (404/400), and the external-vs-internal `inference_id` namespacing invariant.
  - One intentional behavior delta: the missing-`id` case now returns **400** (the internal endpoint deserializes raw bytes and maps parse errors to `validation_error`) instead of **422** (the old `Json` extractor rejection).
- Refresh stale doc/comment references to the removed endpoint (`config/types.rs`, `services/usage/mod.rs`, internal-endpoint module comment).

## ⚠️ Deployment prerequisite

`CLOUD_API_USAGE_TOKEN` **must** be configured on cloud-api **and** on every inference-proxy reporter before this ships. With the legacy fallback gone:
- cloud-api returns **503** on `/v1/internal/usage` while the token is unset.
- there is no `/v1/usage` to fall back to.

So a deploy without the token set everywhere = usage/billing recording stops. Verify the token is present in prod + staging cloud-api and inference-proxy env before merging.

## Test

```
cargo check --all-targets   # clean
cargo clippy --all-targets  # clean
cargo test --test e2e_all usage_recording  # 18 passed (local docker postgres)
```