### PR TITLE
Preserve hidden-state fields in chat completions (supersedes #679)

### DIFF
--- a/crates/api/src/conversions.rs
+++ b/crates/api/src/conversions.rs
@@ -937,4 +937,37 @@ mod tests {
         let domain: ChatCompletionParams = many.into();
         assert_eq!(domain.stop, Some(vec!["a".to_string(), "b".to_string()]));
     }
+
+    /// The mechanistic-interpretability workflow sends `return_hidden_states`
+    /// / `layers` on the chat-completions request. We deliberately do NOT
+    /// model these as typed fields: they ride the flattened `extra` catch-all
+    /// on both `ChatCompletionRequest` and `ChatCompletionParams`, so they
+    /// survive the request -> params conversion and serialize back out to the
+    /// backend verbatim (vLLM/sglang reads them directly). This is the request
+    /// half of hidden-state passthrough; the response half is covered by the
+    /// per-choice / delta catch-alls in `inference_providers::models`.
+    #[test]
+    fn return_hidden_states_request_fields_pass_through_to_backend() {
+        let req: ChatCompletionRequest = serde_json::from_str(
+            r#"{"model":"sglang-model","messages":[],"return_hidden_states":true,"layers":[0,5,11]}"#,
+        )
+        .unwrap();
+
+        let params: ChatCompletionParams = req.into();
+
+        // Land in the catch-all that is serialized straight to the backend.
+        assert_eq!(
+            params.extra.get("return_hidden_states"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(
+            params.extra.get("layers"),
+            Some(&serde_json::json!([0, 5, 11]))
+        );
+
+        // And survive serialization of the outgoing backend request body.
+        let wire = serde_json::to_value(&params).unwrap();
+        assert_eq!(wire["return_hidden_states"], serde_json::json!(true));
+        assert_eq!(wire["layers"], serde_json::json!([0, 5, 11]));
+    }
 }

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -807,6 +807,7 @@ fn build_flush_chunks(states: &mut StreamUnredactStates, template: &ChunkTemplat
             usage: None,
             prompt_token_ids: None,
             modality: None,
+            extra: Default::default(),
         };
         if let Ok(s) = serde_json::to_string(&chunk) {
             out.push(Bytes::from(format!("data: {s}\n\n")));
@@ -868,6 +869,7 @@ fn build_flush_chunks(states: &mut StreamUnredactStates, template: &ChunkTemplat
             usage: None,
             prompt_token_ids: None,
             modality: None,
+            extra: Default::default(),
         };
         if let Ok(s) = serde_json::to_string(&chunk) {
             out.push(Bytes::from(format!("data: {s}\n\n")));
@@ -2306,6 +2308,7 @@ mod tests {
             usage: None,
             prompt_token_ids: None,
             modality: None,
+            extra: Default::default(),
         })
     }
 
@@ -2380,6 +2383,7 @@ mod tests {
             usage: None,
             prompt_token_ids: None,
             modality: None,
+            extra: Default::default(),
         })
     }
 
@@ -2600,6 +2604,7 @@ mod tests {
             usage: Some(inference_providers::models::TokenUsage::new(10, 5)),
             prompt_token_ids: None,
             modality: None,
+            extra: Default::default(),
         };
 
         let stream_chunk = inference_providers::StreamChunk::Chat(chunk.clone());

--- a/crates/inference_providers/src/chunk_builder.rs
+++ b/crates/inference_providers/src/chunk_builder.rs
@@ -45,6 +45,7 @@ impl ChunkContext {
             usage,
             prompt_token_ids: None,
             modality: None,
+            extra: Default::default(),
         }
     }
 

--- a/crates/inference_providers/src/external/anthropic/mod.rs
+++ b/crates/inference_providers/src/external/anthropic/mod.rs
@@ -343,6 +343,7 @@ impl ExternalBackend for AnthropicBackend {
                 logprobs: None,
                 finish_reason: map_finish_reason_string(anthropic_response.stop_reason),
                 token_ids: None,
+                extra: Default::default(),
             }],
             service_tier: None,
             system_fingerprint: None,
@@ -356,6 +357,7 @@ impl ExternalBackend for AnthropicBackend {
             prompt_logprobs: None,
             prompt_token_ids: None,
             kv_transfer_params: None,
+            extra: Default::default(),
         };
 
         // Serialize our normalized response. We intentionally overwrite fields

--- a/crates/inference_providers/src/external/gemini/mod.rs
+++ b/crates/inference_providers/src/external/gemini/mod.rs
@@ -91,6 +91,7 @@ fn convert_to_openai_response(
             logprobs: None,
             finish_reason,
             token_ids: None,
+            extra: Default::default(),
         }],
         service_tier: None,
         system_fingerprint: None,
@@ -103,6 +104,7 @@ fn convert_to_openai_response(
         prompt_logprobs: None,
         prompt_token_ids: None,
         kv_transfer_params: None,
+        extra: Default::default(),
     })
 }
 

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -335,6 +335,7 @@ impl ResponseTemplate {
                 logprobs: None,
                 finish_reason: Some(finish_reason.to_string()),
                 token_ids: None,
+                extra: Default::default(),
             }],
             service_tier: None,
             system_fingerprint: None,
@@ -342,6 +343,7 @@ impl ResponseTemplate {
             prompt_logprobs: None,
             prompt_token_ids: None,
             kv_transfer_params: None,
+            extra: Default::default(),
         }
     }
 
@@ -394,6 +396,7 @@ impl ResponseTemplate {
                     usage: Some(self.token_usage(input_tokens, output_token_count)),
                     prompt_token_ids: None,
                     modality: None,
+                    extra: Default::default(),
                 });
             }
         }
@@ -439,6 +442,7 @@ impl ResponseTemplate {
                     usage: Some(self.token_usage(input_tokens, output_token_count)),
                     prompt_token_ids: None,
                     modality: None,
+                    extra: Default::default(),
                 });
             }
         }
@@ -485,6 +489,7 @@ impl ResponseTemplate {
                     usage: Some(self.token_usage(input_tokens, output_token_count)),
                     prompt_token_ids: None,
                     modality: None,
+                    extra: Default::default(),
                 });
 
                 // Stream arguments split by spaces (like content)
@@ -536,6 +541,7 @@ impl ResponseTemplate {
                         usage: Some(self.token_usage(input_tokens, output_token_count)),
                         prompt_token_ids: None,
                         modality: None,
+                        extra: Default::default(),
                     });
                 }
             }
@@ -552,6 +558,7 @@ impl ResponseTemplate {
             usage: Some(self.token_usage(input_tokens, output_token_count)),
             prompt_token_ids: None,
             modality: None,
+            extra: Default::default(),
         });
 
         chunks

--- a/crates/inference_providers/src/models.rs
+++ b/crates/inference_providers/src/models.rs
@@ -436,6 +436,15 @@ pub struct ChatCompletionChunk {
     /// Modality indicator for Qwen3-Omni streaming ("text" or "audio")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub modality: Option<String>,
+
+    /// Preserve any additional top-level fields the upstream emits on a
+    /// streaming chunk that we don't have an explicit slot for, so they
+    /// survive the re-serialized streaming path (auto-redact / alias /
+    /// non-OpenAI upstream normalization) instead of being silently
+    /// dropped. Note: sglang attaches streaming hidden states inside
+    /// `choices[].delta` (see [`ChatDelta::extra`]), not at this level.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Text completion streaming chunk (matches OpenAI legacy format)
@@ -606,6 +615,15 @@ pub struct ChatCompletionResponse {
     /// KV cache transfer parameters
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kv_transfer_params: Option<serde_json::Value>,
+
+    /// Preserve any additional top-level fields the upstream emits that we
+    /// don't have an explicit slot for (e.g. sglang's `sglext`/`metadata`),
+    /// so they survive re-serialized response paths instead of being
+    /// silently dropped. Per-choice provider fields (such as sglang's
+    /// `hidden_states`) are captured by the catch-all on
+    /// [`ChatCompletionResponseChoice`] instead.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Wrapper for chat completion response that includes raw bytes.
@@ -642,6 +660,22 @@ pub struct ChatCompletionResponseChoice {
     /// Token IDs generated for this choice
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_ids: Option<Vec<i64>>,
+
+    /// Preserve any additional fields the upstream emits at the choice
+    /// level that we don't have an explicit slot for. Without this, serde
+    /// silently drops unknown per-choice fields on deserialize, so they
+    /// never reach the client on re-serialized response paths (e.g. the
+    /// auto-redact path, which rebuilds the body from this struct instead
+    /// of forwarding the provider's raw bytes).
+    ///
+    /// Specifically: sglang attaches per-layer activations to each choice
+    /// as `choices[].hidden_states` (sibling of `message`) when a request
+    /// sets `return_hidden_states` — see
+    /// sglang `entrypoints/openai/protocol.py::ChatCompletionResponseChoice`.
+    /// Streaming hidden states live in `choices[].delta` and are covered by
+    /// the catch-all on [`ChatDelta`] instead.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Message in a complete chat completion response
@@ -1091,7 +1125,7 @@ pub enum AudioTranscriptionError {
 /// # Examples
 ///
 /// ```
-/// # use inference_providers::detect_audio_content_type;
+/// # use inference_providers::models::detect_audio_content_type;
 /// assert_eq!(detect_audio_content_type("speech.mp3"), "audio/mpeg");
 /// assert_eq!(detect_audio_content_type("recording.wav"), "audio/wav");
 /// assert_eq!(detect_audio_content_type("unknown.xyz"), "application/octet-stream");
@@ -1263,6 +1297,100 @@ mod tests {
         assert!(reserialized.contains("\"nearai_tool_result\""));
         assert!(reserialized.contains("\"web_context_search\""));
         assert!(reserialized.contains("\"call_1\""));
+    }
+
+    #[test]
+    fn non_streaming_choice_preserves_hidden_states_round_trip() {
+        // sglang attaches per-layer activations to each choice as
+        // `choices[].hidden_states` (a sibling of `message`) when a
+        // request sets `return_hidden_states`. Without the choice-level
+        // `extra` catch-all, serde drops it on deserialize, so it never
+        // reaches the client on re-serialized response paths (e.g.
+        // auto-redact). See sglang
+        // entrypoints/openai/protocol.py::ChatCompletionResponseChoice.
+        let json_response = r#"{
+            "id": "chatcmpl-hidden",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "sglang-model",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "hi" },
+                "finish_reason": "stop",
+                "hidden_states": [[0.1, 0.2], [0.3, 0.4]]
+            }],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+        }"#;
+
+        let response: ChatCompletionResponse = serde_json::from_str(json_response).unwrap();
+        let hidden_states = response.choices[0]
+            .extra
+            .get("hidden_states")
+            .expect("per-choice hidden_states must survive deserialization");
+        assert_eq!(hidden_states[1][0], 0.3);
+
+        let reserialized = serde_json::to_string(&response).unwrap();
+        assert!(reserialized.contains("\"hidden_states\""));
+    }
+
+    #[test]
+    fn streaming_delta_preserves_hidden_states_round_trip() {
+        // sglang attaches streaming hidden states inside the delta as
+        // `choices[].delta.hidden_states` (see protocol.py::DeltaMessage).
+        // This is already covered by the `ChatDelta` catch-all; this test
+        // locks that behavior for the hidden-states use case specifically.
+        let json_chunk = r#"{
+            "id": "chatcmpl-hidden",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "sglang-model",
+            "choices": [{
+                "index": 0,
+                "delta": { "hidden_states": [[0.1, 0.2]] }
+            }]
+        }"#;
+
+        let chunk: ChatCompletionChunk = serde_json::from_str(json_chunk).unwrap();
+        let delta = chunk.choices[0]
+            .delta
+            .as_ref()
+            .expect("delta should deserialize");
+        let hidden_states = delta
+            .extra
+            .get("hidden_states")
+            .expect("delta hidden_states must survive deserialization");
+        assert_eq!(hidden_states[0][1], 0.2);
+
+        let reserialized = serde_json::to_string(&chunk).unwrap();
+        assert!(reserialized.contains("\"hidden_states\""));
+    }
+
+    #[test]
+    fn response_preserves_top_level_unknown_fields_round_trip() {
+        // Top-level provider fields we don't model (e.g. sglang's
+        // `sglext`/`metadata`) must survive re-serialized response paths
+        // via the top-level `extra` catch-all.
+        let json_response = r#"{
+            "id": "chatcmpl-meta",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "sglang-model",
+            "choices": [],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+            "sglext": { "spec_verify_ct": 3 }
+        }"#;
+
+        let response: ChatCompletionResponse = serde_json::from_str(json_response).unwrap();
+        assert_eq!(
+            response
+                .extra
+                .get("sglext")
+                .expect("top-level sglext must survive")["spec_verify_ct"],
+            3
+        );
+
+        let reserialized = serde_json::to_string(&response).unwrap();
+        assert!(reserialized.contains("\"sglext\""));
     }
 }
 

--- a/crates/inference_providers/src/vllm/mod.rs
+++ b/crates/inference_providers/src/vllm/mod.rs
@@ -2261,6 +2261,7 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
+                extra: Default::default(),
             })),
             raw_passthrough: true,
         }

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -1854,6 +1854,7 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
+                extra: Default::default(),
             })),
         };
 
@@ -1881,6 +1882,7 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
+                extra: Default::default(),
             })),
         };
 
@@ -1994,6 +1996,7 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
+                extra: Default::default(),
             })),
         };
 
@@ -2010,6 +2013,7 @@ mod tests {
                 prompt_token_ids: None,
                 system_fingerprint: None,
                 modality: None,
+                extra: Default::default(),
             })),
         };
 
@@ -2037,6 +2041,7 @@ mod tests {
                 prompt_token_ids: None,
                 modality: None,
                 system_fingerprint: None,
+                extra: Default::default(),
             })),
         };
 
@@ -2161,6 +2166,7 @@ mod tests {
                 prompt_token_ids: None,
                 modality: None,
                 system_fingerprint: None,
+                extra: Default::default(),
             })),
         };
 


### PR DESCRIPTION
## Summary

Enables **hidden-state passthrough** for mechanistic-interpretability research — a client sets `return_hidden_states` (optionally `layers`) on a chat-completions request and receives the backend's per-layer activations back through cloud-api.

Supersedes #679 by @satojandro, carried forward with credit (`Co-authored-by`). Thanks for the report and the original patch — this reworks the mechanism so it actually reaches the client (see below) and addresses the review feedback on that PR.

## Why a new PR instead of patching #679

#679 added the catch-all at the **top level** of `ChatCompletionResponse`/`ChatCompletionChunk`. But sglang attaches hidden states **per-choice**, so a top-level catch-all can't capture them and they were still dropped on re-serialized paths. Verified against sglang `entrypoints/openai/protocol.py`:

| | `hidden_states` location |
|---|---|
| Non-streaming | `choices[].hidden_states` (sibling of `message`) |
| Streaming | `choices[].delta.hidden_states` |

## Changes

- **Core fix:** `#[serde(flatten)] extra` on **`ChatCompletionResponseChoice`** — preserves non-streaming per-choice `hidden_states` on the re-serialized (auto-redact) path. The default non-streaming path already returns the provider's raw bytes, and streaming is already covered by the existing `ChatDelta.extra`; this closes the one remaining gap.
- Top-level `extra` on `ChatCompletionResponse`/`ChatCompletionChunk` to preserve other unknown top-level provider fields (e.g. sglang `sglext`).
- **Request side:** no typed fields. `return_hidden_states`/`layers` already pass through verbatim via the existing `ChatCompletionParams.extra`, which is serialized straight to vLLM/sglang. This avoids dead plumbing **and** the silent-drop-on-mistype behavior the reviewers flagged on #679 (a mis-typed value now passes through rather than being dropped). Locked with a test.
- Regression tests for both sglang response shapes + request passthrough; fixed a stale `detect_audio_content_type` doctest import.

## Caveat

This is a **no-op until an sglang backend is launched with `--enable-return-hidden-states`** (cvm-conf / infra side). cloud-api is the proxy-layer half and is now ready.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test`: `inference_providers --lib` (227), `services --lib` (342), `api --lib` (131), doctests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ⚠️ Depends on an inference-proxy change (not sufficient alone)

inference-proxy sits between cloud-api and sglang and does its own deserialize/reassemble:
- **Streaming** already works through it (`SseTransformer` is `serde_json::Value`-based and preserves `delta.hidden_states`); this PR's `ChatDelta`-level coverage already existed.
- **Non-streaming** is dropped *inside inference-proxy*: it forces `stream:true` upstream and reassembles via `StreamAssembler`, which rebuilds `message` from only `role/content/reasoning_content/tool_calls` (no catch-all). So this PR's `ChatCompletionResponseChoice.extra` only takes effect once inference-proxy preserves `hidden_states` in that reassembly.
- Also note: forcing upstream streaming means only **last-token** hidden states are produced; full per-token activations need a true non-streaming upstream call.

This PR is the cloud-api half (correct + harmless on its own); the inference-proxy reassembler is the gating change for non-streaming.
