### PR TITLE
fix(completions): forward streamed SSE bytes verbatim for byte-exact TEE verification

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -33,6 +33,14 @@ use uuid::Uuid;
 // Timeout for synchronous usage recording before response is returned
 const USAGE_RECORDING_TIMEOUT_SECS: u64 = 5;
 
+// Upper bound on leading SSE control events (keepalive comments, blank
+// lines) consumed while peeking for the first parsed chunk. Real upstreams
+// emit zero before the first data chunk; the cap stops a misbehaving or
+// malicious upstream from stalling response start or growing the stash
+// unbounded. Past the cap we proceed without an Inference-Id header and let
+// the remaining stream (including the buffered control events) flow through.
+const MAX_LEADING_CONTROL_EVENTS: usize = 32;
+
 /// Insert validated E2EE headers into a provider `extra` HashMap.
 fn insert_encryption_headers(
     encryption_headers: &crate::routes::common::EncryptionHeaders,
@@ -1120,7 +1128,11 @@ async fn chat_completions_inner(
                 // upstream keepalive comment) may precede the first data
                 // chunk; consume and stash them so they are still forwarded
                 // to the client in order (they're part of the signed byte
-                // stream — issue #701).
+                // stream — issue #701). Bounded by MAX_LEADING_CONTROL_EVENTS
+                // so a misbehaving upstream that only emits keepalives can't
+                // stall response start or grow this buffer unbounded — past
+                // the cap we proceed without an Inference-Id and let the rest
+                // flow through the byte stream below.
                 let mut leading_control: Vec<
                     Result<inference_providers::SSEEvent, inference_providers::CompletionError>,
                 > = Vec::new();
@@ -1135,6 +1147,9 @@ async fn chat_completions_inner(
                         _ => break None,
                     };
                     if is_control {
+                        if leading_control.len() >= MAX_LEADING_CONTROL_EVENTS {
+                            break None;
+                        }
                         if let Some(ev) = peekable_stream.next().await {
                             leading_control.push(ev);
                         }
@@ -1218,7 +1233,9 @@ async fn chat_completions_inner(
                                     // and are non-byte-verifiable anyway since the TEE
                                     // signs under the canonical model name, not the alias
                                     // the client requested.
-                                    if event.raw_passthrough && !auto_redact_enabled && !alias_served
+                                    if event.raw_passthrough
+                                        && !auto_redact_enabled
+                                        && !alias_served
                                     {
                                         if event.is_done_marker() {
                                             upstream_done
@@ -1268,15 +1285,17 @@ async fn chat_completions_inner(
                                     let alias_warning =
                                         pending_warning.lock().ok().and_then(|mut g| g.take());
                                     let json_data = match alias_warning {
-                                        Some(warning) => serde_json::to_value(&chunk).map(|mut v| {
-                                            if let Some(obj) = v.as_object_mut() {
-                                                obj.insert(
-                                                    "warning".to_string(),
-                                                    serde_json::Value::String(warning),
-                                                );
-                                            }
-                                            v.to_string()
-                                        }),
+                                        Some(warning) => {
+                                            serde_json::to_value(&chunk).map(|mut v| {
+                                                if let Some(obj) = v.as_object_mut() {
+                                                    obj.insert(
+                                                        "warning".to_string(),
+                                                        serde_json::Value::String(warning),
+                                                    );
+                                                }
+                                                v.to_string()
+                                            })
+                                        }
                                         None => serde_json::to_string(&chunk),
                                     }
                                     .unwrap_or_else(|e| {
@@ -1730,8 +1749,11 @@ async fn completions_inner(
                 // header, consuming any leading control events. This route
                 // reshapes chat chunks into text-completion format, so
                 // control lines are never forwarded (no byte passthrough
-                // here by design) and the stash can be discarded.
+                // here by design) and the consumed events can be discarded.
+                // Bounded so a keepalive-only upstream can't stall the
+                // response: past the cap we proceed without an Inference-Id.
                 let mut peekable_stream = Box::pin(stream.peekable());
+                let mut control_skipped = 0usize;
                 let inference_id = loop {
                     let is_control = match peekable_stream.as_mut().peek().await {
                         Some(Ok(event)) => {
@@ -1743,6 +1765,10 @@ async fn completions_inner(
                         _ => break None,
                     };
                     if is_control {
+                        if control_skipped >= MAX_LEADING_CONTROL_EVENTS {
+                            break None;
+                        }
+                        control_skipped += 1;
                         peekable_stream.next().await;
                     }
                 };

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -322,14 +322,6 @@ fn extract_inference_id_from_chunk(chunk: &inference_providers::StreamChunk) -> 
     hash_inference_id_to_uuid(id)
 }
 
-/// Extract the provider-assigned chat ID string from a parsed stream chunk.
-fn extract_chat_id_from_chunk(chunk: &inference_providers::StreamChunk) -> String {
-    match chunk {
-        inference_providers::StreamChunk::Chat(c) => c.id.clone(),
-        inference_providers::StreamChunk::Text(c) => c.id.clone(),
-    }
-}
-
 // Convert MessageContent to serde_json::Value, preserving multimodal parts (images, audio, etc.)
 fn message_content_to_value(content: &Option<MessageContent>) -> serde_json::Value {
     match content {
@@ -1124,13 +1116,30 @@ async fn chat_completions_inner(
                 // Make stream peekable to extract chat_id for Inference-Id header
                 let mut peekable_stream = Box::pin(stream.peekable());
 
-                // Peek at first chunk to extract chat_id and generate Inference-Id UUID
-                let inference_id = peekable_stream
-                    .as_mut()
-                    .peek()
-                    .await
-                    .and_then(|result| result.as_ref().ok())
-                    .map(|event| extract_inference_id_from_chunk(&event.chunk));
+                // Peek for the Inference-Id header. Control events (e.g. an
+                // upstream keepalive comment) may precede the first data
+                // chunk; consume and stash them so they are still forwarded
+                // to the client in order (they're part of the signed byte
+                // stream — issue #701).
+                let mut leading_control: Vec<
+                    Result<inference_providers::SSEEvent, inference_providers::CompletionError>,
+                > = Vec::new();
+                let inference_id = loop {
+                    let is_control = match peekable_stream.as_mut().peek().await {
+                        Some(Ok(event)) => {
+                            if let Some(chunk) = &event.chunk {
+                                break Some(extract_inference_id_from_chunk(chunk));
+                            }
+                            true
+                        }
+                        _ => break None,
+                    };
+                    if is_control {
+                        if let Some(ev) = peekable_stream.next().await {
+                            leading_control.push(ev);
+                        }
+                    }
+                };
 
                 // Warning to inject into the first streamed chunk. Skipped
                 // for E2EE (the chunks are opaque; the response header is
@@ -1142,6 +1151,10 @@ async fn chat_completions_inner(
                             .filter(|_| !e2ee_active)
                             .map(|canonical| alias_warning_message(&request.model, canonical)),
                     ));
+                // Alias-served responses can't use byte-exact passthrough: the
+                // first chunk is rewritten to carry the warning, and the TEE
+                // signs under the canonical model name anyway.
+                let alias_served = alias_canonical.is_some();
 
                 if inference_id.is_none() {
                     tracing::warn!(
@@ -1151,16 +1164,17 @@ async fn chat_completions_inner(
                     );
                 }
 
-                // Accumulate all SSE bytes for response hash computation
-                let accumulated_bytes = Arc::new(tokio::sync::Mutex::new(Vec::new()));
-                let chat_id_state = Arc::new(tokio::sync::Mutex::new(None::<String>));
                 let stream_error_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
 
-                let accumulated_clone = accumulated_bytes.clone();
-                let chat_id_clone = chat_id_state.clone();
                 let error_count_clone = stream_error_count.clone();
                 let request_model = request.model.clone();
                 let organization_id = api_key.organization.id.0;
+
+                // Set when the upstream's own `data: [DONE]` terminator was
+                // forwarded verbatim, so the end-of-stream tail doesn't
+                // append a second, gateway-minted one.
+                let upstream_done_forwarded = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let upstream_done_for_chain = upstream_done_forwarded.clone();
 
                 // Per-stream un-redact state, keyed by choice index so n>1
                 // completions don't cross-contaminate sliding tails. When
@@ -1175,30 +1189,51 @@ async fn chat_completions_inner(
                     Arc::new(tokio::sync::Mutex::new(None));
                 let chunk_template_for_chain = chunk_template.clone();
                 let unredact_states_for_chain = unredact_states.clone();
-                let accumulated_for_chain = accumulated_bytes.clone();
                 let redaction_map_for_chunks = redaction_map.clone();
 
-                // Convert to raw bytes stream with proper SSE formatting
-                let byte_stream = peekable_stream
-                    .then(move |result| {
-                        let accumulated_inner = accumulated_clone.clone();
-                        let chat_id_inner = chat_id_clone.clone();
+                // Re-attach any stashed leading control events, then convert
+                // to a raw bytes stream.
+                let event_stream = futures::stream::iter(leading_control).chain(peekable_stream);
+
+                let byte_stream = event_stream
+                    .filter_map(move |result| {
                         let error_count_inner = error_count_clone.clone();
                         let model_for_err = request_model.clone();
                         let states = unredact_states.clone();
                         let template = chunk_template.clone();
                         let map = redaction_map_for_chunks.clone();
                         let pending_warning = alias_warning_pending.clone();
+                        let upstream_done = upstream_done_forwarded.clone();
                         async move {
                             match result {
-                                Ok(mut event) => {
-                                    // Extract chat_id from the parsed chunk
+                                Ok(event) => {
+                                    // Byte-exact passthrough (issue #701): the upstream
+                                    // emits OpenAI-format SSE and no chunk rewriting is
+                                    // active, so forward the wire bytes untouched. This
+                                    // keeps sha256(received bytes) reproducible against
+                                    // the response hash signed inside the inference TEE.
+                                    //
+                                    // Disabled for alias-served responses: those inject
+                                    // a top-level `warning` into the first chunk (below),
+                                    // and are non-byte-verifiable anyway since the TEE
+                                    // signs under the canonical model name, not the alias
+                                    // the client requested.
+                                    if event.raw_passthrough && !auto_redact_enabled && !alias_served
                                     {
-                                        let mut cid = chat_id_inner.lock().await;
-                                        if cid.is_none() {
-                                            *cid = Some(extract_chat_id_from_chunk(&event.chunk));
+                                        if event.is_done_marker() {
+                                            upstream_done
+                                                .store(true, std::sync::atomic::Ordering::Relaxed);
                                         }
+                                        return Some(Ok::<Bytes, Infallible>(event.raw_bytes));
                                     }
+
+                                    // Re-serialization path: auto-redact rewrites chunk
+                                    // text, and non-OpenAI upstreams (Gemini native,
+                                    // Anthropic) need normalization to OpenAI format.
+                                    // Control lines carry no parsed payload — drop them
+                                    // here; the end-of-stream tail appends the gateway's
+                                    // own [DONE] terminator.
+                                    let mut chunk = event.chunk?;
 
                                     if auto_redact_enabled {
                                         // Cache a template for the synthetic
@@ -1207,7 +1242,7 @@ async fn chat_completions_inner(
                                             let mut t = template.lock().await;
                                             if t.is_none() {
                                                 if let inference_providers::StreamChunk::Chat(c) =
-                                                    &event.chunk
+                                                    &chunk
                                                 {
                                                     *t = Some((
                                                         c.id.clone(),
@@ -1222,7 +1257,7 @@ async fn chat_completions_inner(
                                         // Swap minted placeholders in this
                                         // chunk's text deltas back to originals.
                                         let mut s = states.lock().await;
-                                        unredact_chunk_in_place(&mut event.chunk, &mut s, &map);
+                                        unredact_chunk_in_place(&mut chunk, &mut s, &map);
                                     }
 
                                     // Serialize the parsed chunk (normalized to OpenAI format)
@@ -1233,18 +1268,16 @@ async fn chat_completions_inner(
                                     let alias_warning =
                                         pending_warning.lock().ok().and_then(|mut g| g.take());
                                     let json_data = match alias_warning {
-                                        Some(warning) => {
-                                            serde_json::to_value(&event.chunk).map(|mut v| {
-                                                if let Some(obj) = v.as_object_mut() {
-                                                    obj.insert(
-                                                        "warning".to_string(),
-                                                        serde_json::Value::String(warning),
-                                                    );
-                                                }
-                                                v.to_string()
-                                            })
-                                        }
-                                        None => serde_json::to_string(&event.chunk),
+                                        Some(warning) => serde_json::to_value(&chunk).map(|mut v| {
+                                            if let Some(obj) = v.as_object_mut() {
+                                                obj.insert(
+                                                    "warning".to_string(),
+                                                    serde_json::Value::String(warning),
+                                                );
+                                            }
+                                            v.to_string()
+                                        }),
+                                        None => serde_json::to_string(&chunk),
                                     }
                                     .unwrap_or_else(|e| {
                                         tracing::error!(
@@ -1263,8 +1296,7 @@ async fn chat_completions_inner(
                                     }
                                     // Format as SSE event with proper newlines
                                     let sse_bytes = Bytes::from(format!("data: {json_data}\n\n"));
-                                    accumulated_inner.lock().await.extend_from_slice(&sse_bytes);
-                                    Ok::<Bytes, Infallible>(sse_bytes)
+                                    Some(Ok::<Bytes, Infallible>(sse_bytes))
                                 }
                                 Err(e) => {
                                     let count = error_count_inner
@@ -1277,49 +1309,59 @@ async fn chat_completions_inner(
                                             "Completion stream error"
                                         );
                                     }
-                                    Ok::<Bytes, Infallible>(sse_error_frame(&e))
+                                    Some(Ok::<Bytes, Infallible>(sse_error_frame(&e)))
                                 }
                             }
                         }
                     })
-                    .chain(futures::stream::once({
-                        // End-of-stream tail: emit any flush chunks (held
-                        // tail bytes that the sliding window didn't get to
-                        // resolve) inline with [DONE]. They're framed as
-                        // separate SSE events by `\n\n` so the client sees
-                        // them as distinct deltas.
-                        let organization_id = api_key.organization.id.0;
-                        let model_name = request.model.clone();
-                        async move {
-                            let mut combined: Vec<u8> = Vec::new();
-                            if auto_redact_enabled {
-                                let mut states = unredact_states_for_chain.lock().await;
-                                let template = chunk_template_for_chain.lock().await.clone();
-                                for bytes in build_flush_chunks(&mut states, &template) {
-                                    combined.extend_from_slice(&bytes);
+                    .chain(
+                        futures::stream::once({
+                            // End-of-stream tail: emit any flush chunks (held
+                            // tail bytes that the sliding window didn't get to
+                            // resolve) inline with [DONE]. They're framed as
+                            // separate SSE events by `\n\n` so the client sees
+                            // them as distinct deltas. When the upstream's own
+                            // [DONE] was already forwarded verbatim
+                            // (passthrough), nothing is appended — the byte
+                            // stream must end exactly as the upstream's did.
+                            let organization_id = api_key.organization.id.0;
+                            let model_name = request.model.clone();
+                            async move {
+                                let mut combined: Vec<u8> = Vec::new();
+                                if auto_redact_enabled {
+                                    let mut states = unredact_states_for_chain.lock().await;
+                                    let template = chunk_template_for_chain.lock().await.clone();
+                                    for bytes in build_flush_chunks(&mut states, &template) {
+                                        combined.extend_from_slice(&bytes);
+                                    }
+                                }
+
+                                let error_count_final =
+                                    stream_error_count.load(std::sync::atomic::Ordering::Relaxed);
+                                if error_count_final > 1 {
+                                    tracing::error!(
+                                        %organization_id,
+                                        model = %model_name,
+                                        total_stream_errors = error_count_final,
+                                        "Completion stream ended with multiple errors"
+                                    );
+                                }
+
+                                if !upstream_done_for_chain
+                                    .load(std::sync::atomic::Ordering::Relaxed)
+                                {
+                                    combined.extend_from_slice(b"data: [DONE]\n\n");
+                                }
+                                if combined.is_empty() {
+                                    // Avoid emitting an empty body frame.
+                                    None
+                                } else {
+                                    Some(Ok::<Bytes, Infallible>(Bytes::from(combined)))
                                 }
                             }
-
-                            let error_count_final =
-                                stream_error_count.load(std::sync::atomic::Ordering::Relaxed);
-                            if error_count_final > 1 {
-                                tracing::error!(
-                                    %organization_id,
-                                    model = %model_name,
-                                    total_stream_errors = error_count_final,
-                                    "Completion stream ended with multiple errors"
-                                );
-                            }
-
-                            combined.extend_from_slice(b"data: [DONE]\n\n");
-                            let final_bytes = Bytes::from(combined);
-                            accumulated_for_chain
-                                .lock()
-                                .await
-                                .extend_from_slice(&final_bytes);
-                            Ok::<Bytes, Infallible>(final_bytes)
-                        }
-                    }));
+                        })
+                        .filter_map(std::future::ready),
+                    );
 
                 // Return raw streaming response with SSE headers
                 let mut response_builder = Response::builder()
@@ -1684,14 +1726,26 @@ async fn completions_inner(
             .await
         {
             Ok(stream) => {
-                // Peek the first chunk to surface the Inference-Id header.
+                // Peek the first data chunk to surface the Inference-Id
+                // header, consuming any leading control events. This route
+                // reshapes chat chunks into text-completion format, so
+                // control lines are never forwarded (no byte passthrough
+                // here by design) and the stash can be discarded.
                 let mut peekable_stream = Box::pin(stream.peekable());
-                let inference_id = peekable_stream
-                    .as_mut()
-                    .peek()
-                    .await
-                    .and_then(|result| result.as_ref().ok())
-                    .map(|event| extract_inference_id_from_chunk(&event.chunk));
+                let inference_id = loop {
+                    let is_control = match peekable_stream.as_mut().peek().await {
+                        Some(Ok(event)) => {
+                            if let Some(chunk) = &event.chunk {
+                                break Some(extract_inference_id_from_chunk(chunk));
+                            }
+                            true
+                        }
+                        _ => break None,
+                    };
+                    if is_control {
+                        peekable_stream.next().await;
+                    }
+                };
 
                 if inference_id.is_none() {
                     tracing::warn!(
@@ -1713,41 +1767,56 @@ async fn completions_inner(
                 let pending_warning = alias_warning_pending.clone();
 
                 let byte_stream = peekable_stream
-                    .map(move |result| match result {
-                        Ok(event) => {
-                            let text_chunk = chat_chunk_to_text_chunk(event.chunk);
-                            let alias_warning =
-                                pending_warning.lock().ok().and_then(|mut g| g.take());
-                            let json_data = match alias_warning {
-                                Some(warning) => serde_json::to_value(&text_chunk).map(|mut v| {
-                                    if let Some(obj) = v.as_object_mut() {
-                                        obj.insert(
-                                            "warning".to_string(),
-                                            serde_json::Value::String(warning),
-                                        );
+                    .filter_map(move |result| {
+                        let model_for_err = model_for_err.clone();
+                        let pending_warning = pending_warning.clone();
+                        std::future::ready(match result {
+                            // Control lines (blank/comment/[DONE]) carry no
+                            // parsed payload — skip; the gateway appends its
+                            // own [DONE] terminator below. This route reshapes
+                            // chat chunks into text-completion format, so it
+                            // always re-serializes (no byte passthrough).
+                            Ok(event) => event.chunk.map(|chunk| {
+                                let text_chunk = chat_chunk_to_text_chunk(chunk);
+                                // The first chunk of an alias-served response
+                                // gets a top-level "warning" (issue #573).
+                                let alias_warning =
+                                    pending_warning.lock().ok().and_then(|mut g| g.take());
+                                let json_data = match alias_warning {
+                                    Some(warning) => {
+                                        serde_json::to_value(&text_chunk).map(|mut v| {
+                                            if let Some(obj) = v.as_object_mut() {
+                                                obj.insert(
+                                                    "warning".to_string(),
+                                                    serde_json::Value::String(warning),
+                                                );
+                                            }
+                                            v.to_string()
+                                        })
                                     }
-                                    v.to_string()
-                                }),
-                                None => serde_json::to_string(&text_chunk),
-                            }
-                            .unwrap_or_else(|e| {
+                                    None => serde_json::to_string(&text_chunk),
+                                }
+                                .unwrap_or_else(|e| {
+                                    tracing::error!(
+                                        %organization_id,
+                                        "Failed to serialize text completion chunk: {e}"
+                                    );
+                                    "{}".to_string()
+                                });
+                                Ok::<Bytes, Infallible>(Bytes::from(format!(
+                                    "data: {json_data}\n\n"
+                                )))
+                            }),
+                            Err(e) => {
                                 tracing::error!(
                                     %organization_id,
-                                    "Failed to serialize text completion chunk: {e}"
+                                    model = %model_for_err,
+                                    error_type = %completion_stream_error_category(&e),
+                                    "Text completion stream error"
                                 );
-                                "{}".to_string()
-                            });
-                            Ok::<Bytes, Infallible>(Bytes::from(format!("data: {json_data}\n\n")))
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                %organization_id,
-                                model = %model_for_err,
-                                error_type = %completion_stream_error_category(&e),
-                                "Text completion stream error"
-                            );
-                            Ok::<Bytes, Infallible>(sse_error_frame(&e))
-                        }
+                                Some(Ok::<Bytes, Infallible>(sse_error_frame(&e)))
+                            }
+                        })
                     })
                     .chain(futures::stream::once(async move {
                         Ok::<Bytes, Infallible>(Bytes::from_static(b"data: [DONE]\n\n"))
@@ -2239,13 +2308,6 @@ mod tests {
         let uuid1 = extract_inference_id_from_chunk(&chunk1);
         let uuid2 = extract_inference_id_from_chunk(&chunk2);
         assert_ne!(uuid1, uuid2);
-    }
-
-    #[test]
-    fn test_extract_chat_id_from_chunk() {
-        let chunk = make_chat_chunk("chatcmpl-abc123");
-        let id = extract_chat_id_from_chunk(&chunk);
-        assert_eq!(id, "chatcmpl-abc123");
     }
 
     #[test]

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -737,6 +737,27 @@ impl MockProvider {
         format!("chatcmpl-{:x}", hasher.finish())
     }
 
+    /// Wire-format encoding for streamed mock chat chunks, as an upstream
+    /// would emit them. Deliberately differs from serde struct serialization
+    /// in two ways real OpenAI-format upstreams do: alphabetically ordered
+    /// keys (`serde_json::to_value` uses a sorted map) and an extra field our
+    /// `ChatCompletionChunk` struct doesn't know (like vLLM's `matched_stop`).
+    /// Decode→re-encode through the typed struct can never reproduce these
+    /// bytes, so a response-hash match in tests proves the gateway forwarded
+    /// the upstream bytes verbatim (issue #701).
+    fn mock_chunk_wire_bytes(chunk: &ChatCompletionChunk) -> Result<Vec<u8>, CompletionError> {
+        let mut value = serde_json::to_value(chunk).map_err(|e| {
+            CompletionError::CompletionError(format!("Failed to serialize mock chunk to JSON: {e}"))
+        })?;
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert(
+                "mock_upstream_only_field".to_string(),
+                serde_json::Value::String("dropped-by-typed-parse".to_string()),
+            );
+        }
+        Ok(format!("data: {value}\n\n").into_bytes())
+    }
+
     /// Get current timestamp
     fn current_timestamp(&self) -> i64 {
         SystemTime::now()
@@ -873,22 +894,21 @@ impl crate::InferenceProvider for MockProvider {
         }
 
         // Register signature hashes for this chat_id.
-        // response_hash is computed over SSE bytes in the same format as returned by the API:
-        // concatenated "data: {json}\n\n" lines plus the final "data: [DONE]\n\n" terminator.
-        // IMPORTANT: Use serde_json::to_string (preserves struct field order) rather than
-        // serde_json::to_value().to_string() (sorts keys alphabetically via BTreeMap).
-        // The server serializes StreamChunk with to_string, so the mock must match.
+        // response_hash is computed over the exact wire bytes this mock emits
+        // (mock_chunk_wire_bytes) plus the final "data: [DONE]\n\n" terminator —
+        // mirroring inference-proxy, which signs the bytes it actually sends.
+        // IMPORTANT: mock_chunk_wire_bytes deliberately uses a DIFFERENT (but
+        // semantically equal) JSON encoding than serde struct serialization
+        // (alphabetically sorted keys via serde_json::to_value). The gateway
+        // can only reproduce this hash by forwarding the upstream bytes
+        // verbatim — re-serializing the parsed chunk yields different bytes.
+        // This makes the e2e signature tests a regression guard for byte-exact
+        // streaming passthrough (issue #701).
         let chat_id_opt = chunks.first().map(|c| c.id.clone());
         if let Some(chat_id) = chat_id_opt {
             let mut accumulated: Vec<u8> = Vec::new();
             for chunk in &chunks {
-                let json_str = serde_json::to_string(chunk).map_err(|e| {
-                    CompletionError::CompletionError(format!(
-                        "Failed to serialize mock chunk to JSON for hashing: {e}"
-                    ))
-                })?;
-                let sse_line = format!("data: {json_str}\n\n");
-                accumulated.extend_from_slice(sse_line.as_bytes());
+                accumulated.extend_from_slice(&Self::mock_chunk_wire_bytes(chunk)?);
             }
             if response_template.disconnect_after_chunks.is_none() {
                 accumulated.extend_from_slice(b"data: [DONE]\n\n");
@@ -898,15 +918,31 @@ impl crate::InferenceProvider for MockProvider {
                 .await;
         }
 
-        // Convert chunks to SSE stream
-        let stream = stream::iter(chunks.into_iter().map(move |chunk| {
-            let json_str = serde_json::to_string(&chunk).unwrap();
-            let raw_bytes = Bytes::from(format!("data: {json_str}\n\n"));
-            Ok(SSEEvent {
-                raw_bytes,
-                chunk: StreamChunk::Chat(chunk),
-            })
-        }));
+        let send_done = response_template.disconnect_after_chunks.is_none();
+
+        // Convert chunks to an SSE event stream carrying the exact wire bytes
+        // alongside the parsed chunk, like the real BufferedSSEParser does.
+        // The trailing [DONE] terminator is emitted as a chunk-less control
+        // event, matching the lossless passthrough parser behavior.
+        let stream = stream::iter(
+            chunks
+                .into_iter()
+                .map(move |chunk| {
+                    let raw_bytes = Bytes::from(Self::mock_chunk_wire_bytes(&chunk)?);
+                    Ok(SSEEvent {
+                        raw_bytes,
+                        chunk: Some(StreamChunk::Chat(chunk)),
+                        raw_passthrough: true,
+                    })
+                })
+                .chain(send_done.then(|| {
+                    Ok(SSEEvent {
+                        raw_bytes: Bytes::from_static(b"data: [DONE]\n\n"),
+                        chunk: None,
+                        raw_passthrough: true,
+                    })
+                })),
+        );
 
         Ok(Box::pin(stream))
     }
@@ -994,7 +1030,8 @@ impl crate::InferenceProvider for MockProvider {
             let raw_bytes = Bytes::from(format!("data: {json_str}\n\n"));
             Ok(SSEEvent {
                 raw_bytes,
-                chunk: StreamChunk::Text(chunk),
+                chunk: Some(StreamChunk::Text(chunk)),
+                raw_passthrough: true,
             })
         }));
 

--- a/crates/inference_providers/src/sse_parser.rs
+++ b/crates/inference_providers/src/sse_parser.rs
@@ -13,8 +13,35 @@ pub struct SSEEvent {
     /// The raw bytes of this SSE event (including "data: " prefix and newline)
     #[serde(skip)]
     pub raw_bytes: Bytes,
-    /// The parsed StreamChunk
-    pub chunk: StreamChunk,
+    /// The parsed StreamChunk. `None` for control lines (blank separator
+    /// lines, `: comments`, the `data: [DONE]` terminator, non-data SSE
+    /// fields like `event:`/`id:`, and the end-of-stream tail flush) — these
+    /// carry only `raw_bytes` so the upstream byte stream can be reassembled
+    /// exactly for TEE signature verification (issue #701). Control events
+    /// are only emitted by passthrough-capable parsers (see
+    /// [`SSEEventParser::passthrough_raw`]).
+    pub chunk: Option<StreamChunk>,
+    /// True when `raw_bytes` are the upstream's OpenAI-format SSE wire bytes
+    /// and may be forwarded to clients verbatim. False for providers whose
+    /// raw bytes are in a native non-OpenAI format (Gemini, Anthropic) that
+    /// must be re-serialized before reaching clients.
+    #[serde(skip)]
+    pub raw_passthrough: bool,
+}
+
+impl SSEEvent {
+    /// True if this is the upstream `data: [DONE]` terminator control line.
+    /// Used by the route layer to avoid appending a duplicate gateway-minted
+    /// `[DONE]` after forwarding the upstream one verbatim.
+    pub fn is_done_marker(&self) -> bool {
+        if self.chunk.is_some() {
+            return false;
+        }
+        let line = String::from_utf8_lossy(&self.raw_bytes);
+        line.trim()
+            .strip_prefix("data:")
+            .is_some_and(|d| d.trim() == "[DONE]")
+    }
 }
 
 /// Trait for provider-specific SSE event parsing
@@ -41,6 +68,18 @@ pub trait SSEEventParser: Send + Unpin {
     /// If true, lines without "data: " prefix are also parsed.
     /// Used by Gemini which can return raw JSON lines.
     fn handles_raw_json() -> bool {
+        false
+    }
+
+    /// Whether the upstream wire format is OpenAI-format SSE that clients can
+    /// consume directly. When true, the parser is lossless: control lines
+    /// (blank separators, comments, `[DONE]`, non-data fields) and any
+    /// trailing unterminated bytes are emitted as chunk-less [`SSEEvent`]s so
+    /// concatenating every event's `raw_bytes` reproduces the upstream byte
+    /// stream exactly — required for byte-exact TEE signature verification
+    /// through the gateway (issue #701). When false (Gemini, Anthropic
+    /// native formats), control lines are silently skipped as before.
+    fn passthrough_raw() -> bool {
         false
     }
 }
@@ -102,8 +141,19 @@ where
             let line = String::from_utf8_lossy(&raw_bytes[..newline_pos]);
             let line = line.trim();
 
-            // Skip empty lines and comments
+            let passthrough = P::passthrough_raw();
+
+            // Empty lines and comments carry no parseable payload. For
+            // passthrough parsers, emit them as control events so the raw
+            // byte stream stays reconstructable; otherwise skip as before.
             if line.is_empty() || line.starts_with(':') {
+                if passthrough {
+                    results.push(Ok(SSEEvent {
+                        raw_bytes,
+                        chunk: None,
+                        raw_passthrough: true,
+                    }));
+                }
                 continue;
             }
 
@@ -119,11 +169,33 @@ where
             if let Some(data) = data {
                 match P::parse_event(&mut self.state, data) {
                     Ok(Some(chunk)) => {
-                        results.push(Ok(SSEEvent { raw_bytes, chunk }));
+                        results.push(Ok(SSEEvent {
+                            raw_bytes,
+                            chunk: Some(chunk),
+                            raw_passthrough: passthrough,
+                        }));
                     }
-                    Ok(None) => {} // Skip (e.g., [DONE] marker)
+                    Ok(None) => {
+                        // [DONE] marker: control event in passthrough mode,
+                        // skipped otherwise.
+                        if passthrough {
+                            results.push(Ok(SSEEvent {
+                                raw_bytes,
+                                chunk: None,
+                                raw_passthrough: true,
+                            }));
+                        }
+                    }
                     Err(e) => results.push(Err(e)),
                 }
+            } else if passthrough {
+                // Non-data SSE field line (event:, id:, retry:). We don't
+                // parse these, but they're part of the signed byte stream.
+                results.push(Ok(SSEEvent {
+                    raw_bytes,
+                    chunk: None,
+                    raw_passthrough: true,
+                }));
             }
         }
 
@@ -175,11 +247,23 @@ where
                 }
                 Poll::Ready(None) => {
                     this.finished = true;
-                    // Stream ended - check for any remaining incomplete data
-                    if !this.bytes_buffer.is_empty()
-                        && this.bytes_buffer.iter().any(|&b| !b.is_ascii_whitespace())
-                    {
-                        warn!("Incomplete SSE data in buffer at stream end");
+                    // Stream ended - flush or report any remaining incomplete data
+                    if !this.bytes_buffer.is_empty() {
+                        if P::passthrough_raw() {
+                            // A trailing line without a final newline is part
+                            // of the signed upstream byte stream — emit it as
+                            // a control event so byte-exact reassembly holds
+                            // (mirrors inference-proxy's transformer flush).
+                            let leftover = Bytes::from(std::mem::take(&mut this.bytes_buffer));
+                            return Poll::Ready(Some(Ok(SSEEvent {
+                                raw_bytes: leftover,
+                                chunk: None,
+                                raw_passthrough: true,
+                            })));
+                        }
+                        if this.bytes_buffer.iter().any(|&b| !b.is_ascii_whitespace()) {
+                            warn!("Incomplete SSE data in buffer at stream end");
+                        }
                     }
                     return Poll::Ready(None);
                 }
@@ -229,6 +313,14 @@ pub struct OpenAIEventParser;
 
 impl SSEEventParser for OpenAIEventParser {
     type State = OpenAIParserState;
+
+    /// vLLM/SGLang (and OpenAI-compatible third parties) emit the same SSE
+    /// wire format clients consume, so raw bytes may be forwarded verbatim.
+    /// This is what makes gateway streams byte-exact verifiable against the
+    /// inference TEE's response-hash signature (issue #701).
+    fn passthrough_raw() -> bool {
+        true
+    }
 
     fn parse_event(
         state: &mut Self::State,
@@ -353,20 +445,20 @@ mod tests {
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
 
-        // Should have received all 3 events
-        assert_eq!(events.len(), 3, "Expected 3 events, got {}", events.len());
+        // 3 data events + 3 blank-line control events (lossless passthrough)
+        assert_eq!(events.len(), 6, "Expected 6 events, got {}", events.len());
 
         // Verify each event is Ok
         for (i, event) in events.iter().enumerate() {
             assert!(event.is_ok(), "Event {} should be Ok", i);
         }
 
-        // Verify the content of each event
+        // Verify the content of each parsed event
         let contents: Vec<String> = events
             .into_iter()
             .filter_map(|e| e.ok())
             .filter_map(|e| {
-                if let StreamChunk::Chat(chunk) = e.chunk {
+                if let Some(StreamChunk::Chat(chunk)) = e.chunk {
                     chunk
                         .choices
                         .first()
@@ -394,7 +486,13 @@ mod tests {
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
 
-        assert_eq!(events.len(), 2, "Expected 2 events, got {}", events.len());
+        // 2 data events + 2 blank-line control events
+        assert_eq!(events.len(), 4, "Expected 4 events, got {}", events.len());
+        let parsed = events
+            .iter()
+            .filter(|e| e.as_ref().is_ok_and(|ev| ev.chunk.is_some()))
+            .count();
+        assert_eq!(parsed, 2, "Expected 2 parsed events");
 
         for event in &events {
             assert!(event.is_ok());
@@ -414,9 +512,22 @@ mod tests {
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
 
-        // Should only have 1 event (the [DONE] marker is skipped)
-        assert_eq!(events.len(), 1, "Expected 1 event, got {}", events.len());
-        assert!(events[0].is_ok());
+        // 1 data event + blank control + [DONE] control + blank control
+        assert_eq!(events.len(), 4, "Expected 4 events, got {}", events.len());
+        let events: Vec<SSEEvent> = events.into_iter().map(|e| e.unwrap()).collect();
+        assert!(
+            events[0].chunk.is_some(),
+            "First event should be parsed data"
+        );
+        assert!(
+            events[2].is_done_marker(),
+            "[DONE] should surface as a control event marked as done"
+        );
+        assert_eq!(
+            events.iter().filter(|e| e.is_done_marker()).count(),
+            1,
+            "Exactly one [DONE] marker expected"
+        );
     }
 
     #[tokio::test]
@@ -434,9 +545,14 @@ mod tests {
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
 
-        // Should only have 1 event (comments and empty lines are skipped)
-        assert_eq!(events.len(), 1, "Expected 1 event, got {}", events.len());
-        assert!(events[0].is_ok());
+        // Comments and blank lines surface as chunk-less control events so
+        // the byte stream stays reconstructable; exactly 1 parsed event.
+        assert_eq!(events.len(), 5, "Expected 5 events, got {}", events.len());
+        let parsed: Vec<_> = events
+            .iter()
+            .filter(|e| e.as_ref().is_ok_and(|ev| ev.chunk.is_some()))
+            .collect();
+        assert_eq!(parsed.len(), 1, "Expected 1 parsed event");
     }
 
     #[tokio::test]
@@ -453,8 +569,10 @@ mod tests {
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
 
-        assert_eq!(events.len(), 1, "Expected 1 event, got {}", events.len());
+        // 1 data event + 1 blank-line control event
+        assert_eq!(events.len(), 2, "Expected 2 events, got {}", events.len());
         assert!(events[0].is_ok());
+        assert!(events[0].as_ref().unwrap().chunk.is_some());
     }
 
     #[tokio::test]
@@ -509,11 +627,14 @@ mod tests {
             BufferedSSEParser::<_, OpenAIEventParser>::new(stream, OpenAIParserState::new(true));
         let events: Vec<_> = parser.collect().await;
 
-        // Should have exactly 1 event (the good chunk).
-        // The stream ended after that, and the parser must NOT poll again.
-        // If the `finished` flag is broken, the ErrorThenPanicStream will panic.
-        assert_eq!(events.len(), 1, "Expected 1 event, got {}", events.len());
+        // Should have exactly 2 events (the good chunk + its blank-line
+        // control event). The stream ended after that, and the parser must
+        // NOT poll again. If the `finished` flag is broken, the
+        // ErrorThenPanicStream will panic.
+        assert_eq!(events.len(), 2, "Expected 2 events, got {}", events.len());
         assert!(events[0].is_ok(), "Event should be Ok");
+        assert!(events[0].as_ref().unwrap().chunk.is_some());
+        assert!(events[1].as_ref().unwrap().chunk.is_none());
     }
 
     #[tokio::test]
@@ -533,8 +654,10 @@ mod tests {
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
 
-        assert_eq!(events.len(), 1, "Expected 1 event, got {}", events.len());
+        // 1 data event + 1 blank-line control event
+        assert_eq!(events.len(), 2, "Expected 2 events, got {}", events.len());
         assert!(events[0].is_ok());
+        assert!(events[0].as_ref().unwrap().chunk.is_some());
     }
 
     #[tokio::test]
@@ -567,10 +690,12 @@ mod tests {
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
 
-        // Should get 1 event without panicking. The content will contain the
-        // correctly reassembled é since bytes are buffered until newline.
-        assert_eq!(events.len(), 1, "Expected 1 event, got {}", events.len());
+        // Should get the data event + blank-line control event without
+        // panicking. The content will contain the correctly reassembled é
+        // since bytes are buffered until newline.
+        assert_eq!(events.len(), 2, "Expected 2 events, got {}", events.len());
         assert!(events[0].is_ok(), "The event should be parsed successfully");
+        assert!(events[0].as_ref().unwrap().chunk.is_some());
     }
 
     #[tokio::test]
@@ -587,11 +712,21 @@ mod tests {
             futures_util::stream::iter(vec![Ok::<_, reqwest::Error>(bytes::Bytes::from(packet))]);
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
+        // The error event, plus control events for the blank separators and
+        // the [DONE] terminator (lossless passthrough).
         assert_eq!(
             events.len(),
-            1,
-            "Expected exactly one error event before stream termination, got {}",
+            4,
+            "Expected error event + 3 control events, got {}",
             events.len()
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, Err(CompletionError::HttpError { .. })))
+                .count(),
+            1,
+            "Exactly one error event expected"
         );
         match &events[0] {
             Err(CompletionError::HttpError {
@@ -673,11 +808,150 @@ mod tests {
             futures_util::stream::iter(vec![Ok::<_, reqwest::Error>(bytes::Bytes::from(packet))]);
         let parser = new_sse_parser(mock_stream, true);
         let events: Vec<_> = parser.collect().await;
-        assert_eq!(events.len(), 1);
+        // 1 data event + 1 blank-line control event
+        assert_eq!(events.len(), 2);
         assert!(
             events[0].is_ok(),
             "null `error` field must not trigger the error path: got {:?}",
             events[0]
         );
+        assert!(events[0].as_ref().unwrap().chunk.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_sse_parser_passthrough_byte_exact_reassembly() {
+        // Core property behind issue #701: for an OpenAI-format upstream,
+        // concatenating raw_bytes of every Ok event must reproduce the
+        // upstream byte stream EXACTLY — including comments, blank lines,
+        // CRLF line endings, non-data SSE fields, the [DONE] terminator and
+        // a trailing unterminated line. This is what makes
+        // sha256(client-received bytes) match the response hash signed by
+        // the inference TEE (which hashes the bytes it sends).
+        let part1: &[u8] = b": keepalive comment\n\ndata: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hel";
+        let part2: &[u8] = b"lo\"},\"finish_reason\":null}]}\r\n\r\nevent: ping\ndata: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"!\"},\"finish_reason\":\"stop\"}]}\n\n";
+        let part3: &[u8] = b"data: [DONE]\n\ntrailing-unterminated";
+
+        let mock_stream = futures_util::stream::iter(vec![
+            Ok::<_, reqwest::Error>(bytes::Bytes::from(part1)),
+            Ok(bytes::Bytes::from(part2)),
+            Ok(bytes::Bytes::from(part3)),
+        ]);
+
+        let parser = new_sse_parser(mock_stream, true);
+        let events: Vec<_> = parser.collect().await;
+
+        let mut reassembled: Vec<u8> = Vec::new();
+        let mut parsed_count = 0;
+        let mut done_count = 0;
+        for event in events {
+            let event = event.expect("No errors expected in this stream");
+            assert!(
+                event.raw_passthrough,
+                "OpenAI-format parser events must be passthrough-capable"
+            );
+            if event.chunk.is_some() {
+                parsed_count += 1;
+            }
+            if event.is_done_marker() {
+                done_count += 1;
+            }
+            reassembled.extend_from_slice(&event.raw_bytes);
+        }
+
+        let mut original: Vec<u8> = Vec::new();
+        original.extend_from_slice(part1);
+        original.extend_from_slice(part2);
+        original.extend_from_slice(part3);
+
+        assert_eq!(parsed_count, 2, "Expected 2 parsed data chunks");
+        assert_eq!(done_count, 1, "Expected exactly one [DONE] control event");
+        assert_eq!(
+            reassembled, original,
+            "Concatenated raw_bytes must reproduce the upstream byte stream exactly"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sse_parser_non_passthrough_parser_skips_control_lines() {
+        // A parser that does NOT opt into passthrough (Gemini/Anthropic
+        // native formats) must keep the historical behavior: control lines
+        // are silently dropped, no tail flush, and events are not marked
+        // passthrough.
+        struct NonPassthroughParser;
+        impl SSEEventParser for NonPassthroughParser {
+            type State = OpenAIParserState;
+            fn parse_event(
+                state: &mut Self::State,
+                data: &str,
+            ) -> Result<Option<StreamChunk>, CompletionError> {
+                OpenAIEventParser::parse_event(state, data)
+            }
+        }
+
+        let packet = ": comment\n\ndata: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n\ntrailing";
+        let mock_stream =
+            futures_util::stream::iter(vec![Ok::<_, reqwest::Error>(bytes::Bytes::from(packet))]);
+
+        let parser = BufferedSSEParser::<_, NonPassthroughParser>::new(
+            mock_stream,
+            OpenAIParserState::new(true),
+        );
+        let events: Vec<_> = parser.collect().await;
+
+        assert_eq!(
+            events.len(),
+            1,
+            "Non-passthrough parser must emit only parsed events"
+        );
+        let event = events[0].as_ref().unwrap();
+        assert!(event.chunk.is_some());
+        assert!(
+            !event.raw_passthrough,
+            "Non-passthrough parser events must not be marked passthrough"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sse_event_is_done_marker() {
+        let done = SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(
+                b"data: [DONE]
+",
+            ),
+            chunk: None,
+            raw_passthrough: true,
+        };
+        assert!(done.is_done_marker());
+
+        // No space after the colon is still a valid SSE data line
+        let done_no_space = SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(
+                b"data:[DONE]
+",
+            ),
+            chunk: None,
+            raw_passthrough: true,
+        };
+        assert!(done_no_space.is_done_marker());
+
+        let comment = SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(
+                b": keepalive
+",
+            ),
+            chunk: None,
+            raw_passthrough: true,
+        };
+        assert!(!comment.is_done_marker());
+
+        let blank = SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(
+                b"
+",
+            ),
+            chunk: None,
+            raw_passthrough: true,
+        };
+        assert!(!blank.is_done_marker());
     }
 }

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1113,19 +1113,7 @@ impl VLlmProvider {
             };
             let parser = new_sse_parser(response.bytes_stream(), true);
             let stream: StreamingResult = Box::pin(parser);
-            let mut peekable = StreamingResultExt::peekable(stream);
-            let first_chunk_status =
-                if let Some(Err(CompletionError::HttpError { status_code, .. })) =
-                    peekable.peek().await
-                {
-                    if Self::is_rotation_retryable_status(*status_code) {
-                        Some(*status_code)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+            let (first_chunk_status, stream) = Self::peek_first_payload_status(stream).await;
             if let Some(status_code) = first_chunk_status {
                 tracing::debug!(
                     index,
@@ -1137,7 +1125,7 @@ impl VLlmProvider {
                     message: "Upstream stream emitted an error event".to_string(),
                     is_external: false,
                 };
-                drop(peekable);
+                drop(stream);
                 continue;
             }
             self.pending_rotation
@@ -1148,9 +1136,50 @@ impl VLlmProvider {
                 index,
                 "Rotation-SNI chat_completion_stream served by alternative backend"
             );
-            return Ok(Box::pin(peekable));
+            return Ok(stream);
         }
         Err(last_error)
+    }
+
+    /// Peek past any leading control events (chunk-less `SSEEvent`s — e.g. a
+    /// keepalive comment or blank line surfaced by the lossless passthrough
+    /// parser, issue #701) to classify the first real SSE payload. Returns
+    /// the upstream status code when that first payload is an in-stream
+    /// `HttpError` eligible for rotation fallback, together with the stream
+    /// with all consumed control events re-attached in order (they are part
+    /// of the signed byte stream and must still reach the client). Without
+    /// the skip, a leading control event would mask a first-chunk error frame
+    /// (e.g. SGLang queue-full) and bypass rotation.
+    async fn peek_first_payload_status(stream: StreamingResult) -> (Option<u16>, StreamingResult) {
+        let mut peekable = StreamingResultExt::peekable(stream);
+        let mut leading_control: Vec<Result<SSEEvent, CompletionError>> = Vec::new();
+        while matches!(peekable.peek().await, Some(Ok(event)) if event.chunk.is_none()) {
+            if let Some(ev) = tokio_stream::StreamExt::next(&mut peekable).await {
+                leading_control.push(ev);
+            }
+        }
+
+        let status = if let Some(Err(CompletionError::HttpError { status_code, .. })) =
+            peekable.peek().await
+        {
+            if Self::is_rotation_retryable_status(*status_code) {
+                Some(*status_code)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let stream: StreamingResult = if leading_control.is_empty() {
+            Box::pin(peekable)
+        } else {
+            Box::pin(futures_util::StreamExt::chain(
+                futures_util::stream::iter(leading_control),
+                peekable,
+            ))
+        };
+        (status, stream)
     }
 }
 
@@ -1594,32 +1623,20 @@ impl InferenceProvider for VLlmProvider {
             Ok(response) => {
                 let parser = new_sse_parser(response.bytes_stream(), true);
                 let stream: StreamingResult = Box::pin(parser);
-                let mut peekable = StreamingResultExt::peekable(stream);
-                let first_chunk_status =
-                    if let Some(Err(CompletionError::HttpError { status_code, .. })) =
-                        peekable.peek().await
-                    {
-                        if Self::is_rotation_retryable_status(*status_code) {
-                            Some(*status_code)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
+                let (first_chunk_status, stream) = Self::peek_first_payload_status(stream).await;
                 match first_chunk_status {
                     None => {
                         self.pending_buckets
                             .lock()
                             .unwrap_or_else(|e| e.into_inner())
                             .insert(request_hash, bucket_id);
-                        Ok(Box::pin(peekable))
+                        Ok(stream)
                     }
                     Some(status_code) => {
                         // rotation_count() > 0 is guaranteed by the arm
                         // guard above, so the fallback will actually iterate
                         // at least one alternative backend.
-                        drop(peekable);
+                        drop(stream);
                         self.try_chat_completion_stream_rotation(
                             &streaming_params,
                             &headers,
@@ -2216,6 +2233,104 @@ impl InferenceProvider for VLlmProvider {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    fn control_event(raw: &'static str) -> SSEEvent {
+        SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(raw.as_bytes()),
+            chunk: None,
+            raw_passthrough: true,
+        }
+    }
+
+    fn data_event() -> SSEEvent {
+        SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(b"data: {}\n"),
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
+                id: "chat-1".to_string(),
+                object: "chat.completion.chunk".to_string(),
+                created: 0,
+                model: "test".to_string(),
+                choices: vec![],
+                usage: None,
+                prompt_token_ids: None,
+                system_fingerprint: None,
+                modality: None,
+            })),
+            raw_passthrough: true,
+        }
+    }
+
+    /// A leading control event (keepalive comment) must not mask a
+    /// first-payload in-stream error frame: rotation classification has to
+    /// skip past chunk-less events, and the skipped events must be
+    /// re-attached so the byte stream stays exact (issue #701).
+    #[tokio::test]
+    async fn peek_first_payload_status_skips_leading_control_events() {
+        let items: Vec<Result<SSEEvent, CompletionError>> = vec![
+            Ok(control_event(": keepalive\n")),
+            Ok(control_event("\n")),
+            Err(CompletionError::HttpError {
+                status_code: 503,
+                message: "queue full".to_string(),
+                is_external: false,
+            }),
+        ];
+        let stream: StreamingResult = Box::pin(futures_util::stream::iter(items));
+        let (status, stream) = VLlmProvider::peek_first_payload_status(stream).await;
+        assert_eq!(
+            status,
+            Some(503),
+            "Control events must not mask a retryable first-payload error"
+        );
+
+        // The consumed control events must still come out of the returned
+        // stream, in order, before the error.
+        let replayed: Vec<Result<SSEEvent, CompletionError>> =
+            futures_util::StreamExt::collect(stream).await;
+        assert_eq!(replayed.len(), 3);
+        assert_eq!(
+            replayed[0].as_ref().unwrap().raw_bytes.as_ref(),
+            b": keepalive\n"
+        );
+        assert_eq!(replayed[1].as_ref().unwrap().raw_bytes.as_ref(), b"\n");
+        assert!(matches!(
+            replayed[2],
+            Err(CompletionError::HttpError {
+                status_code: 503,
+                ..
+            })
+        ));
+    }
+
+    /// Happy path: first payload is a parsed data chunk — no rotation, and
+    /// the stream is returned intact.
+    #[tokio::test]
+    async fn peek_first_payload_status_data_first_returns_none() {
+        let items: Vec<Result<SSEEvent, CompletionError>> =
+            vec![Ok(control_event(": ping\n")), Ok(data_event())];
+        let stream: StreamingResult = Box::pin(futures_util::stream::iter(items));
+        let (status, stream) = VLlmProvider::peek_first_payload_status(stream).await;
+        assert_eq!(status, None);
+        let replayed: Vec<Result<SSEEvent, CompletionError>> =
+            futures_util::StreamExt::collect(stream).await;
+        assert_eq!(replayed.len(), 2);
+        assert!(replayed[0].as_ref().unwrap().chunk.is_none());
+        assert!(replayed[1].as_ref().unwrap().chunk.is_some());
+    }
+
+    /// A non-retryable first-payload error (e.g. 400) must not trigger
+    /// rotation.
+    #[tokio::test]
+    async fn peek_first_payload_status_non_retryable_error_returns_none() {
+        let items: Vec<Result<SSEEvent, CompletionError>> = vec![Err(CompletionError::HttpError {
+            status_code: 400,
+            message: "bad request".to_string(),
+            is_external: false,
+        })];
+        let stream: StreamingResult = Box::pin(futures_util::stream::iter(items));
+        let (status, _stream) = VLlmProvider::peek_first_payload_status(stream).await;
+        assert_eq!(status, None);
+    }
 
     #[derive(Debug)]
     struct ChainedErr {

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -1151,9 +1151,15 @@ impl VLlmProvider {
     /// the skip, a leading control event would mask a first-chunk error frame
     /// (e.g. SGLang queue-full) and bypass rotation.
     async fn peek_first_payload_status(stream: StreamingResult) -> (Option<u16>, StreamingResult) {
+        // Cap the control-event skip so a keepalive-only upstream can't stall
+        // first-chunk classification or grow the stash unbounded; past the cap
+        // we stop skipping and classify whatever we've reached.
+        const MAX_LEADING_CONTROL_EVENTS: usize = 32;
         let mut peekable = StreamingResultExt::peekable(stream);
         let mut leading_control: Vec<Result<SSEEvent, CompletionError>> = Vec::new();
-        while matches!(peekable.peek().await, Some(Ok(event)) if event.chunk.is_none()) {
+        while leading_control.len() < MAX_LEADING_CONTROL_EVENTS
+            && matches!(peekable.peek().await, Some(Ok(event)) if event.chunk.is_none())
+        {
             if let Some(ev) = tokio_stream::StreamExt::next(&mut peekable).await {
                 leading_control.push(ev);
             }

--- a/crates/inference_providers/tests/integration_tests.rs
+++ b/crates/inference_providers/tests/integration_tests.rs
@@ -669,6 +669,8 @@ async fn test_reasoning_content() {
                     }
                 }
             }
+            // Control events (blank lines, comments, [DONE]) carry no chunk
+            None => {}
             _ => panic!("Unexpected chunk type"),
         }
     }

--- a/crates/inference_providers/tests/integration_tests.rs
+++ b/crates/inference_providers/tests/integration_tests.rs
@@ -144,7 +144,7 @@ async fn test_chat_completion_streaming() {
             {
                 match chunk_result {
                     Ok(sse_event) => match sse_event.chunk {
-                        StreamChunk::Chat(chat_chunk) => {
+                        Some(StreamChunk::Chat(chat_chunk)) => {
                             chunks_received += 1;
                             println!("Received chat chunk #{chunks_received}: {chat_chunk:?}");
 
@@ -175,9 +175,11 @@ async fn test_chat_completion_streaming() {
                                 }
                             }
                         }
-                        StreamChunk::Text(text_chunk) => {
+                        Some(StreamChunk::Text(text_chunk)) => {
                             panic!("CRITICAL ERROR: Received text chunk in chat completion stream! This indicates stream isolation failure. Chunk: {text_chunk:?}");
                         }
+                        // Control events (comments, blank lines, [DONE]) carry no chunk
+                        None => {}
                     },
                     Err(e) => {
                         // Stream errors should be treated as test failures
@@ -260,7 +262,7 @@ async fn test_text_completion_streaming() {
             {
                 match chunk_result {
                     Ok(sse_event) => match sse_event.chunk {
-                        StreamChunk::Text(text_chunk) => {
+                        Some(StreamChunk::Text(text_chunk)) => {
                             chunks_received += 1;
                             println!("Received text chunk #{chunks_received}: {text_chunk:?}");
 
@@ -287,9 +289,11 @@ async fn test_text_completion_streaming() {
                                 content_received.push_str(&choice.text);
                             }
                         }
-                        StreamChunk::Chat(chat_chunk) => {
+                        Some(StreamChunk::Chat(chat_chunk)) => {
                             panic!("CRITICAL ERROR: Received chat chunk in text completion stream! This indicates stream isolation failure. Chunk: {chat_chunk:?}");
                         }
+                        // Control events (comments, blank lines, [DONE]) carry no chunk
+                        None => {}
                     },
                     Err(e) => {
                         panic!("Stream error in text completion: {e}. This could indicate SSE parsing issues or stream corruption.");
@@ -468,7 +472,7 @@ async fn test_chat_completion_streaming_with_tool_calls() {
             {
                 match chunk_result {
                     Ok(sse_event) => match sse_event.chunk {
-                        StreamChunk::Chat(chat_chunk) => {
+                        Some(StreamChunk::Chat(chat_chunk)) => {
                             chunks_received += 1;
 
                             // Check for tool calls in delta
@@ -529,9 +533,11 @@ async fn test_chat_completion_streaming_with_tool_calls() {
                                 println!("Processed {chunks_received} chunks so far...");
                             }
                         }
-                        StreamChunk::Text(text_chunk) => {
+                        Some(StreamChunk::Text(text_chunk)) => {
                             panic!("CRITICAL ERROR: Received text chunk in chat completion stream with tool calls! Chunk: {text_chunk:?}");
                         }
+                        // Control events (comments, blank lines, [DONE]) carry no chunk
+                        None => {}
                     },
                     Err(e) => {
                         // Stream errors should be treated as test failures
@@ -651,7 +657,7 @@ async fn test_reasoning_content() {
     while let Some(chunk_result) = stream.next().await {
         let event = chunk_result.expect("Stream error");
         match event.chunk {
-            StreamChunk::Chat(chunk) => {
+            Some(StreamChunk::Chat(chunk)) => {
                 if let Some(choice) = chunk.choices.first() {
                     if let Some(delta) = &choice.delta {
                         if let Some(reasoning) = &delta.reasoning_content {

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -350,6 +350,14 @@ where
                 StreamState::Streaming => {
                     match Pin::new(&mut self.inner).poll_next(cx) {
                         Poll::Ready(Some(Ok(ref event))) => {
+                            // Control events (blank lines, comments, [DONE])
+                            // carry no tokens: pass them through untouched so
+                            // the route can forward their raw bytes, but keep
+                            // them out of TTFT/ITL metrics and chat tracking.
+                            if event.chunk.is_none() {
+                                return Poll::Ready(Some(Ok(event.clone())));
+                            }
+
                             let now = Instant::now();
 
                             if !self.first_token_received {
@@ -379,7 +387,7 @@ where
                                 self.last_token_time = Some(now);
                             }
 
-                            if let StreamChunk::Chat(ref chat_chunk) = event.chunk {
+                            if let Some(StreamChunk::Chat(ref chat_chunk)) = event.chunk {
                                 // Track chat_id for attestation (updated on each chunk)
                                 self.last_chat_id = Some(chat_chunk.id.clone());
 
@@ -1835,7 +1843,8 @@ mod tests {
         // Create a stream with a content chunk and a usage chunk
         let content_chunk = SSEEvent {
             raw_bytes: Bytes::from("data: ..."),
-            chunk: StreamChunk::Chat(ChatCompletionChunk {
+            raw_passthrough: true,
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
                 id: "chat-1".to_string(),
                 object: "chat.completion.chunk".to_string(),
                 created: 1234567890,
@@ -1845,12 +1854,13 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
-            }),
+            })),
         };
 
         let usage_chunk = SSEEvent {
             raw_bytes: Bytes::from("data: ..."),
-            chunk: StreamChunk::Chat(ChatCompletionChunk {
+            raw_passthrough: true,
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
                 id: "chat-1".to_string(),
                 object: "chat.completion.chunk".to_string(),
                 created: 1234567890,
@@ -1871,7 +1881,7 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
-            }),
+            })),
         };
 
         let stream = stream::iter(vec![Ok(content_chunk), Ok(usage_chunk)]);
@@ -1973,7 +1983,8 @@ mod tests {
         // Create multiple content chunks to test ITL calculation
         let chunk1 = SSEEvent {
             raw_bytes: Bytes::from("data: chunk1"),
-            chunk: StreamChunk::Chat(ChatCompletionChunk {
+            raw_passthrough: true,
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
                 id: "chat-1".to_string(),
                 object: "chat.completion.chunk".to_string(),
                 created: 1234567890,
@@ -1983,12 +1994,13 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
-            }),
+            })),
         };
 
         let chunk2 = SSEEvent {
             raw_bytes: Bytes::from("data: chunk2"),
-            chunk: StreamChunk::Chat(ChatCompletionChunk {
+            raw_passthrough: true,
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
                 id: "chat-1".to_string(),
                 object: "chat.completion.chunk".to_string(),
                 created: 1234567890,
@@ -1998,12 +2010,13 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
-            }),
+            })),
         };
 
         let usage_chunk = SSEEvent {
             raw_bytes: Bytes::from("data: usage"),
-            chunk: StreamChunk::Chat(ChatCompletionChunk {
+            raw_passthrough: true,
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
                 id: "chat-1".to_string(),
                 object: "chat.completion.chunk".to_string(),
                 created: 1234567890,
@@ -2024,7 +2037,7 @@ mod tests {
                 prompt_token_ids: None,
                 modality: None,
                 system_fingerprint: None,
-            }),
+            })),
         };
 
         // Simulate a stream with delays between chunks
@@ -2126,7 +2139,8 @@ mod tests {
         // Single chunk with usage (no inter-token latency to measure)
         let usage_chunk = SSEEvent {
             raw_bytes: Bytes::from("data: usage"),
-            chunk: StreamChunk::Chat(ChatCompletionChunk {
+            raw_passthrough: true,
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
                 id: "chat-1".to_string(),
                 object: "chat.completion.chunk".to_string(),
                 created: 1234567890,
@@ -2147,7 +2161,7 @@ mod tests {
                 prompt_token_ids: None,
                 modality: None,
                 system_fingerprint: None,
-            }),
+            })),
         };
 
         let stream = stream::iter(vec![Ok(usage_chunk)]);

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -2015,8 +2015,24 @@ impl InferenceProviderPool {
         // Must be synchronous to ensure attestation service can find the provider
         let mut peekable = StreamingResultExt::peekable(stream);
         let mut pinned = false;
+
+        // Control events (blank lines, comments — no parsed chunk) may
+        // precede the first data chunk. Consume and stash them so the peek
+        // below sees the first parsed chunk; they are re-attached in order
+        // since their raw bytes are part of the signed stream (issue #701).
+        let mut leading_control: Vec<Result<inference_providers::SSEEvent, CompletionError>> =
+            Vec::new();
+        {
+            use futures::StreamExt as _;
+            while matches!(peekable.peek().await, Some(Ok(event)) if event.chunk.is_none()) {
+                if let Some(ev) = peekable.next().await {
+                    leading_control.push(ev);
+                }
+            }
+        }
+
         if let Some(Ok(event)) = peekable.peek().await {
-            if let inference_providers::StreamChunk::Chat(chat_chunk) = &event.chunk {
+            if let Some(inference_providers::StreamChunk::Chat(chat_chunk)) = &event.chunk {
                 let chat_id = chat_chunk.id.clone();
                 tracing::info!(
                     chat_id = %chat_id,
@@ -2034,7 +2050,14 @@ impl InferenceProviderPool {
             provider.pin_chat_connection(&request_hash, "");
             provider.unpin_chat_connection("");
         }
-        Ok(Box::pin(peekable))
+        if leading_control.is_empty() {
+            Ok(Box::pin(peekable))
+        } else {
+            use futures::StreamExt as _;
+            Ok(Box::pin(
+                futures::stream::iter(leading_control).chain(peekable),
+            ))
+        }
     }
 
     pub async fn chat_completion(
@@ -3998,7 +4021,7 @@ mod tests {
 
         let first_event = stream.next().await.unwrap().unwrap();
         let chat_id = match first_event.chunk {
-            inference_providers::StreamChunk::Chat(chunk) => chunk.id,
+            Some(inference_providers::StreamChunk::Chat(chunk)) => chunk.id,
             _ => panic!("Expected chat chunk"),
         };
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -22,6 +22,13 @@ use tracing::{debug, info, warn};
 
 type InferenceProviderTrait = dyn InferenceProvider + Send + Sync;
 
+/// Upper bound on leading SSE control events (keepalive comments, blank
+/// lines — chunk-less `SSEEvent`s) consumed while peeking for the first
+/// parsed chunk to establish sticky-routing. Real upstreams emit zero before
+/// the first data chunk; the cap stops a misbehaving upstream from stalling
+/// stream return or growing the stash unbounded (issue #701).
+const MAX_LEADING_CONTROL_EVENTS: usize = 32;
+
 /// Trait for fetching external model configurations from a data source (e.g., database).
 /// This decouples the InferenceProviderPool from the database crate (hexagonal architecture).
 #[async_trait::async_trait]
@@ -2020,11 +2027,16 @@ impl InferenceProviderPool {
         // precede the first data chunk. Consume and stash them so the peek
         // below sees the first parsed chunk; they are re-attached in order
         // since their raw bytes are part of the signed stream (issue #701).
+        // Bounded by MAX_LEADING_CONTROL_EVENTS so a keepalive-only upstream
+        // can't stall stream return or grow the stash unbounded — past the
+        // cap we return the stream without pinning a sticky-routing mapping.
         let mut leading_control: Vec<Result<inference_providers::SSEEvent, CompletionError>> =
             Vec::new();
         {
             use futures::StreamExt as _;
-            while matches!(peekable.peek().await, Some(Ok(event)) if event.chunk.is_none()) {
+            while leading_control.len() < MAX_LEADING_CONTROL_EVENTS
+                && matches!(peekable.peek().await, Some(Ok(event)) if event.chunk.is_none())
+            {
                 if let Some(ev) = peekable.next().await {
                     leading_control.push(ev);
                 }

--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -2491,7 +2491,7 @@ impl ResponseServiceImpl {
         use inference_providers::StreamChunk;
 
         match &event.chunk {
-            StreamChunk::Chat(chat_chunk) => {
+            Some(StreamChunk::Chat(chat_chunk)) => {
                 // Extract delta content from choices
                 for choice in &chat_chunk.choices {
                     if let Some(delta) = &choice.delta {
@@ -2724,7 +2724,7 @@ impl ResponseServiceImpl {
     ) {
         use inference_providers::StreamChunk;
 
-        if let StreamChunk::Chat(chat_chunk) = &event.chunk {
+        if let Some(StreamChunk::Chat(chat_chunk)) = &event.chunk {
             if let Some(usage) = &chat_chunk.usage {
                 tracing::debug!(
                     "Extracted usage from completion stream: input={}, output={}",
@@ -2747,7 +2747,7 @@ impl ResponseServiceImpl {
     ) {
         use inference_providers::StreamChunk;
 
-        if let StreamChunk::Chat(chat_chunk) = &event.chunk {
+        if let Some(StreamChunk::Chat(chat_chunk)) = &event.chunk {
             for choice in &chat_chunk.choices {
                 if let Some(delta) = &choice.delta {
                     if let Some(tool_calls) = &delta.tool_calls {


### PR DESCRIPTION
Fixes #701.

## Problem

The documented [chat verification flow](https://docs.near.ai/cloud/verification/chat) doesn't work through the gateway for streaming: cloud-api decoded every upstream SSE chunk into `ChatCompletionChunk` and re-serialized it (`completions.rs` streaming path), so the bytes the client received differed from the bytes the inference TEE emitted and signed — `sha256(received bytes)` could never match the signed response hash. Non-streaming already forwards `raw_bytes` verbatim; this brings streaming to parity.

## Approach (option 1 from #701)

**Lossless parser.** `BufferedSSEParser` gains `SSEEventParser::passthrough_raw()` (true for `OpenAIEventParser`, i.e. our vLLM/SGLang path + external OpenAI-compatible upstreams). For passthrough parsers, control lines — blank separators, `: comments`, non-data SSE fields (`event:`/`id:`), `data: [DONE]`, and any trailing unterminated bytes at stream end — are emitted as chunk-less events (`SSEEvent.chunk: Option<StreamChunk>`, `None` = control) so concatenating every event's `raw_bytes` reproduces the upstream byte stream **exactly**. This mirrors what inference-proxy hashes: the bytes it actually sends, including non-data lines and a final-line flush. Gemini/Anthropic parsers keep the historical skip behavior (their raw bytes are native-format and must be re-serialized).

**Route passthrough.** The chat streaming route forwards `event.raw_bytes` untouched when the event is passthrough-capable and auto-redact is inactive, and suppresses the gateway-minted `[DONE]` when the upstream's own terminator was forwarded. Auto-redact (mutates chunk text) and non-OpenAI providers (need normalization) keep the re-serialization path. Parsing still happens alongside — usage/billing (`InterceptStream`), TTFT/ITL metrics, `Inference-Id`, first-chunk error classification/rotation are all unchanged; none of them needs to rewrite client bytes.

**Not changed:**
- `/v1/completions` (text) reshapes chat chunks into text-completion format by design → stays on re-serialization, just skips control events.
- Mid-stream error frames still surface as a gateway-minted error frame (#630 territory; inference-proxy doesn't cache a signature for streams that don't complete cleanly anyway).
- Clients already received per-chunk `usage` (the gateway requests `continuous_usage_stats` upstream) — no behavior change there.

**Cleanups:** removed `accumulated_bytes` (buffered every streamed response in memory, never read) and `chat_id_state` (write-only) from the chat streaming route.

## Tests

- New parser test `test_sse_parser_passthrough_byte_exact_reassembly`: multi-packet stream with comments, CRLF endings, `event:` fields, `[DONE]`, trailing unterminated bytes — asserts byte-exact reassembly.
- New `test_sse_parser_non_passthrough_parser_skips_control_lines` pins the Gemini/Anthropic-style behavior.
- **Regression guard:** the mock provider now emits wire bytes in a deliberately different-but-equivalent JSON encoding (sorted keys + a field unknown to our structs) and registers signature hashes over those bytes — exactly how inference-proxy signs what it sends. `test_streaming_chat_completion_signature_verification` (asserts `sha256(received) == signed hash` end-to-end) **fails on the re-serialization path (verified by temporarily disabling passthrough) and passes only with verbatim forwarding**.
- Full suite green locally: 667 unit + 508 e2e (docker postgres).

## Verification after deploy

`nearai/infra-tests#30` added byte-exact hash assertions for all four paths with gateway-stream xfail'd (non-strict) referencing #701 — it will show **XPASS** in the infra suite once this reaches prod, then the marker can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
