### PR TITLE
feat(billing): bill interrupted Anthropic streams for input tokens

### DIFF
--- a/crates/inference_providers/src/chunk_builder.rs
+++ b/crates/inference_providers/src/chunk_builder.rs
@@ -50,6 +50,21 @@ impl ChunkContext {
 
     /// Create a chunk with assistant role (typically first chunk)
     pub fn role_chunk(&self) -> ChatCompletionChunk {
+        self.role_chunk_with_usage(None)
+    }
+
+    /// Create a chunk with assistant role, optionally carrying early usage stats.
+    ///
+    /// Some providers (notably Anthropic) only emit complete token usage in the
+    /// final stream event, but expose the prompt/input token count at the very
+    /// start (Anthropic's `message_start`). Attaching that partial usage to the
+    /// first chunk lets the billing layer (`InterceptStream`) capture it as
+    /// `last_usage_stats`, so an interrupted stream (client disconnect or
+    /// provider error before the final chunk) is still billed for the input
+    /// tokens the provider already charged us for. On a clean stream the final
+    /// chunk's complete usage overwrites this partial value, so billing is
+    /// unaffected.
+    pub fn role_chunk_with_usage(&self, usage: Option<TokenUsage>) -> ChatCompletionChunk {
         self.build(
             ChatDelta {
                 role: Some(MessageRole::Assistant),
@@ -62,7 +77,7 @@ impl ChunkContext {
                 extra: Default::default(),
             },
             None,
-            None,
+            usage,
         )
     }
 

--- a/crates/inference_providers/src/external/anthropic/converter.rs
+++ b/crates/inference_providers/src/external/anthropic/converter.rs
@@ -523,7 +523,21 @@ impl SSEEventParser for AnthropicEventParser {
                 state.message_id = Some(message.id);
                 state.input_tokens = message.usage.input_tokens;
                 let ctx = state.chunk_context();
-                Ok(Some(StreamChunk::Chat(ctx.role_chunk())))
+                // Anthropic reports input tokens up front in `message_start`, but
+                // completion tokens only in the final `message_delta`. Carry the
+                // known input tokens on the first chunk so an interrupted stream is
+                // still billed for the prompt tokens Anthropic charged us for
+                // (completion tokens stay 0 until the final chunk). On a clean
+                // stream the final chunk's full usage overwrites this.
+                let early_usage = TokenUsage {
+                    prompt_tokens: state.input_tokens,
+                    completion_tokens: 0,
+                    total_tokens: state.input_tokens,
+                    prompt_tokens_details: None,
+                };
+                Ok(Some(StreamChunk::Chat(
+                    ctx.role_chunk_with_usage(Some(early_usage)),
+                )))
             }
 
             AnthropicStreamEvent::ContentBlockStart {
@@ -806,5 +820,30 @@ mod tests {
         let calls = tool_calls.unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].id, Some("toolu_123".to_string()));
+    }
+
+    #[test]
+    fn test_message_start_chunk_carries_input_usage() {
+        // Regression test for nearai/infra#98: an interrupted Anthropic stream
+        // (client disconnect / provider error before the final message_delta)
+        // must still be billable for the prompt tokens Anthropic charged us for.
+        // The billing layer (`InterceptStream`) only sees usage attached to a
+        // chunk, so `message_start` must surface the input tokens immediately.
+        let mut state = AnthropicParserState::new("claude-test".to_string());
+        let data =
+            r#"{"type":"message_start","message":{"id":"msg_123","usage":{"input_tokens":42}}}"#;
+
+        let chunk = AnthropicEventParser::parse_event(&mut state, data)
+            .unwrap()
+            .expect("message_start should produce a chunk");
+
+        let StreamChunk::Chat(chat) = chunk else {
+            panic!("expected a chat chunk");
+        };
+        let usage = chat.usage.expect("role chunk should carry early usage");
+        assert_eq!(usage.prompt_tokens, 42);
+        assert_eq!(usage.completion_tokens, 0);
+        assert_eq!(usage.total_tokens, 42);
+        assert_eq!(state.input_tokens, 42);
     }
 }


### PR DESCRIPTION
## Problem

Part of nearai/infra#98 — *"Implement billing for interrupted streams"*. We see many:

> `Stream interrupted before usage stats received (client disconnect or provider error)` (`stream_error: false`)

When a stream is interrupted (client disconnect, or provider error before the final usage chunk), `InterceptStream` has no `last_usage_stats` and the request goes **unbilled** even though tokens were consumed.

## Root cause (per-provider)

Billing happens in `InterceptStream` (`crates/services/src/completions/mod.rs`), which captures usage from any chunk carrying a `usage` object. Whether partial usage is *available* at interruption depends on the provider:

| Provider | Incremental usage? | Billed on interruption before this PR? |
|---|---|---|
| Internal vLLM/sglang | `continuous_usage_stats:true` → every chunk | ✅ already |
| Gemini | per-chunk `usageMetadata` | ✅ already |
| **Anthropic** | input at `message_start`, output only in final `message_delta`; input never attached to a chunk | ❌ |
| OpenAI / openai_compatible | usage only in final chunk (OpenAI rejects `continuous_usage_stats`) | ❌ (no mid-stream data available — out of scope) |

## Fix

Attach the input tokens Anthropic reports at `message_start` to the first (role) chunk, via a new `ChunkContext::role_chunk_with_usage` helper. `InterceptStream` then captures it as `last_usage_stats`, so an interrupted Anthropic stream is billed for the prompt tokens Anthropic charged us for. Completion tokens stay `0` until the final chunk (Anthropic gives no mid-stream output count — we bill only what's real). On a clean stream the final chunk's full usage overwrites this, so billing is unchanged.

This mirrors what Gemini already does (usage on every chunk).

## Scope / known limitation

Real partial usage only — **no estimation**. OpenAI/openai_compatible interrupted streams still can't be billed because the provider sends no mid-stream usage; those keep the existing WARN and bill \$0. Documented intentionally.

The inference-proxy side (billing interrupted internal-model streams from its own usage reporter) is in nearai/inference-proxy#155.

## Tests

- `test_message_start_chunk_carries_input_usage` — new regression test.
- Full `inference_providers` lib suite green (224 tests).
