### PR TITLE
PR1: add ProviderTier { Near, Attested3p, NonAttested } (Chutes attested-provider scaffolding)

### DIFF
--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -103,6 +103,50 @@ pub use non_attested::external::{
     OpenAiCompatibleBackend, ProviderConfig,
 };
 
+/// Trust tier of an inference provider, along the attestation axis introduced in
+/// the `attested::` / `non_attested::` module split.
+///
+/// This is the taxonomy the inference stack branches on — *can we cryptographically
+/// verify what served the response?* — not the engine or who operates the backend:
+///
+/// - [`ProviderTier::Near`] — NEAR AI's own TEE fleet ([`attested::nearai`]). Full
+///   chain: per-request TDX quote + GPU evidence + TLS-SPKI pin + per-response
+///   signature, all rooted in NEAR's own KMS / compose-manager / gateway.
+/// - [`ProviderTier::Attested3p`] — a third party that produces a *verifiable* TEE
+///   attestation we can bind to the response (e.g. Chutes, future siblings of
+///   `attested::nearai`). Earns the "attested" badge **only** when the per-response
+///   bindings that NEAR's verifier requires (fresh nonce, signing key, TLS
+///   fingerprint, authenticated measurement) are present; otherwise it is
+///   [`ProviderTier::NonAttested`].
+/// - [`ProviderTier::NonAttested`] — plaintext third parties
+///   ([`non_attested::external`]: OpenAI / Anthropic / Gemini / OpenRouter) with no
+///   verifiable attestation. No "verified" badge.
+///
+/// PR1 of the Chutes integration: this enum is the scaffolding that later PRs use to
+/// select a per-provider measurement policy and report-data verifier at pool
+/// construction time. It carries no behavior on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderTier {
+    /// NEAR AI's own attested TEE fleet (`attested::nearai`).
+    Near,
+    /// A third party with a verifiable, response-bound TEE attestation
+    /// (`attested::<provider>`, e.g. Chutes).
+    Attested3p,
+    /// A plaintext third party with no verifiable attestation
+    /// (`non_attested::external`).
+    NonAttested,
+}
+
+impl ProviderTier {
+    /// Whether this tier carries a verifiable TEE attestation we gate a
+    /// "verified" badge on. True for [`Near`](ProviderTier::Near) and
+    /// [`Attested3p`](ProviderTier::Attested3p); false for
+    /// [`NonAttested`](ProviderTier::NonAttested).
+    pub fn is_attested(self) -> bool {
+        matches!(self, ProviderTier::Near | ProviderTier::Attested3p)
+    }
+}
+
 /// Creates a verified `reqwest::Client` with an H2 connection to a specific backend.
 ///
 /// Used by `nearai::Provider` for inline backend verification: when a bucket needs a new
@@ -300,6 +344,18 @@ pub trait InferenceProvider {
         params: AudioTranscriptionParams,
         request_hash: String,
     ) -> Result<AudioTranscriptionResponse, AudioTranscriptionError>;
+}
+
+#[cfg(test)]
+mod provider_tier_tests {
+    use super::ProviderTier;
+
+    #[test]
+    fn attested_tiers_gate_the_verified_badge() {
+        assert!(ProviderTier::Near.is_attested());
+        assert!(ProviderTier::Attested3p.is_attested());
+        assert!(!ProviderTier::NonAttested.is_attested());
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

**PR1 of the Chutes third-party-attested-provider integration.** Adds a single trust-tier enum, `ProviderTier`, to the `inference_providers` crate. Pure scaffolding — a `pub enum` + `is_attested()` + one unit test, **no behavior change**. Later PRs use it to select a per-provider measurement policy and report-data verifier at pool-construction time.

## Background

PR #741 reorganized `inference_providers` along the **attestation axis** — `attested::nearai` (NEAR's own TEE fleet) and `non_attested::external` (plaintext 3p) — with an `attested/` parent that already anticipates third-party attested providers (its module doc literally says *"Future: attested 3p (e.g. Chutes)"*). This enum names that axis as a type so the verifier and pool can branch on it.

The branch is **trust**, not engine or operator: *can we cryptographically verify what served the response?*

## The tiers

| Variant | Maps to | Meaning |
|---|---|---|
| `Near` | `attested::nearai` | NEAR AI's own TEE fleet. Full chain: per-request TDX quote + GPU evidence + TLS-SPKI pin + per-response signature, rooted in NEAR's own KMS / compose-manager / gateway. |
| `Attested3p` | `attested::<provider>` (e.g. Chutes) | A third party with a *verifiable, response-bound* TEE attestation. Earns the "attested" badge **only** when the per-response bindings NEAR's verifier requires (fresh nonce, signing key, TLS fingerprint, authenticated measurement) are present; otherwise it degrades to `NonAttested`. |
| `NonAttested` | `non_attested::external` | Plaintext third parties (OpenAI / Anthropic / Gemini / OpenRouter). No verified badge. |

`is_attested()` returns true for `Near` and `Attested3p` — the gate for the "verified" badge.

## Why an enum now (decision + example)

The Chutes design (manually validated against Chutes' real `/evidence` endpoint) requires the verifier to apply **per-provider** policy: a Chutes TDX measurement must be *mathematically incapable* of validating a NEAR backend, and an `Attested3p` provider must be held to stricter checks (e.g. TCB-up-to-date enforced, no padded-address `report_data` fallback) than NEAR's own fleet inherits by default. Selecting that policy needs a tier discriminator chosen at pool construction — never derived from attacker-influenced report fields. This enum is that discriminator.

Example (later PR, illustrative):
```rust
let (policy, report_data_verifier) = match tier {
    ProviderTier::Near       => (MeasurementPolicy::near_from_env(), NearReportDataVerifier::boxed()),
    ProviderTier::Attested3p => (chutes::measurement::chutes_policy(), StrictBoundReportDataVerifier::boxed()),
    ProviderTier::NonAttested => /* no attestation path */,
};
```

## Scope / impact

- **Behavior:** none. Nothing constructs or matches on `ProviderTier` yet.
- **Risk:** none. Additive `pub enum` in one internal crate; `cargo build --workspace` green.
- **Tests:** `provider_tier_tests::attested_tiers_gate_the_verified_badge` (234 existing unit tests unaffected); fmt + clippy clean.

## Follow-ups (this epic)

PR2 `MeasurementPolicy` (fail-closed) → PR3 `ReportDataVerifier` (strict) → PR4 TCB/GPU policy per-tier → PR5 `attested::chutes` data-path skeleton (hard-off flag) → PR6 evidence models + transform (synthetic fixtures) → PR7 `ChutesBackendVerifier` + observed-SPKI co-binding + pool wiring. PR8 (flag-on) is gated on confirming a few specifics with Chutes (exact nonce→report_data derivation, per-response signing, signed golden-measurement manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
