### PR TITLE
fix(passthrough): Anthropic/Gemini param fidelity — temperature drop, seed, response_format (#696 #669 #668)

### DIFF
--- a/crates/api/tests/e2e_all/openrouter_params.rs
+++ b/crates/api/tests/e2e_all/openrouter_params.rs
@@ -422,3 +422,43 @@ async fn test_json_schema_response_format_accepted_and_forwarded() {
         "response_format.type not preserved on passthrough"
     );
 }
+
+// ── response_format json_object (nearai/cloud-api #668) ─────────────────────
+
+/// `response_format: { type: json_object }` must be accepted and forwarded in
+/// `extra` so the provider adapters (Gemini → responseMimeType, Anthropic →
+/// fence-strip) can act on it. #668 tracks the markdown-fence breakage on
+/// passthroughs; cloud-api must not reject or drop the param.
+#[tokio::test]
+async fn test_json_object_response_format_accepted_and_forwarded() {
+    let (server, mock, model, api_key) = setup().await;
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&serde_json::json!({
+            "model": model,
+            "messages": [{"role": "user", "content": "Give me a JSON object."}],
+            "response_format": {"type": "json_object"},
+            "max_tokens": 200,
+            "stream": false,
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        200,
+        "json_object response_format should be accepted, got: {}",
+        response.text()
+    );
+    let params = mock.last_chat_params().await.expect("provider was called");
+    let forwarded = params
+        .extra
+        .get("response_format")
+        .expect("response_format forwarded in `extra`");
+    assert_eq!(
+        forwarded.get("type").and_then(|v| v.as_str()),
+        Some("json_object"),
+        "response_format.type not preserved on passthrough"
+    );
+}

--- a/crates/inference_providers/src/external/anthropic/mod.rs
+++ b/crates/inference_providers/src/external/anthropic/mod.rs
@@ -32,6 +32,58 @@ const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
 /// accept and will reject with its own 400, instead of us silently dropping it).
 const ANTHROPIC_PASSTHROUGH_KEYS: &[&str] = &["thinking", "reasoning_effort"];
 
+/// Anthropic model-name fragments that **reject any non-default `temperature`**
+/// with a 400 (`temperature is deprecated for this model`), even though they
+/// still advertise `temperature` (nearai/cloud-api #696).
+///
+/// These are matched as substrings so both the bare alias (`claude-opus-4-7`)
+/// and the dated form (`claude-opus-4-7-20XXYYZZ`) are covered. opus-4-6 and
+/// earlier still accept `temperature`, so they are intentionally absent — do
+/// not over-strip.
+const ANTHROPIC_MODELS_REJECTING_TEMPERATURE: &[&str] = &["claude-opus-4-7"];
+
+/// Whether `model` rejects a non-default `temperature` and we must drop it
+/// (forwarding `top_p` instead) rather than 400 the caller (#696).
+fn rejects_non_default_temperature(model: &str) -> bool {
+    ANTHROPIC_MODELS_REJECTING_TEMPERATURE
+        .iter()
+        .any(|fragment| model.contains(fragment))
+}
+
+/// Whether a requested `response_format` asks for JSON output, which Anthropic
+/// has no native mode for and tends to return markdown-fenced (#668). When
+/// true, we strip code fences from the response so `JSON.parse` works.
+fn wants_json_output(extra: &std::collections::HashMap<String, serde_json::Value>) -> bool {
+    extra
+        .get("response_format")
+        .and_then(|rf| rf.get("type"))
+        .and_then(|t| t.as_str())
+        .map(|t| t == "json_object" || t == "json_schema")
+        .unwrap_or(false)
+}
+
+/// Strip a single leading/trailing markdown code fence from `content`.
+///
+/// Anthropic has no native JSON-output mode, so when a caller requests
+/// `response_format: json_object`/`json_schema` the model frequently wraps the
+/// JSON in a ` ```json … ``` ` block. This unwraps that fence so the content is
+/// raw parseable JSON (#668). Content without a fence is returned unchanged.
+fn strip_json_code_fence(content: &str) -> String {
+    let trimmed = content.trim();
+    let Some(rest) = trimmed.strip_prefix("```") else {
+        return content.to_string();
+    };
+    // Drop the optional language tag on the opening fence line (e.g. `json`).
+    let after_lang = match rest.find('\n') {
+        Some(idx) => &rest[idx + 1..],
+        None => return content.to_string(),
+    };
+    let Some(inner) = after_lang.trim_end().strip_suffix("```") else {
+        return content.to_string();
+    };
+    inner.trim().to_string()
+}
+
 /// Pick the allowlisted reasoning-control fields out of `extra`.
 fn extract_passthrough(
     extra: &std::collections::HashMap<String, serde_json::Value>,
@@ -96,7 +148,14 @@ impl AnthropicBackend {
 
         // Anthropic doesn't allow both temperature and top_p - prefer temperature if both are set.
         // Also clamp temperature to Anthropic's valid range [0.0, 1.0] (OpenAI allows up to 2.0).
-        let (temperature, top_p) = if let Some(temp) = params.temperature {
+        //
+        // #696: some newer models (e.g. claude-opus-4-7) 400 on ANY non-default
+        // `temperature`. For those we drop `temperature` entirely and forward
+        // `top_p` instead, so OpenAI/OpenRouter clients that routinely send
+        // `temperature: 0`/`0.7` get a 200 (param ignored) instead of a 400.
+        let (temperature, top_p) = if rejects_non_default_temperature(model) {
+            (None, params.top_p)
+        } else if let Some(temp) = params.temperature {
             (Some(temp.clamp(0.0, 1.0)), None)
         } else {
             (None, params.top_p)
@@ -154,6 +213,13 @@ impl ExternalBackend for AnthropicBackend {
         model: &str,
         params: ChatCompletionParams,
     ) -> Result<StreamingResult, CompletionError> {
+        // NOTE (#668): markdown-fence stripping for `response_format` JSON modes
+        // is applied on the non-streaming path only. A fence marker (```) can
+        // split across SSE deltas, so reliably stripping it mid-stream would
+        // require buffering the whole response and defeats streaming. The
+        // model's own behaviour with the json hint is usually fence-free when
+        // streaming; callers needing guaranteed raw JSON should use the
+        // non-streaming endpoint.
         let url = format!("{}/messages", config.base_url);
         let request = self.build_request(model, &params, true);
 
@@ -239,6 +305,16 @@ impl ExternalBackend for AnthropicBackend {
 
         // Convert to OpenAI format using the converter
         let (content, tool_calls) = extract_response_content(&anthropic_response.content);
+
+        // #668: Anthropic has no native JSON-output mode, so when the caller
+        // requested `response_format: json_object`/`json_schema` it tends to
+        // wrap the JSON in a markdown ```json … ``` fence, breaking
+        // `JSON.parse`. Strip that fence so the content is raw parseable JSON.
+        let content = if wants_json_output(&params.extra) {
+            content.map(|c| strip_json_code_fence(&c))
+        } else {
+            content
+        };
 
         let openai_response = ChatCompletionResponse {
             id: anthropic_response.id,
@@ -543,7 +619,9 @@ mod tests {
     fn test_build_request_empty_extra_adds_no_fields() {
         let backend = AnthropicBackend::new();
         let params = make_params(Some(1.0), None);
-        let request = backend.build_request("claude-opus-4-7", &params, false);
+        // Use a model that accepts temperature so this test isolates the
+        // "extra adds nothing" property (opus-4-7 drops temperature, see #696).
+        let request = backend.build_request("claude-sonnet-4-5-20250514", &params, false);
         let body = serde_json::to_value(&request).unwrap();
 
         // With no extra fields, the flattened `extra` map contributes nothing:
@@ -559,6 +637,85 @@ mod tests {
                 .into_iter()
                 .collect();
         assert_eq!(keys, expected);
+    }
+
+    // ── #696: temperature dropped for models that reject non-default values ──
+
+    #[test]
+    fn test_opus_4_7_drops_non_default_temperature_forwards_top_p() {
+        let backend = AnthropicBackend::new();
+        // opus-4-7 400s on any non-default temperature; we must drop it.
+        let mut params = make_params(Some(0.0), Some(0.5));
+        let request = backend.build_request("claude-opus-4-7", &params, false);
+        assert_eq!(
+            request.temperature, None,
+            "temperature must be dropped for opus-4-7"
+        );
+        assert_eq!(
+            request.top_p,
+            Some(0.5),
+            "top_p must still be forwarded for opus-4-7"
+        );
+
+        // Same when only temperature is set (no top_p): just drop it.
+        params = make_params(Some(0.7), None);
+        let request = backend.build_request("claude-opus-4-7-20991231", &params, false);
+        assert_eq!(request.temperature, None);
+        assert_eq!(request.top_p, None);
+    }
+
+    #[test]
+    fn test_opus_4_6_still_accepts_temperature() {
+        let backend = AnthropicBackend::new();
+        // Regression guard against over-stripping: opus-4-6 still accepts it.
+        let params = make_params(Some(0.5), None);
+        let request = backend.build_request("claude-opus-4-6", &params, false);
+        assert_eq!(
+            request.temperature,
+            Some(0.5),
+            "opus-4-6 must still forward temperature"
+        );
+    }
+
+    // ── #668: strip markdown code fences when json output was requested ──────
+
+    fn json_format_extra(type_: &str) -> std::collections::HashMap<String, serde_json::Value> {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert(
+            "response_format".to_string(),
+            serde_json::json!({"type": type_}),
+        );
+        extra
+    }
+
+    #[test]
+    fn test_wants_json_output() {
+        assert!(wants_json_output(&json_format_extra("json_object")));
+        assert!(wants_json_output(&json_format_extra("json_schema")));
+        assert!(!wants_json_output(&json_format_extra("text")));
+        assert!(!wants_json_output(&std::collections::HashMap::new()));
+    }
+
+    #[test]
+    fn test_strip_json_code_fence_unwraps_fenced_json() {
+        let fenced = "```json\n{\n  \"city\": \"Paris\"\n}\n```";
+        let stripped = strip_json_code_fence(fenced);
+        assert_eq!(stripped, "{\n  \"city\": \"Paris\"\n}");
+        // Result is valid parseable JSON.
+        let v: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(v["city"], "Paris");
+    }
+
+    #[test]
+    fn test_strip_json_code_fence_handles_no_language_tag() {
+        let fenced = "```\n{\"a\":1}\n```";
+        assert_eq!(strip_json_code_fence(fenced), "{\"a\":1}");
+    }
+
+    #[test]
+    fn test_strip_json_code_fence_passes_through_raw_json() {
+        let raw = "{\"city\":\"Paris\"}";
+        assert_eq!(strip_json_code_fence(raw), raw);
     }
 
     #[tokio::test]

--- a/crates/inference_providers/src/external/gemini/converter.rs
+++ b/crates/inference_providers/src/external/gemini/converter.rs
@@ -123,10 +123,26 @@ pub struct GeminiGenerationConfig {
     /// and `json_schema` (nearai/cloud-api #668).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_mime_type: Option<String>,
-    /// Structured-output schema, translated from OpenAI `json_schema` and
-    /// sanitized to Gemini's OpenAPI subset (nearai/cloud-api #668).
+    /// Structured-output schema, translated from a non-strict OpenAI
+    /// `json_schema` and sanitized to Gemini's OpenAPI 3.0 subset
+    /// (nearai/cloud-api #668). Lossy: keywords Gemini's OpenAPI subset rejects
+    /// (`additionalProperties`, `$ref`, `$defs`, `oneOf`, ...) are dropped.
+    ///
+    /// Mutually exclusive with `response_json_schema`: Gemini rejects a request
+    /// that sets both. We only ever populate one of the two.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_schema: Option<serde_json::Value>,
+    /// Structured-output schema sent as **standard JSON Schema**, used for
+    /// strict requests (`response_format.json_schema.strict == true`). Unlike
+    /// `response_schema`, this preserves constraints the client asked for —
+    /// `additionalProperties: false`, `$ref`, `$defs`, `oneOf` — so we don't
+    /// silently weaken a strict schema (nearai/cloud-api #720 review).
+    ///
+    /// Gemini's REST API expects `responseJsonSchema` and treats it as mutually
+    /// exclusive with `responseSchema`; it must be paired with
+    /// `responseMimeType: application/json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_json_schema: Option<serde_json::Value>,
 }
 
 /// Gemini function declaration (tool definition)
@@ -435,41 +451,89 @@ fn sanitize_schema_for_gemini(value: &mut serde_json::Value) {
     }
 }
 
+/// Outcome of translating an OpenAI `response_format` into Gemini's
+/// structured-output `generationConfig` fields.
+///
+/// `response_schema` and `response_json_schema` are mutually exclusive — at most
+/// one is ever `Some`, because Gemini rejects a request that sets both.
+#[derive(Debug, Default, PartialEq)]
+pub struct GeminiResponseFormat {
+    /// `generationConfig.responseMimeType`.
+    pub mime_type: Option<String>,
+    /// `generationConfig.responseSchema` (lossy OpenAPI-subset schema; used for
+    /// non-strict `json_schema`).
+    pub schema: Option<serde_json::Value>,
+    /// `generationConfig.responseJsonSchema` (lossless standard JSON Schema;
+    /// used for strict `json_schema`).
+    pub json_schema: Option<serde_json::Value>,
+}
+
 /// Translate an OpenAI `response_format` value into Gemini's structured-output
-/// `generationConfig` fields (nearai/cloud-api #668).
+/// `generationConfig` fields (nearai/cloud-api #668, #720).
 ///
-/// Returns `(response_mime_type, response_schema)`:
-/// - `{"type": "json_object"}` → `("application/json", None)` so Gemini emits
-///   raw JSON instead of markdown-fenced text.
-/// - `{"type": "json_schema", "json_schema": {"schema": {...}}}` →
-///   `("application/json", Some(sanitized schema))` so Gemini enforces the
-///   schema natively (it was previously ignored entirely).
-/// - anything else (including `{"type": "text"}`) → `(None, None)`.
+/// - `{"type": "json_object"}` → `responseMimeType = application/json` only, so
+///   Gemini emits raw JSON instead of markdown-fenced text.
+/// - `{"type": "json_schema", "json_schema": {"strict": true, "schema": {...}}}`
+///   → `responseMimeType = application/json` + `responseJsonSchema = <original
+///   schema, unmodified>`. We use Gemini's standard-JSON-Schema field so strict
+///   constraints the client asked for — `additionalProperties: false`, `$ref`,
+///   `$defs`, `oneOf` — are preserved and actually enforced, rather than being
+///   silently dropped (the concern Pierre raised on PR #720).
+/// - `{"type": "json_schema", ...}` without `strict: true` → `responseMimeType =
+///   application/json` + `responseSchema = <sanitized schema>`. This is the
+///   best-effort, OpenAPI-3.0-subset path: keywords Gemini's `responseSchema`
+///   rejects are stripped via `sanitize_schema_for_gemini`. Acceptable here
+///   because the caller did not request strict enforcement.
+/// - anything else (including `{"type": "text"}`) → all `None`.
 ///
-/// The schema is sanitized through `sanitize_schema_for_gemini` so JSON-Schema
-/// keywords Gemini's OpenAPI subset rejects (e.g. `additionalProperties`,
-/// `$schema`) do not 400 the request.
-pub fn response_format_to_gemini(
-    response_format: &serde_json::Value,
-) -> (Option<String>, Option<serde_json::Value>) {
+/// `responseSchema` and `responseJsonSchema` are mutually exclusive in Gemini's
+/// API, so this never returns both.
+pub fn response_format_to_gemini(response_format: &serde_json::Value) -> GeminiResponseFormat {
     let Some(type_) = response_format.get("type").and_then(|v| v.as_str()) else {
-        return (None, None);
+        return GeminiResponseFormat::default();
     };
 
     match type_ {
-        "json_object" => (Some("application/json".to_string()), None),
+        "json_object" => GeminiResponseFormat {
+            mime_type: Some("application/json".to_string()),
+            ..Default::default()
+        },
         "json_schema" => {
-            let schema = response_format
-                .get("json_schema")
-                .and_then(|js| js.get("schema"))
-                .cloned()
-                .map(|mut s| {
-                    sanitize_schema_for_gemini(&mut s);
-                    s
-                });
-            (Some("application/json".to_string()), schema)
+            let json_schema = response_format.get("json_schema");
+            let Some(schema) = json_schema.and_then(|js| js.get("schema")).cloned() else {
+                // `json_schema` requested but no schema body: fall back to plain
+                // JSON mode rather than emitting an empty/invalid schema.
+                return GeminiResponseFormat {
+                    mime_type: Some("application/json".to_string()),
+                    ..Default::default()
+                };
+            };
+
+            let strict = json_schema
+                .and_then(|js| js.get("strict"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+
+            if strict {
+                // Strict: preserve the ORIGINAL schema verbatim via Gemini's
+                // standard-JSON-Schema field so constraints are enforced.
+                GeminiResponseFormat {
+                    mime_type: Some("application/json".to_string()),
+                    json_schema: Some(schema),
+                    ..Default::default()
+                }
+            } else {
+                // Non-strict: best-effort via the OpenAPI-subset field.
+                let mut sanitized = schema;
+                sanitize_schema_for_gemini(&mut sanitized);
+                GeminiResponseFormat {
+                    mime_type: Some("application/json".to_string()),
+                    schema: Some(sanitized),
+                    ..Default::default()
+                }
+            }
         }
-        _ => (None, None),
+        _ => GeminiResponseFormat::default(),
     }
 }
 
@@ -1009,33 +1073,79 @@ mod tests {
     #[test]
     fn test_response_format_json_object_sets_mime_type_only() {
         let rf = serde_json::json!({"type": "json_object"});
-        let (mime, schema) = response_format_to_gemini(&rf);
-        assert_eq!(mime.as_deref(), Some("application/json"));
-        assert!(schema.is_none());
+        let rf = response_format_to_gemini(&rf);
+        assert_eq!(rf.mime_type.as_deref(), Some("application/json"));
+        assert!(rf.schema.is_none());
+        assert!(rf.json_schema.is_none());
     }
 
+    /// #720: a strict `json_schema` must be forwarded VERBATIM through Gemini's
+    /// standard-JSON-Schema field (`responseJsonSchema`) so constraints the
+    /// client asked for are preserved and enforced — NOT stripped.
     #[test]
-    fn test_response_format_json_schema_sets_mime_and_sanitized_schema() {
-        let rf = serde_json::json!({
+    fn test_response_format_strict_json_schema_preserves_original_via_json_schema_field() {
+        let original = serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["city", "temp_c"],
+            "$defs": {
+                "City": {"type": "string"}
+            },
+            "properties": {
+                "city": {"$ref": "#/$defs/City"},
+                "temp_c": {"type": "number"},
+                "kind": {"oneOf": [{"type": "string"}, {"type": "null"}]}
+            }
+        });
+        let rf = response_format_to_gemini(&serde_json::json!({
             "type": "json_schema",
             "json_schema": {
                 "name": "weather",
                 "strict": true,
+                "schema": original.clone()
+            }
+        }));
+        assert_eq!(rf.mime_type.as_deref(), Some("application/json"));
+        // Mutually exclusive: the lossy `responseSchema` field must be unset.
+        assert!(
+            rf.schema.is_none(),
+            "strict schemas must NOT use the lossy responseSchema field"
+        );
+        let json_schema = rf.json_schema.expect("responseJsonSchema populated");
+        // The original strict schema is preserved byte-for-byte: constraints
+        // Gemini's OpenAPI subset would have dropped are all still present.
+        assert_eq!(json_schema, original);
+        assert_eq!(
+            json_schema["additionalProperties"],
+            serde_json::json!(false)
+        );
+        assert!(json_schema["$defs"]["City"].is_object());
+        assert_eq!(json_schema["properties"]["city"]["$ref"], "#/$defs/City");
+        assert!(json_schema["properties"]["kind"]["oneOf"].is_array());
+    }
+
+    /// Non-strict `json_schema` is best-effort: it goes through the lossy
+    /// OpenAPI-subset `responseSchema` field (constraints stripped) so Gemini
+    /// does not 400 on unsupported keywords.
+    #[test]
+    fn test_response_format_non_strict_json_schema_uses_sanitized_response_schema() {
+        let rf = response_format_to_gemini(&serde_json::json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "weather",
                 "schema": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["city", "temp_c"],
-                    "properties": {
-                        "city": {"type": "string"},
-                        "temp_c": {"type": "number"}
-                    }
+                    "required": ["city"],
+                    "properties": {"city": {"type": "string"}}
                 }
             }
-        });
-        let (mime, schema) = response_format_to_gemini(&rf);
-        assert_eq!(mime.as_deref(), Some("application/json"));
-        let schema = schema.expect("schema translated");
-        // `additionalProperties` (rejected by Gemini) must be stripped.
+        }));
+        assert_eq!(rf.mime_type.as_deref(), Some("application/json"));
+        // Mutually exclusive: the strict JSON-Schema field must be unset.
+        assert!(rf.json_schema.is_none());
+        let schema = rf.schema.expect("responseSchema populated");
+        // Lossy path: `additionalProperties` (rejected by Gemini) is stripped.
         assert!(schema
             .as_object()
             .unwrap()
@@ -1044,14 +1154,15 @@ mod tests {
         // Structural keys survive.
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"]["city"].is_object());
-        assert_eq!(schema["required"], serde_json::json!(["city", "temp_c"]));
+        assert_eq!(schema["required"], serde_json::json!(["city"]));
     }
 
     #[test]
     fn test_response_format_text_is_noop() {
-        let (mime, schema) = response_format_to_gemini(&serde_json::json!({"type": "text"}));
-        assert!(mime.is_none());
-        assert!(schema.is_none());
+        let rf = response_format_to_gemini(&serde_json::json!({"type": "text"}));
+        assert!(rf.mime_type.is_none());
+        assert!(rf.schema.is_none());
+        assert!(rf.json_schema.is_none());
     }
 
     #[test]

--- a/crates/inference_providers/src/external/gemini/converter.rs
+++ b/crates/inference_providers/src/external/gemini/converter.rs
@@ -102,7 +102,7 @@ pub struct GeminiSystemInstruction {
 }
 
 /// Gemini generation config
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GeminiGenerationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -113,6 +113,20 @@ pub struct GeminiGenerationConfig {
     pub max_output_tokens: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_sequences: Option<Vec<String>>,
+    /// Deterministic-sampling seed. Gemini's native API supports this via
+    /// `generationConfig.seed`; OpenAI clients send the OpenAI-standard `seed`
+    /// (nearai/cloud-api #669).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i64>,
+    /// Structured-output MIME type. `"application/json"` enables Gemini's JSON
+    /// mode (raw JSON, no markdown fences) for `response_format: json_object`
+    /// and `json_schema` (nearai/cloud-api #668).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_mime_type: Option<String>,
+    /// Structured-output schema, translated from OpenAI `json_schema` and
+    /// sanitized to Gemini's OpenAPI subset (nearai/cloud-api #668).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_schema: Option<serde_json::Value>,
 }
 
 /// Gemini function declaration (tool definition)
@@ -418,6 +432,44 @@ fn sanitize_schema_for_gemini(value: &mut serde_json::Value) {
             }
         }
         _ => {}
+    }
+}
+
+/// Translate an OpenAI `response_format` value into Gemini's structured-output
+/// `generationConfig` fields (nearai/cloud-api #668).
+///
+/// Returns `(response_mime_type, response_schema)`:
+/// - `{"type": "json_object"}` → `("application/json", None)` so Gemini emits
+///   raw JSON instead of markdown-fenced text.
+/// - `{"type": "json_schema", "json_schema": {"schema": {...}}}` →
+///   `("application/json", Some(sanitized schema))` so Gemini enforces the
+///   schema natively (it was previously ignored entirely).
+/// - anything else (including `{"type": "text"}`) → `(None, None)`.
+///
+/// The schema is sanitized through `sanitize_schema_for_gemini` so JSON-Schema
+/// keywords Gemini's OpenAPI subset rejects (e.g. `additionalProperties`,
+/// `$schema`) do not 400 the request.
+pub fn response_format_to_gemini(
+    response_format: &serde_json::Value,
+) -> (Option<String>, Option<serde_json::Value>) {
+    let Some(type_) = response_format.get("type").and_then(|v| v.as_str()) else {
+        return (None, None);
+    };
+
+    match type_ {
+        "json_object" => (Some("application/json".to_string()), None),
+        "json_schema" => {
+            let schema = response_format
+                .get("json_schema")
+                .and_then(|js| js.get("schema"))
+                .cloned()
+                .map(|mut s| {
+                    sanitize_schema_for_gemini(&mut s);
+                    s
+                });
+            (Some("application/json".to_string()), schema)
+        }
+        _ => (None, None),
     }
 }
 
@@ -950,6 +1002,56 @@ mod tests {
             "serialized parameters must not contain `additionalProperties`; got: {}",
             serialized
         );
+    }
+
+    // ── #668: response_format → Gemini structured output ────────────────────
+
+    #[test]
+    fn test_response_format_json_object_sets_mime_type_only() {
+        let rf = serde_json::json!({"type": "json_object"});
+        let (mime, schema) = response_format_to_gemini(&rf);
+        assert_eq!(mime.as_deref(), Some("application/json"));
+        assert!(schema.is_none());
+    }
+
+    #[test]
+    fn test_response_format_json_schema_sets_mime_and_sanitized_schema() {
+        let rf = serde_json::json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "weather",
+                "strict": true,
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["city", "temp_c"],
+                    "properties": {
+                        "city": {"type": "string"},
+                        "temp_c": {"type": "number"}
+                    }
+                }
+            }
+        });
+        let (mime, schema) = response_format_to_gemini(&rf);
+        assert_eq!(mime.as_deref(), Some("application/json"));
+        let schema = schema.expect("schema translated");
+        // `additionalProperties` (rejected by Gemini) must be stripped.
+        assert!(schema
+            .as_object()
+            .unwrap()
+            .get("additionalProperties")
+            .is_none());
+        // Structural keys survive.
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["city"].is_object());
+        assert_eq!(schema["required"], serde_json::json!(["city", "temp_c"]));
+    }
+
+    #[test]
+    fn test_response_format_text_is_noop() {
+        let (mime, schema) = response_format_to_gemini(&serde_json::json!({"type": "text"}));
+        assert!(mime.is_none());
+        assert!(schema.is_none());
     }
 
     #[test]

--- a/crates/inference_providers/src/external/gemini/mod.rs
+++ b/crates/inference_providers/src/external/gemini/mod.rs
@@ -151,22 +151,26 @@ impl GeminiBackend {
             .seed
             .or_else(|| params.extra.get("seed").and_then(serde_json::Value::as_i64));
 
-        // `response_format` (nearai/cloud-api #668): rides in `extra`. Translate
-        // json_object/json_schema into Gemini's native structured-output fields
-        // so it returns raw JSON (no markdown fences) and enforces the schema.
-        let (response_mime_type, response_schema) = params
+        // `response_format` (nearai/cloud-api #668, #720): rides in `extra`.
+        // Translate json_object/json_schema into Gemini's native structured-output
+        // fields so it returns raw JSON (no markdown fences) and enforces the
+        // schema. Strict json_schema goes through `responseJsonSchema` so
+        // constraints (`additionalProperties:false`, `$ref`, `$defs`, `oneOf`)
+        // are preserved; non-strict uses the lossy OpenAPI-subset `responseSchema`.
+        let response_format = params
             .extra
             .get("response_format")
             .map(response_format_to_gemini)
-            .unwrap_or((None, None));
+            .unwrap_or_default();
 
         let generation_config = if params.temperature.is_some()
             || params.top_p.is_some()
             || max_tokens.is_some()
             || params.stop.is_some()
             || seed.is_some()
-            || response_mime_type.is_some()
-            || response_schema.is_some()
+            || response_format.mime_type.is_some()
+            || response_format.schema.is_some()
+            || response_format.json_schema.is_some()
         {
             Some(GeminiGenerationConfig {
                 temperature: params.temperature,
@@ -174,8 +178,9 @@ impl GeminiBackend {
                 max_output_tokens: max_tokens,
                 stop_sequences: params.stop.clone(),
                 seed,
-                response_mime_type,
-                response_schema,
+                response_mime_type: response_format.mime_type,
+                response_schema: response_format.schema,
+                response_json_schema: response_format.json_schema,
             })
         } else {
             None
@@ -575,8 +580,47 @@ mod tests {
         assert!(body["generationConfig"].get("responseSchema").is_none());
     }
 
+    /// #720: a strict `json_schema` request must be wired to
+    /// `generationConfig.responseJsonSchema` with the ORIGINAL schema preserved
+    /// (`additionalProperties:false` and friends intact), and must NOT populate
+    /// the lossy `responseSchema` field (they are mutually exclusive in Gemini).
     #[test]
-    fn test_build_request_json_schema_sets_mime_and_schema() {
+    fn test_build_request_strict_json_schema_uses_response_json_schema() {
+        let backend = GeminiBackend::new();
+        let mut params = base_params();
+        params.extra.insert(
+            "response_format".to_string(),
+            serde_json::json!({
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "weather",
+                    "strict": true,
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {"city": {"type": "string"}}
+                    }
+                }
+            }),
+        );
+        let request = backend.build_request(&params);
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            body["generationConfig"]["responseMimeType"],
+            "application/json"
+        );
+        // Lossy field must be absent for strict schemas.
+        assert!(body["generationConfig"].get("responseSchema").is_none());
+        let schema = &body["generationConfig"]["responseJsonSchema"];
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["city"].is_object());
+        // Strict constraint preserved (would have been stripped before #720).
+        assert_eq!(schema["additionalProperties"], serde_json::json!(false));
+    }
+
+    /// Non-strict `json_schema` uses the lossy `responseSchema` (best-effort).
+    #[test]
+    fn test_build_request_non_strict_json_schema_uses_response_schema() {
         let backend = GeminiBackend::new();
         let mut params = base_params();
         params.extra.insert(
@@ -599,6 +643,8 @@ mod tests {
             body["generationConfig"]["responseMimeType"],
             "application/json"
         );
+        // Strict JSON-Schema field must be absent for non-strict schemas.
+        assert!(body["generationConfig"].get("responseJsonSchema").is_none());
         let schema = &body["generationConfig"]["responseSchema"];
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"]["city"].is_object());

--- a/crates/inference_providers/src/external/gemini/mod.rs
+++ b/crates/inference_providers/src/external/gemini/mod.rs
@@ -16,8 +16,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use converter::{
     convert_messages, convert_tools, extract_response_content, map_finish_reason_string,
-    GeminiEventParser, GeminiGenerationConfig, GeminiParserState, GeminiPart, GeminiRequest,
-    GeminiResponse,
+    response_format_to_gemini, GeminiEventParser, GeminiGenerationConfig, GeminiParserState,
+    GeminiPart, GeminiRequest, GeminiResponse,
 };
 use futures_util::Stream;
 use reqwest::Client;
@@ -143,16 +143,39 @@ impl GeminiBackend {
         let (system_instruction, contents) = convert_messages(&params.messages);
         let max_tokens = params.max_completion_tokens.or(params.max_tokens);
 
+        // `seed` (nearai/cloud-api #669): Gemini supports deterministic sampling
+        // via `generationConfig.seed`. The service layer hardcodes the typed
+        // `seed` field to None and forwards the original in `extra`, so read
+        // both (typed first, then the passthrough map).
+        let seed = params
+            .seed
+            .or_else(|| params.extra.get("seed").and_then(serde_json::Value::as_i64));
+
+        // `response_format` (nearai/cloud-api #668): rides in `extra`. Translate
+        // json_object/json_schema into Gemini's native structured-output fields
+        // so it returns raw JSON (no markdown fences) and enforces the schema.
+        let (response_mime_type, response_schema) = params
+            .extra
+            .get("response_format")
+            .map(response_format_to_gemini)
+            .unwrap_or((None, None));
+
         let generation_config = if params.temperature.is_some()
             || params.top_p.is_some()
             || max_tokens.is_some()
             || params.stop.is_some()
+            || seed.is_some()
+            || response_mime_type.is_some()
+            || response_schema.is_some()
         {
             Some(GeminiGenerationConfig {
                 temperature: params.temperature,
                 top_p: params.top_p,
                 max_output_tokens: max_tokens,
                 stop_sequences: params.stop.clone(),
+                seed,
+                response_mime_type,
+                response_schema,
             })
         } else {
             None
@@ -461,6 +484,131 @@ impl ExternalBackend for GeminiBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn base_params() -> ChatCompletionParams {
+        ChatCompletionParams {
+            model: "gemini-2.5-flash".to_string(),
+            messages: vec![crate::ChatMessage {
+                role: MessageRole::User,
+                content: Some(serde_json::Value::String("Hello".to_string())),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            max_completion_tokens: None,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            n: None,
+            stream: None,
+            stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            logit_bias: None,
+            logprobs: None,
+            top_logprobs: None,
+            user: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            metadata: None,
+            store: None,
+            stream_options: None,
+            modalities: None,
+            extra: std::collections::HashMap::new(),
+        }
+    }
+
+    // ── #669: seed forwarded to generationConfig.seed ───────────────────────
+
+    #[test]
+    fn test_build_request_forwards_seed_from_extra() {
+        let backend = GeminiBackend::new();
+        let mut params = base_params();
+        // The service layer hardcodes the typed `seed` to None and forwards the
+        // original in `extra`; we must still pick it up.
+        params
+            .extra
+            .insert("seed".to_string(), serde_json::json!(42));
+        let request = backend.build_request(&params);
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(body["generationConfig"]["seed"], 42);
+    }
+
+    #[test]
+    fn test_build_request_forwards_typed_seed() {
+        let backend = GeminiBackend::new();
+        let mut params = base_params();
+        params.seed = Some(7);
+        let request = backend.build_request(&params);
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(body["generationConfig"]["seed"], 7);
+    }
+
+    #[test]
+    fn test_build_request_no_seed_omits_field() {
+        let backend = GeminiBackend::new();
+        let params = base_params();
+        let request = backend.build_request(&params);
+        let body = serde_json::to_value(&request).unwrap();
+        // No generationConfig at all when nothing is set.
+        assert!(body.get("generationConfig").is_none());
+    }
+
+    // ── #668: response_format → generationConfig structured output ──────────
+
+    #[test]
+    fn test_build_request_json_object_sets_mime_type() {
+        let backend = GeminiBackend::new();
+        let mut params = base_params();
+        params.extra.insert(
+            "response_format".to_string(),
+            serde_json::json!({"type": "json_object"}),
+        );
+        let request = backend.build_request(&params);
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            body["generationConfig"]["responseMimeType"],
+            "application/json"
+        );
+        assert!(body["generationConfig"].get("responseSchema").is_none());
+    }
+
+    #[test]
+    fn test_build_request_json_schema_sets_mime_and_schema() {
+        let backend = GeminiBackend::new();
+        let mut params = base_params();
+        params.extra.insert(
+            "response_format".to_string(),
+            serde_json::json!({
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "weather",
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {"city": {"type": "string"}}
+                    }
+                }
+            }),
+        );
+        let request = backend.build_request(&params);
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            body["generationConfig"]["responseMimeType"],
+            "application/json"
+        );
+        let schema = &body["generationConfig"]["responseSchema"];
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["city"].is_object());
+        // sanitized: Gemini-unsupported keyword removed
+        assert!(schema
+            .as_object()
+            .unwrap()
+            .get("additionalProperties")
+            .is_none());
+    }
 
     #[test]
     fn test_strip_vendor_prefix_google() {


### PR DESCRIPTION
Brings the Anthropic and Gemini passthrough converters up to OpenAI/OpenRouter parameter parity. Three related fixes shipped together.

## #696 — `temperature` 400 on `claude-opus-4-7`
Newer Anthropic models deprecate `temperature` and 400 on any non-default value, even though they still advertise it. The Anthropic adapter now drops `temperature` for those models (matched by a per-model substring list, currently `claude-opus-4-7`) and forwards `top_p` instead. `claude-opus-4-6` and earlier still forward `temperature` — verified by a regression test so we don't over-strip.

## #669 — `seed` silently ignored on Gemini
Gemini's native API supports deterministic sampling via `generationConfig.seed`. We now forward it (reading the typed `seed` field or the `extra` passthrough map the service layer actually populates). Anthropic has no native `seed`; left as graceful accept-and-ignore per the issue's preferred option (no hard 400).

## #668 — `response_format` broken on passthroughs
- **Gemini**: `json_object` → `responseMimeType: "application/json"`; `json_schema` → `responseMimeType` + a sanitized `responseSchema` (run through the existing Gemini OpenAPI-subset sanitizer so `additionalProperties` etc. don't 400). Previously `json_schema` was ignored entirely and `json_object` came back markdown-fenced.
- **Anthropic**: no native JSON mode, so on the non-streaming path we strip a leading/trailing markdown ` ```json … ``` ` fence when `json_object`/`json_schema` was requested, so `JSON.parse` works. Streaming is documented as best-effort (a fence marker can split across SSE deltas; buffering would defeat streaming).

## Tests
- New converter unit tests: opus-4-7 temperature drop + opus-4-6 guard; fence-stripping; Gemini seed (typed + extra); Gemini `responseMimeType`/`responseSchema` mapping; `response_format_to_gemini` translation.
- New e2e `json_object` passthrough guard in `openrouter_params.rs`.
- `cargo build --workspace` clean; `cargo test -p inference_providers --lib` 194 passed; `cargo test --test e2e_all -- openrouter` 10 passed. (The pre-existing `detect_audio_content_type` doctest failure on `main` is unrelated.)

Fixes #696
Fixes #669
Fixes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)