### PR TITLE
fix(inference_provider_pool): cover both algos when backend_count < ALGOS.len()

### DIFF
--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -61,10 +61,12 @@ struct DiscoveryOutcome {
     /// they're identical across backends of the same model.
     pubkeys_by_algo: HashMap<String, String>,
     /// Per-call verified TLS fingerprints observed in this pass, in launch
-    /// order (by index — `futures::future::join_all` preserves the input
-    /// order, not completion order). With rotation, each index lands on a
-    /// distinct backend, so under complete coverage every entry is unique
-    /// and `observed_fingerprints.len() == backend_count`.
+    /// order (`futures::future::join_all` preserves input order, not
+    /// completion order). One entry per call, not per backend, so under
+    /// complete coverage `observed_fingerprints.len() == max(backend_count,
+    /// ALGOS.len())`. When `backend_count == 1`, the two algo calls hit
+    /// the same backend and entries repeat — the set of *distinct*
+    /// fingerprints is `verified_this_round` (used for pin updates).
     observed_fingerprints: Vec<String>,
     /// Per-call failure reasons that prevented a fingerprint observation, in
     /// launch order. Each entry is `"{category}: {detail}"` where category
@@ -766,10 +768,18 @@ impl InferenceProviderPool {
         None
     }
 
-    /// Run N attestation-discovery calls against a model URL, each on its own
+    /// Run attestation-discovery calls against a model URL, each on its own
     /// minimal `reqwest::Client` (fresh TCP connection, isolated `FingerprintState`),
-    /// alternating signing algorithms to harvest both ECDSA and Ed25519 signing
-    /// pubkeys in the same pass.
+    /// covering every (backend_index, signing_algo) pair needed to harvest
+    /// both ECDSA and Ed25519 signing pubkeys in the same pass.
+    ///
+    /// The number of calls is `max(backend_count, ALGOS.len())`: one per
+    /// backend (for TLS-cert fingerprint coverage across all serving CVMs)
+    /// and at least one per algo (so both ECDSA and Ed25519 pubkeys are
+    /// fetched even when a model has only a single backend). For
+    /// `backend_count >= ALGOS.len()`, this degenerates to one call per
+    /// backend; for `backend_count == 1` it issues two calls to the same
+    /// backend, one per algo.
     ///
     /// Why a fresh client per call: reqwest with HTTP/2 multiplexes many
     /// concurrent requests onto a single TCP connection, which hashes to a
@@ -780,8 +790,8 @@ impl InferenceProviderPool {
     /// (see model-proxy PR #27). A fresh-TCP probe to that SNI is routed
     /// deterministically to `backends_sorted_by_address[N % healthy_count]`,
     /// bypassing the least-connections LB. We fetch the healthy count from
-    /// `/backends/count`, then fan out one call per backend index. One cycle
-    /// = full coverage.
+    /// `/backends/count`, then fan out calls across backend indices and
+    /// algos. One cycle = full coverage.
     ///
     /// Why an isolated Bootstrap state per call: if discovery calls shared
     /// the caller's `fingerprint_state`, the first call that completed and
@@ -793,11 +803,12 @@ impl InferenceProviderPool {
     /// accumulator *after* the HTTP calls return.
     ///
     /// Why extract pubkeys here: the attestation report already contains
-    /// `signing_public_key` for the requested `signing_algo`. Alternating
-    /// algos across the N calls yields both keys in one pass. Pubkeys are
-    /// derived from the TEE compose hash so they're identical across
-    /// backends of the same model+algo; the first verified response per
-    /// algo wins.
+    /// `signing_public_key` for the requested `signing_algo`. The
+    /// `max(backend_count, ALGOS.len())` fan-out guarantees both ECDSA and
+    /// Ed25519 are queried at least once per cycle, even when a model has
+    /// only a single backend. Pubkeys are derived from the TEE compose
+    /// hash so they're identical across backends of the same model+algo;
+    /// the first verified response per algo wins.
     ///
     /// Rapid eviction: when every healthy backend produced exactly one
     /// verified fingerprint, the pin set is REPLACED with the observed set
@@ -945,11 +956,20 @@ impl InferenceProviderPool {
             backend_count
         };
 
-        // Step 2: fan out one attestation call per backend index, in
-        // parallel (no stagger — each call lands on a distinct backend, so
-        // per-backend pressure is exactly one attestation per cycle).
-        let futures = (0..backend_count)
+        // Step 2: fan out attestation calls across (backend_index, algo) pairs
+        // in parallel (no stagger). Total calls = max(backend_count,
+        // ALGOS.len()) so every algo is sampled at least once even when a
+        // model has only a single backend (which would otherwise leave one
+        // algo's pubkey out of pubkey_to_providers, breaking E2EE routing
+        // for that algo — see nearai/cloud-api#710).
+        //
+        // backend_index = i % backend_count maps the call sequence back to a
+        // rotation backend; for backend_count >= 2 this equals i and the
+        // loop degenerates to one call per backend (unchanged from before).
+        let call_count = backend_count.max(ALGOS.len());
+        let futures = (0..call_count)
             .map(|i| {
+                let backend_index = i % backend_count;
                 let parts = parts.clone();
                 let api_key = api_key.clone();
                 let model = model_name.to_string();
@@ -970,7 +990,7 @@ impl InferenceProviderPool {
                         Err(e) => {
                             debug!(
                                 model = %model,
-                                index = i,
+                                index = backend_index,
                                 algo = %algo,
                                 error = %e,
                                 "Failed to build discovery client"
@@ -979,10 +999,11 @@ impl InferenceProviderPool {
                         }
                     };
 
-                    let mut request_url = match rotation::rotation_base_url(&parts, i as u64) {
-                        Some(u) => u,
-                        None => return Err("rotation_url_build: failed".to_string()),
-                    };
+                    let mut request_url =
+                        match rotation::rotation_base_url(&parts, backend_index as u64) {
+                            Some(u) => u,
+                            None => return Err("rotation_url_build: failed".to_string()),
+                        };
                     request_url.set_path("/v1/attestation/report");
 
                     let nonce_bytes: [u8; 32] = rand::random();
@@ -1012,7 +1033,7 @@ impl InferenceProviderPool {
                         Ok(Err(e)) => {
                             debug!(
                                 model = %model,
-                                index = i,
+                                index = backend_index,
                                 algo = %algo,
                                 elapsed_ms,
                                 error = %e,
@@ -1037,7 +1058,7 @@ impl InferenceProviderPool {
                         Err(_) => {
                             debug!(
                                 model = %model,
-                                index = i,
+                                index = backend_index,
                                 algo = %algo,
                                 elapsed_ms,
                                 "Discovery call timed out"
@@ -1050,7 +1071,7 @@ impl InferenceProviderPool {
                         let status = resp.status().as_u16();
                         debug!(
                             model = %model,
-                            index = i,
+                            index = backend_index,
                             algo = %algo,
                             status = status,
                             elapsed_ms,
@@ -1064,7 +1085,7 @@ impl InferenceProviderPool {
                         Err(e) => {
                             debug!(
                                 model = %model,
-                                index = i,
+                                index = backend_index,
                                 algo = %algo,
                                 error = %e,
                                 "Discovery call returned malformed JSON"
@@ -1074,7 +1095,7 @@ impl InferenceProviderPool {
                     };
                     debug!(
                         model = %model,
-                        index = i,
+                        index = backend_index,
                         algo = %algo,
                         elapsed_ms,
                         "Discovery call succeeded"


### PR DESCRIPTION
Fixes #710.

## Bug

`discover_model` uses

```rust
let algo = ALGOS[i % ALGOS.len()].to_string();   // ALGOS = ["ecdsa","ed25519"]
```

across `i in 0..backend_count`. For `backend_count == 1`, only `i = 0` is ever evaluated, so only `"ecdsa"` is fetched. The ed25519 signing pubkey never lands in `pubkey_to_providers`, and chat completions with `X-Signing-Algo: ed25519` return 421 `no provider found for model … with public key …` — even though the live `/v1/attestation/report?signing_algo=ed25519` (which hits the backend directly, bypassing the cache) returns the correct ed25519 pubkey.

Models with `backend_count >= 2` were unaffected because indices 0 and 1 modulo 2 happen to cover both algos.

## Empirical cross-check

Across prod today (`completions.near.ai/backends/count?domain=...`):

| Model | `backend_count` | ed25519 routing pre-fix |
|---|---|---|
| `dsv4-flash` | 1 | ❌ 421 |
| `qwen3-6-27b` | 1 | ❌ (not added to cloud-api yet — same bug would apply) |
| `qwen3-6-35b` | 2 | ✅ |
| `qwen3-30b` | 2 | ✅ |
| `gpt-oss-120b` | 2 | ✅ |
| `gemma-4-31b` | 3 | ✅ |
| `glm-5-1` | 4 | ✅ |

`X-Encryption-Version: 2` was ruled out as a cause: that header gates payload v1/v2 codec selection at the backend, not routing. Without it, every multi-backend model returns 400 `Decryption failed`; with it, 200. The 421 from DSV4 is independent and identical regardless of the header.

## Fix

Decouple the algo from the backend index. Total calls = `max(backend_count, ALGOS.len())`:

- `backend_index = i % backend_count` for rotation-SNI routing
- `algo = ALGOS[i % ALGOS.len()]` for algo selection

For `backend_count >= ALGOS.len()` (≥2 today) this is identical to the previous behavior — same number of calls, same algo coverage. For `backend_count == 1` it issues **two** calls to the same backend (one per algo).

The `complete_coverage` check in `apply_pin_update` still keys off `backend_count` (not `call_count`): under the single-backend case, both algo calls hit the same backend so the deduped fingerprint set has size 1, matching `backend_count`. Rapid-eviction semantics preserved.

## What's untouched

- TLS-cert pinning logic (`apply_pin_update`, `FingerprintState`) — unchanged.
- `pubkeys_by_algo` write semantics (first-write-wins per algo) — unchanged; just gets at least one write per algo now.
- Refresh / reuse path at `sync_inference_url_models` — already merges `pubkeys_by_algo` additively. With this fix, the ed25519 entry actually gets harvested and backfilled on the same cycle the bug previously silently dropped it.
- `DiscoveryOutcome::observed_fingerprints` — docstring updated; for `backend_count == 1` it now contains the same fingerprint twice (one entry per call). The deduped set used for pin updates is `verified_this_round`.

## Verification plan

- [x] `cargo build -p services`
- [x] `cargo clippy -p services -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --lib -p services inference_provider_pool` → 48 pass / 0 fail
- [ ] Post-deploy on staging: PATCH a single-backend model (e.g. add DSV4 there), then `POST /v1/chat/completions` with `X-Signing-Algo: ed25519` + correct `X-Model-Pub-Key` → expect 200, not 421.
- [ ] Post-deploy on prod: same check against the existing DSV4 deployment.

Existing tests use `MockProvider` and don't traverse the live `discover_model` HTTP path, so no unit test in this file directly exercises the bug. The behavioral change is small enough — and the empirical evidence narrow enough — that I held off introducing a wiremock-based test for the discovery loop in this PR. Happy to add one in a follow-up if reviewers want it.

## Cost

Discovery is one cycle every 5 minutes per model. For single-backend models, this adds **one extra HTTP call per 5 min**. Negligible.