### PR TITLE
chore: ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained, no fix)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,6 +21,14 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0388
     "RUSTSEC-2024-0388",
 
+    # proc-macro-error2 is unmaintained - build-time transitive dependency from
+    # dstack-sdk -> alloy -> alloy-sol-types -> alloy-sol-macro (proc-macro).
+    # This is informational only (no security issue) and a build-time-only dep.
+    # We cannot update it directly; the original proc-macro-error is also unmaintained.
+    # Tracking: nearai/cloud-api#732 - waiting for alloy-sol-macro to migrate away.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173
+    "RUSTSEC-2026-0173",
+
 ]
 
 # Treat unmaintained crates as warnings (not errors)


### PR DESCRIPTION
## What

Adds `RUSTSEC-2026-0173` to the `cargo-audit` ignore list in `.cargo/audit.toml` with justification, consistent with the existing `paste` (RUSTSEC-2024-0436) and `derivative` (RUSTSEC-2024-0388) unmaintained-crate entries.

## Why

`cargo audit` now flags `proc-macro-error2 2.0.1` as unmaintained ([RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173), published 2026-06-07).

It is a **build-time-only, transitive** dependency:

```
proc-macro-error2 2.0.1
└── alloy-sol-macro 1.5.2 (proc-macro)
    └── alloy-sol-types 1.5.2
        └── ... alloy 1.2.1
            └── dstack-sdk 0.1.3
                └── (cloud-api crates)
```

- **No fix available**: this is the maintained fork of the original `proc-macro-error`; the author has confirmed it is now also unmaintained. There is no patched version to upgrade to.
- **No security impact**: informational/unmaintained advisory only, and the dependency is build-time (proc-macro) only.
- **Cannot be fixed directly**: removing it requires `alloy-sol-macro` upstream to migrate away (e.g. to `manyhow` / `proc-macro2-diagnostics`).

## Verification

`cargo audit` exits 0 with no warnings after this change.

Refs #732 (kept open as a blocked-upstream tracker, mirroring the paste/derivative entries).
