### PR TITLE
refactor(api): stop defaulting temperature/top_p to 1.0 (#696 follow-up, per Pierre)

### DIFF
--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -41,9 +41,9 @@ pub struct ChatCompletionRequest {
     pub model: String,
     pub messages: Vec<Message>,
     pub max_tokens: Option<i64>,
-    #[serde(default = "default_temperature")]
+    #[serde(default)]
     pub temperature: Option<f32>,
-    #[serde(default = "default_top_p")]
+    #[serde(default)]
     pub top_p: Option<f32>,
     #[serde(default = "default_n")]
     pub n: Option<i64>,
@@ -226,9 +226,9 @@ pub struct CompletionRequest {
     pub model: String,
     pub prompt: CompletionPrompt,
     pub max_tokens: Option<i64>,
-    #[serde(default = "default_temperature")]
+    #[serde(default)]
     pub temperature: Option<f32>,
-    #[serde(default = "default_top_p")]
+    #[serde(default)]
     pub top_p: Option<f32>,
     #[serde(default = "default_n")]
     pub n: Option<i64>,
@@ -1012,14 +1012,6 @@ pub struct WebSearchQueryParams {
     /// Enable search operators interpretation in query
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operators: Option<bool>,
-}
-
-fn default_temperature() -> Option<f32> {
-    Some(1.0)
-}
-
-fn default_top_p() -> Option<f32> {
-    Some(1.0)
 }
 
 fn default_n() -> Option<i64> {
@@ -3740,6 +3732,24 @@ mod tests {
 
         // Text-only content array should pass validation
         assert!(request.validate().is_ok());
+    }
+
+    #[test]
+    fn test_chat_completion_request_omits_unset_sampling_defaults() {
+        // Regression guard (nearai/cloud-api #696 follow-up): cloud-api must NOT
+        // inject a default `temperature`/`top_p`. A request that omits them must
+        // deserialize to `None` so we forward neither upstream — some models
+        // (e.g. anthropic/claude-opus-4-7) 400 on a `top_p` the caller never set.
+        let req: ChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}],
+        }))
+        .expect("minimal request should deserialize");
+        assert_eq!(
+            req.temperature, None,
+            "temperature must not default to Some(1.0)"
+        );
+        assert_eq!(req.top_p, None, "top_p must not default to Some(1.0)");
     }
 
     #[test]


### PR DESCRIPTION
## What

Per @PierreLeGuen's suggestion on #724: cloud-api defaulted both `temperature` and `top_p` to `Some(1.0)` at deserialization (`default_temperature` / `default_top_p`), so **every** request forwarded `temperature:1.0, top_p:1.0` to **every** backend unless an adapter happened to strip them.

This change makes both fields plain `#[serde(default)]` → `None` when the caller omits them, and deletes the two default functions.

## Why

- **Root cause of the opus-4-7 regression** (#724): the model 400s on a `top_p` the caller never set, because the gateway injected `top_p:1.0`. With no injected default, the no-params case just works.
- **More OpenAI-faithful**: OpenAI omits unset sampling params rather than forcing 1.0.
- **Simpler**: −2 functions, no surprising "force 1.0" behavior.

## Consequences (verified)

- `cargo build --workspace` + all unit tests green (api 126, inference_providers 217); no code relied on the defaults — the response repository / responses route already use `.unwrap_or(1.0)` for storage, and adapters use `Option`/`if let Some`.
- **Behavioral nuance:** a client that previously sent *no* `temperature` got an implicit `1.0`; now it gets each model's own default. Since `1.0` is the identity for both knobs this is effectively a no-op for well-behaved backends, but it's a real cross-provider change worth calling out.
- Gemini now builds `generationConfig` only when a param is actually set (was always sending temp+top_p=1.0).
- Added a deserialize regression test (`test_chat_completion_request_omits_unset_sampling_defaults`).

## Relationship to #724

Complementary, not redundant. This fixes the no-params / injected-default case generally; **#724** still gracefully drops an *explicitly-sent* `temperature`/`top_p` for opus-4-7 (which OpenRouter clients do send). Touches only `models.rs` — independent of the anthropic adapter, no conflict with #724.

Refs #696 #724