### PR TITLE
feat(metrics): per-model billed-usage metrics

### DIFF
--- a/crates/services/src/metrics/consts.rs
+++ b/crates/services/src/metrics/consts.rs
@@ -22,6 +22,17 @@ pub const METRIC_REQUEST_ERRORS: &str = "cloud_api.request.errors";
 // Cost metrics
 pub const METRIC_COST_USD: &str = "cloud_api.cost.usd";
 
+// Billed-usage metrics (emitted once per newly-recorded usage row, covering every
+// inference type, dimensioned by model + inference_type). These are the authoritative
+// "what we billed" counters; tokens.input/output above are throughput-oriented and only
+// cover the chat-completions path.
+pub const METRIC_BILLED_REQUESTS: &str = "cloud_api.billed.requests";
+pub const METRIC_BILLED_INPUT_TOKENS: &str = "cloud_api.billed.input_tokens";
+pub const METRIC_BILLED_OUTPUT_TOKENS: &str = "cloud_api.billed.output_tokens";
+pub const METRIC_BILLED_CACHE_READ_TOKENS: &str = "cloud_api.billed.cache_read_tokens";
+pub const METRIC_BILLED_INPUT_COST_USD: &str = "cloud_api.billed.input_cost_usd";
+pub const METRIC_BILLED_OUTPUT_COST_USD: &str = "cloud_api.billed.output_cost_usd";
+
 // Provider data quality metrics
 pub const METRIC_PROVIDER_TOKEN_ANOMALIES: &str = "cloud_api.provider.token_anomalies";
 pub const METRIC_PROVIDER_ZERO_TOKENS: &str = "cloud_api.provider.zero_tokens";
@@ -39,6 +50,7 @@ pub const TAG_ENDPOINT: &str = "endpoint";
 pub const TAG_METHOD: &str = "method";
 pub const TAG_REASON: &str = "reason";
 pub const TAG_INPUT_BUCKET: &str = "input_bucket";
+pub const TAG_INFERENCE_TYPE: &str = "inference_type";
 
 // Error types for TAG_ERROR_TYPE
 pub const ERROR_TYPE_INVALID_MODEL: &str = "invalid_model";

--- a/crates/services/src/metrics/mod.rs
+++ b/crates/services/src/metrics/mod.rs
@@ -98,6 +98,24 @@ impl MetricsServiceTrait for OtlpMetricsService {
                 }
                 consts::METRIC_REQUEST_ERRORS => "API request errors by error type",
                 consts::METRIC_COST_USD => "Total cost in nano-dollars (USD) by model",
+                consts::METRIC_BILLED_REQUESTS => {
+                    "Billed requests by model and inference_type (one per recorded usage row)"
+                }
+                consts::METRIC_BILLED_INPUT_TOKENS => {
+                    "Billed input tokens by model and inference_type"
+                }
+                consts::METRIC_BILLED_OUTPUT_TOKENS => {
+                    "Billed output tokens by model and inference_type"
+                }
+                consts::METRIC_BILLED_CACHE_READ_TOKENS => {
+                    "Billed cache-read tokens by model and inference_type"
+                }
+                consts::METRIC_BILLED_INPUT_COST_USD => {
+                    "Billed input cost in nano-dollars (USD) by model and inference_type"
+                }
+                consts::METRIC_BILLED_OUTPUT_COST_USD => {
+                    "Billed output cost in nano-dollars (USD) by model and inference_type"
+                }
                 consts::METRIC_PROVIDER_TOKEN_ANOMALIES => {
                     "Count of provider token count anomalies (capped values)"
                 }

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -1,7 +1,11 @@
 pub mod ports;
 
 use crate::metrics::{
-    consts::{get_environment, METRIC_COST_USD, TAG_ENVIRONMENT, TAG_MODEL},
+    consts::{
+        get_environment, METRIC_BILLED_CACHE_READ_TOKENS, METRIC_BILLED_INPUT_COST_USD,
+        METRIC_BILLED_INPUT_TOKENS, METRIC_BILLED_OUTPUT_COST_USD, METRIC_BILLED_OUTPUT_TOKENS,
+        METRIC_BILLED_REQUESTS, METRIC_COST_USD, TAG_ENVIRONMENT, TAG_INFERENCE_TYPE, TAG_MODEL,
+    },
     MetricsServiceTrait,
 };
 pub use ports::*;
@@ -269,18 +273,46 @@ impl UsageServiceTrait for UsageServiceImpl {
             .await
             .map_err(|e| UsageError::InternalError(format!("Failed to record usage: {e}")))?;
 
-        // Record cost metric ONLY for new inserts (not duplicates)
-        // This prevents metric inflation when idempotent requests are retried
-        if log.was_inserted && total_cost > 0 {
+        // Record billed-usage metrics ONLY for new inserts (not duplicates).
+        // This prevents metric inflation when idempotent requests are retried.
+        // Recorded at this single, authoritative billing point so every inference
+        // type (chat, image, audio, rerank, embedding, ...) is captured uniformly,
+        // dimensioned by model + inference_type.
+        if log.was_inserted {
             let environment = get_environment();
             let tags = [
                 format!("{}:{}", TAG_MODEL, model.model_name),
+                format!("{}:{}", TAG_INFERENCE_TYPE, request.inference_type.as_str()),
                 format!("{TAG_ENVIRONMENT}:{environment}"),
             ];
             let tags_str: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
-            self.metrics_service
-                .record_count(METRIC_COST_USD, total_cost, &tags_str);
-        } else if !log.was_inserted {
+
+            let metrics = &self.metrics_service;
+            metrics.record_count(METRIC_BILLED_REQUESTS, 1, &tags_str);
+            metrics.record_count(
+                METRIC_BILLED_INPUT_TOKENS,
+                request.input_tokens as i64,
+                &tags_str,
+            );
+            metrics.record_count(
+                METRIC_BILLED_OUTPUT_TOKENS,
+                request.output_tokens as i64,
+                &tags_str,
+            );
+            metrics.record_count(
+                METRIC_BILLED_CACHE_READ_TOKENS,
+                cache_read_tokens as i64,
+                &tags_str,
+            );
+            metrics.record_count(METRIC_BILLED_INPUT_COST_USD, input_cost, &tags_str);
+            metrics.record_count(METRIC_BILLED_OUTPUT_COST_USD, output_cost, &tags_str);
+
+            // Existing total-cost metric, kept for backward compatibility with
+            // dashboards; now also dimensioned by inference_type.
+            if total_cost > 0 {
+                metrics.record_count(METRIC_COST_USD, total_cost, &tags_str);
+            }
+        } else {
             // Log when we skip metrics for a duplicate (aids debugging)
             tracing::debug!(
                 organization_id = %log.organization_id,


### PR DESCRIPTION
## What

Adds a per-model **billed-usage** metric family, emitted at the single authoritative billing point — `UsageServiceImpl::record_usage()`. This is where *every* inference type flows through after cost is computed, so coverage is uniform — unlike the existing `cloud_api.tokens.*` metrics which only fire on the chat-completions streaming/non-streaming path.

## New metrics

All OTLP counters, dimensioned by `model` + `inference_type` + `environment`:

| Metric | Meaning |
|---|---|
| `cloud_api.billed.requests` | billed requests (one per recorded usage row) |
| `cloud_api.billed.input_tokens` | billed input tokens |
| `cloud_api.billed.output_tokens` | billed output tokens |
| `cloud_api.billed.cache_read_tokens` | billed cache-read tokens |
| `cloud_api.billed.input_cost_usd` | input cost (nano-dollars) |
| `cloud_api.billed.output_cost_usd` | output cost (nano-dollars) |

## Design notes

- **Coverage:** recorded in the central `record_usage()` billing path, so chat, image, audio, rerank, embedding and privacy-classify are all captured (the existing `cloud_api.tokens.*` only cover chat completions).
- **No double counting:** gated by the existing `log.was_inserted` idempotency guard, so retried requests with the same `inference_id` don't inflate the counters.
- **`inference_type` tag:** added to the new metrics *and* to the existing `cloud_api.cost.usd` total. This is additive/backward-compatible in Datadog (queries summing over all `inference_type` values are unaffected) and lets you slice billed usage by operation type. `total == input + output` is derivable from the breakdown.
- **`cloud_api.cost.usd`** keeps its existing semantics (still guarded by `total_cost > 0`) so current dashboards are unaffected.
- **Cardinality:** the tag fan-out is `model × inference_type × environment` — bounded and low, consistent with the `consts.rs` "low-cardinality tags only" rule (no org/workspace/api_key).

## Files changed

- `crates/services/src/metrics/consts.rs` — 6 metric-name constants + `TAG_INFERENCE_TYPE`
- `crates/services/src/metrics/mod.rs` — counter descriptions
- `crates/services/src/usage/mod.rs` — emit block

## Testing

- `cargo check -p services` — clean
- `cargo fmt -p services` — clean
- `cargo test -p services usage:: --lib` — 8 passed
