### PR TITLE
feat(db): per-model attestation_policy migration (V0056)

### DIFF
--- a/crates/database/src/migrations/sql/V0056__add_attestation_policy.sql
+++ b/crates/database/src/migrations/sql/V0056__add_attestation_policy.sql
@@ -1,6 +1,6 @@
 -- Per-model attestation policy: what a model REQUIRES of the providers that
--- may serve it. Supersedes the binary `attestation_supported` flag for routing
--- (wired up in a later phase); this migration only adds the data model.
+-- may serve it. This migration only adds the data model as groundwork — no code
+-- reads or writes the column yet, and behavior is unchanged.
 --
 -- Policy values:
 --   near_only           - only NEAR AI TEE backends (current behavior for vLLM models)
@@ -8,28 +8,38 @@
 --   attested_3p_only    - only attested 3rd-party providers
 --   non_attested        - any provider, including plaintext 3rd parties
 --
--- Routing must never fall back from a more-attested to a less-attested provider
--- than the policy requires; that enforcement lands with the routing changes.
+-- The column is NULLABLE with NO default on purpose: existing rows are backfilled
+-- below, but a row created before the consuming routing code lands is left NULL
+-- ("not yet classified") rather than misclassified as a real policy. The phase
+-- that adds policy-aware routing will set it on insert, re-backfill any NULLs,
+-- and tighten it to NOT NULL.
+ALTER TABLE models ADD COLUMN attestation_policy VARCHAR(32);
 
--- The old constraint hard-codes "external == non-attested", which makes an
--- attested 3rd-party provider unstorable. Drop it; the new policy column plus
--- the routing-time, capability-derived tier check replace this invariant.
-ALTER TABLE models DROP CONSTRAINT IF EXISTS chk_external_provider_no_attestation;
-
--- Default to the safe value: a model is treated as non-attested unless it is
--- explicitly assigned a stricter policy.
-ALTER TABLE models ADD COLUMN attestation_policy VARCHAR(32) NOT NULL DEFAULT 'non_attested';
-
--- Backfill existing rows from their provider_type: vLLM models are NEAR TEE
--- backends (near_only); external models stay non_attested.
+-- Backfill existing rows from their provider_type (constrained to 'vllm' |
+-- 'external'; OpenRouter etc. are stored as 'external'). The models table is
+-- small, so a full one-time UPDATE is fine.
 UPDATE models
 SET attestation_policy = CASE WHEN provider_type = 'vllm' THEN 'near_only' ELSE 'non_attested' END;
 
 ALTER TABLE models ADD CONSTRAINT chk_attestation_policy_valid
-    CHECK (attestation_policy IN ('near_only', 'near_or_attested_3p', 'attested_3p_only', 'non_attested'));
+    CHECK (attestation_policy IS NULL
+        OR attestation_policy IN ('near_only', 'near_or_attested_3p', 'attested_3p_only', 'non_attested'));
 
--- Audit mirror (nullable, like the other model_history columns).
+-- Audit mirror (nullable, like the other model_history columns), backfilled
+-- where the historical provider_type is known (pre-V0042 rows have NULL
+-- provider_type and stay NULL — we don't invent a policy for them).
 ALTER TABLE model_history ADD COLUMN attestation_policy VARCHAR(32);
 
+UPDATE model_history
+SET attestation_policy = CASE provider_type WHEN 'vllm' THEN 'near_only' WHEN 'external' THEN 'non_attested' END
+WHERE provider_type IS NOT NULL;
+
+-- NOTE: chk_external_provider_no_attestation is intentionally KEPT here. The
+-- runtime still treats models.attestation_supported as authoritative, so an
+-- attested 3rd-party row would be inconsistent today. Dropping that constraint
+-- (to allow attested 3p), setting attestation_policy on insert, and tightening
+-- it to NOT NULL all land with the policy-aware routing phase, which also
+-- updates the write paths and the external-provider attestation tests.
+
 COMMENT ON COLUMN models.attestation_policy IS
-    'Attestation a model requires of its providers: near_only | near_or_attested_3p | attested_3p_only | non_attested. Authoritative for routing/fallback (never falls back below the required tier).';
+    'Attestation a model requires of its providers: near_only | near_or_attested_3p | attested_3p_only | non_attested (NULL until the routing phase classifies it). Will be authoritative for routing/fallback (never falls back below the required tier).';

--- a/crates/database/src/migrations/sql/V0056__add_attestation_policy.sql
+++ b/crates/database/src/migrations/sql/V0056__add_attestation_policy.sql
@@ -1,0 +1,35 @@
+-- Per-model attestation policy: what a model REQUIRES of the providers that
+-- may serve it. Supersedes the binary `attestation_supported` flag for routing
+-- (wired up in a later phase); this migration only adds the data model.
+--
+-- Policy values:
+--   near_only           - only NEAR AI TEE backends (current behavior for vLLM models)
+--   near_or_attested_3p - prefer NEAR AI, may fall back to an attested 3rd party
+--   attested_3p_only    - only attested 3rd-party providers
+--   non_attested        - any provider, including plaintext 3rd parties
+--
+-- Routing must never fall back from a more-attested to a less-attested provider
+-- than the policy requires; that enforcement lands with the routing changes.
+
+-- The old constraint hard-codes "external == non-attested", which makes an
+-- attested 3rd-party provider unstorable. Drop it; the new policy column plus
+-- the routing-time, capability-derived tier check replace this invariant.
+ALTER TABLE models DROP CONSTRAINT IF EXISTS chk_external_provider_no_attestation;
+
+-- Default to the safe value: a model is treated as non-attested unless it is
+-- explicitly assigned a stricter policy.
+ALTER TABLE models ADD COLUMN attestation_policy VARCHAR(32) NOT NULL DEFAULT 'non_attested';
+
+-- Backfill existing rows from their provider_type: vLLM models are NEAR TEE
+-- backends (near_only); external models stay non_attested.
+UPDATE models
+SET attestation_policy = CASE WHEN provider_type = 'vllm' THEN 'near_only' ELSE 'non_attested' END;
+
+ALTER TABLE models ADD CONSTRAINT chk_attestation_policy_valid
+    CHECK (attestation_policy IN ('near_only', 'near_or_attested_3p', 'attested_3p_only', 'non_attested'));
+
+-- Audit mirror (nullable, like the other model_history columns).
+ALTER TABLE model_history ADD COLUMN attestation_policy VARCHAR(32);
+
+COMMENT ON COLUMN models.attestation_policy IS
+    'Attestation a model requires of its providers: near_only | near_or_attested_3p | attested_3p_only | non_attested. Authoritative for routing/fallback (never falls back below the required tier).';


### PR DESCRIPTION
## What

**P5** of the inference-stack refactor (epic #735). Schema-only and rollout-safe: this migration introduces policy storage without changing current runtime behavior.

- Keeps `chk_external_provider_no_attestation` in place (no premature enablement of attested external providers before policy-aware runtime/write paths land).
- Adds `models.attestation_policy VARCHAR(32)` as **nullable** with **no default**.
- Adds `chk_attestation_policy_valid` with `attestation_policy IS NULL OR attestation_policy IN (...)` where allowed values are:
  `near_only | near_or_attested_3p | attested_3p_only | non_attested`.
- Backfills existing `models` rows:
  - `provider_type='vllm'` → `near_only`
  - `provider_type='external'` → `non_attested`
- Adds nullable `model_history.attestation_policy` audit mirror and backfills it where `provider_type` is known.

## Policy semantics (for the later routing phase)
- `near_only` — only NEAR AI TEE backends (today's vLLM behavior)
- `near_or_attested_3p` — prefer NEAR, may fall back to an **attested** 3rd party
- `attested_3p_only` — only attested 3rd parties
- `non_attested` — any provider, incl. plaintext 3rd parties

Routing/enforcement and insert-time population of this column land in a later phase; this migration intentionally allows `NULL` as “not yet classified”.

## Migration number
Next free is **V0056** (the dir jumps V0053 → V0055; V0054 never existed). Refinery `load_sql_migrations` picks up the new file automatically — no code change.

## Verification
Applied the **full chain V0001..V0056** on a clean Postgres 16 — all apply cleanly. Asserted: `models.attestation_policy` is nullable with no default, `chk_attestation_policy_valid` present, `chk_external_provider_no_attestation` still present, and `model_history.attestation_policy` nullable.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>