### PR TITLE
fix(completions): forward frequency_penalty/presence_penalty to self-hosted backends (#622)

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -288,6 +288,26 @@ fn convert_chat_request_to_service(
     body_hash: RequestBodyHash,
     request_id: Uuid,
 ) -> ServiceCompletionRequest {
+    // `presence_penalty` / `frequency_penalty` are typed fields on
+    // `ChatCompletionRequest`, so `#[serde(flatten)] extra` never captures them.
+    // The service layer hardcodes the typed `ChatCompletionParams` penalty slots
+    // to `None`, so forward them through `extra` (matching seed/logprobs and the
+    // text-completion path) — otherwise they are silently dropped before reaching
+    // the self-hosted backend (nearai/cloud-api #622).
+    let mut extra = request.extra.clone();
+    if let Some(presence_penalty) = request.presence_penalty {
+        extra.insert(
+            "presence_penalty".to_string(),
+            serde_json::json!(presence_penalty),
+        );
+    }
+    if let Some(frequency_penalty) = request.frequency_penalty {
+        extra.insert(
+            "frequency_penalty".to_string(),
+            serde_json::json!(frequency_penalty),
+        );
+    }
+
     ServiceCompletionRequest {
         request_id,
         model: request.model.clone(),
@@ -325,7 +345,7 @@ fn convert_chat_request_to_service(
         store: None,
         body_hash: body_hash.hash.clone(),
         response_id: None, // Direct chat completions API calls don't have a response_id
-        extra: request.extra.clone(),
+        extra,
     }
 }
 

--- a/crates/api/tests/e2e_all/openrouter_params.rs
+++ b/crates/api/tests/e2e_all/openrouter_params.rs
@@ -422,3 +422,55 @@ async fn test_json_schema_response_format_accepted_and_forwarded() {
         "response_format.type not preserved on passthrough"
     );
 }
+
+// ── frequency_penalty / presence_penalty (nearai/cloud-api #622) ─────────────
+
+/// `frequency_penalty` and `presence_penalty` are typed fields on
+/// `ChatCompletionRequest`, so they don't fall through `#[serde(flatten)] extra`
+/// on their own. They must still reach the self-hosted backend — the service
+/// layer hardcodes the typed `ChatCompletionParams` penalty slots to `None`, so
+/// the route forwards them via the `extra` passthrough map. Regression guard for
+/// #622, where both penalties were silently dropped (output byte-identical at
+/// penalty 0 vs 2.0).
+#[tokio::test]
+async fn test_penalties_accepted_and_forwarded() {
+    let (server, mock, model, api_key) = setup().await;
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&serde_json::json!({
+            "model": model,
+            "messages": [{"role": "user", "content": "Repeat banana ten times."}],
+            "frequency_penalty": 1.5,
+            "presence_penalty": 0.75,
+            "max_tokens": 20,
+            "temperature": 0,
+            "stream": false,
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        200,
+        "penalties should be accepted, got: {}",
+        response.text()
+    );
+    let params = mock.last_chat_params().await.expect("provider was called");
+    assert_eq!(
+        params
+            .extra
+            .get("frequency_penalty")
+            .and_then(|v| v.as_f64()),
+        Some(1.5),
+        "frequency_penalty not forwarded in `extra` (#622)"
+    );
+    assert_eq!(
+        params
+            .extra
+            .get("presence_penalty")
+            .and_then(|v| v.as_f64()),
+        Some(0.75),
+        "presence_penalty not forwarded in `extra` (#622)"
+    );
+}


### PR DESCRIPTION
## Summary

`frequency_penalty` and `presence_penalty` had no observable effect on any self-hosted (vLLM/SGLang) model — output was byte-identical at penalty 0 vs 2.0.

**Root cause:** Both are typed fields on `ChatCompletionRequest`, so serde `#[flatten] extra` never captured them. The service layer (`create_chat_completion[_stream]`) hardcodes the typed `ChatCompletionParams.frequency_penalty`/`presence_penalty` slots to `None`. With nothing in `extra` and the typed slots nulled, both penalties were dropped before reaching the backend.

**Fix:** In `convert_chat_request_to_service`, forward the typed penalty fields into the `extra` passthrough map — matching how `seed`/`logprobs`/`top_logprobs` and the text-completion path already work. The vLLM adapter spreads `extra` into the upstream JSON body, so both penalties now reach the self-hosted backend.

Scope kept tight: only penalty forwarding. Out-of-range validation is a separate issue (same family as #613) and intentionally not addressed here.

## Testing
- `cargo build --workspace` — passes
- `cargo test -p inference_providers --lib --tests` — 180 + 8 pass (the one doctest failure on `detect_audio_content_type` pre-exists on main, unrelated)
- `cargo test --test e2e_all -- openrouter` — 10/10 pass, incl. new `test_penalties_accepted_and_forwarded` asserting both penalties land in `params.extra`

Fixes #622