### PR TITLE
[codex] Allow org admins to cancel invitations

### DIFF
--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -86,6 +86,8 @@ use utoipa::{Modify, OpenApi};
         crate::routes::organization_members::update_organization_member,
         crate::routes::organization_members::remove_organization_member,
         crate::routes::organization_members::list_organization_members,
+        crate::routes::organization_members::list_organization_invitations,
+        crate::routes::organization_members::cancel_organization_invitation,
         // Workspace endpoints
         crate::routes::workspaces::create_workspace,
         crate::routes::workspaces::list_organization_workspaces,

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -74,6 +74,10 @@ pub fn build_management_router(app_state: AppState, auth_state: AuthState) -> Ro
             get(list_organization_invitations),
         )
         .route(
+            "/{id}/members/invitations/{invitation_id}",
+            delete(cancel_organization_invitation),
+        )
+        .route(
             "/{id}/members/{user_id}",
             put(update_organization_member).delete(remove_organization_member),
         )

--- a/crates/api/src/routes/organization_members.rs
+++ b/crates/api/src/routes/organization_members.rs
@@ -468,6 +468,79 @@ pub async fn list_organization_invitations(
     }
 }
 
+/// Cancel an organization invitation
+///
+/// Cancels a pending invitation for the organization. Only owners and admins can cancel invitations.
+#[utoipa::path(
+    delete,
+    path = "/v1/organizations/{org_id}/members/invitations/{invitation_id}",
+    tag = "Organization Members",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID"),
+        ("invitation_id" = Uuid, Path, description = "Invitation ID")
+    ),
+    responses(
+        (status = 204, description = "Invitation cancelled successfully"),
+        (status = 400, description = "Bad request - invitation is not pending", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden - not an admin or owner", body = ErrorResponse),
+        (status = 404, description = "Organization or invitation not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn cancel_organization_invitation(
+    State(app_state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path((org_id, invitation_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    debug!(
+        "Cancelling invitation {} for organization: {} by user: {}",
+        invitation_id, org_id, user.0.id
+    );
+
+    let organization_id = OrganizationId(org_id);
+    let requester_id = authenticated_user_to_user_id(user);
+
+    match app_state
+        .organization_service
+        .cancel_organization_invitation(organization_id, requester_id, invitation_id)
+        .await
+    {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(OrganizationError::InvalidParams(msg)) => Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(msg, "bad_request".to_string())),
+        )),
+        Err(OrganizationError::Unauthorized(msg)) => Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(msg, "forbidden".to_string())),
+        )),
+        Err(OrganizationError::NotFound) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new(
+                "Invitation not found".to_string(),
+                "not_found".to_string(),
+            )),
+        )),
+        Err(OrganizationError::UserNotFound)
+        | Err(OrganizationError::AlreadyExists)
+        | Err(OrganizationError::AlreadyMember)
+        | Err(OrganizationError::InternalError(_)) => {
+            error!("Failed to cancel organization invitation");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "Failed to cancel organization invitation".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            ))
+        }
+    }
+}
+
 /// List organization members with limited user information
 ///
 /// Returns limited user information for privacy and security:

--- a/crates/database/src/repositories/organization_invitation.rs
+++ b/crates/database/src/repositories/organization_invitation.rs
@@ -706,6 +706,27 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
         Ok(rows_affected > 0)
     }
 
+    async fn delete_pending(&self, id: Uuid) -> Result<bool> {
+        let rows_affected = retry_db!("delete_pending_organization_invitation", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .execute(
+                    "DELETE FROM organization_invitations WHERE id = $1 AND status = 'pending'",
+                    &[&id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows_affected > 0)
+    }
+
     async fn mark_expired(&self) -> Result<usize> {
         let rows_affected = retry_db!("mark_expired_organization_invitations", {
             let client = self

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -1123,6 +1123,14 @@ mod tests {
         async fn decline_invitation(&self, _: Uuid, _: &str) -> Result<(), OrganizationError> {
             unimplemented!()
         }
+        async fn cancel_organization_invitation(
+            &self,
+            _: OrganizationId,
+            _: UserId,
+            _: Uuid,
+        ) -> Result<(), OrganizationError> {
+            unimplemented!()
+        }
         async fn list_organization_invitations(
             &self,
             _: OrganizationId,

--- a/crates/services/src/organization/mod.rs
+++ b/crates/services/src/organization/mod.rs
@@ -1201,6 +1201,89 @@ impl OrganizationServiceImpl {
         Ok(())
     }
 
+    async fn ensure_can_manage_organization_invitations(
+        &self,
+        organization_id: &OrganizationId,
+        requester_id: &UserId,
+    ) -> Result<MemberRole, OrganizationError> {
+        let org = self.get_organization_impl(organization_id.clone()).await?;
+        if org.owner_id == *requester_id {
+            return Ok(MemberRole::Owner);
+        }
+
+        let member = self
+            .repository
+            .get_member(organization_id.0, requester_id.0)
+            .await
+            .map_err(Self::map_repository_error)?
+            .ok_or_else(|| {
+                OrganizationError::Unauthorized(
+                    "User is not a member of this organization".to_string(),
+                )
+            })?;
+
+        if !member.role.can_manage_members() {
+            return Err(OrganizationError::Unauthorized(
+                "Only owners and admins can manage invitations".to_string(),
+            ));
+        }
+
+        Ok(member.role)
+    }
+
+    async fn cancel_organization_invitation_impl(
+        &self,
+        organization_id: OrganizationId,
+        requester_id: UserId,
+        invitation_id: uuid::Uuid,
+    ) -> Result<(), OrganizationError> {
+        let requester_role = self
+            .ensure_can_manage_organization_invitations(&organization_id, &requester_id)
+            .await?;
+
+        let invitation = self
+            .invitation_repository
+            .get_by_id(invitation_id)
+            .await
+            .map_err(|e| {
+                OrganizationError::InternalError(format!("Failed to get invitation: {e}"))
+            })?
+            .ok_or(OrganizationError::NotFound)?;
+
+        if invitation.organization_id != organization_id {
+            return Err(OrganizationError::NotFound);
+        }
+
+        if invitation.status != ports::InvitationStatus::Pending {
+            return Err(OrganizationError::InvalidParams(
+                "Invitation is not pending".to_string(),
+            ));
+        }
+
+        if !requester_role.can_invite_as(&invitation.role) {
+            return Err(OrganizationError::Unauthorized(format!(
+                "Insufficient permissions to cancel {role} invitations",
+                role = invitation.role
+            )));
+        }
+
+        let deleted = self
+            .invitation_repository
+            .delete_pending(invitation_id)
+            .await
+            .map_err(|e| {
+                OrganizationError::InternalError(format!("Failed to cancel invitation: {e}"))
+            })?;
+
+        if !deleted {
+            return Err(OrganizationError::InvalidParams(
+                "Invitation is not pending".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// List invitations for an organization (admin/owner only, private helper)
     async fn list_organization_invitations_impl(
         &self,
@@ -1602,6 +1685,16 @@ impl OrganizationServiceTrait for OrganizationServiceImpl {
         user_email: &str,
     ) -> Result<(), OrganizationError> {
         self.decline_invitation_impl(invitation_id, user_email)
+            .await
+    }
+
+    async fn cancel_organization_invitation(
+        &self,
+        organization_id: OrganizationId,
+        requester_id: UserId,
+        invitation_id: uuid::Uuid,
+    ) -> Result<(), OrganizationError> {
+        self.cancel_organization_invitation_impl(organization_id, requester_id, invitation_id)
             .await
     }
 
@@ -2041,6 +2134,7 @@ mod tests {
                 .find(|invitation| invitation.id == id)
                 .unwrap();
             invitation.status = status;
+            invitation.responded_at = Some(chrono::Utc::now());
             Ok(invitation.clone())
         }
 
@@ -2066,6 +2160,15 @@ mod tests {
 
         async fn delete(&self, _: Uuid) -> anyhow::Result<bool> {
             unimplemented!()
+        }
+
+        async fn delete_pending(&self, id: Uuid) -> anyhow::Result<bool> {
+            let mut records = self.records.lock().unwrap();
+            let original_len = records.len();
+            records.retain(|invitation| {
+                !(invitation.id == id && invitation.status == InvitationStatus::Pending)
+            });
+            Ok(records.len() != original_len)
         }
 
         async fn mark_expired(&self) -> anyhow::Result<usize> {
@@ -2593,5 +2696,185 @@ mod tests {
         assert!(email_sender.sent_to.lock().unwrap().is_empty());
         let stored = invitation_repo.records.lock().unwrap()[0].clone();
         assert_eq!(stored.status, InvitationStatus::Expired);
+    }
+
+    #[tokio::test]
+    async fn cancel_organization_invitation_allows_org_admin() {
+        let (service, invitation_repo, _, user_repo) = make_service_with_requester_role(
+            Ok(EmailDeliveryOutcome::Skipped),
+            None,
+            MemberRole::Admin,
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+        let requester_id = user_repo.inviter.id.clone();
+
+        let result = service
+            .create_invitations(
+                org.id.clone(),
+                requester_id.clone(),
+                vec![("invitee@example.com".to_string(), MemberRole::Member)],
+                24,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.successful, 1);
+        let invitation_id = invitation_repo.records.lock().unwrap()[0].id;
+
+        service
+            .cancel_organization_invitation(org.id, requester_id, invitation_id)
+            .await
+            .unwrap();
+
+        assert!(invitation_repo.records.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_organization_invitation_rejects_member() {
+        let (service, invitation_repo, _, user_repo) = make_service_with_requester_role(
+            Ok(EmailDeliveryOutcome::Skipped),
+            None,
+            MemberRole::Member,
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+        let invitation = invitation_repo
+            .create(
+                org.id.0,
+                CreateInvitationRequest {
+                    email: "invitee@example.com".to_string(),
+                    role: MemberRole::Member,
+                    expires_in_hours: 24,
+                },
+                org.owner_id.0,
+            )
+            .await
+            .unwrap();
+
+        let error = service
+            .cancel_organization_invitation(org.id, user_repo.inviter.id.clone(), invitation.id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, OrganizationError::Unauthorized(_)));
+        assert_eq!(invitation_repo.records.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cancel_organization_invitation_hides_cross_org_invitation() {
+        let (service, invitation_repo, _, user_repo) = make_service_with_requester_role(
+            Ok(EmailDeliveryOutcome::Skipped),
+            None,
+            MemberRole::Admin,
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+        let other_org_id = Uuid::new_v4();
+        let invitation = invitation_repo
+            .create(
+                other_org_id,
+                CreateInvitationRequest {
+                    email: "invitee@example.com".to_string(),
+                    role: MemberRole::Member,
+                    expires_in_hours: 24,
+                },
+                org.owner_id.0,
+            )
+            .await
+            .unwrap();
+
+        let error = service
+            .cancel_organization_invitation(org.id, user_repo.inviter.id.clone(), invitation.id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, OrganizationError::NotFound));
+        assert_eq!(invitation_repo.records.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cancel_organization_invitation_rejects_non_pending_invitation() {
+        let (service, invitation_repo, _, user_repo) = make_service_with_requester_role(
+            Ok(EmailDeliveryOutcome::Skipped),
+            None,
+            MemberRole::Admin,
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+        let invitation = invitation_repo
+            .create(
+                org.id.0,
+                CreateInvitationRequest {
+                    email: "invitee@example.com".to_string(),
+                    role: MemberRole::Member,
+                    expires_in_hours: 24,
+                },
+                org.owner_id.0,
+            )
+            .await
+            .unwrap();
+        invitation_repo
+            .update_status(invitation.id, InvitationStatus::Declined)
+            .await
+            .unwrap();
+
+        let error = service
+            .cancel_organization_invitation(org.id, user_repo.inviter.id.clone(), invitation.id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, OrganizationError::InvalidParams(_)));
+        assert_eq!(invitation_repo.records.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cancel_organization_invitation_rejects_admin_for_owner_invite() {
+        let (service, invitation_repo, _, user_repo) = make_service_with_requester_role(
+            Ok(EmailDeliveryOutcome::Skipped),
+            None,
+            MemberRole::Admin,
+        );
+        let org = service
+            .repository
+            .get_by_id(Uuid::nil())
+            .await
+            .unwrap()
+            .unwrap();
+        let invitation = invitation_repo
+            .create(
+                org.id.0,
+                CreateInvitationRequest {
+                    email: "new-owner@example.com".to_string(),
+                    role: MemberRole::Owner,
+                    expires_in_hours: 24,
+                },
+                org.owner_id.0,
+            )
+            .await
+            .unwrap();
+
+        let error = service
+            .cancel_organization_invitation(org.id, user_repo.inviter.id.clone(), invitation.id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, OrganizationError::Unauthorized(_)));
+        assert_eq!(invitation_repo.records.lock().unwrap().len(), 1);
     }
 }

--- a/crates/services/src/organization/ports.rs
+++ b/crates/services/src/organization/ports.rs
@@ -418,6 +418,9 @@ pub trait OrganizationInvitationRepository: Send + Sync {
     /// Delete invitation
     async fn delete(&self, id: Uuid) -> Result<bool>;
 
+    /// Delete invitation only if it is still pending
+    async fn delete_pending(&self, id: Uuid) -> Result<bool>;
+
     /// Mark expired invitations
     async fn mark_expired(&self) -> Result<usize>;
 }
@@ -616,6 +619,14 @@ pub trait OrganizationServiceTrait: Send + Sync {
         &self,
         invitation_id: uuid::Uuid,
         user_email: &str,
+    ) -> Result<(), OrganizationError>;
+
+    /// Cancel a pending invitation for an organization (admin/owner only)
+    async fn cancel_organization_invitation(
+        &self,
+        organization_id: OrganizationId,
+        requester_id: UserId,
+        invitation_id: uuid::Uuid,
     ) -> Result<(), OrganizationError>;
 
     /// List invitations for an organization (admin/owner only)


### PR DESCRIPTION
## Summary

Adds an org-scoped invitation cancellation endpoint so organization owners and admins can cancel pending invitations they sent for their org.

## Root Cause

Invitees could decline their own invitations, and org admins could list org invitations, but there was no admin/owner cancellation path. The existing decline path required the authenticated user's email to match the invitee email, so senders could not cancel their own org invitations.

## Changes

- Adds `DELETE /v1/organizations/{org_id}/members/invitations/{invitation_id}` returning `204 No Content` on success.
- Authorizes organization owners/admins and verifies the invitation belongs to the requested organization.
- Deletes only still-pending invitations with an atomic `DELETE ... WHERE status = 'pending'`, avoiding historical status unique-constraint collisions and accepted/declined overwrite races.
- Requires the requester to have permission for the invitation role, so admins cannot cancel owner invitations.
- Handles all `OrganizationError` variants explicitly in the route.
- Adds service tests for admin success, member denial, cross-org IDOR hiding, non-pending rejection, and admin denial for owner invites.

## Validation

- `cargo test -p services cancel_organization_invitation`
- `cargo check -p api`

## Related PRs

- UI PR: https://github.com/nearai/nearai-cloud-ui/pull/237
