### PR TITLE
PR3: strict report_data binding for all attested tiers, NEAR included (remove padded-address fallback)

### DIFF
--- a/crates/services/src/attestation/mod.rs
+++ b/crates/services/src/attestation/mod.rs
@@ -1,9 +1,11 @@
 pub mod measurement;
 pub mod models;
+pub mod report_data;
 pub mod verification;
 use dstack_sdk::dstack_client;
 pub use measurement::MeasurementPolicy;
 pub use models::{AttestationError, ChatSignature, SignatureLookupResult};
+pub use report_data::{NearReportDataVerifier, ReportDataVerifier, StrictBoundReportDataVerifier};
 use std::sync::Arc;
 pub use verification::{AttestationVerificationError, AttestationVerifier, VerifiedAttestation};
 

--- a/crates/services/src/attestation/mod.rs
+++ b/crates/services/src/attestation/mod.rs
@@ -5,7 +5,7 @@ pub mod verification;
 use dstack_sdk::dstack_client;
 pub use measurement::MeasurementPolicy;
 pub use models::{AttestationError, ChatSignature, SignatureLookupResult};
-pub use report_data::{NearReportDataVerifier, ReportDataVerifier, StrictBoundReportDataVerifier};
+pub use report_data::{ReportDataVerifier, StrictBoundReportDataVerifier};
 use std::sync::Arc;
 pub use verification::{AttestationVerificationError, AttestationVerifier, VerifiedAttestation};
 

--- a/crates/services/src/attestation/report_data.rs
+++ b/crates/services/src/attestation/report_data.rs
@@ -8,14 +8,17 @@
 //!   when a TLS fingerprint is present, binding the signing key **and** the live
 //!   TLS endpoint into the quote.
 //!
-//! NEAR's own fleet has historically also accepted a *fallback* form for the
-//! first 32 bytes when no fingerprint is present: `signing_address` zero-padded
-//! to 32 bytes. That fallback drops the TLS co-binding, so for an **attested
-//! third party** (whose nodes we do not operate) it is unsafe — an attacker who
-//! can set `signing_address` could satisfy the check without binding the
-//! connection. [`StrictBoundReportDataVerifier`] therefore requires the
-//! fingerprint binding and forbids the padded-address fallback, while
-//! [`NearReportDataVerifier`] preserves today's behavior byte-for-byte.
+//! The verifier has historically also accepted a *fallback* for the first 32
+//! bytes when no fingerprint was present: `signing_address` zero-padded to 32
+//! bytes. That fallback drops the TLS co-binding — an attacker who can set the
+//! JSON `signing_address` could satisfy the check against a quote that isn't
+//! bound to the TLS endpoint we're actually talking to. [`StrictBoundReportDataVerifier`]
+//! removes that fallback and requires the fingerprint binding for **every**
+//! attested provider, NEAR's own fleet included: a uniform, no-exceptions bar.
+//! NEAR backends already bind the fingerprint (the fallback was never exercised
+//! in practice), so this is a hardening, but it must be validated across the
+//! whole NEAR fleet in staging before promotion — any model that does not bind
+//! a fingerprint would now be (correctly) rejected.
 
 use sha2::{Digest as Sha2Digest, Sha256};
 
@@ -86,47 +89,20 @@ fn check_fingerprint_binding(
     Ok(())
 }
 
-/// NEAR's own-fleet report-data verifier: preserves today's behavior exactly.
-/// Uses the TLS-fingerprint binding when present, else falls back to the
-/// zero-padded `signing_address` form.
-pub struct NearReportDataVerifier;
-
-impl ReportDataVerifier for NearReportDataVerifier {
-    fn verify(
-        &self,
-        report_data: &[u8; 64],
-        signing_address: &str,
-        tls_cert_fingerprint: Option<&str>,
-        nonce: &str,
-    ) -> Result<(), AttestationVerificationError> {
-        check_nonce(report_data, nonce)?;
-        let addr_bytes = decode_addr(signing_address)?;
-
-        if let Some(fp_hex) = tls_cert_fingerprint {
-            check_fingerprint_binding(report_data, &addr_bytes, fp_hex)
-        } else {
-            // No TLS fingerprint: first 32 bytes = signing_address padded to 32.
-            let mut expected = [0u8; 32];
-            let copy_len = addr_bytes.len().min(32);
-            expected[..copy_len].copy_from_slice(&addr_bytes[..copy_len]);
-            if report_data[..32] != expected[..] {
-                return Err(AttestationVerificationError::ReportDataMismatch(format!(
-                    "report_data[0:32] does not match padded signing_address. \
-                     Expected: {}, got: {}",
-                    hex::encode(expected),
-                    hex::encode(&report_data[..32])
-                )));
-            }
-            Ok(())
-        }
-    }
-}
-
-/// Strict report-data verifier for attested third parties: requires the
-/// TLS-fingerprint binding (the padded-`signing_address` fallback is forbidden),
-/// and re-checks the per-request nonce. A report with no `tls_cert_fingerprint`
-/// is rejected outright, closing the connection-hijack hole the fallback opens
-/// when we do not operate the backend.
+/// The report-data verifier used for **every** attested provider — NEAR's own
+/// fleet included. It requires the full binding and admits no exceptions:
+///
+/// - `report_data[32:64]` == the caller's per-request nonce (freshness), and
+/// - `report_data[0:32]` == `SHA256(signing_address ‖ tls_cert_fingerprint)`,
+///   so a `tls_cert_fingerprint` is **mandatory** — the legacy zero-padded
+///   `signing_address` fallback is gone.
+///
+/// NEAR backends already bind the TLS fingerprint into `report_data` (the
+/// fallback was never exercised in practice), so holding NEAR to this bar is a
+/// hardening with no intended behavior change — and it removes the
+/// connection-hijack surface that the padded-address fallback opened for any
+/// backend we do not operate. Keeping one uniform, no-exceptions rule is the
+/// point: the verifier presents the same high bar to NEAR and to third parties.
 pub struct StrictBoundReportDataVerifier;
 
 impl ReportDataVerifier for StrictBoundReportDataVerifier {
@@ -141,9 +117,8 @@ impl ReportDataVerifier for StrictBoundReportDataVerifier {
         let addr_bytes = decode_addr(signing_address)?;
         let fp_hex = tls_cert_fingerprint.ok_or_else(|| {
             AttestationVerificationError::ReportDataMismatch(
-                "attested third-party report has no tls_cert_fingerprint; the padded \
-                 signing_address fallback is forbidden for this tier (would drop the \
-                 TLS co-binding)"
+                "attestation report has no tls_cert_fingerprint; the padded signing_address \
+                 fallback is not accepted (it would drop the TLS co-binding from report_data)"
                     .to_string(),
             )
         })?;
@@ -179,30 +154,6 @@ mod tests {
         let mut a = [0u8; 32];
         a.copy_from_slice(&v);
         a
-    }
-
-    #[test]
-    fn near_accepts_fingerprint_binding() {
-        let rd = bound_report_data(
-            &hex::decode(ADDR).unwrap(),
-            &hex::decode(FP).unwrap(),
-            &nonce_bytes(),
-        );
-        assert!(NearReportDataVerifier
-            .verify(&rd, ADDR, Some(FP), NONCE)
-            .is_ok());
-    }
-
-    #[test]
-    fn near_accepts_padded_address_fallback() {
-        // No fingerprint: [0:32] = addr padded.
-        let mut rd = [0u8; 64];
-        let addr = hex::decode(ADDR).unwrap();
-        rd[..addr.len()].copy_from_slice(&addr);
-        rd[32..].copy_from_slice(&nonce_bytes());
-        assert!(NearReportDataVerifier
-            .verify(&rd, ADDR, None, NONCE)
-            .is_ok());
     }
 
     #[test]
@@ -246,16 +197,13 @@ mod tests {
     }
 
     #[test]
-    fn both_reject_wrong_fingerprint_binding() {
+    fn rejects_wrong_fingerprint_binding() {
         let rd = bound_report_data(
             &hex::decode(ADDR).unwrap(),
             &hex::decode(FP).unwrap(),
             &nonce_bytes(),
         );
         let wrong_fp = "5555555555555555555555555555555555555555555555555555555555555555";
-        assert!(NearReportDataVerifier
-            .verify(&rd, ADDR, Some(wrong_fp), NONCE)
-            .is_err());
         assert!(StrictBoundReportDataVerifier
             .verify(&rd, ADDR, Some(wrong_fp), NONCE)
             .is_err());

--- a/crates/services/src/attestation/report_data.rs
+++ b/crates/services/src/attestation/report_data.rs
@@ -1,0 +1,263 @@
+//! Report-data binding verification, pluggable per provider tier.
+//!
+//! A TDX quote's 64-byte `report_data` is sealed inside the Intel-signed quote
+//! and is where the attestation binds to *this* request and *this* backend:
+//!
+//! - `report_data[32:64]` = the caller's per-request nonce (freshness).
+//! - `report_data[0:32]`  = `SHA256(signing_address ‖ tls_cert_fingerprint)`
+//!   when a TLS fingerprint is present, binding the signing key **and** the live
+//!   TLS endpoint into the quote.
+//!
+//! NEAR's own fleet has historically also accepted a *fallback* form for the
+//! first 32 bytes when no fingerprint is present: `signing_address` zero-padded
+//! to 32 bytes. That fallback drops the TLS co-binding, so for an **attested
+//! third party** (whose nodes we do not operate) it is unsafe — an attacker who
+//! can set `signing_address` could satisfy the check without binding the
+//! connection. [`StrictBoundReportDataVerifier`] therefore requires the
+//! fingerprint binding and forbids the padded-address fallback, while
+//! [`NearReportDataVerifier`] preserves today's behavior byte-for-byte.
+
+use sha2::{Digest as Sha2Digest, Sha256};
+
+use super::verification::AttestationVerificationError;
+
+/// Verifies the `report_data` binding of a TDX quote. Selected per provider tier
+/// at `AttestationVerifier` construction (never from a report field).
+pub trait ReportDataVerifier: Send + Sync {
+    fn verify(
+        &self,
+        report_data: &[u8; 64],
+        signing_address: &str,
+        tls_cert_fingerprint: Option<&str>,
+        nonce: &str,
+    ) -> Result<(), AttestationVerificationError>;
+}
+
+/// `report_data[32:64]` must equal the caller's per-request nonce. Shared by all
+/// tiers — freshness is non-negotiable.
+fn check_nonce(report_data: &[u8; 64], nonce: &str) -> Result<(), AttestationVerificationError> {
+    let nonce_bytes = hex::decode(nonce.strip_prefix("0x").unwrap_or(nonce)).map_err(|e| {
+        AttestationVerificationError::InvalidFormat(format!("nonce hex decode: {e}"))
+    })?;
+    if nonce_bytes.len() != 32 {
+        return Err(AttestationVerificationError::ReportDataMismatch(format!(
+            "nonce must be 32 bytes, got {}",
+            nonce_bytes.len()
+        )));
+    }
+    if report_data[32..64] != nonce_bytes[..] {
+        return Err(AttestationVerificationError::ReportDataMismatch(
+            "nonce mismatch in report_data[32:64]".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn decode_addr(signing_address: &str) -> Result<Vec<u8>, AttestationVerificationError> {
+    let addr_hex = signing_address
+        .strip_prefix("0x")
+        .unwrap_or(signing_address);
+    hex::decode(addr_hex).map_err(|e| {
+        AttestationVerificationError::InvalidFormat(format!("signing_address hex decode: {e}"))
+    })
+}
+
+/// `report_data[0:32]` must equal `SHA256(signing_address ‖ tls_fingerprint)`.
+fn check_fingerprint_binding(
+    report_data: &[u8; 64],
+    addr_bytes: &[u8],
+    fp_hex: &str,
+) -> Result<(), AttestationVerificationError> {
+    let fp_bytes = hex::decode(fp_hex.strip_prefix("0x").unwrap_or(fp_hex)).map_err(|e| {
+        AttestationVerificationError::InvalidFormat(format!("tls_cert_fingerprint hex decode: {e}"))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(addr_bytes);
+    hasher.update(&fp_bytes);
+    let expected = hasher.finalize();
+    if report_data[..32] != expected[..] {
+        return Err(AttestationVerificationError::ReportDataMismatch(format!(
+            "report_data[0:32] does not match SHA256(signing_address || tls_fingerprint). \
+             Expected: {}, got: {}",
+            hex::encode(expected),
+            hex::encode(&report_data[..32])
+        )));
+    }
+    Ok(())
+}
+
+/// NEAR's own-fleet report-data verifier: preserves today's behavior exactly.
+/// Uses the TLS-fingerprint binding when present, else falls back to the
+/// zero-padded `signing_address` form.
+pub struct NearReportDataVerifier;
+
+impl ReportDataVerifier for NearReportDataVerifier {
+    fn verify(
+        &self,
+        report_data: &[u8; 64],
+        signing_address: &str,
+        tls_cert_fingerprint: Option<&str>,
+        nonce: &str,
+    ) -> Result<(), AttestationVerificationError> {
+        check_nonce(report_data, nonce)?;
+        let addr_bytes = decode_addr(signing_address)?;
+
+        if let Some(fp_hex) = tls_cert_fingerprint {
+            check_fingerprint_binding(report_data, &addr_bytes, fp_hex)
+        } else {
+            // No TLS fingerprint: first 32 bytes = signing_address padded to 32.
+            let mut expected = [0u8; 32];
+            let copy_len = addr_bytes.len().min(32);
+            expected[..copy_len].copy_from_slice(&addr_bytes[..copy_len]);
+            if report_data[..32] != expected[..] {
+                return Err(AttestationVerificationError::ReportDataMismatch(format!(
+                    "report_data[0:32] does not match padded signing_address. \
+                     Expected: {}, got: {}",
+                    hex::encode(expected),
+                    hex::encode(&report_data[..32])
+                )));
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Strict report-data verifier for attested third parties: requires the
+/// TLS-fingerprint binding (the padded-`signing_address` fallback is forbidden),
+/// and re-checks the per-request nonce. A report with no `tls_cert_fingerprint`
+/// is rejected outright, closing the connection-hijack hole the fallback opens
+/// when we do not operate the backend.
+pub struct StrictBoundReportDataVerifier;
+
+impl ReportDataVerifier for StrictBoundReportDataVerifier {
+    fn verify(
+        &self,
+        report_data: &[u8; 64],
+        signing_address: &str,
+        tls_cert_fingerprint: Option<&str>,
+        nonce: &str,
+    ) -> Result<(), AttestationVerificationError> {
+        check_nonce(report_data, nonce)?;
+        let addr_bytes = decode_addr(signing_address)?;
+        let fp_hex = tls_cert_fingerprint.ok_or_else(|| {
+            AttestationVerificationError::ReportDataMismatch(
+                "attested third-party report has no tls_cert_fingerprint; the padded \
+                 signing_address fallback is forbidden for this tier (would drop the \
+                 TLS co-binding)"
+                    .to_string(),
+            )
+        })?;
+        check_fingerprint_binding(report_data, &addr_bytes, fp_hex)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build a report_data with the fingerprint binding in [0:32] and nonce in [32:64].
+    fn bound_report_data(addr: &[u8], fp: &[u8], nonce: &[u8; 32]) -> [u8; 64] {
+        let mut hasher = Sha256::new();
+        hasher.update(addr);
+        hasher.update(fp);
+        let head = hasher.finalize();
+        let mut rd = [0u8; 64];
+        rd[..32].copy_from_slice(&head);
+        rd[32..].copy_from_slice(nonce);
+        rd
+    }
+
+    const ADDR: &str = "1111111111111111111111111111111111111111";
+    const FP: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+    const NONCE: &str = "3333333333333333333333333333333333333333333333333333333333333333";
+
+    fn nonce_bytes() -> [u8; 32] {
+        bytes32(NONCE)
+    }
+    fn bytes32(h: &str) -> [u8; 32] {
+        let v = hex::decode(h).unwrap();
+        let mut a = [0u8; 32];
+        a.copy_from_slice(&v);
+        a
+    }
+
+    #[test]
+    fn near_accepts_fingerprint_binding() {
+        let rd = bound_report_data(
+            &hex::decode(ADDR).unwrap(),
+            &hex::decode(FP).unwrap(),
+            &nonce_bytes(),
+        );
+        assert!(NearReportDataVerifier
+            .verify(&rd, ADDR, Some(FP), NONCE)
+            .is_ok());
+    }
+
+    #[test]
+    fn near_accepts_padded_address_fallback() {
+        // No fingerprint: [0:32] = addr padded.
+        let mut rd = [0u8; 64];
+        let addr = hex::decode(ADDR).unwrap();
+        rd[..addr.len()].copy_from_slice(&addr);
+        rd[32..].copy_from_slice(&nonce_bytes());
+        assert!(NearReportDataVerifier
+            .verify(&rd, ADDR, None, NONCE)
+            .is_ok());
+    }
+
+    #[test]
+    fn strict_accepts_fingerprint_binding() {
+        let rd = bound_report_data(
+            &hex::decode(ADDR).unwrap(),
+            &hex::decode(FP).unwrap(),
+            &nonce_bytes(),
+        );
+        assert!(StrictBoundReportDataVerifier
+            .verify(&rd, ADDR, Some(FP), NONCE)
+            .is_ok());
+    }
+
+    #[test]
+    fn strict_rejects_missing_fingerprint() {
+        // Even with a correctly padded address, strict must reject when no fp.
+        let mut rd = [0u8; 64];
+        let addr = hex::decode(ADDR).unwrap();
+        rd[..addr.len()].copy_from_slice(&addr);
+        rd[32..].copy_from_slice(&nonce_bytes());
+        let err = StrictBoundReportDataVerifier
+            .verify(&rd, ADDR, None, NONCE)
+            .unwrap_err();
+        assert!(format!("{err}").contains("tls_cert_fingerprint"));
+    }
+
+    #[test]
+    fn strict_rejects_stale_nonce_replay() {
+        // Quote bound to NONCE, but verifier challenged with a different nonce.
+        let rd = bound_report_data(
+            &hex::decode(ADDR).unwrap(),
+            &hex::decode(FP).unwrap(),
+            &nonce_bytes(),
+        );
+        let other = "4444444444444444444444444444444444444444444444444444444444444444";
+        let err = StrictBoundReportDataVerifier
+            .verify(&rd, ADDR, Some(FP), other)
+            .unwrap_err();
+        assert!(format!("{err}").contains("nonce mismatch"));
+    }
+
+    #[test]
+    fn both_reject_wrong_fingerprint_binding() {
+        let rd = bound_report_data(
+            &hex::decode(ADDR).unwrap(),
+            &hex::decode(FP).unwrap(),
+            &nonce_bytes(),
+        );
+        let wrong_fp = "5555555555555555555555555555555555555555555555555555555555555555";
+        assert!(NearReportDataVerifier
+            .verify(&rd, ADDR, Some(wrong_fp), NONCE)
+            .is_err());
+        assert!(StrictBoundReportDataVerifier
+            .verify(&rd, ADDR, Some(wrong_fp), NONCE)
+            .is_err());
+    }
+}

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -3,10 +3,16 @@
 //! Verifies TDX quotes, report_data bindings (signing address + TLS fingerprint),
 //! image hashes, and GPU evidence from attestation reports returned by inference-proxy.
 
-use sha2::{Digest as Sha2Digest, Sha256};
+use sha2::Digest;
 use std::collections::HashSet;
+use std::sync::Arc;
+
+use inference_providers::ProviderTier;
 
 use super::measurement::MeasurementPolicy;
+use super::report_data::{
+    NearReportDataVerifier, ReportDataVerifier, StrictBoundReportDataVerifier,
+};
 
 const NVIDIA_NRAS_URL: &str = "https://nras.attestation.nvidia.com/v3/attest/gpu";
 
@@ -65,6 +71,11 @@ pub struct AttestationVerifier {
     /// Selected by provider tier at construction; NEAR's own fleet reproduces
     /// the previous env-driven, fail-open-on-empty behavior exactly.
     policy: MeasurementPolicy,
+    /// Per-tier `report_data` binding verifier. NEAR keeps the historical
+    /// behavior (TLS-fingerprint binding with a padded-address fallback); an
+    /// attested third party gets the strict verifier (fingerprint binding
+    /// required, no fallback). Selected from `policy.tier()` at construction.
+    report_data_verifier: Arc<dyn ReportDataVerifier>,
     /// Optional PCCS URL override for Intel collateral fetching.
     pccs_url: Option<String>,
 }
@@ -94,9 +105,17 @@ impl AttestationVerifier {
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("failed to create HTTP client for attestation verification");
+        // Select the report_data verifier from the tier (never from a report
+        // field). Attested third parties must bind the TLS fingerprint into the
+        // quote; NEAR keeps its historical behavior including the fallback.
+        let report_data_verifier: Arc<dyn ReportDataVerifier> = match policy.tier() {
+            ProviderTier::Attested3p => Arc::new(StrictBoundReportDataVerifier),
+            ProviderTier::Near | ProviderTier::NonAttested => Arc::new(NearReportDataVerifier),
+        };
         Self {
             http_client,
             policy,
+            report_data_verifier,
             pccs_url,
         }
     }
@@ -206,15 +225,11 @@ impl AttestationVerifier {
             .get("tls_cert_fingerprint")
             .and_then(|v| v.as_str());
 
-        self.verify_report_data(
+        self.report_data_verifier.verify(
             report_data,
             signing_address,
             tls_cert_fingerprint,
             request_nonce,
-            attestation_report
-                .get("signing_algo")
-                .and_then(|v| v.as_str())
-                .unwrap_or("ed25519"),
         )?;
 
         // 3. Replay RTMR3 from event log and verify against the TDX quote.
@@ -253,85 +268,6 @@ impl AttestationVerifier {
             compose_hash: event_log_data.compose_hash,
             gpu_verdict,
         })
-    }
-
-    /// Verify that `report_data` correctly binds the signing address, TLS fingerprint, and nonce.
-    ///
-    /// When `tls_cert_fingerprint` is present:
-    ///   `report_data[0:32] = SHA256(signing_address_bytes || fingerprint_bytes)`
-    /// Otherwise:
-    ///   `report_data[0:32] = signing_address_bytes padded to 32`
-    ///
-    /// Always: `report_data[32:64] = nonce_bytes`
-    fn verify_report_data(
-        &self,
-        report_data: &[u8; 64],
-        signing_address: &str,
-        tls_cert_fingerprint: Option<&str>,
-        nonce: &str,
-        _signing_algo: &str,
-    ) -> Result<(), AttestationVerificationError> {
-        // Verify nonce (second 32 bytes)
-        let nonce_bytes = hex::decode(nonce.strip_prefix("0x").unwrap_or(nonce)).map_err(|e| {
-            AttestationVerificationError::InvalidFormat(format!("nonce hex decode: {e}"))
-        })?;
-        if nonce_bytes.len() != 32 {
-            return Err(AttestationVerificationError::ReportDataMismatch(format!(
-                "nonce must be 32 bytes, got {}",
-                nonce_bytes.len()
-            )));
-        }
-        if report_data[32..64] != nonce_bytes[..] {
-            return Err(AttestationVerificationError::ReportDataMismatch(
-                "nonce mismatch in report_data[32:64]".to_string(),
-            ));
-        }
-
-        // Verify first 32 bytes
-        let addr_hex = signing_address
-            .strip_prefix("0x")
-            .unwrap_or(signing_address);
-        let addr_bytes = hex::decode(addr_hex).map_err(|e| {
-            AttestationVerificationError::InvalidFormat(format!("signing_address hex decode: {e}"))
-        })?;
-
-        if let Some(fp_hex) = tls_cert_fingerprint {
-            // TLS fingerprint binding: SHA256(signing_address_bytes || fingerprint_bytes)
-            let fp_bytes =
-                hex::decode(fp_hex.strip_prefix("0x").unwrap_or(fp_hex)).map_err(|e| {
-                    AttestationVerificationError::InvalidFormat(format!(
-                        "tls_cert_fingerprint hex decode: {e}"
-                    ))
-                })?;
-            let mut hasher = Sha256::new();
-            hasher.update(&addr_bytes);
-            hasher.update(&fp_bytes);
-            let expected = hasher.finalize();
-
-            if report_data[..32] != expected[..] {
-                return Err(AttestationVerificationError::ReportDataMismatch(format!(
-                    "report_data[0:32] does not match SHA256(signing_address || tls_fingerprint). \
-                     Expected: {}, got: {}",
-                    hex::encode(expected),
-                    hex::encode(&report_data[..32])
-                )));
-            }
-        } else {
-            // No TLS fingerprint: first 32 bytes = signing_address padded to 32
-            let mut expected = [0u8; 32];
-            let copy_len = addr_bytes.len().min(32);
-            expected[..copy_len].copy_from_slice(&addr_bytes[..copy_len]);
-            if report_data[..32] != expected[..] {
-                return Err(AttestationVerificationError::ReportDataMismatch(format!(
-                    "report_data[0:32] does not match padded signing_address. \
-                     Expected: {}, got: {}",
-                    hex::encode(expected),
-                    hex::encode(&report_data[..32])
-                )));
-            }
-        }
-
-        Ok(())
     }
 
     /// Replay RTMR3 from the event log and verify it matches the TDX quote.

--- a/crates/services/src/attestation/verification.rs
+++ b/crates/services/src/attestation/verification.rs
@@ -7,12 +7,8 @@ use sha2::Digest;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use inference_providers::ProviderTier;
-
 use super::measurement::MeasurementPolicy;
-use super::report_data::{
-    NearReportDataVerifier, ReportDataVerifier, StrictBoundReportDataVerifier,
-};
+use super::report_data::{ReportDataVerifier, StrictBoundReportDataVerifier};
 
 const NVIDIA_NRAS_URL: &str = "https://nras.attestation.nvidia.com/v3/attest/gpu";
 
@@ -83,7 +79,7 @@ pub struct AttestationVerifier {
 impl AttestationVerifier {
     /// Construct a NEAR-fleet verifier from explicit allowlist + TCB flag.
     ///
-    /// Preserved for existing callers/tests: builds a [`ProviderTier::Near`]
+    /// Preserved for existing callers/tests: builds a `Near`-tier
     /// [`MeasurementPolicy`] with the historical semantics (empty allowlist =
     /// skip the image-hash check).
     pub fn new(
@@ -105,13 +101,13 @@ impl AttestationVerifier {
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("failed to create HTTP client for attestation verification");
-        // Select the report_data verifier from the tier (never from a report
-        // field). Attested third parties must bind the TLS fingerprint into the
-        // quote; NEAR keeps its historical behavior including the fallback.
-        let report_data_verifier: Arc<dyn ReportDataVerifier> = match policy.tier() {
-            ProviderTier::Attested3p => Arc::new(StrictBoundReportDataVerifier),
-            ProviderTier::Near | ProviderTier::NonAttested => Arc::new(NearReportDataVerifier),
-        };
+        // Strict report_data binding for EVERY attested provider — NEAR's own
+        // fleet is held to the same bar as third parties (TLS fingerprint
+        // required; no padded-`signing_address` fallback). The `Arc<dyn>` seam
+        // is kept so a provider with a different report_data layout can plug its
+        // own verifier in a later PR.
+        let report_data_verifier: Arc<dyn ReportDataVerifier> =
+            Arc::new(StrictBoundReportDataVerifier);
         Self {
             http_client,
             policy,


### PR DESCRIPTION
## Summary

**PR3 of the Chutes attested-provider integration** (follows #745 `ProviderTier`, #746 `MeasurementPolicy`). Replaces the inline `report_data` check with a pluggable `ReportDataVerifier` and applies a **single strict binding rule to every attested provider — NEAR's own fleet included**: `report_data[0:32]` MUST equal `SHA256(signing_address ‖ tls_cert_fingerprint)` (a TLS fingerprint is **mandatory**) and `report_data[32:64]` MUST equal the per-request nonce. The legacy zero-padded-`signing_address` fallback is **removed**.

> **This is a deliberate NEAR hardening, not a no-op refactor.** Per review feedback: the code will be audited and we want NEAR held to the same bar as third parties — no weaker path for our own fleet. See *Validation* for why it's safe and what must be checked in staging before prod.

## Background — why the fallback is removed

A TDX quote's 64-byte `report_data` is sealed inside the Intel-signed quote and binds it to *this* request and *this* backend:

- `report_data[32:64]` = caller's per-request nonce (**freshness**).
- `report_data[0:32]` = `SHA256(signing_address ‖ tls_cert_fingerprint)` — binds the signing key **and** the live TLS endpoint into the quote.

The verifier historically also accepted a fallback when no fingerprint was present: `report_data[0:32] = signing_address` zero-padded. That fallback **drops the TLS co-binding** — an attacker who can influence the JSON `signing_address` could satisfy `report_data[0:32]` against a quote not bound to the TLS endpoint we're actually talking to (a `breaks_trust=critical` finding in the design's adversarial review). There is no reason NEAR should retain a weaker path than a third party, so the fallback is removed for everyone.

## What changed

New `crates/services/src/attestation/report_data.rs`:
- **`trait ReportDataVerifier`** — `verify(report_data, signing_address, tls_cert_fingerprint, nonce)`.
- **`StrictBoundReportDataVerifier`** — the single verifier used for all attested tiers: requires `tls_cert_fingerprint` (rejects when absent), re-checks the nonce, verifies the `SHA256(addr‖fp)` binding.

`AttestationVerifier` holds an `Arc<dyn ReportDataVerifier>` (the seam is kept so a provider with a *different* `report_data` layout can plug its own verifier in a later PR), set to `StrictBoundReportDataVerifier` for every tier. `new()` / `from_env()` (NEAR) and `with_policy()` (3p, PR7) all get strict. The unused `signing_algo` argument is dropped.

## Validation — why this is safe for NEAR

NEAR backends already bind the TLS fingerprint into `report_data`; the padded-address fallback was never exercised in practice. Evidence:

- The existing **live fixture tests now run under the strict verifier** and pass: `test_verify_glm5_attestation` and `test_verify_qwen35_attestation` fetch *real* attestation reports from production NEAR backends and verify them strictly (they also assert `tls_cert_fingerprint.is_some()`). So real NEAR reports carry the binding.
- `report_data::tests` (4): accepts the fingerprint binding; **rejects missing fingerprint**; **rejects stale-nonce replay**; rejects a wrong fingerprint binding.
- PR2 fail-closed tests unchanged; full `services` lib green; `cargo build --workspace` green; local `cargo test --test e2e_all` green; fmt + clippy clean.

**Staging gate before prod promotion:** this changes NEAR verification, so the full infra-tests staging suite must be run across **all** NEAR models after deploy. Any NEAR model whose report does not bind a fingerprint would now be (correctly) rejected and drop from rotation — that would surface as that model failing attestation/discovery in staging, and must be fixed on the backend before promotion. The 2 fixture models are already proven; the rest are validated by the staging suite.

## Impact

- **Behavior:** NEAR `report_data` verification is now strict (no fallback). Intended to be a no-op for the live fleet (fingerprint always present), but it *is* a behavior change — hence the staging gate above. No `Attested3p` provider is wired yet.
- **Risk:** medium-low and self-announcing — a NEAR model lacking a fingerprint fails loudly in staging rather than silently downgrading trust. Mitigated by fixtures (2 models proven) + full staging validation.
- **Unblocks:** PR7 (Chutes) reuses the same strict binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
