### PR TITLE
inference_provider_pool: harvest both signing algos for single-backend models

### DIFF
--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -793,6 +793,17 @@ impl InferenceProviderPool {
     /// `/backends/count`, then fan out calls across backend indices and
     /// algos. One cycle = full coverage.
     ///
+    /// Single-backend floor: when `backend_count < ALGOS.len()`, the loop
+    /// would otherwise miss an algorithm — e.g., `backend_count=1` would
+    /// only fetch ECDSA and never harvest the Ed25519 pubkey, leaving
+    /// `pubkey_to_providers` permanently missing that entry and breaking
+    /// Ed25519 E2EE for that model (nearai/infra#167). We pad the iteration
+    /// count to `max(backend_count, ALGOS.len())` so every algo is hit at
+    /// least once; the rotation index wraps with `i % backend_count`, so
+    /// the extra iterations re-probe an existing backend with the missing
+    /// algo. Pubkeys are TEE-derived from the compose hash so the same
+    /// backend serves a deterministic pubkey per algo.
+    ///
     /// Why an isolated Bootstrap state per call: if discovery calls shared
     /// the caller's `fingerprint_state`, the first call that completed and
     /// pinned its backend's SPKI would transition the state to `Pinned({A})`,
@@ -3335,6 +3346,69 @@ impl InferenceProviderPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pure mirror of the `discover_model` call-plan: returns `(backend_idx, algo)`
+    /// for each of the `max(backend_count, algos.len())` calls. Lets us pin the
+    /// invariant without spinning up a real provider + verifier. Drifts only if
+    /// the loop in `discover_model` changes; bring this helper in sync if it does.
+    fn discover_model_call_plan<'a>(
+        backend_count: usize,
+        algos: &'a [&'a str],
+    ) -> Vec<(usize, &'a str)> {
+        let n_calls = backend_count.max(algos.len());
+        (0..n_calls)
+            .map(|i| (i % backend_count.max(1), algos[i % algos.len()]))
+            .collect()
+    }
+
+    #[test]
+    fn discover_model_single_backend_covers_both_algos() {
+        // Regression for nearai/infra#167: pre-fix, `backend_count=1` produced
+        // exactly one call with `ALGOS[0]` ("ecdsa"), so Ed25519 was never
+        // harvested and E2EE-via-ed25519 failed with HTTP 421 NoPubKeyProvider.
+        let algos = ["ecdsa", "ed25519"];
+        let plan = discover_model_call_plan(1, &algos);
+        assert_eq!(plan.len(), 2, "expected 2 calls to cover both algos");
+        // Both calls target the only backend (index 0). The extra iteration
+        // wraps via `i % backend_count` so the rotation URL is buildable.
+        assert!(plan.iter().all(|(idx, _)| *idx == 0));
+        let covered: std::collections::HashSet<&str> = plan.iter().map(|(_, a)| *a).collect();
+        for algo in &algos {
+            assert!(
+                covered.contains(algo),
+                "missing algo {algo} in single-backend plan"
+            );
+        }
+    }
+
+    #[test]
+    fn discover_model_multi_backend_unchanged() {
+        // Multi-backend models were already correct (alternating algos across
+        // distinct backends); this test pins that pre-fix behavior.
+        let algos = ["ecdsa", "ed25519"];
+
+        // backend_count == ALGOS.len(): one call per backend, both algos.
+        let plan = discover_model_call_plan(2, &algos);
+        assert_eq!(plan, vec![(0, "ecdsa"), (1, "ed25519")]);
+
+        // backend_count > ALGOS.len(): every backend gets a call, algos alternate.
+        let plan = discover_model_call_plan(5, &algos);
+        assert_eq!(
+            plan,
+            vec![
+                (0, "ecdsa"),
+                (1, "ed25519"),
+                (2, "ecdsa"),
+                (3, "ed25519"),
+                (4, "ecdsa"),
+            ]
+        );
+        // Both algos still covered.
+        let covered: std::collections::HashSet<&str> = plan.iter().map(|(_, a)| *a).collect();
+        for algo in &algos {
+            assert!(covered.contains(algo));
+        }
+    }
 
     /// Helper for `apply_pin_update` tests: build a state, run the policy,
     /// return the (PinUpdate, current pinned-set) pair.


### PR DESCRIPTION
## Summary

Closes nearai/infra#167. Fixes ed25519 E2EE 421 (`NoPubKeyProvider`) on staging for any inference_url-routed model with `healthy = 1` in model-proxy `/registry`.

## What was wrong

`discover_model` fans out one attestation call per backend index, alternating signing algorithms across calls:

```rust
const ALGOS: [&str; 2] = ["ecdsa", "ed25519"];
let futures = (0..backend_count)
    .map(|i| {
        ...
        let algo = ALGOS[i % ALGOS.len()].to_string();
        ...
    });
```

For `backend_count = 1`: loop runs once with `ALGOS[0] = "ecdsa"`. The ed25519 pubkey is never harvested. `pubkey_to_providers` ends up missing the ed25519 entry permanently, and ed25519-encrypted requests return 421 with the misleading "The encryption key is no longer valid" message — even though the actual TEE keypair on the backend is fresh and valid.

DeepSeek-V4-Flash on staging (`healthy=1`) tripped this; all three `test_stg_e2ee.py::TestStaging{NonStreaming,Streaming}` ed25519 cases failed. Multi-backend models (`healthy ≥ 2`) were spared by coincidence — the alternating loop happened to hit both algos.

## What this changes

| backend_count | calls (before) | calls (after) | algo coverage |
|---|---|---|---|
| 1 | `(0, ecdsa)` | `(0, ecdsa)`, `(0, ed25519)` | **was ECDSA only, now both ✓** |
| 2 | `(0, ecdsa)`, `(1, ed25519)` | unchanged | both |
| ≥3 | `(i, ALGOS[i%2])` per backend | unchanged | both |

Iterate `max(backend_count, ALGOS.len())` times, wrap the rotation index with `i % backend_count`. The extra call re-probes the same backend with the missing algo — TEE-derived pubkeys are deterministic per `(model, algo)`, so the response is the expected ed25519 key.

Cost: one extra HTTP call per single-backend model per discovery cycle. With the default 5-min refresh interval and a handful of single-backend self-hosted models on staging, that's ~bytes per minute of additional traffic to TEEs that are already serving these probes regularly.

## Trade-off: `apply_pin_update` regression on partial failures

`apply_pin_update`'s "complete coverage → replace pin set" gate is `failed_calls == 0 && verify_failures == 0 && verified.len() == backend_count`. When an extra-algo retry call fails on a single-backend model, `failed_calls` is now 1 even though the backend's primary call succeeded, so the gate flips to "additive merge". A stale pinned fingerprint can therefore linger one extra refresh cycle longer if ed25519 has a transient failure. The next clean cycle (2/2 success) replaces it.

Accepted to keep the patch small. Tracking per-backend coverage cleanly would require threading `backend_idx` through the result tuple — left as a follow-up if dashboards show the additive-merge path firing too often on single-backend models.

## Observability

Debug logs in the per-call closure now use `index = backend_idx` instead of `index = i`. Dashboards keying off the `index` field see only valid backend indices (0..backend_count-1) rather than the synthetic call index (which can exceed `backend_count - 1` after this patch).

## Test plan

- [x] `cargo test -p services --lib inference_provider_pool::tests::discover_model` — 2 new tests pass:
  - `discover_model_single_backend_covers_both_algos`: pins the single-backend invariant. Pre-fix this would fail with `expected 2 calls`.
  - `discover_model_multi_backend_unchanged`: pins that `backend_count ∈ {2, 5}` still produces the original alternating plan (no regression on the working path).
- [x] `cargo test -p services --lib` — all 333 tests pass.
- [x] `cargo build -p services` clean.
- [ ] After deploy to staging: `pytest tests/test_stg_e2ee.py -k DeepSeek` → 14/14 pass. Currently 11/14 (ed25519 non-streaming, system-message, streaming all fail).
- [ ] No regression on multi-backend ed25519: `pytest tests/test_stg_e2ee.py -k 'Qwen3.5 or GLM-5.1'` still pass.
- [ ] Watch for `pubkey_to_providers` growth (each single-backend model now adds 2 entries instead of 1) — expected; the map is keyed by pubkey not provider, and per-model size doubles only for the previously-broken single-backend case.

## Related

- nearai/infra#167 — this RCA
- nearai/infra#164 — staging-side SNI fall-through, separate bug (closed by nearai/cvm-compose-files#53)
- nearai/infra#165 — promote/rollback verbatim-URL footgun (open: nearai/cvm-ansible-playbooks#273)

All three came in on 2026-06-02's staging cloud-api redeploy.