### PR TITLE
fix(billing): accept per-type usage on /v1/internal/usage (#169 prereq)

### DIFF
--- a/crates/api/tests/e2e_all/usage_recording.rs
+++ b/crates/api/tests/e2e_all/usage_recording.rs
@@ -868,3 +868,74 @@ async fn test_internal_usage_returns_401_on_wrong_token() {
 
     assert_eq!(response.status_code(), 401);
 }
+
+/// `/v1/internal/usage` accepts the input-token-billed kinds (embedding,
+/// rerank, score, privacy_classify) that inference-proxy now reports for
+/// direct `sk-` requests. Each bills `input_tokens × input_rate` with no
+/// output cost. See nearai/infra#169. (The internal ack echoes the
+/// chat-completion shape; the *stored* `inference_type` carries the label.)
+#[tokio::test]
+async fn test_record_input_only_usage_types() {
+    let server = enable_internal_usage_server().await;
+    setup_qwen_model(&server).await;
+    let id = provision_identity(&server).await;
+
+    for (idx, ty) in ["embedding", "rerank", "score", "privacy_classify"]
+        .iter()
+        .enumerate()
+    {
+        let response = post_internal_usage(
+            &server,
+            &id,
+            serde_json::json!({
+                "type": ty,
+                "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+                "input_tokens": 100,
+                "id": format!("test-{ty}-{idx}"),
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            response.status_code(),
+            200,
+            "{ty} usage should record: {}",
+            response.text()
+        );
+
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["input_tokens"], 100);
+        assert_eq!(body["output_tokens"], 0);
+        // 100 input tokens * 1_000_000 nano-dollars input rate; no output cost.
+        assert_eq!(body["input_cost"], 100_000_000i64);
+        assert_eq!(body["output_cost"], 0i64);
+        assert_eq!(body["total_cost"], 100_000_000i64);
+    }
+}
+
+/// The input-token-billed kinds reject a non-positive `input_tokens`.
+#[tokio::test]
+async fn test_record_input_only_usage_rejects_zero_tokens() {
+    let server = enable_internal_usage_server().await;
+    setup_qwen_model(&server).await;
+    let id = provision_identity(&server).await;
+
+    let response = post_internal_usage(
+        &server,
+        &id,
+        serde_json::json!({
+            "type": "embedding",
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input_tokens": 0,
+            "id": "test-embedding-zero",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        response.status_code(),
+        400,
+        "zero input_tokens should be rejected: {}",
+        response.text()
+    );
+}

--- a/crates/services/src/test_utils.rs
+++ b/crates/services/src/test_utils.rs
@@ -148,6 +148,54 @@ impl UsageServiceTrait for MockUsageService {
                     Some(*image_count),
                     InferenceType::ImageGeneration,
                 ),
+                RecordUsageApiRequest::Embedding {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Embedding,
+                ),
+                RecordUsageApiRequest::Rerank {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Rerank,
+                ),
+                RecordUsageApiRequest::Score {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Score,
+                ),
+                RecordUsageApiRequest::PrivacyClassify {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::PrivacyClassify,
+                ),
             };
         Ok(UsageLogEntry {
             id: Uuid::new_v4(),
@@ -338,6 +386,54 @@ impl UsageServiceTrait for CapturingUsageService {
                     0,
                     Some(*image_count),
                     InferenceType::ImageGeneration,
+                ),
+                RecordUsageApiRequest::Embedding {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Embedding,
+                ),
+                RecordUsageApiRequest::Rerank {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Rerank,
+                ),
+                RecordUsageApiRequest::Score {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Score,
+                ),
+                RecordUsageApiRequest::PrivacyClassify {
+                    model,
+                    input_tokens,
+                    ..
+                } => (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::PrivacyClassify,
                 ),
             };
         Ok(UsageLogEntry {

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -102,6 +102,23 @@ pub fn compute_token_cost(
     })
 }
 
+/// Validate the shared fields of the input-token-billed, output-less usage
+/// kinds (`embedding`, `rerank`, `score`, `privacy_classify`): a non-empty
+/// idempotency id and a positive input-token count.
+fn validate_input_only_usage(id: &str, input_tokens: i32) -> Result<(), UsageError> {
+    if id.trim().is_empty() {
+        return Err(UsageError::ValidationError(
+            "id must be a non-empty string".into(),
+        ));
+    }
+    if input_tokens <= 0 {
+        return Err(UsageError::ValidationError(
+            "input_tokens must be positive".into(),
+        ));
+    }
+    Ok(())
+}
+
 pub struct UsageServiceImpl {
     usage_repository: Arc<dyn UsageRepository>,
     model_repository: Arc<dyn ModelRepository>,
@@ -211,8 +228,9 @@ impl UsageServiceTrait for UsageServiceImpl {
             }
             ports::InferenceType::Rerank
             | ports::InferenceType::Embedding
+            | ports::InferenceType::Score
             | ports::InferenceType::PrivacyClassify => {
-                // For rerank/embedding/privacy_classify: use input tokens as the billing unit.
+                // For rerank/embedding/score/privacy_classify: use input tokens as the billing unit.
                 // Cache pricing is intentionally NOT applied, even if
                 // cache_read_cost_per_token is configured on the model.
                 // Use checked arithmetic to prevent integer overflow in billing-critical path
@@ -404,6 +422,70 @@ impl UsageServiceTrait for UsageServiceImpl {
                     0,
                     Some(*image_count),
                     InferenceType::ImageGeneration,
+                    id.clone(),
+                )
+            }
+            RecordUsageApiRequest::Embedding {
+                model,
+                input_tokens,
+                id,
+            } => {
+                validate_input_only_usage(id, *input_tokens)?;
+                (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Embedding,
+                    id.clone(),
+                )
+            }
+            RecordUsageApiRequest::Rerank {
+                model,
+                input_tokens,
+                id,
+            } => {
+                validate_input_only_usage(id, *input_tokens)?;
+                (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Rerank,
+                    id.clone(),
+                )
+            }
+            RecordUsageApiRequest::Score {
+                model,
+                input_tokens,
+                id,
+            } => {
+                validate_input_only_usage(id, *input_tokens)?;
+                (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::Score,
+                    id.clone(),
+                )
+            }
+            RecordUsageApiRequest::PrivacyClassify {
+                model,
+                input_tokens,
+                id,
+            } => {
+                validate_input_only_usage(id, *input_tokens)?;
+                (
+                    model.clone(),
+                    *input_tokens,
+                    0,
+                    0,
+                    None,
+                    InferenceType::PrivacyClassify,
                     id.clone(),
                 )
             }

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -414,6 +414,39 @@ pub enum RecordUsageApiRequest {
         /// return the existing record without double-charging.
         id: String,
     },
+    /// Input-token-billed, output-less inference. Bills
+    /// `input_tokens × input_cost_per_token` on the named model (no output
+    /// cost, no cache pricing) and differs from its siblings only in the
+    /// recorded `inference_type` label. inference-proxy reports these for
+    /// direct `sk-` requests to the matching `completions.near.ai`
+    /// endpoints — previously mislabeled as `chat_completion`, or (for
+    /// privacy classify) dropped entirely. See nearai/infra#169.
+    Embedding {
+        /// Model name to look up pricing
+        model: String,
+        /// Number of input tokens (must be positive)
+        input_tokens: i32,
+        /// External idempotency key (see [`Self::ChatCompletion`]'s `id`)
+        id: String,
+    },
+    /// Document reranking (billed like [`Self::Embedding`])
+    Rerank {
+        model: String,
+        input_tokens: i32,
+        id: String,
+    },
+    /// Text similarity scoring (billed like [`Self::Embedding`])
+    Score {
+        model: String,
+        input_tokens: i32,
+        id: String,
+    },
+    /// Privacy/PII classification (billed like [`Self::Embedding`])
+    PrivacyClassify {
+        model: String,
+        input_tokens: i32,
+        id: String,
+    },
 }
 
 /// Request to record usage (service layer)


### PR DESCRIPTION
## What

Extends the internal usage wire union so inference-proxy can report direct-`sk-` usage with the **correct inference type** instead of mislabeling everything as `chat_completion`.

Adds four input-token-billed, output-less variants to `RecordUsageApiRequest` (`crates/services/src/usage/ports.rs`):

- `embedding`, `rerank`, `score`, `privacy_classify`

Each bills `input_tokens × input_cost_per_token` (no output cost, no cache pricing) via the existing per-type cost arm in `record_usage`. Also folds `Score` into that cost arm — it previously fell through to the chat-token formula (equivalent today since score carries 0 output tokens, but a latent mislabel/mispricing hazard).

## Why

This is the **prerequisite half** of nearai/infra#169. Today inference-proxy's `/v1/internal/usage` reporter only knows two shapes, so:

- **privacy-classify** (direct `sk-`) is **unbilled** — its response has no top-level `usage` object, so it falls through to the chat extractor and reports nothing.
- **embeddings / rerank / score** are billed but **mislabeled** as `chat_completion`, corrupting per-type analytics on `organization_usage_log.inference_type`.

cloud-api must accept the new type tags **before** the proxy starts sending them, otherwise the new-type reports would be rejected and usage dropped. This PR is that step.

## Safety

**Purely additive.** Nothing emits the new types until the inference-proxy side ships (tracked in nearai/infra#169), so existing traffic and billing are unchanged. The internal ack (`RecordUsageResponse`) still echoes the chat-completion shape; the **stored** `inference_type` carries the correct label.

## Test plan

- `cargo test --test e2e_all usage_recording` — adds `test_record_input_only_usage_types` (records embedding/rerank/score/privacy_classify, asserts `input_tokens × input_rate`, no output cost) and `test_record_input_only_usage_rejects_zero_tokens`. ✅ 6/6 pass locally (incl. chat/image baselines).
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt --all --check` clean.

## Follow-ups

- inference-proxy side of #169 (per-endpoint `UsageType` + correct extraction + SAFE-LOUD `catch_all`) — depends on this being deployed.
- Part of the broader billing refactor (cloud-api#602 / infra#98 residual / infra#169).