### PR TITLE
fix(vision): preserve image bytes/media_type on Anthropic & Gemini passthrough (#640)

### DIFF
--- a/crates/inference_providers/src/external/anthropic/converter.rs
+++ b/crates/inference_providers/src/external/anthropic/converter.rs
@@ -49,6 +49,23 @@ pub enum AnthropicContentPart {
         tool_use_id: String,
         content: String,
     },
+    #[serde(rename = "image")]
+    Image { source: AnthropicImageSource },
+}
+
+/// Anthropic image source. Anthropic accepts either inline base64 bytes
+/// (`type: "base64"`) or a remote URL (`type: "url"`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum AnthropicImageSource {
+    #[serde(rename = "base64")]
+    Base64 {
+        media_type: String,
+        /// Exact base64 payload, forwarded verbatim (no re-encoding).
+        data: String,
+    },
+    #[serde(rename = "url")]
+    Url { url: String },
 }
 
 /// Anthropic tool definition
@@ -221,15 +238,12 @@ pub struct AnthropicResponse {
 
 /// Convert OpenAI messages to Anthropic format
 pub fn convert_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<AnthropicMessage>) {
+    use crate::external::content::{
+        parse_content, text_from_content as extract_content, ContentPart,
+    };
+
     let mut system_message = None;
     let mut anthropic_messages = Vec::new();
-
-    let extract_content = |value: &serde_json::Value| -> String {
-        match value {
-            serde_json::Value::String(s) => s.clone(),
-            _ => value.to_string(),
-        }
-    };
 
     for msg in messages {
         match msg.role {
@@ -239,15 +253,49 @@ pub fn convert_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<Anthro
                 }
             }
             MessageRole::User => {
-                let content = msg
-                    .content
-                    .as_ref()
-                    .map(&extract_content)
-                    .unwrap_or_default();
-                anthropic_messages.push(AnthropicMessage {
-                    role: "user".to_string(),
-                    content: AnthropicMessageContent::Text(content),
-                });
+                // User messages may be multimodal (text + image parts). Build
+                // native Anthropic content blocks so images are transmitted as
+                // images, not flattened into a JSON text blob (issue #640).
+                let parts = msg.content.as_ref().map(parse_content).unwrap_or_default();
+
+                let has_image = parts.iter().any(|p| !matches!(p, ContentPart::Text(_)));
+
+                if has_image {
+                    let mut blocks = Vec::with_capacity(parts.len());
+                    for part in parts {
+                        match part {
+                            ContentPart::Text(text) => {
+                                if !text.is_empty() {
+                                    blocks.push(AnthropicContentPart::Text { text });
+                                }
+                            }
+                            ContentPart::ImageBase64 { media_type, data } => {
+                                blocks.push(AnthropicContentPart::Image {
+                                    source: AnthropicImageSource::Base64 { media_type, data },
+                                });
+                            }
+                            ContentPart::ImageUrl { url } => {
+                                blocks.push(AnthropicContentPart::Image {
+                                    source: AnthropicImageSource::Url { url },
+                                });
+                            }
+                        }
+                    }
+                    anthropic_messages.push(AnthropicMessage {
+                        role: "user".to_string(),
+                        content: AnthropicMessageContent::Blocks(blocks),
+                    });
+                } else {
+                    let content = msg
+                        .content
+                        .as_ref()
+                        .map(&extract_content)
+                        .unwrap_or_default();
+                    anthropic_messages.push(AnthropicMessage {
+                        role: "user".to_string(),
+                        content: AnthropicMessageContent::Text(content),
+                    });
+                }
             }
             MessageRole::Assistant => {
                 // Check if the assistant message contains tool calls
@@ -585,6 +633,90 @@ mod tests {
 
         assert_eq!(system, Some("You are helpful.".to_string()));
         assert_eq!(anthropic_messages.len(), 1);
+    }
+
+    /// A real, minimal 1x1 solid-red PNG (constructed by hand, base64-encoded).
+    /// Used to prove the converter forwards the EXACT bytes (issue #640).
+    const RED_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAD\
+        UlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+    #[test]
+    fn test_convert_messages_image_preserves_base64_and_media_type() {
+        // Strip the line-continuation whitespace so the constant is a clean
+        // base64 string, exactly as a client would send it.
+        let payload: String = RED_PNG_B64.split_whitespace().collect();
+        let data_uri = format!("data:image/png;base64,{payload}");
+
+        let messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {"type": "text", "text": "Describe this image."},
+                {"type": "image_url", "image_url": {"url": data_uri}}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, anthropic_messages) = convert_messages(&messages);
+        assert_eq!(anthropic_messages.len(), 1);
+
+        let blocks = match &anthropic_messages[0].content {
+            AnthropicMessageContent::Blocks(b) => b,
+            AnthropicMessageContent::Text(t) => {
+                panic!("image was flattened to text instead of an image block: {t}")
+            }
+        };
+        assert_eq!(blocks.len(), 2, "expected text + image blocks");
+
+        match &blocks[0] {
+            AnthropicContentPart::Text { text } => assert_eq!(text, "Describe this image."),
+            other => panic!("expected text block first, got {other:?}"),
+        }
+        match &blocks[1] {
+            AnthropicContentPart::Image {
+                source: AnthropicImageSource::Base64 { media_type, data },
+            } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, &payload, "base64 payload must be byte-identical");
+            }
+            other => panic!("expected base64 image block, got {other:?}"),
+        }
+
+        // Serialize the whole request shape Anthropic receives and assert the
+        // exact bytes survive (no double-encoding, no JSON-blob flattening).
+        let json = serde_json::to_string(&anthropic_messages[0]).unwrap();
+        assert!(
+            json.contains(&payload),
+            "serialized request lost the base64 payload"
+        );
+        assert!(json.contains("\"type\":\"image\""));
+        assert!(json.contains("\"media_type\":\"image/png\""));
+    }
+
+    #[test]
+    fn test_convert_messages_image_url_uses_url_source() {
+        let messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, anthropic_messages) = convert_messages(&messages);
+        let blocks = match &anthropic_messages[0].content {
+            AnthropicMessageContent::Blocks(b) => b,
+            _ => panic!("expected blocks"),
+        };
+        match &blocks[0] {
+            AnthropicContentPart::Image {
+                source: AnthropicImageSource::Url { url },
+            } => assert_eq!(url, "https://example.com/cat.jpg"),
+            other => panic!("expected url image source, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/inference_providers/src/external/content.rs
+++ b/crates/inference_providers/src/external/content.rs
@@ -1,0 +1,251 @@
+//! Shared parsing of OpenAI-style multimodal message content.
+//!
+//! OpenAI chat messages carry `content` as either a plain string or an array of
+//! typed content parts, e.g.:
+//!
+//! ```json
+//! [
+//!   {"type": "text", "text": "What is in this image?"},
+//!   {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBOR..."}}
+//! ]
+//! ```
+//!
+//! Anthropic and Gemini have their own native image block shapes. Previously the
+//! external converters flattened the entire content array to a string via
+//! `Value::to_string()`, which turned the image into a JSON text blob the model
+//! never decoded as an image (issue #640: fjord photo described as "a red
+//! flower"). This module extracts text and image parts faithfully so the
+//! converters can rebuild the provider-native image blocks, preserving the exact
+//! base64 payload and media type.
+
+/// A single piece of parsed OpenAI message content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentPart {
+    /// Plain text.
+    Text(String),
+    /// An image supplied as a `data:` URI (base64 inline).
+    ImageBase64 {
+        /// MIME type, e.g. `image/png`. Defaults to `image/jpeg` when the data
+        /// URI omits it (matching how providers treat an unspecified type).
+        media_type: String,
+        /// The exact base64 payload, with the `data:[mime];base64,` prefix
+        /// stripped and surrounding ASCII whitespace removed. The bytes
+        /// themselves are not re-encoded.
+        data: String,
+    },
+    /// An image supplied as a remote `http(s)` URL.
+    ImageUrl { url: String },
+}
+
+/// Parse an OpenAI message `content` value into ordered parts.
+///
+/// - A JSON string yields a single [`ContentPart::Text`].
+/// - A JSON array yields one part per recognised element (`text`, `image_url`),
+///   in order. Unrecognised parts are skipped.
+/// - Any other value falls back to its JSON string form as a single text part,
+///   matching the previous lenient behaviour.
+pub fn parse_content(value: &serde_json::Value) -> Vec<ContentPart> {
+    match value {
+        serde_json::Value::String(s) => vec![ContentPart::Text(s.clone())],
+        serde_json::Value::Array(items) => {
+            let mut parts = Vec::with_capacity(items.len());
+            for item in items {
+                if let Some(part) = parse_content_part(item) {
+                    parts.push(part);
+                }
+            }
+            parts
+        }
+        other => vec![ContentPart::Text(other.to_string())],
+    }
+}
+
+fn parse_content_part(item: &serde_json::Value) -> Option<ContentPart> {
+    let obj = item.as_object()?;
+
+    match obj.get("type").and_then(|t| t.as_str()) {
+        Some("text") => obj
+            .get("text")
+            .and_then(|t| t.as_str())
+            .map(|s| ContentPart::Text(s.to_string())),
+        Some("image_url") => {
+            // OpenAI shape: {"type":"image_url","image_url":{"url":"..."}}.
+            // Also tolerate {"type":"image_url","image_url":"..."}.
+            let url = match obj.get("image_url") {
+                Some(serde_json::Value::Object(m)) => m.get("url").and_then(|u| u.as_str()),
+                Some(serde_json::Value::String(s)) => Some(s.as_str()),
+                _ => None,
+            }?;
+            Some(parse_image_url(url))
+        }
+        _ => None,
+    }
+}
+
+/// Classify an image URL string as either an inline base64 data URI or a remote
+/// URL, splitting the data URI into media type + payload without re-encoding.
+pub fn parse_image_url(url: &str) -> ContentPart {
+    if let Some(rest) = url.strip_prefix("data:") {
+        // rest = "[media_type][;base64],<payload>"  (media_type / params optional)
+        if let Some(comma) = rest.find(',') {
+            let meta = &rest[..comma];
+            let payload = &rest[comma + 1..];
+
+            let is_base64 = meta
+                .split(';')
+                .any(|p| p.trim().eq_ignore_ascii_case("base64"));
+
+            // media type is the segment before the first ';' (if any)
+            let media_type = meta.split(';').next().unwrap_or("").trim();
+            let media_type = if media_type.is_empty() {
+                "image/jpeg".to_string()
+            } else {
+                media_type.to_string()
+            };
+
+            if is_base64 {
+                // Strip only surrounding ASCII whitespace (e.g. accidental
+                // newlines around the payload). Do NOT touch interior bytes —
+                // the payload is forwarded verbatim so providers decode the
+                // exact original image.
+                let data = payload.trim().to_string();
+                return ContentPart::ImageBase64 { media_type, data };
+            }
+        }
+        // Malformed / non-base64 data URI: forward the whole thing as a URL so
+        // we never silently corrupt it.
+        return ContentPart::ImageUrl {
+            url: url.to_string(),
+        };
+    }
+
+    ContentPart::ImageUrl {
+        url: url.to_string(),
+    }
+}
+
+/// Flatten parsed parts back into a single text string.
+///
+/// Used by code paths that only support text (e.g. system messages). Image
+/// parts are dropped rather than serialised as a JSON blob.
+pub fn parts_to_text(parts: &[ContentPart]) -> String {
+    let mut out = String::new();
+    for part in parts {
+        if let ContentPart::Text(t) = part {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(t);
+        }
+    }
+    out
+}
+
+/// Convenience: extract text from a raw content value (string or array),
+/// dropping any image parts.
+pub fn text_from_content(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(_) => parts_to_text(&parse_content(value)),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_string() {
+        let v = serde_json::json!("hello");
+        assert_eq!(parse_content(&v), vec![ContentPart::Text("hello".into())]);
+    }
+
+    #[test]
+    fn parses_text_and_image_data_uri() {
+        let v = serde_json::json!([
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+        ]);
+        assert_eq!(
+            parse_content(&v),
+            vec![
+                ContentPart::Text("describe".into()),
+                ContentPart::ImageBase64 {
+                    media_type: "image/png".into(),
+                    data: "AAAA".into(),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_exact_base64_payload() {
+        // base64 of arbitrary bytes including '+', '/', '=' padding
+        let payload = "iVBORw0KGgo+/AB==";
+        let url = format!("data:image/png;base64,{payload}");
+        match parse_image_url(&url) {
+            ContentPart::ImageBase64 { media_type, data } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, payload, "base64 payload must be byte-identical");
+            }
+            other => panic!("expected ImageBase64, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strips_surrounding_whitespace_only() {
+        let url = "data:image/jpeg;base64,  AAAA\n ";
+        match parse_image_url(url) {
+            ContentPart::ImageBase64 { data, media_type } => {
+                assert_eq!(media_type, "image/jpeg");
+                assert_eq!(data, "AAAA");
+            }
+            other => panic!("expected ImageBase64, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn defaults_media_type_when_missing() {
+        let url = "data:;base64,AAAA";
+        match parse_image_url(url) {
+            ContentPart::ImageBase64 { media_type, .. } => assert_eq!(media_type, "image/jpeg"),
+            other => panic!("expected ImageBase64, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn treats_http_url_as_remote() {
+        let url = "https://example.com/cat.jpg";
+        assert_eq!(
+            parse_image_url(url),
+            ContentPart::ImageUrl {
+                url: url.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn handles_image_url_as_bare_string() {
+        let v = serde_json::json!([
+            {"type": "image_url", "image_url": "data:image/png;base64,ZZZ"}
+        ]);
+        assert_eq!(
+            parse_content(&v),
+            vec![ContentPart::ImageBase64 {
+                media_type: "image/png".into(),
+                data: "ZZZ".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn text_from_content_drops_images() {
+        let v = serde_json::json!([
+            {"type": "text", "text": "a"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            {"type": "text", "text": "b"}
+        ]);
+        assert_eq!(text_from_content(&v), "a\nb");
+    }
+}

--- a/crates/inference_providers/src/external/gemini/converter.rs
+++ b/crates/inference_providers/src/external/gemini/converter.rs
@@ -242,6 +242,32 @@ pub struct GeminiResponse {
 // Conversion Functions
 // =============================================================================
 
+/// Infer an image MIME type from a remote URL's path extension.
+///
+/// Gemini's `fileData` requires a `mimeType` for media references; a bare URL
+/// carries none, so we derive it from the file extension. Returns `None` when
+/// the extension is missing or unrecognised, so the caller can skip the part
+/// instead of emitting a `fileData` that Gemini would reject.
+///
+/// Query strings and fragments are stripped before inspecting the extension
+/// (e.g. `https://host/cat.jpg?sig=abc#frag` → `jpg`). Matching is
+/// case-insensitive.
+fn mime_type_from_url(url: &str) -> Option<String> {
+    // Trim query (`?`) and fragment (`#`) so they don't pollute the extension.
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    let ext = path.rsplit('.').next()?.to_ascii_lowercase();
+    let mime = match ext.as_str() {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "heic" => "image/heic",
+        "heif" => "image/heif",
+        _ => return None,
+    };
+    Some(mime.to_string())
+}
+
 /// Convert OpenAI messages to Gemini format
 pub fn convert_messages(
     messages: &[ChatMessage],
@@ -280,9 +306,31 @@ pub fn convert_messages(
                             parts.push(GeminiPart::inline_image(media_type, data));
                         }
                         ContentPart::ImageUrl { url } => {
-                            // Gemini's fileData accepts a remote URI and fetches
-                            // it itself. MIME type is unknown for a bare URL.
-                            parts.push(GeminiPart::file_image(None, url));
+                            // Gemini's `fileData` accepts a public HTTPS URI and
+                            // fetches the bytes itself, but it *requires* a
+                            // `mimeType` — an empty/omitted `fileData.mimeType`
+                            // is rejected upstream with 400 "empty mimeType
+                            // parameter in fileData". cloud-api does not pre-fetch
+                            // remote images (Gemini is an external passthrough to
+                            // Google's API with no engine in the loop, see #606),
+                            // so we infer the MIME type from the URL path
+                            // extension. If we cannot determine a supported image
+                            // type, we skip the part rather than emit a broken
+                            // `fileData` that would fail the whole request.
+                            // Remote-URL image support is provider-dependent and
+                            // not guaranteed; base64 data URIs (the common,
+                            // advertised case) go through `inlineData` above.
+                            match mime_type_from_url(&url) {
+                                Some(mime_type) => {
+                                    parts.push(GeminiPart::file_image(Some(mime_type), url));
+                                }
+                                None => {
+                                    tracing::warn!(
+                                        "skipping Gemini image: cannot infer mimeType from \
+                                         remote URL extension (fileData requires a mimeType)"
+                                    );
+                                }
+                            }
                         }
                     }
                 }
@@ -791,7 +839,11 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_messages_image_url_uses_file_data() {
+    fn test_convert_messages_image_url_uses_file_data_with_mime_type() {
+        // Remote image URL with a recognisable extension: must emit `fileData`
+        // WITH an inferred `mimeType`. Gemini rejects a `fileData` whose
+        // `mimeType` is empty/omitted with 400 "empty mimeType parameter in
+        // fileData", so the serialized request must always carry it (#719).
         let messages = vec![ChatMessage {
             role: MessageRole::User,
             content: Some(serde_json::json!([
@@ -808,6 +860,94 @@ mod tests {
             .as_ref()
             .expect("expected fileData for remote URL");
         assert_eq!(file.file_uri, "https://example.com/cat.jpg");
+        assert_eq!(
+            file.mime_type.as_deref(),
+            Some("image/jpeg"),
+            "fileData must carry an inferred mimeType"
+        );
+
+        // Serialization guard: the camelCase `mimeType` must be present in the
+        // wire body. A regression to `file_image(None, ..)` would drop it.
+        let json = serde_json::to_string(&contents[0]).unwrap();
+        assert!(
+            json.contains("\"fileData\""),
+            "expected fileData on the wire"
+        );
+        assert!(
+            json.contains("\"mimeType\":\"image/jpeg\""),
+            "serialized fileData is missing the required mimeType; got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_convert_messages_image_url_infers_mime_from_various_extensions() {
+        // Extension → mimeType inference, including query-string stripping and
+        // case-insensitivity.
+        let cases = [
+            ("https://example.com/a.png", "image/png"),
+            ("https://example.com/a.JPEG", "image/jpeg"),
+            ("https://example.com/a.webp", "image/webp"),
+            ("https://example.com/a.gif", "image/gif"),
+            (
+                "https://cdn.example.com/img/cat.jpg?sig=abc&x=1#frag",
+                "image/jpeg",
+            ),
+        ];
+        for (url, expected) in cases {
+            let messages = vec![ChatMessage {
+                role: MessageRole::User,
+                content: Some(serde_json::json!([
+                    {"type": "image_url", "image_url": {"url": url}}
+                ])),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }];
+            let (_system, contents) = convert_messages(&messages);
+            let file = contents[0].parts[0]
+                .file_data
+                .as_ref()
+                .unwrap_or_else(|| panic!("expected fileData for {url}"));
+            assert_eq!(
+                file.mime_type.as_deref(),
+                Some(expected),
+                "wrong mimeType inferred for {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_convert_messages_image_url_unknown_extension_is_skipped() {
+        // No / unknown extension → we cannot infer a mimeType, so we skip the
+        // image part rather than emit a `fileData` lacking `mimeType` (which
+        // Gemini rejects, breaking the *entire* request). Text is preserved.
+        let messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {"type": "text", "text": "look at this"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image"}},
+                {"type": "image_url", "image_url": {"url": "https://example.com/file.bin"}}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, contents) = convert_messages(&messages);
+        assert_eq!(contents.len(), 1);
+        let parts = &contents[0].parts;
+        // Only the text part survives; both unknown-extension images dropped.
+        assert_eq!(parts.len(), 1, "unknown-extension images must be skipped");
+        assert_eq!(parts[0].text.as_deref(), Some("look at this"));
+        assert!(parts.iter().all(|p| p.file_data.is_none()));
+
+        // And crucially: the serialized request never contains a `fileData`
+        // without a `mimeType`.
+        let json = serde_json::to_string(&contents[0]).unwrap();
+        assert!(
+            !json.contains("\"fileData\""),
+            "must not emit fileData when mimeType is unknown; got: {json}"
+        );
     }
 
     #[test]

--- a/crates/inference_providers/src/external/gemini/converter.rs
+++ b/crates/inference_providers/src/external/gemini/converter.rs
@@ -27,9 +27,33 @@ pub struct GeminiPart {
     pub function_call: Option<GeminiFunctionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_response: Option<GeminiFunctionResponse>,
+    /// Inline image (or other binary) data, base64-encoded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline_data: Option<GeminiInlineData>,
+    /// Reference to remote media by URI (Gemini fetches it itself).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_data: Option<GeminiFileData>,
     /// Thought signature for Gemini 3 models - required for tool calls to work correctly
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thought_signature: Option<String>,
+}
+
+/// Inline base64 media payload for a Gemini part (`inlineData`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiInlineData {
+    pub mime_type: String,
+    /// Exact base64 payload, forwarded verbatim (no re-encoding).
+    pub data: String,
+}
+
+/// Remote media reference for a Gemini part (`fileData`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiFileData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    pub file_uri: String,
 }
 
 impl GeminiPart {
@@ -38,6 +62,33 @@ impl GeminiPart {
             text: Some(s),
             function_call: None,
             function_response: None,
+            inline_data: None,
+            file_data: None,
+            thought_signature: None,
+        }
+    }
+
+    pub fn inline_image(mime_type: String, data: String) -> Self {
+        Self {
+            text: None,
+            function_call: None,
+            function_response: None,
+            inline_data: Some(GeminiInlineData { mime_type, data }),
+            file_data: None,
+            thought_signature: None,
+        }
+    }
+
+    pub fn file_image(mime_type: Option<String>, file_uri: String) -> Self {
+        Self {
+            text: None,
+            function_call: None,
+            function_response: None,
+            inline_data: None,
+            file_data: Some(GeminiFileData {
+                mime_type,
+                file_uri,
+            }),
             thought_signature: None,
         }
     }
@@ -47,6 +98,8 @@ impl GeminiPart {
             text: None,
             function_call: None,
             function_response: Some(GeminiFunctionResponse { name, response }),
+            inline_data: None,
+            file_data: None,
             thought_signature: None,
         }
     }
@@ -60,6 +113,8 @@ impl GeminiPart {
             text: None,
             function_call: Some(GeminiFunctionCall { name, args }),
             function_response: None,
+            inline_data: None,
+            file_data: None,
             thought_signature,
         }
     }
@@ -191,11 +246,8 @@ pub struct GeminiResponse {
 pub fn convert_messages(
     messages: &[ChatMessage],
 ) -> (Option<GeminiSystemInstruction>, Vec<GeminiContent>) {
-    let extract_content = |value: &serde_json::Value| -> String {
-        match value {
-            serde_json::Value::String(s) => s.clone(),
-            _ => value.to_string(),
-        }
+    use crate::external::content::{
+        parse_content, text_from_content as extract_content, ContentPart,
     };
 
     let mut system_instruction = None;
@@ -211,14 +263,38 @@ pub fn convert_messages(
                 }
             }
             MessageRole::User => {
+                // User messages may be multimodal (text + image parts). Emit
+                // native Gemini parts so images are sent as `inlineData`/
+                // `fileData`, not flattened into a JSON text blob (issue #640).
+                let content_parts = msg.content.as_ref().map(parse_content).unwrap_or_default();
+
+                let mut parts = Vec::with_capacity(content_parts.len());
+                for part in content_parts {
+                    match part {
+                        ContentPart::Text(text) => {
+                            if !text.is_empty() {
+                                parts.push(GeminiPart::text(text));
+                            }
+                        }
+                        ContentPart::ImageBase64 { media_type, data } => {
+                            parts.push(GeminiPart::inline_image(media_type, data));
+                        }
+                        ContentPart::ImageUrl { url } => {
+                            // Gemini's fileData accepts a remote URI and fetches
+                            // it itself. MIME type is unknown for a bare URL.
+                            parts.push(GeminiPart::file_image(None, url));
+                        }
+                    }
+                }
+                // Preserve prior behaviour for empty/text-only content: at least
+                // one (possibly empty) text part.
+                if parts.is_empty() {
+                    parts.push(GeminiPart::text(String::new()));
+                }
+
                 contents.push(GeminiContent {
                     role: "user".to_string(),
-                    parts: vec![GeminiPart::text(
-                        msg.content
-                            .as_ref()
-                            .map(&extract_content)
-                            .unwrap_or_default(),
-                    )],
+                    parts,
                 });
             }
             MessageRole::Assistant => {
@@ -666,6 +742,72 @@ mod tests {
         assert!(system.is_some());
         assert_eq!(contents.len(), 1);
         assert_eq!(contents[0].role, "user");
+    }
+
+    /// Real minimal 1x1 solid-red PNG, base64-encoded (issue #640 guard).
+    const RED_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAD\
+        UlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+    #[test]
+    fn test_convert_messages_image_preserves_base64_and_mime() {
+        let payload: String = RED_PNG_B64.split_whitespace().collect();
+        let data_uri = format!("data:image/png;base64,{payload}");
+
+        let messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {"type": "text", "text": "Describe this image."},
+                {"type": "image_url", "image_url": {"url": data_uri}}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, contents) = convert_messages(&messages);
+        assert_eq!(contents.len(), 1);
+        let parts = &contents[0].parts;
+        assert_eq!(parts.len(), 2, "expected text + inlineData parts");
+
+        assert_eq!(parts[0].text.as_deref(), Some("Describe this image."));
+        let inline = parts[1]
+            .inline_data
+            .as_ref()
+            .expect("expected inlineData image part, not a flattened text blob");
+        assert_eq!(inline.mime_type, "image/png");
+        assert_eq!(
+            inline.data, payload,
+            "base64 payload must be byte-identical"
+        );
+
+        // Serialize and check Gemini camelCase wire shape + exact bytes survive.
+        let json = serde_json::to_string(&contents[0]).unwrap();
+        assert!(
+            json.contains(&payload),
+            "serialized request lost the base64 payload"
+        );
+        assert!(json.contains("\"inlineData\""));
+        assert!(json.contains("\"mimeType\":\"image/png\""));
+    }
+
+    #[test]
+    fn test_convert_messages_image_url_uses_file_data() {
+        let messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, contents) = convert_messages(&messages);
+        let file = contents[0].parts[0]
+            .file_data
+            .as_ref()
+            .expect("expected fileData for remote URL");
+        assert_eq!(file.file_uri, "https://example.com/cat.jpg");
     }
 
     #[test]

--- a/crates/inference_providers/src/external/mod.rs
+++ b/crates/inference_providers/src/external/mod.rs
@@ -25,6 +25,7 @@
 
 pub mod anthropic;
 pub mod backend;
+pub mod content;
 pub mod gemini;
 pub mod openai_compatible;
 


### PR DESCRIPTION
## Root cause

The Anthropic and Gemini message converters flattened OpenAI multimodal content (an array of `{type:"text"|"image_url",...}` parts) into a single **text** string via `serde_json::Value::to_string()`. Images were never sent as native image blocks — they reached the upstream model as a JSON text blob containing the base64 string, so the model hallucinated.

This explains every symptom in #640:
- Deterministic-but-wrong descriptions at temp=0 (the image is literally absent; the model invents content from the garbled text).
- Self-hosted Qwen3-VL reads the same images correctly (the vLLM path forwards `content` as `serde_json::Value` verbatim — no flattening).
- "32x32 blue passes / 16x16 red fails" — pure noise; in both cases the image was never transmitted as an image.

Neither converter even had an image representation:
- `AnthropicContentPart` had no `Image` variant.
- `GeminiPart` had no `inlineData`/`fileData` field.

## Fix

- New shared `external/content.rs` parser splits OpenAI content into ordered `Text` / `ImageBase64` / `ImageUrl` parts. Data URIs are split on the **first** `,` into `media_type` + payload; the base64 payload is forwarded **verbatim** (only surrounding ASCII whitespace trimmed) — no re-encoding, no double-encoding, no byte/char confusion.
- **Anthropic**: add `AnthropicContentPart::Image` with a `base64`/`url` source; build native image blocks for user messages.
- **Gemini**: add `inlineData` (base64) and `fileData` (remote URL) parts; emit them for user messages.
- System/tool messages keep text-only behaviour (images dropped, not serialized as a JSON blob).

## Tests

- Converter unit tests for both providers use a real 1x1 red PNG and assert the **exact** base64 payload and `media_type`/`mimeType` survive serialization (proves the bug and guards the fix).
- Content-parser tests cover data-URI splitting, whitespace trimming, missing media type, bare-string `image_url`, remote URLs, and base64 byte-identity.

## Validation

- `cargo build --workspace` — ok
- `cargo clippy -p inference_providers --lib --tests` — clean (exit 0)
- `cargo fmt --all -- --check` — clean
- `cargo test -p inference_providers --lib` — 192 passed, 0 failed (12 new). The only doctest failure (`detect_audio_content_type`) is pre-existing on `origin/main` and unrelated.

Fixes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)