### PR TITLE
fix(billing): bill the x-auto-redact classify pass (#602)

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -503,12 +503,36 @@ async fn bill_auto_redact_classify(
     api_key: &crate::middleware::auth::AuthenticatedApiKey,
     classify_tokens: i64,
 ) {
-    // Clamp to the i32 the usage row stores: an implausibly large count is
-    // capped (billed) rather than dropped, and 0/negative is nothing to bill.
-    let input_tokens = classify_tokens.clamp(0, i32::MAX as i64) as i32;
-    if input_tokens == 0 {
-        return;
+    if classify_tokens <= 0 {
+        return; // nothing to bill
     }
+    // Cap an anomalous count at the same `MAX_REASONABLE_TOKENS` the explicit
+    // `/v1/privacy/{classify,redact}` paths use, emitting the same anomaly
+    // metric — so x-auto-redact (which shares the privacy-filter classify
+    // call) can't massively overcharge on a buggy/malicious provider response
+    // instead of just clamping to i32::MAX. See nearai/cloud-api#602 review.
+    const MAX_REASONABLE_TOKENS: i32 = 1_000_000;
+    let input_tokens = if classify_tokens > MAX_REASONABLE_TOKENS as i64 {
+        tracing::error!(
+            token_count = classify_tokens,
+            max_expected = MAX_REASONABLE_TOKENS,
+            model = auto_redact::DEFAULT_PII_MODEL,
+            "auto_redact: provider returned unreasonable classify token count - capping"
+        );
+        let model_tag = format!("model:{}", auto_redact::DEFAULT_PII_MODEL);
+        let reason_tag = format!(
+            "reason:{}",
+            services::metrics::consts::REASON_TOKEN_OVERFLOW
+        );
+        app_state.metrics_service.record_count(
+            services::metrics::consts::METRIC_PROVIDER_TOKEN_ANOMALIES,
+            1,
+            &[model_tag.as_str(), reason_tag.as_str()],
+        );
+        MAX_REASONABLE_TOKENS
+    } else {
+        classify_tokens as i32 // safe: 0 < classify_tokens <= 1_000_000
+    };
 
     let model = match app_state
         .models_service

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -417,11 +417,15 @@ fn convert_chat_request_to_service(
 /// detector + rewrite messages in place. Returns the placeholder map for
 /// downstream un-redact; an empty map is also returned when auto-redact is
 /// off.
+/// The tuple is `(requested, map, classify_input_tokens)`. `classify_input_tokens`
+/// is the number of tokens the privacy-filter billed for the classify pass,
+/// for the caller to charge (nearai/cloud-api#602); it is 0 when auto-redact
+/// is off or there was nothing to classify.
 async fn maybe_redact(
     headers: &header::HeaderMap,
     service_request: &mut ServiceCompletionRequest,
     pool: &services::inference_provider_pool::InferenceProviderPool,
-) -> Result<(bool, RedactionMap), AutoRedactError> {
+) -> Result<(bool, RedactionMap, i64), AutoRedactError> {
     let header_values: Vec<&str> = headers
         .get_all(auto_redact::AUTO_REDACT_HEADER)
         .iter()
@@ -437,16 +441,16 @@ async fn maybe_redact(
     auto_redact::strip_body_field(&mut service_request.extra);
 
     if !enabled {
-        return Ok((false, RedactionMap::new()));
+        return Ok((false, RedactionMap::new(), 0));
     }
 
-    let map = auto_redact::redact_messages(
+    let (map, classify_tokens) = auto_redact::redact_messages(
         &mut service_request.messages,
         auto_redact::DEFAULT_PII_MODEL,
         pool,
     )
     .await?;
-    Ok((true, map))
+    Ok((true, map, classify_tokens))
 }
 
 /// Convert an [`AutoRedactError`] into the user-facing error response.
@@ -476,6 +480,75 @@ fn auto_redact_error_response(err: AutoRedactError) -> Response {
             )
                 .into_response()
         }
+    }
+}
+
+/// Record usage for the privacy-filter classify pass that auto-redact runs
+/// before a completion (nearai/cloud-api#602). The classify is a real
+/// inference call to the PII model, so it is billed like an explicit
+/// `/v1/privacy/classify`: `input_tokens × input_rate` on the privacy-filter
+/// model, one record per request (a fresh v4 id, matching the explicit
+/// privacy endpoints).
+///
+/// Best-effort: a model-lookup or record failure is logged and swallowed so
+/// it never fails the user's completion (which bills separately via
+/// `InterceptStream`). The classify already happened and cost GPU time, so
+/// it is billed even if the downstream completion later fails.
+async fn bill_auto_redact_classify(
+    app_state: &AppState,
+    api_key: &crate::middleware::auth::AuthenticatedApiKey,
+    classify_tokens: i64,
+) {
+    let input_tokens = match i32::try_from(classify_tokens) {
+        Ok(t) if t > 0 => t,
+        // 0 (or, defensively, negative/overflow) means nothing to bill.
+        _ => return,
+    };
+
+    let model = match app_state
+        .models_service
+        .get_model_by_name(auto_redact::DEFAULT_PII_MODEL)
+        .await
+    {
+        Ok(model) => model,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                model = auto_redact::DEFAULT_PII_MODEL,
+                "auto_redact: could not resolve PII model; classify usage not recorded"
+            );
+            return;
+        }
+    };
+
+    let api_key_id = match Uuid::parse_str(&api_key.api_key.id.0) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!(error = %e, "auto_redact: invalid API key id; classify usage not recorded");
+            return;
+        }
+    };
+
+    let usage_request = services::usage::RecordUsageServiceRequest {
+        organization_id: api_key.organization.id.0,
+        workspace_id: api_key.workspace.id.0,
+        api_key_id,
+        model_id: model.id,
+        input_tokens,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        inference_type: services::usage::ports::InferenceType::PrivacyClassify,
+        ttft_ms: None,
+        avg_itl_ms: None,
+        inference_id: Some(Uuid::new_v4()),
+        provider_request_id: None,
+        stop_reason: Some(services::usage::StopReason::Completed),
+        response_id: None,
+        image_count: None,
+    };
+
+    if let Err(e) = app_state.usage_service.record_usage(usage_request).await {
+        tracing::error!(error = %e, "auto_redact: failed to record classify usage");
     }
 }
 
@@ -1094,7 +1167,7 @@ async fn chat_completions_inner(
     // Auto-redact (opt-in via x-auto-redact header or auto_redact body field).
     // On success this may rewrite service_request.messages to substitute
     // placeholders for PII; the returned map drives the response un-redact.
-    let (auto_redact_requested, redaction_map) = match maybe_redact(
+    let (auto_redact_requested, redaction_map, auto_redact_classify_tokens) = match maybe_redact(
         &headers,
         &mut service_request,
         &app_state.inference_provider_pool,
@@ -1104,6 +1177,13 @@ async fn chat_completions_inner(
         Ok(out) => out,
         Err(e) => return auto_redact_error_response(e),
     };
+    // Bill the privacy-filter classify pass that auto-redact ran (it is a
+    // real inference call to the PII model). Charged like an explicit
+    // `/v1/privacy/classify`; best-effort so a billing hiccup never fails
+    // the user's completion. See nearai/cloud-api#602.
+    if auto_redact_requested {
+        bill_auto_redact_classify(&app_state, &api_key, auto_redact_classify_tokens).await;
+    }
     // Treat auto-redact as effectively *enabled* only when the detector
     // actually minted placeholders. A request that opts in but contains no
     // PII has nothing to substitute, so we skip the response re-serialize

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -483,6 +483,10 @@ fn auto_redact_error_response(err: AutoRedactError) -> Response {
     }
 }
 
+/// Upper bound on the spawned auto-redact billing task so a stuck billing DB
+/// or model lookup can't leak a background task indefinitely.
+const AUTO_REDACT_BILL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Record usage for the privacy-filter classify pass that auto-redact runs
 /// before a completion (nearai/cloud-api#602). The classify is a real
 /// inference call to the PII model, so it is billed like an explicit
@@ -499,11 +503,12 @@ async fn bill_auto_redact_classify(
     api_key: &crate::middleware::auth::AuthenticatedApiKey,
     classify_tokens: i64,
 ) {
-    let input_tokens = match i32::try_from(classify_tokens) {
-        Ok(t) if t > 0 => t,
-        // 0 (or, defensively, negative/overflow) means nothing to bill.
-        _ => return,
-    };
+    // Clamp to the i32 the usage row stores: an implausibly large count is
+    // capped (billed) rather than dropped, and 0/negative is nothing to bill.
+    let input_tokens = classify_tokens.clamp(0, i32::MAX as i64) as i32;
+    if input_tokens == 0 {
+        return;
+    }
 
     let model = match app_state
         .models_service
@@ -1179,10 +1184,24 @@ async fn chat_completions_inner(
     };
     // Bill the privacy-filter classify pass that auto-redact ran (it is a
     // real inference call to the PII model). Charged like an explicit
-    // `/v1/privacy/classify`; best-effort so a billing hiccup never fails
-    // the user's completion. See nearai/cloud-api#602.
+    // `/v1/privacy/classify`. Spawned (not awaited) and time-bounded so a
+    // slow/exhausted billing DB or model lookup can never stall the user's
+    // completion before dispatch — the classify already succeeded, and the
+    // chat bills separately via InterceptStream. See nearai/cloud-api#602.
     if auto_redact_requested {
-        bill_auto_redact_classify(&app_state, &api_key, auto_redact_classify_tokens).await;
+        let app_state = app_state.clone();
+        let api_key = api_key.clone();
+        tokio::spawn(async move {
+            if tokio::time::timeout(
+                AUTO_REDACT_BILL_TIMEOUT,
+                bill_auto_redact_classify(&app_state, &api_key, auto_redact_classify_tokens),
+            )
+            .await
+            .is_err()
+            {
+                tracing::error!("auto_redact: classify billing timed out; usage not recorded");
+            }
+        });
     }
     // Treat auto-redact as effectively *enabled* only when the detector
     // actually minted placeholders. A request that opts in but contains no

--- a/crates/api/tests/e2e_all/auto_redact.rs
+++ b/crates/api/tests/e2e_all/auto_redact.rs
@@ -643,3 +643,72 @@ async fn auto_redact_unredacts_tool_call_arguments() {
         "placeholder should be swapped back; got {args}"
     );
 }
+
+/// x-auto-redact bills the privacy-filter classify pass it runs before the
+/// completion (nearai/cloud-api#602). The mock privacy filter reports 10
+/// input tokens per fragment; one user message => one fragment => one
+/// `privacy_classify` usage row with 10 input tokens (the test model is
+/// priced at 0, so the dollar amount is 0 — we assert the metered row, not
+/// the price).
+#[tokio::test]
+async fn auto_redact_bills_classify_pass() {
+    let (server, _pool, mock_provider, db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    setup_privacy_filter_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+
+    mock_provider
+        .set_default_response(inference_providers::mock::ResponseTemplate::new("Done."))
+        .await;
+
+    let resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .add_header("x-auto-redact", "on")
+        .json(&serde_json::json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{
+                "role": "user",
+                "content": "Please reach out to alice@example.com"
+            }],
+        }))
+        .await;
+    assert_eq!(
+        resp.status_code(),
+        200,
+        "chat should succeed: {}",
+        resp.text()
+    );
+
+    // Exactly one privacy_classify row should be billed for the inline
+    // classify pass, carrying the mock's 10 input tokens and no output.
+    let org_uuid = uuid::Uuid::parse_str(&org.id).expect("org id is a uuid");
+    let pool = db.pool();
+    let client = pool.get().await.expect("db connection");
+    let rows = client
+        .query(
+            "SELECT input_tokens, output_tokens, model_name \
+             FROM organization_usage_log \
+             WHERE organization_id = $1 AND inference_type = 'privacy_classify'",
+            &[&org_uuid],
+        )
+        .await
+        .expect("query privacy_classify usage");
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected exactly one privacy_classify usage row for the auto-redact classify pass"
+    );
+    let input_tokens: i32 = rows[0].get("input_tokens");
+    let output_tokens: i32 = rows[0].get("output_tokens");
+    let model_name: String = rows[0].get("model_name");
+    assert_eq!(
+        input_tokens, 10,
+        "mock privacy filter reports 10 tokens/fragment"
+    );
+    assert_eq!(output_tokens, 0, "classify has no output tokens");
+    assert_eq!(model_name, "openai/privacy-filter");
+}

--- a/crates/api/tests/e2e_all/auto_redact.rs
+++ b/crates/api/tests/e2e_all/auto_redact.rs
@@ -684,18 +684,27 @@ async fn auto_redact_bills_classify_pass() {
 
     // Exactly one privacy_classify row should be billed for the inline
     // classify pass, carrying the mock's 10 input tokens and no output.
+    // Billing runs on a spawned background task, so poll (bounded) until the
+    // row lands rather than querying once.
     let org_uuid = uuid::Uuid::parse_str(&org.id).expect("org id is a uuid");
     let pool = db.pool();
-    let client = pool.get().await.expect("db connection");
-    let rows = client
-        .query(
-            "SELECT input_tokens, output_tokens, model_name \
-             FROM organization_usage_log \
-             WHERE organization_id = $1 AND inference_type = 'privacy_classify'",
-            &[&org_uuid],
-        )
-        .await
-        .expect("query privacy_classify usage");
+    let mut rows = Vec::new();
+    for _ in 0..40 {
+        let client = pool.get().await.expect("db connection");
+        rows = client
+            .query(
+                "SELECT input_tokens, output_tokens, model_name \
+                 FROM organization_usage_log \
+                 WHERE organization_id = $1 AND inference_type = 'privacy_classify'",
+                &[&org_uuid],
+            )
+            .await
+            .expect("query privacy_classify usage");
+        if !rows.is_empty() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
 
     assert_eq!(
         rows.len(),

--- a/crates/services/src/auto_redact/detect.rs
+++ b/crates/services/src/auto_redact/detect.rs
@@ -109,12 +109,13 @@ pub(super) fn parse_response(
     let parsed: DetectResponse = serde_json::from_slice(bytes)
         .map_err(|e| AutoRedactError::Internal(format!("decode detect resp: {e}")))?;
 
+    // Saturating sum: a malicious/buggy detector returning huge or many
+    // per-item counts must not wrap to a negative total and mis-bill.
     let input_tokens: i64 = parsed
         .data
         .iter()
         .filter_map(|item| item.usage.as_ref())
-        .map(|u| u.input_tokens.max(0))
-        .sum();
+        .fold(0i64, |acc, u| acc.saturating_add(u.input_tokens.max(0)));
 
     let mut out: Vec<Vec<Span>> = (0..expected_len).map(|_| Vec::new()).collect();
     for item in parsed.data {

--- a/crates/services/src/auto_redact/detect.rs
+++ b/crates/services/src/auto_redact/detect.rs
@@ -13,8 +13,9 @@ use std::collections::HashMap;
 /// positive resistance.
 pub const DEFAULT_THRESHOLD: f64 = 0.5;
 
-/// Call the privacy-filter model with the list of input texts. Returns
-/// one Span vec per input, in the same order.
+/// Call the privacy-filter model with the list of input texts. Returns one
+/// Span vec per input (in the same order) plus the total `input_tokens` the
+/// model billed for the classify pass.
 ///
 /// On any transport / parse / status error, returns `AutoRedactError`.
 /// Callers should fail closed (return 503 to the client) when this errors.
@@ -22,9 +23,9 @@ pub async fn detect_pii(
     texts: &[String],
     model: &str,
     pool: &InferenceProviderPool,
-) -> Result<Vec<Vec<Span>>, AutoRedactError> {
+) -> Result<(Vec<Vec<Span>>, i64), AutoRedactError> {
     if texts.is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), 0));
     }
 
     let req_body = serde_json::json!({
@@ -78,6 +79,14 @@ struct DetectItem {
     index: usize,
     #[serde(default)]
     spans: Vec<RawSpan>,
+    #[serde(default)]
+    usage: Option<DetectUsage>,
+}
+
+#[derive(Deserialize)]
+struct DetectUsage {
+    #[serde(default)]
+    input_tokens: i64,
 }
 
 #[derive(Deserialize)]
@@ -87,12 +96,25 @@ struct RawSpan {
     end: usize,
 }
 
+/// Parse a privacy-filter response into per-text spans plus the total
+/// `input_tokens` the model reported across all `data` entries. The token
+/// total is summed independently of the per-index span mapping so it
+/// reflects the full classify cost even if the model returns an unexpected
+/// index (which is otherwise dropped). Used to bill the classify pass
+/// (nearai/cloud-api#602).
 pub(super) fn parse_response(
     bytes: &[u8],
     expected_len: usize,
-) -> Result<Vec<Vec<Span>>, AutoRedactError> {
+) -> Result<(Vec<Vec<Span>>, i64), AutoRedactError> {
     let parsed: DetectResponse = serde_json::from_slice(bytes)
         .map_err(|e| AutoRedactError::Internal(format!("decode detect resp: {e}")))?;
+
+    let input_tokens: i64 = parsed
+        .data
+        .iter()
+        .filter_map(|item| item.usage.as_ref())
+        .map(|u| u.input_tokens.max(0))
+        .sum();
 
     let mut out: Vec<Vec<Span>> = (0..expected_len).map(|_| Vec::new()).collect();
     for item in parsed.data {
@@ -108,7 +130,7 @@ pub(super) fn parse_response(
             end: s.end,
         }));
     }
-    Ok(out)
+    Ok((out, input_tokens))
 }
 
 #[cfg(test)]
@@ -126,13 +148,15 @@ mod tests {
                 {"index": 1, "spans": [], "usage": {"input_tokens": 2}}
             ]
         }"#;
-        let spans = parse_response(body, 2).unwrap();
+        let (spans, input_tokens) = parse_response(body, 2).unwrap();
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].len(), 1);
         assert_eq!(spans[0][0].category, "private_email");
         assert_eq!(spans[0][0].start, 6);
         assert_eq!(spans[0][0].end, 23);
         assert_eq!(spans[1].len(), 0);
+        // Tokens summed across all data entries: 5 + 2.
+        assert_eq!(input_tokens, 7);
     }
 
     #[test]
@@ -140,11 +164,12 @@ mod tests {
         // If the detector omits index 1 entirely, we still return an empty
         // span vec for it so apply.write_back stays index-aligned.
         let body = br#"{"data": [{"index": 0, "spans": [], "usage": {"input_tokens": 1}}]}"#;
-        let spans = parse_response(body, 3).unwrap();
+        let (spans, input_tokens) = parse_response(body, 3).unwrap();
         assert_eq!(spans.len(), 3);
         for s in &spans {
             assert!(s.is_empty());
         }
+        assert_eq!(input_tokens, 1);
     }
 
     #[test]
@@ -153,9 +178,11 @@ mod tests {
         let body = br#"{"data": [
             {"index": 5, "spans": [{"category": "x", "start": 0, "end": 1, "score": 1.0, "text": "h"}], "usage": {"input_tokens": 1}}
         ]}"#;
-        let spans = parse_response(body, 2).unwrap();
+        let (spans, input_tokens) = parse_response(body, 2).unwrap();
         assert_eq!(spans.len(), 2);
         assert!(spans.iter().all(|v| v.is_empty()));
+        // Out-of-range index is dropped for spans, but its tokens still count.
+        assert_eq!(input_tokens, 1);
     }
 
     #[test]

--- a/crates/services/src/auto_redact/detect.rs
+++ b/crates/services/src/auto_redact/detect.rs
@@ -79,14 +79,13 @@ struct DetectItem {
     index: usize,
     #[serde(default)]
     spans: Vec<RawSpan>,
+    /// Billing-only metadata, parsed as a tolerant `Value` (not a typed
+    /// struct) so a malformed `usage` field — wrong type, out-of-range
+    /// number — can never turn a valid span response into a parse error
+    /// and fail the completion. `input_tokens` is extracted leniently in
+    /// `parse_response` (invalid/absent => 0).
     #[serde(default)]
-    usage: Option<DetectUsage>,
-}
-
-#[derive(Deserialize)]
-struct DetectUsage {
-    #[serde(default)]
-    input_tokens: i64,
+    usage: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -109,13 +108,17 @@ pub(super) fn parse_response(
     let parsed: DetectResponse = serde_json::from_slice(bytes)
         .map_err(|e| AutoRedactError::Internal(format!("decode detect resp: {e}")))?;
 
-    // Saturating sum: a malicious/buggy detector returning huge or many
-    // per-item counts must not wrap to a negative total and mis-bill.
+    // Sum `input_tokens` across entries, leniently: a non-integer or absent
+    // value contributes 0 (billing metadata must never break span parsing).
+    // Saturating so a malicious/buggy detector returning huge or many counts
+    // can't wrap to a negative total and mis-bill.
     let input_tokens: i64 = parsed
         .data
         .iter()
         .filter_map(|item| item.usage.as_ref())
-        .fold(0i64, |acc, u| acc.saturating_add(u.input_tokens.max(0)));
+        .filter_map(|u| u.get("input_tokens"))
+        .filter_map(|v| v.as_i64())
+        .fold(0i64, |acc, t| acc.saturating_add(t.max(0)));
 
     let mut out: Vec<Vec<Span>> = (0..expected_len).map(|_| Vec::new()).collect();
     for item in parsed.data {
@@ -184,6 +187,22 @@ mod tests {
         assert!(spans.iter().all(|v| v.is_empty()));
         // Out-of-range index is dropped for spans, but its tokens still count.
         assert_eq!(input_tokens, 1);
+    }
+
+    #[test]
+    fn parse_tolerates_malformed_usage() {
+        // A malformed/missing billing-only `usage` field must NOT fail span
+        // parsing (which would fail the completion). Spans still apply; the
+        // bad usage contributes 0 tokens. (nearai/cloud-api#602 review.)
+        let body = br#"{"data": [
+            {"index": 0, "spans": [{"category": "private_email", "start": 0, "end": 1, "score": 1.0, "text": "a"}], "usage": {"input_tokens": "oops"}},
+            {"index": 1, "spans": [], "usage": "garbage"},
+            {"index": 1, "spans": []}
+        ]}"#;
+        let (spans, input_tokens) = parse_response(body, 2).unwrap();
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].len(), 1, "span must still apply despite bad usage");
+        assert_eq!(input_tokens, 0, "invalid/absent usage contributes 0");
     }
 
     #[test]

--- a/crates/services/src/auto_redact/mod.rs
+++ b/crates/services/src/auto_redact/mod.rs
@@ -106,11 +106,14 @@ fn value_enables(v: &serde_json::Value) -> bool {
 /// On detector failure or timeout (see [`REDACT_TIMEOUT`]), returns
 /// [`AutoRedactError::DetectorUnavailable`] without mutating `messages`.
 /// Callers must fail closed.
+/// The second tuple element is the total `input_tokens` the privacy-filter
+/// billed for the classify pass, so the caller can charge it
+/// (nearai/cloud-api#602). It is 0 when there was nothing to classify.
 pub async fn redact_messages(
     messages: &mut [CompletionMessage],
     pii_model: &str,
     pool: &InferenceProviderPool,
-) -> Result<RedactionMap, AutoRedactError> {
+) -> Result<(RedactionMap, i64), AutoRedactError> {
     match tokio::time::timeout(
         REDACT_TIMEOUT,
         redact_messages_inner(messages, pii_model, pool),
@@ -129,10 +132,10 @@ async fn redact_messages_inner(
     messages: &mut [CompletionMessage],
     pii_model: &str,
     pool: &InferenceProviderPool,
-) -> Result<RedactionMap, AutoRedactError> {
+) -> Result<(RedactionMap, i64), AutoRedactError> {
     let (refs, texts) = apply::collect_text_fragments(messages);
     if texts.is_empty() {
-        return Ok(RedactionMap::new());
+        return Ok((RedactionMap::new(), 0));
     }
 
     let mut map = RedactionMap::new();
@@ -142,7 +145,7 @@ async fn redact_messages_inner(
     // a string we'd otherwise mint.
     let haystack: String = texts.join("\u{0001}");
 
-    let spans_per_text = detect::detect_pii(&texts, pii_model, pool).await?;
+    let (spans_per_text, classify_tokens) = detect::detect_pii(&texts, pii_model, pool).await?;
     debug_assert_eq!(spans_per_text.len(), texts.len());
 
     let mut redacted = Vec::with_capacity(texts.len());
@@ -153,7 +156,7 @@ async fn redact_messages_inner(
         redacted.push(apply::redact_one(text, spans, &mut map, &haystack)?);
     }
     apply::write_back(messages, &refs, redacted);
-    Ok(map)
+    Ok((map, classify_tokens))
 }
 
 /// Apply privacy-filter spans (parsed from a raw classify response) to a
@@ -169,7 +172,9 @@ pub fn apply_detected_spans(
     texts: &[String],
     response_bytes: &[u8],
 ) -> Result<Vec<String>, AutoRedactError> {
-    let spans_per_text = detect::parse_response(response_bytes, texts.len())?;
+    // The `/v1/privacy/redact` handler bills the classify pass from the raw
+    // response bytes itself, so the token count is not needed here.
+    let (spans_per_text, _classify_tokens) = detect::parse_response(response_bytes, texts.len())?;
     let mut map = RedactionMap::new();
     // Same haystack rule as redact_messages_inner: a minted dummy must
     // not appear in any input fragment, so substring substitution stays


### PR DESCRIPTION
## What

Bills the privacy-filter **classify pass** that `x-auto-redact` runs before a chat completion. Closes nearai/cloud-api#602.

- `detect::parse_response` now sums the classify response's `data[].usage.input_tokens` (previously discarded).
- The count is threaded out through `redact_messages` → `maybe_redact` to the chat handler.
- The handler records a `PrivacyClassify` usage row on `openai/privacy-filter` (`input_tokens × input_rate`, no output cost), mirroring the existing explicit `/v1/privacy/classify` recording (fresh v4 id, one record per request).

## Why

The classify pass is a **real inference call** to the PII model (GPU cost), and the explicit `/v1/privacy/classify` endpoint already bills it — but the inline auto-redact path threw the usage away, so auto-redact requests got the classify for free.

## Design notes

- **Billed on `requested`, not `enabled`.** A request that opts in but contains no PII (`auto_redact_enabled == false`) still ran a classify pass and is charged.
- **Fail-closed preserved.** Billing fires only on the detector's `Ok` branch; a timed-out/unavailable detector already returns 503 and is never billed, never mutates messages.
- **Best-effort recording.** A model-lookup or record failure is logged and swallowed so it never fails the user's completion (which bills separately via `InterceptStream`). The classify already cost GPU time, so it's billed even if the downstream completion later fails.
- **No idempotency key needed** beyond the fresh v4 id: each request runs exactly one classify (a real, distinct billable inference), matching how the explicit privacy endpoints record.

## Test plan

- `cargo test -p services auto_redact::detect` — token-sum parsing (incl. multi-fragment + out-of-range-index cases). ✅
- `cargo test --test e2e_all auto_redact` — **21/21 pass**, including a new `auto_redact_bills_classify_pass` that drives a real `x-auto-redact` chat and asserts (via DB) exactly one `privacy_classify` usage row with the mock's 10 input tokens. ✅
- `cargo clippy -p services -p api --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean. (Verified in an isolated target dir.)

## Scope

Independent of the other billing PRs; part of the broader billing refactor (infra#169 / infra#98 residual). No migration, no wire change.