### PR TITLE
feat(chutes): tiered NEAR-primary/Chutes-fallback across all TEE models

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -796,10 +796,14 @@ pub async fn init_inference_providers(
                     services::attestation::chutes::vetted_golden_measurements(),
                     pccs_url,
                 ));
-                for model in &config.external_providers.chutes_models {
+                for entry in &config.external_providers.chutes_models {
+                    // The provider talks to Chutes with the chute SLUG (request_body
+                    // pins it + cached_chute_id resolves it); we expose/route under
+                    // the CANONICAL id (the NEAR-served id when NEAR also serves the
+                    // model, else the OpenRouter id) — never the raw `-TEE` slug.
                     let cfg = inference_providers::attested::chutes::Config::new(
                         api_key.clone(),
-                        model.clone(),
+                        entry.chute_slug.clone(),
                         config.external_providers.timeout_seconds,
                     )
                     .with_streaming(allow_streaming);
@@ -808,18 +812,34 @@ pub async fn init_inference_providers(
                         verifier.clone(),
                     ) {
                         Ok(provider) => {
-                            // Ensure a catalog row exists so the data plane resolves
-                            // the model (and usage can be billed against a real id).
-                            ensure_chutes_catalog_row(&models_repo, model).await;
-                            // Pinned: registered out-of-band (not DB discovery), so
-                            // excluded from the refresh's stale-removal; also skips the
-                            // signing-key discovery Chutes never satisfies.
-                            pool.register_pinned_provider(model.clone(), Arc::new(provider))
-                                .await;
-                            tracing::info!(model = %model, "Registered Chutes attested provider");
+                            // Ensure a catalog row exists under the canonical id so the
+                            // data plane resolves the model (and usage bills against a
+                            // real id). If NEAR already serves this id, its row is left
+                            // untouched and we just add Chutes as a fallback provider.
+                            ensure_chutes_catalog_row(&models_repo, &entry.canonical_id).await;
+                            // Pinned SECONDARY: pushed onto the canonical id's provider
+                            // list (coexists with NEAR's own providers) and excluded from
+                            // discovery's stale-removal/overwrite. Tier ordering puts NEAR
+                            // first and Chutes as fallback; a Chutes-only id has just this
+                            // provider, so it serves as primary.
+                            pool.register_pinned_secondary_provider(
+                                entry.canonical_id.clone(),
+                                Arc::new(provider),
+                            )
+                            .await;
+                            tracing::info!(
+                                canonical = %entry.canonical_id,
+                                chute_slug = %entry.chute_slug,
+                                "Registered Chutes attested provider (fallback tier)"
+                            );
                         }
                         Err(e) => {
-                            tracing::warn!(model = %model, error = %e, "Failed to build Chutes provider");
+                            tracing::warn!(
+                                canonical = %entry.canonical_id,
+                                chute_slug = %entry.chute_slug,
+                                error = %e,
+                                "Failed to build Chutes provider"
+                            );
                         }
                     }
                 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -830,6 +830,7 @@ pub async fn init_inference_providers(
                         entry.chute_slug.clone(),
                         config.external_providers.timeout_seconds,
                     )
+                    .with_canonical_id(entry.canonical_id.clone())
                     .with_streaming(allow_streaming);
                     match inference_providers::attested::chutes::Provider::new(
                         cfg,

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -745,6 +745,30 @@ pub async fn init_inference_providers(
     let models_source =
         models_repo.clone() as Arc<dyn services::inference_provider_pool::ExternalModelsSource>;
 
+    // Fail-closed reservation (MUST run before external/discovery loads below):
+    // when Chutes is enabled, reserve EVERY configured canonical id as a pinned
+    // (verifiable) model up front — even before we try to build the providers. This
+    // guarantees a plaintext external/OpenRouter row sharing a canonical id can
+    // never register for it, even if the Chutes provider fails to build (missing
+    // key / construction error). A reserved id then serves only its attested
+    // provider(s) or fails closed (404); it can never silently serve plaintext for
+    // a model an operator configured as verifiable.
+    if config.external_providers.enable_chutes {
+        let canonical_ids: Vec<String> = config
+            .external_providers
+            .chutes_models
+            .iter()
+            .map(|e| e.canonical_id.clone())
+            .collect();
+        if !canonical_ids.is_empty() {
+            pool.reserve_pinned_models(&canonical_ids);
+            tracing::info!(
+                count = canonical_ids.len(),
+                "Reserved Chutes canonical ids as verifiable (fail-closed) before external load"
+            );
+        }
+    }
+
     // Load inference_url models (our own vLLM/SGLang backends)
     match models_source.fetch_inference_url_models().await {
         Ok(models) if !models.is_empty() => {

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -1255,12 +1255,24 @@ pub async fn delete_model(
             }
         })?;
 
-    // Unregister external provider if it was registered
-    // This is a no-op for vLLM models (they are discovered, not registered)
-    app_state
-        .inference_provider_pool
-        .unregister_provider(&model_name)
-        .await;
+    // Unregister external provider if it was registered.
+    // No-op for vLLM models (discovered, not registered). Skip pinned models
+    // (e.g. a NEAR-served canonical id with a Chutes fallback): unregistering would
+    // tear down the config-pinned provider too, recoverable only by restart. The
+    // catalog delete already 404s the model via resolve_and_get_model's is_active
+    // gate; config remains the source of truth for the pinned provider.
+    if app_state.inference_provider_pool.is_pinned(&model_name) {
+        tracing::warn!(
+            model = %model_name,
+            "delete_model: skipping unregister of a pinned (config-managed) provider; \
+             the catalog row is removed (model 404s), pinned provider left intact"
+        );
+    } else {
+        app_state
+            .inference_provider_pool
+            .unregister_provider(&model_name)
+            .await;
+    }
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -1342,10 +1354,22 @@ pub async fn deprecate_model(
     // resolver will route requests with the deprecated model_id to the
     // successor on subsequent calls — so this prevents in-flight resolution
     // from picking up a stale provider reference for the now-inactive model.
-    app_state
-        .inference_provider_pool
-        .unregister_provider(&model_id)
-        .await;
+    // Skip pinned models (e.g. a NEAR-served canonical id with a Chutes fallback):
+    // unregistering would tear down the config-pinned provider too (recoverable
+    // only by restart), and the alias already routes the deprecated id to the
+    // successor, so the pinned provider isn't reached.
+    if app_state.inference_provider_pool.is_pinned(&model_id) {
+        tracing::warn!(
+            model = %model_id,
+            "deprecate_model: skipping unregister of a pinned (config-managed) provider; \
+             the alias routes the deprecated id to its successor, pinned provider left intact"
+        );
+    } else {
+        app_state
+            .inference_provider_pool
+            .unregister_provider(&model_id)
+            .await;
+    }
 
     let to_api = |model_name: String, m: services::admin::ModelPricing| ModelWithPricing {
         model_id: model_name,

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -460,6 +460,15 @@ pub async fn batch_upsert_models(
         // model — would leave an active catalog row with no serving provider until
         // restart. Pricing/metadata still applied via batch_upsert_models above;
         // serving is gated by the catalog `is_active`, not by this in-memory entry.
+        //
+        // NOTE: with tiered fallback this now also covers a NEAR-served canonical id
+        // that has a Chutes fallback (it's `is_pinned`). So a PATCH that changes its
+        // `inference_url` or deactivates it skips the eager `unregister_provider`
+        // cleanup here: the NEW url is still re-registered below (the merge keeps
+        // Chutes), but the stale OLD-url NEAR provider + its pubkey/failure-counter
+        // entries linger until the next periodic refresh prunes them. Behavior stays
+        // safe (pubkey intersection + catalog `is_active` gating); it just isn't
+        // instantaneously clean for a runtime url change on a Chutes-fallback model.
         if app_state.inference_provider_pool.is_pinned(model_name) {
             continue;
         }

--- a/crates/api/tests/e2e_all/chutes_catalog.rs
+++ b/crates/api/tests/e2e_all/chutes_catalog.rs
@@ -19,7 +19,7 @@ async fn admin_patch_with_provider_type_keeps_pinned_provider() {
     let model = format!("zai-org/GLM-5.1-TEE-pin-{}", uuid::Uuid::new_v4());
 
     // Register a pinned provider exactly as init_inference_providers does for Chutes.
-    pool.register_pinned_provider(
+    pool.register_pinned_secondary_provider(
         model.clone(),
         Arc::new(inference_providers::mock::MockProvider::new()),
     )

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -980,6 +980,59 @@ mod tests {
         std::env::remove_var("RESEND_API_KEY_FILE");
         std::env::remove_var("CLOUD_UI_BASE_URL");
     }
+
+    #[test]
+    #[serial]
+    fn chutes_models_parses_canonical_slug_pairs_and_bare_entries() {
+        // `canonical=chute_slug` pairs; a bare entry means canonical == slug.
+        // Surrounding whitespace is trimmed; empty/half-empty tokens dropped.
+        std::env::set_var(
+            "CHUTES_MODELS",
+            "zai-org/GLM-5.1-FP8=zai-org/GLM-5.1-TEE , moonshotai/Kimi-K2.6-TEE ,, =bad, alsobad=",
+        );
+        let cfg = ExternalProvidersConfig::from_env();
+        std::env::remove_var("CHUTES_MODELS");
+
+        assert_eq!(
+            cfg.chutes_models,
+            vec![
+                ChutesModelEntry {
+                    canonical_id: "zai-org/GLM-5.1-FP8".to_string(),
+                    chute_slug: "zai-org/GLM-5.1-TEE".to_string(),
+                },
+                // Bare entry: canonical == slug.
+                ChutesModelEntry {
+                    canonical_id: "moonshotai/Kimi-K2.6-TEE".to_string(),
+                    chute_slug: "moonshotai/Kimi-K2.6-TEE".to_string(),
+                },
+            ],
+            "pairs split on '='; bare => canonical==slug; empty/half-empty tokens dropped"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn chutes_models_empty_when_unset() {
+        std::env::remove_var("CHUTES_MODELS");
+        let cfg = ExternalProvidersConfig::from_env();
+        assert!(cfg.chutes_models.is_empty());
+    }
+}
+
+/// One Chutes model to register, parsed from a single `CHUTES_MODELS` token.
+///
+/// The token is `canonical_id=chute_slug` (e.g. `zai-org/GLM-5.1-FP8=zai-org/GLM-5.1-TEE`),
+/// or a bare `name` meaning `canonical_id == chute_slug`. We deliberately keep
+/// the two ids distinct: the **canonical id** is what we expose in `/v1/models`
+/// and route under (the NEAR-served id when NEAR also serves the model, else the
+/// OpenRouter id) — never the raw `-TEE` chute slug; the **chute slug** is the
+/// internal upstream identity we send to Chutes and resolve to a `chute_id`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChutesModelEntry {
+    /// User-facing / catalog model id (e.g. `zai-org/GLM-5.1-FP8`).
+    pub canonical_id: String,
+    /// Chutes chute slug sent upstream (e.g. `zai-org/GLM-5.1-TEE`).
+    pub chute_slug: String,
 }
 
 /// External providers configuration for third-party AI providers
@@ -1001,9 +1054,10 @@ pub struct ExternalProvidersConfig {
     pub enable_chutes: bool,
     /// Chutes API key (`cpk_...`), from `CHUTES_API_KEY[_FILE]`. A secret.
     pub chutes_api_key: Option<String>,
-    /// Comma-separated Chutes model ids to register (e.g. `zai-org/GLM-5.1-TEE`),
-    /// from `CHUTES_MODELS`.
-    pub chutes_models: Vec<String>,
+    /// Chutes models to register, from `CHUTES_MODELS` (comma-separated
+    /// `canonical_id=chute_slug` pairs; a bare entry means the two are equal).
+    /// See [`ChutesModelEntry`].
+    pub chutes_models: Vec<ChutesModelEntry>,
     /// Expose Chutes **streaming** as an attested path (`CHUTES_ENABLE_STREAMING`,
     /// default off). Off because Chutes' stream protocol has no authenticated
     /// frame sequence numbers, so an on-path gateway could drop/reorder frames
@@ -1078,11 +1132,24 @@ impl ExternalProvidersConfig {
         // An empty key is not a key — treat "" as absent so a misconfigured
         // secret can't pass as Some("") and silently fail at request time.
         .filter(|s| !s.is_empty());
+        // `canonical_id=chute_slug` per comma-separated token; a bare token means
+        // canonical_id == chute_slug. Drop tokens missing either side.
         let chutes_models = env::var("CHUTES_MODELS")
             .unwrap_or_default()
             .split(',')
-            .map(|s| s.trim().to_string())
+            .map(|s| s.trim())
             .filter(|s| !s.is_empty())
+            .map(|tok| match tok.split_once('=') {
+                Some((canonical, slug)) => ChutesModelEntry {
+                    canonical_id: canonical.trim().to_string(),
+                    chute_slug: slug.trim().to_string(),
+                },
+                None => ChutesModelEntry {
+                    canonical_id: tok.to_string(),
+                    chute_slug: tok.to_string(),
+                },
+            })
+            .filter(|e| !e.canonical_id.is_empty() && !e.chute_slug.is_empty())
             .collect();
         let chutes_enable_streaming = env::var("CHUTES_ENABLE_STREAMING")
             .ok()

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -1017,6 +1017,34 @@ mod tests {
         let cfg = ExternalProvidersConfig::from_env();
         assert!(cfg.chutes_models.is_empty());
     }
+
+    #[test]
+    #[serial]
+    fn chutes_models_dedup_duplicate_canonical_ids_first_wins() {
+        // Duplicate canonical id (even with a different slug) is dropped so a
+        // misconfig can't register redundant fallback providers — first wins.
+        std::env::set_var(
+            "CHUTES_MODELS",
+            "zai-org/GLM-5.1-FP8=zai-org/GLM-5.1-TEE,zai-org/GLM-5.1-FP8=zai-org/GLM-5-TEE,other/model",
+        );
+        let cfg = ExternalProvidersConfig::from_env();
+        std::env::remove_var("CHUTES_MODELS");
+
+        assert_eq!(
+            cfg.chutes_models,
+            vec![
+                ChutesModelEntry {
+                    canonical_id: "zai-org/GLM-5.1-FP8".to_string(),
+                    chute_slug: "zai-org/GLM-5.1-TEE".to_string(),
+                },
+                ChutesModelEntry {
+                    canonical_id: "other/model".to_string(),
+                    chute_slug: "other/model".to_string(),
+                },
+            ],
+            "duplicate canonical id dropped (first wins); the second slug is ignored"
+        );
+    }
 }
 
 /// One Chutes model to register, parsed from a single `CHUTES_MODELS` token.
@@ -1133,24 +1161,38 @@ impl ExternalProvidersConfig {
         // secret can't pass as Some("") and silently fail at request time.
         .filter(|s| !s.is_empty());
         // `canonical_id=chute_slug` per comma-separated token; a bare token means
-        // canonical_id == chute_slug. Drop tokens missing either side.
-        let chutes_models = env::var("CHUTES_MODELS")
-            .unwrap_or_default()
-            .split(',')
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .map(|tok| match tok.split_once('=') {
-                Some((canonical, slug)) => ChutesModelEntry {
-                    canonical_id: canonical.trim().to_string(),
-                    chute_slug: slug.trim().to_string(),
-                },
-                None => ChutesModelEntry {
-                    canonical_id: tok.to_string(),
-                    chute_slug: tok.to_string(),
-                },
-            })
-            .filter(|e| !e.canonical_id.is_empty() && !e.chute_slug.is_empty())
-            .collect();
+        // canonical_id == chute_slug. Drop tokens missing either side, and dedup by
+        // canonical id (first wins) so a misconfig can't register duplicate
+        // fallback providers that every refresh would re-attach.
+        let chutes_models = {
+            let raw = env::var("CHUTES_MODELS").unwrap_or_default();
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut entries: Vec<ChutesModelEntry> = Vec::new();
+            for tok in raw.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                let entry = match tok.split_once('=') {
+                    Some((canonical, slug)) => ChutesModelEntry {
+                        canonical_id: canonical.trim().to_string(),
+                        chute_slug: slug.trim().to_string(),
+                    },
+                    None => ChutesModelEntry {
+                        canonical_id: tok.to_string(),
+                        chute_slug: tok.to_string(),
+                    },
+                };
+                if entry.canonical_id.is_empty() || entry.chute_slug.is_empty() {
+                    continue;
+                }
+                if !seen.insert(entry.canonical_id.clone()) {
+                    eprintln!(
+                        "WARN: duplicate CHUTES_MODELS canonical id '{}' ignored (first wins)",
+                        entry.canonical_id
+                    );
+                    continue;
+                }
+                entries.push(entry);
+            }
+            entries
+        };
         let chutes_enable_streaming = env::var("CHUTES_ENABLE_STREAMING")
             .ok()
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     ImageGenerationError, ImageGenerationParams, ImageGenerationResponseWithBytes,
     InferenceProvider, ListModelsError, ModelInfo, ModelsResponse, PrivacyClassifyError,
     RerankError, RerankParams, RerankResponse, SSEEvent, ScoreError, ScoreParams, ScoreResponse,
-    StreamingResult,
+    StreamChunk, StreamingResult,
 };
 
 /// Sane fallback when a non-positive timeout is supplied; a non-positive value
@@ -370,16 +370,19 @@ const INTERNAL_KEYS: &[&str] = {
     ]
 };
 
-/// Rewrite the `model` field of a decrypted OpenAI SSE event's `data:` JSON to the
-/// canonical id, so a streamed `model` never leaks the chute slug. Only touches
-/// chunk-bearing data lines; control events ([DONE], blanks, the keyed init) have
-/// no chunk and pass through unchanged. On any parse failure the event is returned
-/// as-is (never drop a chunk over a rewrite). `chunk` is left as parsed — it's
-/// internal-only (clients receive `raw_bytes`; usage/billing keys on the resolved
-/// canonical model, not the chunk).
-fn rewrite_sse_event_model(ev: SSEEvent, canonical: &str) -> SSEEvent {
+/// Rewrite the `model` field of a decrypted OpenAI SSE event to the canonical id —
+/// in BOTH `raw_bytes` (the byte-exact passthrough path) AND the parsed `chunk`
+/// (the route re-serializes from `chunk`, not `raw_bytes`, on the auto-redact /
+/// alias-served paths — so leaving the slug there would still leak it). Only
+/// touches chunk-bearing data lines; control events ([DONE], blanks, the keyed
+/// init) have no chunk and pass through unchanged. On any parse failure the event
+/// is returned as-is (never drop a chunk over a rewrite).
+fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: &str) -> SSEEvent {
     if ev.chunk.is_none() {
         return ev;
+    }
+    if let Some(StreamChunk::Chat(c)) = &mut ev.chunk {
+        c.model = canonical.to_string();
     }
     let Ok(s) = std::str::from_utf8(&ev.raw_bytes) else {
         return ev;
@@ -469,12 +472,13 @@ const UNSUPPORTED: &str =
 #[async_trait]
 impl InferenceProvider for Provider {
     async fn models(&self) -> Result<ModelsResponse, ListModelsError> {
-        // The model set is configured explicitly; advertise just this one.
+        // The model set is configured explicitly; advertise just this one, under the
+        // CANONICAL id (never the upstream `-TEE` chute slug).
         Ok(ModelsResponse {
             object: "list".to_string(),
             data: vec![ModelInfo {
                 created: 0,
-                id: self.model_name.clone(),
+                id: self.canonical_id.clone(),
                 object: "model".to_string(),
                 owned_by: "chutes".to_string(),
             }],
@@ -742,7 +746,8 @@ impl InferenceProvider for Provider {
             let mut m = serde_json::Map::new();
             m.insert("provider".to_string(), json!("chutes"));
             m.insert("verified".to_string(), json!(true));
-            m.insert("model".to_string(), json!(self.model_name));
+            // Client-visible surface: report the canonical id, never the chute slug.
+            m.insert("model".to_string(), json!(self.canonical_id));
             m.insert("instance_id".to_string(), json!(info.instance_id));
             m.insert(
                 "measurement_config".to_string(),
@@ -913,9 +918,18 @@ mod tests {
         let s = std::str::from_utf8(&out.raw_bytes).unwrap();
         assert!(
             s.contains("zai-org/GLM-5.1-FP8"),
-            "data chunk model rewritten"
+            "data chunk model rewritten in raw_bytes"
         );
-        assert!(!s.contains("GLM-5.1-TEE"), "slug must not leak");
+        assert!(
+            !s.contains("GLM-5.1-TEE"),
+            "slug must not leak in raw_bytes"
+        );
+        // The PARSED chunk's model must also be canonical — the route re-serializes
+        // from `chunk` (not raw_bytes) on the auto-redact / alias-served paths.
+        match &out.chunk {
+            Some(StreamChunk::Chat(c)) => assert_eq!(c.model, "zai-org/GLM-5.1-FP8"),
+            other => panic!("expected a rewritten Chat chunk, got {other:?}"),
+        }
 
         // A control event (no chunk: [DONE]/blank) passes through unchanged.
         let ctrl = SSEEvent {

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -683,6 +683,12 @@ impl InferenceProvider for Provider {
     /// per-response signature — so the attestation flow skips the signature
     /// fetch/store step entirely (rather than calling `get_signature` and
     /// erroring on every completion).
+    ///
+    /// CLIENT-VISIBLE TRADE-OFF (#758): under one canonical id with tiered fallback,
+    /// a NEAR-served response is signature-available but a response that fell back to
+    /// Chutes is not — so per-request signature availability is non-deterministic for
+    /// such a model. This should be documented for clients of any model that lists
+    /// both a NEAR and a Chutes provider.
     fn supports_chat_signatures(&self) -> bool {
         false
     }
@@ -700,6 +706,14 @@ impl InferenceProvider for Provider {
     /// instead of falling through to a hard streaming-disabled error.
     fn supports_streaming(&self) -> bool {
         self.allow_streaming
+    }
+
+    /// Chutes can't serve client-facing E2EE (responses ride its own ML-KEM
+    /// channel; `reject_client_e2ee` refuses the `x_client_pub_key` headers). The
+    /// pool uses this to keep such requests on a NEAR sibling rather than falling
+    /// through to that hard rejection.
+    fn supports_client_e2ee(&self) -> bool {
+        false
     }
 
     async fn get_signature(

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     EmbeddingError, ImageEditError, ImageEditParams, ImageEditResponseWithBytes,
     ImageGenerationError, ImageGenerationParams, ImageGenerationResponseWithBytes,
     InferenceProvider, ListModelsError, ModelInfo, ModelsResponse, PrivacyClassifyError,
-    RerankError, RerankParams, RerankResponse, ScoreError, ScoreParams, ScoreResponse,
+    RerankError, RerankParams, RerankResponse, SSEEvent, ScoreError, ScoreParams, ScoreResponse,
     StreamingResult,
 };
 
@@ -70,8 +70,14 @@ const CHAT_PATH: &str = "/v1/chat/completions";
 pub struct Config {
     /// Chutes API key (`cpk_...`) — a secret; sourced from env/secret store.
     api_key: String,
-    /// The model id as served by Chutes (e.g. `zai-org/GLM-5.1-TEE`).
+    /// The model id as served by Chutes — the chute SLUG (e.g. `zai-org/GLM-5.1-TEE`).
+    /// Sent upstream and resolved to a `chute_id`; NEVER surfaced to clients.
     model_name: String,
+    /// The CANONICAL id we expose to clients and rewrite `response.model` to (e.g.
+    /// `zai-org/GLM-5.1-FP8`, or the OpenRouter id). Defaults to `model_name` (the
+    /// slug) when not set via [`Config::with_canonical_id`]; when it differs, the
+    /// decrypted response's `model` is rewritten so it never leaks the slug.
+    canonical_id: String,
     /// Per-request timeout, seconds. Always > 0 (see `new`).
     timeout_seconds: i64,
     /// Optional host overrides (tests/staging). Both or neither.
@@ -89,6 +95,7 @@ impl Config {
     pub fn new(api_key: String, model_name: String, timeout_seconds: i64) -> Self {
         Self {
             api_key,
+            canonical_id: model_name.clone(),
             model_name,
             timeout_seconds: if timeout_seconds > 0 {
                 timeout_seconds
@@ -99,6 +106,14 @@ impl Config {
             models_base: None,
             allow_streaming: false,
         }
+    }
+
+    /// Set the canonical id surfaced to clients (the NEAR-served id, or the
+    /// OpenRouter id) when it differs from the chute slug. `response.model` is
+    /// rewritten to this so the raw `-TEE` slug never reaches a client.
+    pub fn with_canonical_id(mut self, canonical_id: impl Into<String>) -> Self {
+        self.canonical_id = canonical_id.into();
+        self
     }
 
     /// Override the Chutes hosts (`api.chutes.ai` / `llm.chutes.ai`) for tests or
@@ -147,6 +162,9 @@ pub struct Provider {
     client: ChutesClient,
     verifier: Arc<dyn ChutesInstanceVerifier>,
     model_name: String,
+    /// Canonical id surfaced to clients; `response.model` is rewritten to this
+    /// when it differs from `model_name` (the chute slug). See [`Config::canonical_id`].
+    canonical_id: String,
     /// Whether the streaming chat path is exposed as attested (see
     /// [`Config::allow_streaming`]).
     allow_streaming: bool,
@@ -182,6 +200,7 @@ impl Provider {
             client,
             verifier,
             model_name: config.model_name,
+            canonical_id: config.canonical_id,
             allow_streaming,
             chute_id_cache: tokio::sync::OnceCell::new(),
         })
@@ -351,6 +370,44 @@ const INTERNAL_KEYS: &[&str] = {
     ]
 };
 
+/// Rewrite the `model` field of a decrypted OpenAI SSE event's `data:` JSON to the
+/// canonical id, so a streamed `model` never leaks the chute slug. Only touches
+/// chunk-bearing data lines; control events ([DONE], blanks, the keyed init) have
+/// no chunk and pass through unchanged. On any parse failure the event is returned
+/// as-is (never drop a chunk over a rewrite). `chunk` is left as parsed — it's
+/// internal-only (clients receive `raw_bytes`; usage/billing keys on the resolved
+/// canonical model, not the chunk).
+fn rewrite_sse_event_model(ev: SSEEvent, canonical: &str) -> SSEEvent {
+    if ev.chunk.is_none() {
+        return ev;
+    }
+    let Ok(s) = std::str::from_utf8(&ev.raw_bytes) else {
+        return ev;
+    };
+    let content = s.strip_prefix("data:").map(str::trim).unwrap_or(s.trim());
+    let Some(rewritten) = set_model_in_json(content.as_bytes(), canonical) else {
+        return ev;
+    };
+    let Ok(json) = String::from_utf8(rewritten) else {
+        return ev;
+    };
+    SSEEvent {
+        raw_bytes: bytes::Bytes::from(format!("data: {json}\n\n")),
+        chunk: ev.chunk,
+        raw_passthrough: ev.raw_passthrough,
+    }
+}
+
+/// Set `model` to `canonical` in an OpenAI JSON body, preserving every other field
+/// (so unmodeled provider fields survive). Returns the re-serialized bytes, or
+/// `None` if the body isn't a JSON object or (de)serialization fails.
+fn set_model_in_json(bytes: &[u8], canonical: &str) -> Option<Vec<u8>> {
+    let mut v: Value = serde_json::from_slice(bytes).ok()?;
+    v.as_object_mut()?
+        .insert("model".to_string(), Value::String(canonical.to_string()));
+    serde_json::to_vec(&v).ok()
+}
+
 /// An OpenAI request body (as JSON) with `model` pinned, `stream` set, and all
 /// internal/tracing/E2EE-marker keys stripped (never sent to the third party).
 fn request_body(model: &str, params: &ChatCompletionParams, stream: bool) -> Result<Value, String> {
@@ -454,14 +511,31 @@ impl InferenceProvider for Provider {
             .session
             .decrypt_response(&resp_blob)
             .map_err(|e| CompletionError::CompletionError(format!("E2EE decrypt: {e}")))?;
+
+        // The upstream body carries the chute SLUG in `model`. When the canonical id
+        // differs (NEAR-served / OpenRouter-id case), rewrite `model` to the
+        // canonical id so the slug never leaks to clients and `response.model`
+        // matches an id listable in /v1/models. We rewrite the JSON *value* (not the
+        // typed struct) so any unmodeled provider fields survive. When canonical ==
+        // slug, keep the plaintext verbatim (byte-exact, preserves unmodeled fields
+        // like `hidden_states`). No signature is sacrificed — Chutes responses aren't
+        // separately signed (`supports_chat_signatures == false`).
+        if self.canonical_id != self.model_name {
+            let raw_bytes = set_model_in_json(&plaintext, &self.canonical_id).ok_or_else(|| {
+                CompletionError::CompletionError(
+                    "failed to rewrite Chutes response model to the canonical id".to_string(),
+                )
+            })?;
+            let response: ChatCompletionResponse = serde_json::from_slice(&raw_bytes)
+                .map_err(|e| CompletionError::CompletionError(format!("parse response: {e}")))?;
+            return Ok(ChatCompletionResponseWithBytes {
+                response,
+                raw_bytes,
+            });
+        }
+
         let response: ChatCompletionResponse = serde_json::from_slice(&plaintext)
             .map_err(|e| CompletionError::CompletionError(format!("parse response: {e}")))?;
-        // The decrypted plaintext IS the backend's exact JSON body, so use it
-        // verbatim as `raw_bytes` rather than re-serializing the parsed struct.
-        // Re-serialization would change the byte representation (key order /
-        // whitespace) and silently drop any provider fields our typed struct
-        // doesn't model (e.g. `hidden_states`); `raw_bytes` is documented as the
-        // exact provider bytes and is what we hand back to the client.
         Ok(ChatCompletionResponseWithBytes {
             response,
             raw_bytes: plaintext,
@@ -513,10 +587,18 @@ impl InferenceProvider for Provider {
         let byte_stream = resp.bytes_stream().map(|r| {
             r.map_err(|e| CompletionError::CompletionError(format!("Chutes stream transport: {e}")))
         });
-        Ok(e2ee_stream::decrypt_e2ee_sse(
-            Box::pin(byte_stream),
-            prep.session,
-        ))
+        let decoded = e2ee_stream::decrypt_e2ee_sse(Box::pin(byte_stream), prep.session);
+        // Same canonical-id rewrite as the non-stream path: when the canonical id
+        // differs from the chute slug, rewrite `model` in each decrypted `data:`
+        // line so streamed chunks never leak the slug to clients. No-op (and no
+        // per-chunk re-serialization) when canonical == slug.
+        if self.canonical_id == self.model_name {
+            return Ok(decoded);
+        }
+        let canonical = self.canonical_id.clone();
+        Ok(Box::pin(decoded.map(move |item| {
+            item.map(|ev| rewrite_sse_event_model(ev, &canonical))
+        })))
     }
 
     async fn text_completion_stream(
@@ -794,6 +876,55 @@ mod tests {
             Config::new("k".into(), "m".into(), 42).timeout_seconds(),
             42
         );
+    }
+
+    #[test]
+    fn set_model_in_json_rewrites_model_and_preserves_other_fields() {
+        // The canonical-id rewrite that keeps the chute slug out of `response.model`
+        // while preserving every other (incl. unmodeled) field.
+        let body =
+            br#"{"id":"x","model":"zai-org/GLM-5.1-TEE","choices":[],"hidden_states":[1,2]}"#;
+        let out = set_model_in_json(body, "zai-org/GLM-5.1-FP8").expect("rewrite");
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["model"], "zai-org/GLM-5.1-FP8");
+        assert_eq!(v["id"], "x");
+        // Unmodeled provider field survives the rewrite.
+        assert_eq!(v["hidden_states"], json!([1, 2]));
+        // Non-object body → None (left untouched by callers).
+        assert!(set_model_in_json(b"[1,2,3]", "x").is_none());
+    }
+
+    #[test]
+    fn rewrite_sse_event_model_rewrites_data_chunk_but_passes_control_through() {
+        use crate::{ChatCompletionChunk, StreamChunk};
+        let chunk: ChatCompletionChunk = serde_json::from_value(json!({
+            "id":"c","object":"chat.completion.chunk","created":0,
+            "model":"zai-org/GLM-5.1-TEE","choices":[]
+        }))
+        .unwrap();
+        let ev = SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(
+                b"data: {\"model\":\"zai-org/GLM-5.1-TEE\",\"id\":\"c\"}\n\n",
+            ),
+            chunk: Some(StreamChunk::Chat(chunk)),
+            raw_passthrough: true,
+        };
+        let out = rewrite_sse_event_model(ev, "zai-org/GLM-5.1-FP8");
+        let s = std::str::from_utf8(&out.raw_bytes).unwrap();
+        assert!(
+            s.contains("zai-org/GLM-5.1-FP8"),
+            "data chunk model rewritten"
+        );
+        assert!(!s.contains("GLM-5.1-TEE"), "slug must not leak");
+
+        // A control event (no chunk: [DONE]/blank) passes through unchanged.
+        let ctrl = SSEEvent {
+            raw_bytes: bytes::Bytes::from_static(b"data: [DONE]\n\n"),
+            chunk: None,
+            raw_passthrough: true,
+        };
+        let out = rewrite_sse_event_model(ctrl, "zai-org/GLM-5.1-FP8");
+        assert_eq!(&out.raw_bytes[..], b"data: [DONE]\n\n");
     }
 
     #[test]

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -687,6 +687,13 @@ impl InferenceProvider for Provider {
         false
     }
 
+    /// Attested third party: a NEAR-served model prefers its own fleet and only
+    /// falls back to Chutes when the NEAR backends can't fulfill the request;
+    /// a Chutes-only model has no NEAR tier so this provider is primary.
+    fn tier(&self) -> crate::ProviderTier {
+        crate::ProviderTier::Attested3p
+    }
+
     async fn get_signature(
         &self,
         _chat_id: &str,

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -694,6 +694,14 @@ impl InferenceProvider for Provider {
         crate::ProviderTier::Attested3p
     }
 
+    /// Chutes only serves an attested STREAM when streaming is explicitly enabled
+    /// (its stream protocol has no authenticated frame ordering, so it's gated).
+    /// Reporting this lets the pool route a streaming request to a NEAR sibling
+    /// instead of falling through to a hard streaming-disabled error.
+    fn supports_streaming(&self) -> bool {
+        self.allow_streaming
+    }
+
     async fn get_signature(
         &self,
         _chat_id: &str,

--- a/crates/inference_providers/src/attested/nearai/mod.rs
+++ b/crates/inference_providers/src/attested/nearai/mod.rs
@@ -1066,6 +1066,13 @@ impl Fleet {
 
 #[async_trait]
 impl InferenceProvider for Fleet {
+    /// NEAR's own attested fleet. `Provider` (which wraps `Fleet`) is what the pool
+    /// actually registers, but mirror the tier here too so the verifiable filter can
+    /// never misclassify a `Fleet` as plaintext if one is ever pooled directly.
+    fn tier(&self) -> crate::ProviderTier {
+        crate::ProviderTier::Near
+    }
+
     async fn get_signature(
         &self,
         chat_id: &str,

--- a/crates/inference_providers/src/attested/nearai/mod.rs
+++ b/crates/inference_providers/src/attested/nearai/mod.rs
@@ -2079,6 +2079,12 @@ impl InferenceProvider for Fleet {
 /// to its Fleet, which holds all NEAR-AI model-proxy state and logic.
 #[async_trait]
 impl InferenceProvider for Provider {
+    /// NEAR AI's own attested TEE fleet — the primary tier for any model NEAR
+    /// serves; an attested third party (Chutes) sits behind it as fallback.
+    fn tier(&self) -> crate::ProviderTier {
+        crate::ProviderTier::Near
+    }
+
     async fn models(&self) -> Result<ModelsResponse, ListModelsError> {
         self.fleet.models().await
     }

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -336,6 +336,16 @@ pub trait InferenceProvider {
         ProviderTier::NonAttested
     }
 
+    /// Whether this provider can serve **streaming** completions. Default `true`.
+    /// A provider that gates streaming (e.g. Chutes when `CHUTES_ENABLE_STREAMING`
+    /// is off — its stream protocol has no authenticated frame ordering) returns
+    /// `false`, so the pool prefers a streaming-capable sibling for streaming
+    /// requests instead of falling through to a hard "streaming not enabled" error
+    /// that would mask the primary's failure and suppress its retry.
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
     /// Clean up the dedicated client for a chat_id after signature fetching.
     fn unpin_chat_connection(&self, _chat_id: &str) {}
 

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -346,6 +346,17 @@ pub trait InferenceProvider {
         true
     }
 
+    /// Whether this provider can serve a request carrying **client-facing E2EE**
+    /// intent (the client asked cloud-api to encrypt the response to its own key,
+    /// via `x_client_pub_key`). Default `true`. A provider that can't (e.g. Chutes,
+    /// whose responses arrive over its own ML-KEM channel and which rejects the
+    /// client encryption headers) returns `false`, so the pool prefers a capable
+    /// sibling for such requests instead of falling through to a hard rejection
+    /// that masks the primary's failure and suppresses its retry.
+    fn supports_client_e2ee(&self) -> bool {
+        true
+    }
+
     /// Clean up the dedicated client for a chat_id after signature fetching.
     fn unpin_chat_connection(&self, _chat_id: &str) {}
 

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -326,6 +326,16 @@ pub trait InferenceProvider {
         true
     }
 
+    /// The trust tier of this provider — see [`ProviderTier`]. Drives provider
+    /// ordering in the pool (NEAR-served models prefer their own attested fleet
+    /// and fall back to an attested third party like Chutes only when the NEAR
+    /// backends can't fulfill the request). Default [`ProviderTier::NonAttested`];
+    /// `attested::nearai` returns [`ProviderTier::Near`] and `attested::chutes`
+    /// returns [`ProviderTier::Attested3p`].
+    fn tier(&self) -> ProviderTier {
+        ProviderTier::NonAttested
+    }
+
     /// Clean up the dedicated client for a chat_id after signature fetching.
     fn unpin_chat_connection(&self, _chat_id: &str) {}
 

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -625,6 +625,10 @@ pub struct MockProvider {
     /// `NonAttested`. Set via [`MockProvider::with_tier`] to exercise tiered
     /// provider selection (e.g. a `Near` primary with an `Attested3p` fallback).
     tier: crate::ProviderTier,
+    /// Value reported by [`InferenceProvider::supports_streaming`]; defaults to
+    /// `true`. Set via [`MockProvider::with_streaming_support`] to exercise the
+    /// streaming-capability filter (e.g. a Chutes-like fallback with streaming off).
+    supports_streaming: bool,
 }
 
 impl MockProvider {
@@ -649,6 +653,7 @@ impl MockProvider {
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tier: crate::ProviderTier::NonAttested,
+            supports_streaming: true,
         }
     }
 
@@ -669,6 +674,7 @@ impl MockProvider {
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tier: crate::ProviderTier::NonAttested,
+            supports_streaming: true,
         }
     }
 
@@ -687,6 +693,7 @@ impl MockProvider {
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tier: crate::ProviderTier::NonAttested,
+            supports_streaming: true,
         }
     }
 
@@ -695,6 +702,13 @@ impl MockProvider {
     /// and the verifiable-never-falls-back-to-plaintext rule).
     pub fn with_tier(mut self, tier: crate::ProviderTier) -> Self {
         self.tier = tier;
+        self
+    }
+
+    /// Set whether this mock reports streaming support (default `true`). Used to
+    /// exercise the streaming-capability filter (a streaming-disabled fallback).
+    pub fn with_streaming_support(mut self, supported: bool) -> Self {
+        self.supports_streaming = supported;
         self
     }
 
@@ -879,6 +893,10 @@ impl Default for MockProvider {
 impl crate::InferenceProvider for MockProvider {
     fn tier(&self) -> crate::ProviderTier {
         self.tier
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.supports_streaming
     }
 
     async fn models(&self) -> Result<ModelsResponse, ListModelsError> {

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -621,6 +621,10 @@ pub struct MockProvider {
     last_chat_params: Arc<Mutex<Option<ChatCompletionParams>>>,
     /// When true, get_attestation_report returns an error (simulates blocked/broken backend)
     fail_attestation: Arc<std::sync::atomic::AtomicBool>,
+    /// Trust tier reported by [`InferenceProvider::tier`]; defaults to
+    /// `NonAttested`. Set via [`MockProvider::with_tier`] to exercise tiered
+    /// provider selection (e.g. a `Near` primary with an `Attested3p` fallback).
+    tier: crate::ProviderTier,
 }
 
 impl MockProvider {
@@ -644,6 +648,7 @@ impl MockProvider {
             })),
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tier: crate::ProviderTier::NonAttested,
         }
     }
 
@@ -663,6 +668,7 @@ impl MockProvider {
             })),
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tier: crate::ProviderTier::NonAttested,
         }
     }
 
@@ -680,7 +686,16 @@ impl MockProvider {
             })),
             last_chat_params: Arc::new(Mutex::new(None)),
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tier: crate::ProviderTier::NonAttested,
         }
+    }
+
+    /// Set the trust tier this mock reports from [`InferenceProvider::tier`].
+    /// Used to exercise tiered provider selection (NEAR-primary / Chutes-fallback
+    /// and the verifiable-never-falls-back-to-plaintext rule).
+    pub fn with_tier(mut self, tier: crate::ProviderTier) -> Self {
+        self.tier = tier;
+        self
     }
 
     /// Make get_attestation_report return an error (simulates blocked/broken backend).
@@ -862,6 +877,10 @@ impl Default for MockProvider {
 
 #[async_trait]
 impl crate::InferenceProvider for MockProvider {
+    fn tier(&self) -> crate::ProviderTier {
+        self.tier
+    }
+
     async fn models(&self) -> Result<ModelsResponse, ListModelsError> {
         Ok(ModelsResponse {
             object: "list".to_string(),

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -629,6 +629,10 @@ pub struct MockProvider {
     /// `true`. Set via [`MockProvider::with_streaming_support`] to exercise the
     /// streaming-capability filter (e.g. a Chutes-like fallback with streaming off).
     supports_streaming: bool,
+    /// Value reported by [`InferenceProvider::supports_client_e2ee`]; defaults to
+    /// `true`. Set via [`MockProvider::with_client_e2ee_support`] to exercise the
+    /// client-E2EE-capability filter (e.g. a Chutes-like fallback that rejects it).
+    supports_client_e2ee: bool,
 }
 
 impl MockProvider {
@@ -654,6 +658,7 @@ impl MockProvider {
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tier: crate::ProviderTier::NonAttested,
             supports_streaming: true,
+            supports_client_e2ee: true,
         }
     }
 
@@ -675,6 +680,7 @@ impl MockProvider {
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tier: crate::ProviderTier::NonAttested,
             supports_streaming: true,
+            supports_client_e2ee: true,
         }
     }
 
@@ -694,6 +700,7 @@ impl MockProvider {
             fail_attestation: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tier: crate::ProviderTier::NonAttested,
             supports_streaming: true,
+            supports_client_e2ee: true,
         }
     }
 
@@ -709,6 +716,13 @@ impl MockProvider {
     /// exercise the streaming-capability filter (a streaming-disabled fallback).
     pub fn with_streaming_support(mut self, supported: bool) -> Self {
         self.supports_streaming = supported;
+        self
+    }
+
+    /// Set whether this mock reports client-E2EE support (default `true`). Used to
+    /// exercise the client-E2EE-capability filter (a Chutes-like fallback).
+    pub fn with_client_e2ee_support(mut self, supported: bool) -> Self {
+        self.supports_client_e2ee = supported;
         self
     }
 
@@ -897,6 +911,10 @@ impl crate::InferenceProvider for MockProvider {
 
     fn supports_streaming(&self) -> bool {
         self.supports_streaming
+    }
+
+    fn supports_client_e2ee(&self) -> bool {
+        self.supports_client_e2ee
     }
 
     async fn models(&self) -> Result<ModelsResponse, ListModelsError> {

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1858,6 +1858,26 @@ impl InferenceProviderPool {
         }
     }
 
+    /// Mirror of [`Self::filter_streaming_capable`] for client-facing E2EE: when a
+    /// request carries `x_client_pub_key` (`needs_client_e2ee`) and ANY provider can
+    /// serve it, drop the ones that can't (e.g. Chutes, which rejects client-E2EE
+    /// non-retryably) — so a retryable NEAR failure doesn't fall through to that hard
+    /// rejection, which would mask the NEAR error and suppress its retry. If NONE can
+    /// (a Chutes-only model), the list is kept so the clear rejection still surfaces.
+    fn filter_client_e2ee_capable(
+        providers: Vec<Arc<InferenceProviderTrait>>,
+        needs_client_e2ee: bool,
+    ) -> Vec<Arc<InferenceProviderTrait>> {
+        if needs_client_e2ee && providers.iter().any(|p| p.supports_client_e2ee()) {
+            providers
+                .into_iter()
+                .filter(|p| p.supports_client_e2ee())
+                .collect()
+        } else {
+            providers
+        }
+    }
+
     /// Combine the discovered (e.g. NEAR) providers for the models in THIS cycle
     /// with the out-of-band pinned providers (e.g. Chutes), upholding the invariant
     /// that DB discovery can never DROP or overwrite a pinned (attested) provider:
@@ -1961,11 +1981,34 @@ impl InferenceProviderPool {
     /// Generic retry helper that tries each provider in order with automatic fallback.
     /// Returns both the result and the provider that succeeded (for chat_id mapping).
     /// If model_pub_key is provided, routes to the specific provider by signing public key.
+    /// Thin wrapper that requests no extra capability (see [`Self::retry_with_fallback_caps`]).
     async fn retry_with_fallback<T, F, Fut>(
         &self,
         model_id: &str,
         operation_name: &str,
         model_pub_key: Option<&str>,
+        provider_fn: F,
+    ) -> Result<(T, Arc<InferenceProviderTrait>), CompletionError>
+    where
+        F: Fn(Arc<InferenceProviderTrait>) -> Fut,
+        Fut: std::future::Future<Output = Result<T, CompletionError>>,
+    {
+        self.retry_with_fallback_caps(model_id, operation_name, model_pub_key, false, provider_fn)
+            .await
+    }
+
+    /// As [`Self::retry_with_fallback`], but filters the provider list to those that
+    /// can serve the request's capabilities before the fallback loop: streaming
+    /// (by `operation_name`) and — when `needs_client_e2ee` — client-facing E2EE. A
+    /// capability-incapable provider is dropped only when a capable sibling exists,
+    /// so it can't mask the primary's failure / suppress retry, while a model whose
+    /// only provider lacks the capability still surfaces that provider's clear error.
+    async fn retry_with_fallback_caps<T, F, Fut>(
+        &self,
+        model_id: &str,
+        operation_name: &str,
+        model_pub_key: Option<&str>,
+        needs_client_e2ee: bool,
         provider_fn: F,
     ) -> Result<(T, Arc<InferenceProviderTrait>), CompletionError>
     where
@@ -2028,6 +2071,7 @@ impl InferenceProviderPool {
         };
 
         let providers = Self::filter_streaming_capable(providers, operation_name);
+        let providers = Self::filter_client_e2ee_capable(providers, needs_client_e2ee);
 
         tracing::info!(
             model_id = %model_id,
@@ -2396,6 +2440,12 @@ impl InferenceProviderPool {
             .and_then(|v| v.as_str().map(|s| s.to_string()));
         let model_pub_key = model_pub_key_str.as_deref();
 
+        // Client-facing E2EE intent: keep such requests on a capable (NEAR) provider
+        // so a retryable NEAR failure doesn't fall through to Chutes' hard rejection.
+        let needs_client_e2ee = params
+            .extra
+            .contains_key(encryption_headers::CLIENT_PUB_KEY);
+
         let params_for_provider = params.clone();
 
         tracing::debug!(
@@ -2404,10 +2454,11 @@ impl InferenceProviderPool {
         );
 
         let (stream, provider) = self
-            .retry_with_fallback(
+            .retry_with_fallback_caps(
                 &model_id,
                 "chat_completion_stream",
                 model_pub_key,
+                needs_client_e2ee,
                 |provider| {
                     let params = params_for_provider.clone();
                     let request_hash = request_hash.clone();
@@ -2486,6 +2537,12 @@ impl InferenceProviderPool {
             .and_then(|v| v.as_str().map(|s| s.to_string()));
         let model_pub_key = model_pub_key_str.as_deref();
 
+        // Client-facing E2EE intent: keep such requests on a capable (NEAR) provider
+        // so a retryable NEAR failure doesn't fall through to Chutes' hard rejection.
+        let needs_client_e2ee = params
+            .extra
+            .contains_key(encryption_headers::CLIENT_PUB_KEY);
+
         tracing::debug!(
             model = %model_id,
             "Starting chat completion request"
@@ -2495,11 +2552,17 @@ impl InferenceProviderPool {
         let params_for_provider = params.clone();
 
         let (response, provider) = self
-            .retry_with_fallback(&model_id, "chat_completion", model_pub_key, |provider| {
-                let params = params_for_provider.clone();
-                let request_hash = request_hash.clone();
-                async move { provider.chat_completion(params, request_hash).await }
-            })
+            .retry_with_fallback_caps(
+                &model_id,
+                "chat_completion",
+                model_pub_key,
+                needs_client_e2ee,
+                |provider| {
+                    let params = params_for_provider.clone();
+                    let request_hash = request_hash.clone();
+                    async move { provider.chat_completion(params, request_hash).await }
+                },
+            )
             .await?;
 
         // Store the chat_id mapping SYNCHRONOUSLY before returning
@@ -3643,13 +3706,20 @@ impl InferenceProviderPool {
     /// Remove models from provider_mappings that are not in `valid_model_names`.
     /// Also cleans up load_balancer_index and provider_failure_counts for removed providers.
     async fn remove_stale_providers(&self, valid_model_names: &std::collections::HashSet<String>) {
-        // Pinned models (e.g. the config-registered Chutes provider) are not in
-        // the DB-backed `valid_model_names`; never treat them as stale.
-        let pinned = self
-            .pinned_models
+        // Skip ids that have an actual pinned PROVIDER (e.g. a registered Chutes
+        // fallback) — they're served out-of-band and aren't in the DB-backed
+        // `valid_model_names`. A *reserved-only* id (in `pinned_models` for the
+        // fail-closed external block, but with no provider because Chutes failed to
+        // build / the key was missing) is deliberately NOT skipped: if NEAR also
+        // drops it, it has no serving provider and must be removed (fail-closed 404)
+        // with full cleanup rather than lingering as a dead NEAR mapping.
+        let pinned: std::collections::HashSet<String> = self
+            .pinned_providers
             .read()
             .unwrap_or_else(|e| e.into_inner())
-            .clone();
+            .keys()
+            .cloned()
+            .collect();
         let mut mappings = self.provider_mappings.write().await;
 
         let stale_models: Vec<String> = mappings
@@ -5144,6 +5214,90 @@ mod tests {
     #[test]
     fn streaming_operations_list_is_explicit() {
         assert!(InferenceProviderPool::STREAMING_OPERATIONS.contains(&"chat_completion_stream"));
+    }
+
+    /// Client-E2EE capability filter (review round 3 blocking): when a request needs
+    /// client-facing E2EE and a capable (NEAR) provider exists, a non-capable Chutes
+    /// fallback is dropped — so a NEAR failure can't fall through to Chutes' hard
+    /// "client E2EE not supported" rejection. When the request doesn't need it, or no
+    /// provider supports it, the list is unchanged (clear error still surfaces).
+    #[test]
+    fn filter_client_e2ee_capable_prefers_capable_providers() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+
+        let near = Arc::new(MockProvider::new().with_tier(ProviderTier::Near))
+            as Arc<InferenceProviderTrait>;
+        let chutes_no_client_e2ee = Arc::new(
+            MockProvider::new()
+                .with_tier(ProviderTier::Attested3p)
+                .with_client_e2ee_support(false),
+        ) as Arc<InferenceProviderTrait>;
+
+        // needs client-E2EE, NEAR supports it + Chutes doesn't → Chutes dropped.
+        let out = InferenceProviderPool::filter_client_e2ee_capable(
+            vec![near.clone(), chutes_no_client_e2ee.clone()],
+            true,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].tier(), ProviderTier::Near);
+
+        // request doesn't need client-E2EE → no filtering.
+        let out = InferenceProviderPool::filter_client_e2ee_capable(
+            vec![near.clone(), chutes_no_client_e2ee.clone()],
+            false,
+        );
+        assert_eq!(out.len(), 2);
+
+        // needs it, but the ONLY provider can't → kept (clear rejection surfaces).
+        let out = InferenceProviderPool::filter_client_e2ee_capable(
+            vec![chutes_no_client_e2ee.clone()],
+            true,
+        );
+        assert_eq!(out.len(), 1);
+    }
+
+    /// Reserved-only cleanup (review round 3 important): a fail-closed RESERVATION
+    /// (in `pinned_models` but with no actual pinned provider — Chutes failed to
+    /// build) must NOT be exempt from stale removal. If NEAR also drops it, it's
+    /// removed entirely (fail-closed 404). A real pinned provider still survives.
+    #[tokio::test]
+    async fn reserved_only_pinned_id_is_removed_when_stale_but_real_pinned_survives() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+        use std::collections::HashSet;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+
+        // Reserved-only: reserved (fail-closed) + a NEAR provider, but Chutes never
+        // built, so it is NOT in pinned_providers.
+        let reserved_only = "reserved/only".to_string();
+        pool.reserve_pinned_models(std::slice::from_ref(&reserved_only));
+        pool.register_provider(
+            reserved_only.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Near)),
+        )
+        .await;
+
+        // Real pinned: has an actual Chutes provider.
+        let real_pinned = "real/pinned".to_string();
+        pool.register_pinned_secondary_provider(
+            real_pinned.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Attested3p)),
+        )
+        .await;
+
+        // A refresh where NEAR serves neither (empty valid set).
+        pool.remove_stale_providers(&HashSet::new()).await;
+
+        assert!(
+            !pool.has_provider(&reserved_only).await,
+            "reserved-only id (no pinned provider) must be removed when stale — fail-closed"
+        );
+        assert!(
+            pool.has_provider(&real_pinned).await,
+            "a real pinned (Chutes) provider must survive stale removal"
+        );
     }
 
     /// Fail-closed reservation (review #1): a configured Chutes canonical id is

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -638,38 +638,6 @@ impl InferenceProviderPool {
         }
     }
 
-    /// Register a provider that is **not** sourced from DB discovery (e.g. the
-    /// config-pinned Chutes provider) and mark its model **pinned** so the
-    /// periodic refresh — whose `valid_model_names` comes only from the DB
-    /// sources — does not remove it.
-    ///
-    /// Unlike [`Self::register_provider`], this does **not** run signing-key
-    /// attestation discovery: it would be a wasted discover→evidence→DCAP→NRAS
-    /// round trip for a provider (like Chutes) that has no signing-address
-    /// pubkey, and would add network/latency at startup. Such a provider verifies
-    /// its backend per request instead, so no `pubkey_to_providers` entry is needed.
-    pub async fn register_pinned_provider(
-        &self,
-        model_id: String,
-        provider: Arc<InferenceProviderTrait>,
-    ) {
-        self.pinned_models
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(model_id.clone());
-        // Record in pinned_providers too so the discovery-refresh merge re-attaches
-        // it: a same-name DB inference_url row can never overwrite this pinned
-        // provider (the security invariant the old skip-if-pinned guard enforced).
-        // Sole-provider semantics: this is THE provider for the id, so replace any
-        // prior pinned entry.
-        self.pinned_providers
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(model_id.clone(), vec![provider.clone()]);
-        let mut mappings = self.provider_mappings.write().await;
-        mappings.model_to_providers.insert(model_id, vec![provider]);
-    }
-
     /// Reserve `model_ids` as pinned (verifiable) **before** any external/discovery
     /// load, WITHOUT attaching a provider. Fail-closed guard for configured Chutes
     /// canonical ids: marking them pinned makes [`Self::load_external_providers`]
@@ -688,25 +656,26 @@ impl InferenceProviderPool {
         }
     }
 
-    /// Register a pinned (out-of-band) provider as a **secondary** under a model
-    /// name that may also be served by DB-discovered (e.g. NEAR) providers —
-    /// **pushing** onto the existing list rather than replacing it (unlike
-    /// [`Self::register_pinned_provider`], which is the sole provider for its name).
+    /// Register a pinned (out-of-band, e.g. config-Chutes) provider as a **secondary**
+    /// under a model name that may also be served by DB-discovered (e.g. NEAR)
+    /// providers — **pushing** onto the existing list rather than replacing it (a
+    /// Chutes-only id ends up with just this provider, so it serves as primary). This
+    /// is the sole pinned-registration path used in production.
     ///
     /// Used for the Chutes fallback tier: a NEAR-served canonical id keeps its own
-    /// attested fleet as primary and gains Chutes as fallback; a Chutes-only id has
-    /// just this provider, so it serves as primary. The provider is recorded in
-    /// [`Self::pinned_providers`] so each discovery refresh re-attaches it after
-    /// rebuilding the NEAR backends (never dropped), and its name is added to
-    /// [`Self::pinned_models`] so the discovery guards never overwrite/evict it.
-    /// Tier ordering (NEAR before Attested3p) is applied at selection time, so the
-    /// push order here does not matter.
+    /// attested fleet as primary and gains Chutes as fallback. The provider is
+    /// recorded in [`Self::pinned_providers`] so each discovery refresh re-attaches it
+    /// after rebuilding the NEAR backends (never dropped/overwritten), and its name is
+    /// added to [`Self::pinned_models`] so the discovery guards never evict it. Tier
+    /// ordering (NEAR before Attested3p) is applied at selection time, so the push
+    /// order here does not matter.
     ///
-    /// Like [`Self::register_pinned_provider`], this does NOT populate
-    /// `pubkey_to_providers` (no signing-key discovery). So a pubkey-routed (E2EE)
-    /// request — which selects via `model_pub_key` — gets NO Chutes fallback by
-    /// design: Chutes has no per-response signing key, its integrity is the ML-KEM
-    /// AEAD channel itself. Chutes fallback applies to the non-pubkey selection path.
+    /// Unlike [`Self::register_provider`], this does NOT run signing-key attestation
+    /// discovery (a wasted round trip for Chutes, which has no signing-address pubkey
+    /// and verifies its backend per request) and so does NOT populate
+    /// `pubkey_to_providers`. A pubkey-routed (E2EE) request — selected via
+    /// `model_pub_key` — therefore gets NO Chutes fallback by design: Chutes has no
+    /// per-response signing key, its integrity is the ML-KEM AEAD channel itself.
     pub async fn register_pinned_secondary_provider(
         &self,
         model_id: String,
@@ -786,7 +755,7 @@ impl InferenceProviderPool {
                 .clone();
             let mut mappings = self.provider_mappings.write().await;
             for (model_id, providers) in model_providers {
-                // Don't clobber a pinned (attested) provider (see register_pinned_provider).
+                // Don't clobber a pinned (attested) provider (see register_pinned_secondary_provider).
                 if pinned.contains(&model_id) {
                     warn!(model = %model_id, "Skipping register_providers for a pinned model");
                     continue;
@@ -1943,25 +1912,34 @@ impl InferenceProviderPool {
                 }
                 let pinned_ptrs: std::collections::HashSet<usize> =
                     pinned.iter().map(&ptr).collect();
-                if let Some(old) = mappings.model_to_providers.get(name) {
-                    for p in old {
-                        if !pinned_ptrs.contains(&ptr(p)) {
-                            dropped.insert(ptr(p));
-                        }
-                    }
-                }
-                // Only rewrite when something actually changes (avoid churn for
-                // already-pinned-only ids like Chutes-only models).
-                let needs_rewrite = mappings
+                let cur_ptrs: std::collections::HashSet<usize> = mappings
                     .model_to_providers
                     .get(name)
-                    .map(|cur| cur.len() != pinned.len())
-                    .unwrap_or(true);
-                if needs_rewrite {
+                    .map(|cur| cur.iter().map(&ptr).collect())
+                    .unwrap_or_default();
+                for &p in cur_ptrs.difference(&pinned_ptrs) {
+                    dropped.insert(p);
+                }
+                // Rewrite only when the current list isn't already exactly the pinned
+                // set (compare pointer SETS, not lengths — a future partial overwrite
+                // could match on length but differ in membership).
+                if cur_ptrs != pinned_ptrs {
                     mappings
                         .model_to_providers
                         .insert(name.clone(), pinned.clone());
                 }
+            }
+            // Shared-Arc guard: providers are cached per-URL, so two model names can
+            // share one Arc. Don't prune a dropped pointer's pubkey/counter entries
+            // if that exact Arc still backs another (still-served) model — that would
+            // transiently break the sibling's pubkey-routed selection.
+            if !dropped.is_empty() {
+                let still_referenced: std::collections::HashSet<usize> = mappings
+                    .model_to_providers
+                    .values()
+                    .flat_map(|ps| ps.iter().map(&ptr))
+                    .collect();
+                dropped.retain(|p| !still_referenced.contains(p));
             }
             if !dropped.is_empty() {
                 mappings.pubkey_to_providers.retain(|_, ps| {
@@ -4861,8 +4839,11 @@ mod tests {
         // A DB-discovered provider + a config-pinned (e.g. Chutes) provider.
         pool.register_provider("db-model".to_string(), Arc::new(MockProvider::new()))
             .await;
-        pool.register_pinned_provider("chutes-model".to_string(), Arc::new(MockProvider::new()))
-            .await;
+        pool.register_pinned_secondary_provider(
+            "chutes-model".to_string(),
+            Arc::new(MockProvider::new()),
+        )
+        .await;
 
         // A refresh tick's `valid_model_names` comes only from the DB sources, so
         // it knows "db-model" but not the config-pinned "chutes-model".
@@ -4893,7 +4874,7 @@ mod tests {
         let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
 
         let pinned: Arc<InferenceProviderTrait> = Arc::new(MockProvider::new());
-        pool.register_pinned_provider("chutes-model".to_string(), pinned.clone())
+        pool.register_pinned_secondary_provider("chutes-model".to_string(), pinned.clone())
             .await;
 
         // A DB-discovered external model with the SAME id must NOT replace the
@@ -4925,8 +4906,11 @@ mod tests {
         use inference_providers::mock::MockProvider;
         let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
 
-        pool.register_pinned_provider("chutes-model".to_string(), Arc::new(MockProvider::new()))
-            .await;
+        pool.register_pinned_secondary_provider(
+            "chutes-model".to_string(),
+            Arc::new(MockProvider::new()),
+        )
+        .await;
         pool.register_provider("db-model".to_string(), Arc::new(MockProvider::new()))
             .await;
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1835,11 +1835,20 @@ impl InferenceProviderPool {
     /// So when the operation streams and ANY provider can stream, drop the ones that
     /// can't. If NONE can stream (e.g. a Chutes-only model with streaming off), keep
     /// the list as-is so the provider's own clear error still surfaces.
+    /// Operation names (as passed to [`Self::retry_with_fallback`]) that produce a
+    /// streamed response and therefore need a streaming-capable provider. Kept as an
+    /// EXPLICIT list rather than a `_stream` name-suffix convention so a new
+    /// streaming op must be added here deliberately (a silently-misnamed op no longer
+    /// skips the filter); `streaming_operations_list_is_explicit` locks it in.
+    const STREAMING_OPERATIONS: &'static [&'static str] = &["chat_completion_stream"];
+
     fn filter_streaming_capable(
         providers: Vec<Arc<InferenceProviderTrait>>,
         operation_name: &str,
     ) -> Vec<Arc<InferenceProviderTrait>> {
-        if operation_name.ends_with("_stream") && providers.iter().any(|p| p.supports_streaming()) {
+        if Self::STREAMING_OPERATIONS.contains(&operation_name)
+            && providers.iter().any(|p| p.supports_streaming())
+        {
             providers
                 .into_iter()
                 .filter(|p| p.supports_streaming())
@@ -1849,29 +1858,24 @@ impl InferenceProviderPool {
         }
     }
 
-    /// Combine a discovery cycle's per-model provider lists with the out-of-band
-    /// pinned providers, upholding the invariant that DB discovery can never DROP
-    /// or overwrite a pinned (attested, e.g. Chutes) provider:
-    ///   - each discovered model keeps its providers PLUS any pinned providers for
-    ///     it, re-appended and deduped by Arc pointer (`[fresh NEAR..] + [Chutes]`);
-    ///   - each pinned model ABSENT from this discovery cycle is rebuilt from its
-    ///     pinned providers alone, dropping a now-stale discovered backend (NEAR
-    ///     stopped serving it) so the attested fallback serves immediately rather
-    ///     than after ~10 failure-demotions. A Chutes-only id is absent every cycle,
-    ///     so this just re-asserts its pinned-only list.
+    /// Combine the discovered (e.g. NEAR) providers for the models in THIS cycle
+    /// with the out-of-band pinned providers (e.g. Chutes), upholding the invariant
+    /// that DB discovery can never DROP or overwrite a pinned (attested) provider:
+    /// each discovered model keeps its providers PLUS any pinned providers for it,
+    /// re-appended and deduped by Arc pointer (`[fresh NEAR..] + [Chutes]`).
     ///
-    /// Pure (no I/O / no locks) so the riskiest refresh logic is unit-testable.
-    /// Callers must only invoke this with a COMPLETE discovery set (the pool does:
-    /// `load_inference_url_models` early-returns on an empty list and
-    /// `fetch_inference_url_models` is an all-or-error DB SELECT), so an absent
-    /// pinned id genuinely is no longer discovery-served.
+    /// This is **re-append only** and touches ONLY the models present in
+    /// `discovered`, so it is safe for a PARTIAL batch (e.g. the admin
+    /// `PATCH /v1/admin/models` runtime registration): models not in the batch are
+    /// untouched. The stale-prune of pinned ids that have *left* discovery lives in
+    /// [`Self::prune_stale_pinned`], which is complete-set-only.
+    ///
+    /// Pure (no I/O / no locks) so the merge logic is unit-testable.
     fn merge_discovered_and_pinned(
         discovered: HashMap<String, Vec<Arc<InferenceProviderTrait>>>,
         pinned: &HashMap<String, Vec<Arc<InferenceProviderTrait>>>,
     ) -> Vec<(String, Vec<Arc<InferenceProviderTrait>>)> {
         let ptr = |p: &Arc<InferenceProviderTrait>| Arc::as_ptr(p) as *const () as usize;
-        let discovered_names: std::collections::HashSet<String> =
-            discovered.keys().cloned().collect();
         let mut out: Vec<(String, Vec<Arc<InferenceProviderTrait>>)> = Vec::new();
         for (name, mut providers) in discovered {
             if let Some(extra) = pinned.get(&name) {
@@ -1885,12 +1889,73 @@ impl InferenceProviderPool {
             }
             out.push((name, providers));
         }
-        for (name, pin) in pinned {
-            if !discovered_names.contains(name) {
-                out.push((name.clone(), pin.clone()));
+        out
+    }
+
+    /// Complete-set-only counterpart to [`Self::merge_discovered_and_pinned`]: given
+    /// the COMPLETE set of model names served by this discovery cycle, rebuild any
+    /// pinned id ABSENT from it as pinned-only — dropping a now-stale discovered
+    /// (e.g. NEAR) backend that has left discovery, so the attested fallback serves
+    /// immediately instead of being tried tier-first until ~10 failure-demotions.
+    /// Dropped provider Arcs are pruned from `pubkey_to_providers` and the failure
+    /// counters so they don't linger as orphaned / `NoPubKeyProvider`-routable entries.
+    ///
+    /// MUST be called ONLY on the complete-discovery path (the periodic refresh via
+    /// [`Self::sync_inference_url_models`]), NEVER on a partial batch like the admin
+    /// `PATCH /v1/admin/models` runtime registration — otherwise it would reset
+    /// models merely absent from the batch to pinned-only.
+    async fn prune_stale_pinned(&self, complete_names: &std::collections::HashSet<String>) {
+        let pinned_providers = self
+            .pinned_providers
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        if pinned_providers.is_empty() {
+            return;
+        }
+        let ptr = |p: &Arc<InferenceProviderTrait>| Arc::as_ptr(p) as *const () as usize;
+        let mut dropped: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        {
+            let mut mappings = self.provider_mappings.write().await;
+            for (name, pinned) in &pinned_providers {
+                if complete_names.contains(name) {
+                    continue; // still discovery-served; the merge handled it this cycle
+                }
+                let pinned_ptrs: std::collections::HashSet<usize> =
+                    pinned.iter().map(&ptr).collect();
+                if let Some(old) = mappings.model_to_providers.get(name) {
+                    for p in old {
+                        if !pinned_ptrs.contains(&ptr(p)) {
+                            dropped.insert(ptr(p));
+                        }
+                    }
+                }
+                // Only rewrite when something actually changes (avoid churn for
+                // already-pinned-only ids like Chutes-only models).
+                let needs_rewrite = mappings
+                    .model_to_providers
+                    .get(name)
+                    .map(|cur| cur.len() != pinned.len())
+                    .unwrap_or(true);
+                if needs_rewrite {
+                    mappings
+                        .model_to_providers
+                        .insert(name.clone(), pinned.clone());
+                }
+            }
+            if !dropped.is_empty() {
+                mappings.pubkey_to_providers.retain(|_, ps| {
+                    ps.retain(|p| !dropped.contains(&ptr(p)));
+                    !ps.is_empty()
+                });
             }
         }
-        out
+        if !dropped.is_empty() {
+            self.provider_failure_counts
+                .write()
+                .unwrap_or_else(|e| e.into_inner())
+                .retain(|k, _| !dropped.contains(k));
+        }
     }
 
     /// Generic retry helper that tries each provider in order with automatic fallback.
@@ -3561,7 +3626,18 @@ impl InferenceProviderPool {
     /// Refresh inference_url models from the database.
     /// Existing entries in provider_mappings are overwritten with new providers.
     async fn sync_inference_url_models(&self, models: Vec<(String, String)>) {
+        // Complete-set discovery path (periodic refresh): re-append pinned providers
+        // for the discovered models (inside load_inference_url_models's merge), then
+        // prune any pinned id that has LEFT discovery to pinned-only. The complete
+        // name set is captured here so it works even when `models` is empty (the
+        // last NEAR backend disappeared and every pinned id must drop its stale NEAR)
+        // — load_inference_url_models early-returns on empty, so the prune is what
+        // rebuilds those. Only the refresh calls this; the admin PATCH path calls
+        // load_inference_url_models directly (partial batch, no prune).
+        let complete_names: std::collections::HashSet<String> =
+            models.iter().map(|(name, _)| name.clone()).collect();
         self.load_inference_url_models(models).await;
+        self.prune_stale_pinned(&complete_names).await;
     }
 
     /// Remove models from provider_mappings that are not in `valid_model_names`.
@@ -4974,11 +5050,13 @@ mod tests {
         assert_eq!(out.len(), 1);
     }
 
-    /// Refresh merge (review #3 + the highest-risk path): discovery can never DROP
-    /// or overwrite a pinned provider, and a pinned id that falls out of discovery
-    /// is rebuilt pinned-only (stale NEAR dropped).
+    /// The shared merge is re-append-only and PARTIAL-BATCH SAFE (review round 2,
+    /// Pierre's blocking): it re-attaches pinned providers for the DISCOVERED models
+    /// and never emits/rebuilds a pinned id absent from this batch — so an admin
+    /// `PATCH /v1/admin/models` carrying a partial inference_url batch can't reset
+    /// unrelated NEAR+Chutes models to Chutes-only.
     #[test]
-    fn merge_discovered_and_pinned_never_drops_pinned_and_prunes_stale() {
+    fn merge_discovered_and_pinned_reappends_and_leaves_absent_pinned_untouched() {
         use inference_providers::mock::MockProvider;
         use inference_providers::ProviderTier;
         use std::collections::HashMap;
@@ -4990,10 +5068,9 @@ mod tests {
 
         let mut pinned: HashMap<String, Vec<Arc<InferenceProviderTrait>>> = HashMap::new();
         pinned.insert("near+chutes".to_string(), vec![chutes.clone()]);
-        pinned.insert("chutes-only".to_string(), vec![chutes.clone()]);
+        pinned.insert("other-pinned".to_string(), vec![chutes.clone()]);
 
-        // This discovery cycle finds NEAR for "near+chutes" only; "chutes-only" and
-        // the previously-NEAR-served "dropped" id are absent.
+        // A PARTIAL batch: only "near+chutes" is discovered this call.
         let mut discovered: HashMap<String, Vec<Arc<InferenceProviderTrait>>> = HashMap::new();
         discovered.insert("near+chutes".to_string(), vec![near.clone()]);
 
@@ -5003,16 +5080,70 @@ mod tests {
                 .map(|(k, v)| (k, v.iter().map(|p| p.tier()).collect()))
                 .collect();
 
-        // NEAR-served pinned id: NEAR refreshed + Chutes re-attached (never dropped).
+        // Discovered model: NEAR refreshed + Chutes re-attached (never dropped).
         assert_eq!(
             merged.get("near+chutes"),
             Some(&vec![ProviderTier::Near, ProviderTier::Attested3p])
         );
-        // Chutes-only id absent from discovery: rebuilt pinned-only.
-        assert_eq!(
-            merged.get("chutes-only"),
-            Some(&vec![ProviderTier::Attested3p])
-        );
+        // A pinned model NOT in this batch must NOT be emitted (left untouched) —
+        // the partial-batch safety the admin PATCH path depends on.
+        assert!(!merged.contains_key("other-pinned"));
+        assert_eq!(merged.len(), 1);
+    }
+
+    /// Complete-set stale-prune (review round 2): on the refresh path, a pinned id
+    /// absent from the COMPLETE discovery set is rebuilt pinned-only (dropping a
+    /// stale NEAR backend), while one still present is left coexisting.
+    #[tokio::test]
+    async fn prune_stale_pinned_rebuilds_absent_pinned_only() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+        use std::collections::HashSet;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model = "zai-org/GLM-5.1-FP8".to_string();
+        pool.register_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Near)),
+        )
+        .await;
+        pool.register_pinned_secondary_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Attested3p)),
+        )
+        .await;
+
+        // Still discovery-served → coexistence preserved.
+        let mut complete = HashSet::new();
+        complete.insert(model.clone());
+        pool.prune_stale_pinned(&complete).await;
+        let tiers: Vec<ProviderTier> = pool
+            .get_providers_with_fallback(&model, None)
+            .await
+            .expect("providers")
+            .iter()
+            .map(|p| p.tier())
+            .collect();
+        assert_eq!(tiers, vec![ProviderTier::Near, ProviderTier::Attested3p]);
+
+        // NEAR dropped it (absent from the complete set) → rebuilt pinned-only.
+        pool.prune_stale_pinned(&HashSet::new()).await;
+        let tiers: Vec<ProviderTier> = pool
+            .get_providers_with_fallback(&model, None)
+            .await
+            .expect("providers")
+            .iter()
+            .map(|p| p.tier())
+            .collect();
+        assert_eq!(tiers, vec![ProviderTier::Attested3p]);
+    }
+
+    /// The streaming-operations list is explicit (review round 2 minor): the known
+    /// streaming op routed through `retry_with_fallback` must be registered, so a
+    /// rename/new op can't silently bypass the streaming-capability filter.
+    #[test]
+    fn streaming_operations_list_is_explicit() {
+        assert!(InferenceProviderPool::STREAMING_OPERATIONS.contains(&"chat_completion_stream"));
     }
 
     /// Fail-closed reservation (review #1): a configured Chutes canonical id is

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -232,6 +232,14 @@ pub struct InferenceProviderPool {
     /// `remove_stale_providers` so a refresh tick — whose `valid_model_names` is
     /// built solely from the DB sources — does not wipe them.
     pinned_models: Arc<std::sync::RwLock<std::collections::HashSet<String>>>,
+    /// Out-of-band (config-pinned) providers keyed by model name — the source of
+    /// truth for the pinned (attested third-party, e.g. Chutes) tier. On every
+    /// discovery refresh the rebuilt provider list for a model becomes
+    /// `[fresh discovered..] + [these]`, so a NEAR-served model refreshes its own
+    /// backends while the attested Chutes fallback is never dropped or overwritten.
+    /// Distinct from [`Self::pinned_models`] (just the name set the no-overwrite /
+    /// no-evict / no-stale-remove guards consult).
+    pinned_providers: Arc<std::sync::RwLock<HashMap<String, Vec<Arc<InferenceProviderTrait>>>>>,
 }
 
 /// Backend verifier that creates verified reqwest clients by connecting to a backend,
@@ -501,6 +509,7 @@ impl InferenceProviderPool {
             tls_roots: SharedTlsRoots::load(),
             attestation_verifier: Arc::new(AttestationVerifier::near_with_pccs(pccs_url)),
             pinned_models: Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
+            pinned_providers: Arc::new(std::sync::RwLock::new(HashMap::new())),
         }
     }
 
@@ -568,6 +577,12 @@ impl InferenceProviderPool {
         // If it was pinned, also clear the pin — otherwise DB discovery could
         // never re-register a model with this name (the insert guards skip pinned).
         self.pinned_models
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(model_name);
+        // Drop any out-of-band (secondary) pinned providers too, so a later
+        // discovery refresh doesn't re-attach a now-unregistered Chutes fallback.
+        self.pinned_providers
             .write()
             .unwrap_or_else(|e| e.into_inner())
             .remove(model_name);
@@ -644,6 +659,46 @@ impl InferenceProviderPool {
             .insert(model_id.clone());
         let mut mappings = self.provider_mappings.write().await;
         mappings.model_to_providers.insert(model_id, vec![provider]);
+    }
+
+    /// Register a pinned (out-of-band) provider as a **secondary** under a model
+    /// name that may also be served by DB-discovered (e.g. NEAR) providers —
+    /// **pushing** onto the existing list rather than replacing it (unlike
+    /// [`Self::register_pinned_provider`], which is the sole provider for its name).
+    ///
+    /// Used for the Chutes fallback tier: a NEAR-served canonical id keeps its own
+    /// attested fleet as primary and gains Chutes as fallback; a Chutes-only id has
+    /// just this provider, so it serves as primary. The provider is recorded in
+    /// [`Self::pinned_providers`] so each discovery refresh re-attaches it after
+    /// rebuilding the NEAR backends (never dropped), and its name is added to
+    /// [`Self::pinned_models`] so the discovery guards never overwrite/evict it.
+    /// Tier ordering (NEAR before Attested3p) is applied at selection time, so the
+    /// push order here does not matter.
+    pub async fn register_pinned_secondary_provider(
+        &self,
+        model_id: String,
+        provider: Arc<InferenceProviderTrait>,
+    ) {
+        self.pinned_models
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(model_id.clone());
+        self.pinned_providers
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(model_id.clone())
+            .or_default()
+            .push(provider.clone());
+        let mut mappings = self.provider_mappings.write().await;
+        let entry = mappings.model_to_providers.entry(model_id).or_default();
+        // Avoid a duplicate if this exact Arc is somehow already present.
+        let ptr = Arc::as_ptr(&provider) as *const () as usize;
+        if !entry
+            .iter()
+            .any(|p| Arc::as_ptr(p) as *const () as usize == ptr)
+        {
+            entry.push(provider);
+        }
     }
 
     /// Whether `model_name` is currently registered as a **pinned** (out-of-band)
@@ -1360,6 +1415,24 @@ impl InferenceProviderPool {
             model_providers
         };
 
+        // Trust-tier safety: a model that can be served by an attested provider
+        // (NEAR's own fleet `Near`, or an attested third party like Chutes
+        // `Attested3p`) is a *verifiable* model and must NEVER fall back to a
+        // non-attested (plaintext) provider — that would silently break the
+        // verifiable promise. So whenever any attested provider is present, drop
+        // every `NonAttested` one: a verifiable request then fails closed (only
+        // attested providers are ever tried) instead of downgrading to plaintext
+        // when the attested backends are unhealthy. Pure non-attested models (no
+        // attested provider at all, e.g. OpenAI/Anthropic) are unaffected.
+        let providers = if providers.iter().any(|p| p.tier().is_attested()) {
+            providers
+                .into_iter()
+                .filter(|p| p.tier().is_attested())
+                .collect::<Vec<_>>()
+        } else {
+            providers
+        };
+
         if providers.is_empty() {
             return None;
         }
@@ -1410,9 +1483,26 @@ impl InferenceProviderPool {
             });
         drop(counts);
 
-        // Healthy providers first (in round-robin order), then demoted as last resort.
-        // This way, if 1 of 2 providers is down, requests immediately go to the healthy
-        // one instead of waiting 5s for the dead one's connect timeout.
+        // Within each health group, order by trust tier so a NEAR-served model
+        // prefers its own attested fleet and only falls back to an attested third
+        // party (Chutes) when the NEAR backends can't fulfill the request. Stable
+        // sort preserves the round-robin order within a tier. A Chutes-only model
+        // has a single provider and never reaches here (early return above).
+        //   Near (0) < Attested3p (1) < NonAttested (2)
+        fn tier_rank(p: &Arc<InferenceProviderTrait>) -> u8 {
+            match p.tier() {
+                inference_providers::ProviderTier::Near => 0,
+                inference_providers::ProviderTier::Attested3p => 1,
+                inference_providers::ProviderTier::NonAttested => 2,
+            }
+        }
+        healthy.sort_by_key(tier_rank);
+        demoted.sort_by_key(tier_rank);
+
+        // Healthy providers first (tier-ordered, round-robin within a tier), then
+        // demoted as last resort. This way, if 1 of 2 providers is down, requests
+        // immediately go to the healthy one instead of waiting 5s for the dead
+        // one's connect timeout.
         healthy.append(&mut demoted);
         let ordered_providers = healthy;
 
@@ -3287,22 +3377,31 @@ impl InferenceProviderPool {
                 }
             }
 
-            // Never let DB discovery overwrite a pinned (out-of-band, attested)
-            // provider — that would silently substitute the per-request-verified
-            // E2EE provider with an unverified one, the exact attack the pinning
-            // is meant to prevent.
-            let pinned = self
-                .pinned_models
+            // Never let DB discovery DROP a pinned (out-of-band, attested) provider
+            // — silently substituting the per-request-verified E2EE provider with an
+            // unverified one is the exact attack the pinning prevents. But a pinned
+            // name CAN also be NEAR-served (Chutes as fallback under a canonical id),
+            // so instead of skipping the whole model we rebuild its list as
+            // [fresh discovered NEAR..] + [re-attached pinned providers]. The pinned
+            // providers come from `pinned_providers` (the source of truth), so they
+            // survive every refresh; discovery never produces a Chutes provider, so
+            // it can only ADD/REFRESH the NEAR side, never overwrite the pinned one.
+            let pinned_providers = self
+                .pinned_providers
                 .read()
                 .unwrap_or_else(|e| e.into_inner())
                 .clone();
-            for (model_name, providers) in model_providers {
-                if pinned.contains(&model_name) {
-                    warn!(
-                        model = %model_name,
-                        "DB discovery attempted to overwrite a pinned (attested) provider; ignoring"
-                    );
-                    continue;
+            for (model_name, mut providers) in model_providers {
+                if let Some(extra) = pinned_providers.get(&model_name) {
+                    let present: std::collections::HashSet<usize> = providers
+                        .iter()
+                        .map(|p| Arc::as_ptr(p) as *const () as usize)
+                        .collect();
+                    for p in extra {
+                        if !present.contains(&(Arc::as_ptr(p) as *const () as usize)) {
+                            providers.push(p.clone());
+                        }
+                    }
                 }
                 mappings.model_to_providers.insert(model_name, providers);
             }
@@ -4621,6 +4720,130 @@ mod tests {
         assert!(
             !pool.has_provider("db-model").await,
             "a non-pinned provider is still unregistered on a provider_type change"
+        );
+    }
+
+    /// A NEAR-served (verifiable) model orders its own attested fleet first, an
+    /// attested third party (Chutes) as fallback, and NEVER includes a
+    /// non-attested (plaintext) provider — even when one is registered under the
+    /// same canonical id (e.g. a stray OpenRouter/external row).
+    #[tokio::test]
+    async fn verifiable_model_prefers_near_then_chutes_and_never_plaintext() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model = "zai-org/GLM-5.1-FP8".to_string();
+
+        // Insert in deliberately-wrong order to prove tier sorting + the filter.
+        pool.register_pinned_secondary_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::NonAttested)),
+        )
+        .await;
+        pool.register_pinned_secondary_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Attested3p)),
+        )
+        .await;
+        pool.register_pinned_secondary_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Near)),
+        )
+        .await;
+
+        let providers = pool
+            .get_providers_with_fallback(&model, None)
+            .await
+            .expect("model has providers");
+        let tiers: Vec<ProviderTier> = providers.iter().map(|p| p.tier()).collect();
+        assert_eq!(
+            tiers,
+            vec![ProviderTier::Near, ProviderTier::Attested3p],
+            "verifiable model: NEAR primary, Chutes fallback, NON-attested dropped entirely"
+        );
+    }
+
+    /// A Chutes-only model (NEAR does not serve it) has the single attested
+    /// provider as primary.
+    #[tokio::test]
+    async fn chutes_only_model_serves_as_single_attested_primary() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model = "moonshotai/kimi-k2.6".to_string();
+        pool.register_pinned_secondary_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Attested3p)),
+        )
+        .await;
+
+        let providers = pool
+            .get_providers_with_fallback(&model, None)
+            .await
+            .expect("model has providers");
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].tier(), ProviderTier::Attested3p);
+    }
+
+    /// A model with NO attested provider (a plain external model) is unaffected by
+    /// the verifiable filter and is still served by its non-attested provider.
+    #[tokio::test]
+    async fn non_verifiable_model_is_served_by_its_non_attested_provider() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model = "openai/gpt-4o".to_string();
+        pool.register_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::NonAttested)),
+        )
+        .await;
+
+        let providers = pool
+            .get_providers_with_fallback(&model, None)
+            .await
+            .expect("model has providers");
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].tier(), ProviderTier::NonAttested);
+    }
+
+    /// `register_pinned_secondary_provider` PUSHES (coexists) rather than
+    /// overwriting: a DB-discovered NEAR provider and the pinned Chutes fallback
+    /// live under one canonical id, NEAR ordered first.
+    #[tokio::test]
+    async fn pinned_secondary_chutes_coexists_with_db_near_provider() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model = "zai-org/GLM-5.1-FP8".to_string();
+
+        // NEAR registered via the DB-discovery path (overwrite semantics)...
+        pool.register_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Near)),
+        )
+        .await;
+        // ...then Chutes pinned as a secondary (push, not overwrite).
+        pool.register_pinned_secondary_provider(
+            model.clone(),
+            Arc::new(MockProvider::new().with_tier(ProviderTier::Attested3p)),
+        )
+        .await;
+
+        assert!(pool.is_pinned(&model));
+        let providers = pool
+            .get_providers_with_fallback(&model, None)
+            .await
+            .expect("model has providers");
+        let tiers: Vec<ProviderTier> = providers.iter().map(|p| p.tier()).collect();
+        assert_eq!(
+            tiers,
+            vec![ProviderTier::Near, ProviderTier::Attested3p],
+            "DB NEAR provider and pinned Chutes secondary must coexist, NEAR first"
         );
     }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -657,8 +657,35 @@ impl InferenceProviderPool {
             .write()
             .unwrap_or_else(|e| e.into_inner())
             .insert(model_id.clone());
+        // Record in pinned_providers too so the discovery-refresh merge re-attaches
+        // it: a same-name DB inference_url row can never overwrite this pinned
+        // provider (the security invariant the old skip-if-pinned guard enforced).
+        // Sole-provider semantics: this is THE provider for the id, so replace any
+        // prior pinned entry.
+        self.pinned_providers
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(model_id.clone(), vec![provider.clone()]);
         let mut mappings = self.provider_mappings.write().await;
         mappings.model_to_providers.insert(model_id, vec![provider]);
+    }
+
+    /// Reserve `model_ids` as pinned (verifiable) **before** any external/discovery
+    /// load, WITHOUT attaching a provider. Fail-closed guard for configured Chutes
+    /// canonical ids: marking them pinned makes [`Self::load_external_providers`]
+    /// (and every periodic refresh) skip them, so a plaintext external/OpenRouter
+    /// row sharing a canonical id can never register — even if the Chutes provider
+    /// later fails to build (missing key / construction error). A reserved id with
+    /// no attested provider then fails closed (404); it never silently serves
+    /// plaintext for a model an operator configured as verifiable.
+    pub fn reserve_pinned_models(&self, model_ids: &[String]) {
+        let mut pinned = self
+            .pinned_models
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        for id in model_ids {
+            pinned.insert(id.clone());
+        }
     }
 
     /// Register a pinned (out-of-band) provider as a **secondary** under a model
@@ -674,25 +701,41 @@ impl InferenceProviderPool {
     /// [`Self::pinned_models`] so the discovery guards never overwrite/evict it.
     /// Tier ordering (NEAR before Attested3p) is applied at selection time, so the
     /// push order here does not matter.
+    ///
+    /// Like [`Self::register_pinned_provider`], this does NOT populate
+    /// `pubkey_to_providers` (no signing-key discovery). So a pubkey-routed (E2EE)
+    /// request — which selects via `model_pub_key` — gets NO Chutes fallback by
+    /// design: Chutes has no per-response signing key, its integrity is the ML-KEM
+    /// AEAD channel itself. Chutes fallback applies to the non-pubkey selection path.
     pub async fn register_pinned_secondary_provider(
         &self,
         model_id: String,
         provider: Arc<InferenceProviderTrait>,
     ) {
+        let ptr = Arc::as_ptr(&provider) as *const () as usize;
         self.pinned_models
             .write()
             .unwrap_or_else(|e| e.into_inner())
             .insert(model_id.clone());
-        self.pinned_providers
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-            .entry(model_id.clone())
-            .or_default()
-            .push(provider.clone());
+        {
+            // Dedup by Arc pointer here too (symmetric with model_to_providers
+            // below) so a repeated registration can't stack duplicate providers
+            // that every refresh would re-attach.
+            let mut pinned_providers = self
+                .pinned_providers
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            let entry = pinned_providers.entry(model_id.clone()).or_default();
+            if !entry
+                .iter()
+                .any(|p| Arc::as_ptr(p) as *const () as usize == ptr)
+            {
+                entry.push(provider.clone());
+            }
+        }
         let mut mappings = self.provider_mappings.write().await;
         let entry = mappings.model_to_providers.entry(model_id).or_default();
         // Avoid a duplicate if this exact Arc is somehow already present.
-        let ptr = Arc::as_ptr(&provider) as *const () as usize;
         if !entry
             .iter()
             .any(|p| Arc::as_ptr(p) as *const () as usize == ptr)
@@ -1441,54 +1484,15 @@ impl InferenceProviderPool {
             return Some(providers);
         }
 
-        // Apply round-robin load balancing
-        let index_key = if let Some(pub_key) = model_pub_key {
-            format!("pubkey:{}", pub_key)
-        } else {
-            format!("id:{}", model_id)
-        };
-
-        let mut indices = self
-            .load_balancer_index
-            .write()
-            .unwrap_or_else(|e| e.into_inner());
-        let index = indices.entry(index_key.clone()).or_insert(0);
-        let selected_index = *index % providers.len();
-
-        // Increment for next request
-        *index = (*index + 1) % providers.len();
-        drop(indices);
-
-        // Build ordered list following round-robin pattern:
-        // selected provider first, then continue round-robin (selected+1, selected+2, ...)
-        let mut ordered_providers = Vec::with_capacity(providers.len());
-        for i in 0..providers.len() {
-            let provider_index = (selected_index + i) % providers.len();
-            ordered_providers.push(providers[provider_index].clone());
-        }
-
-        // Partition providers by failure count: healthy providers first, then demoted.
-        // Demoted providers (>= MAX_CONSECUTIVE_FAILURES) are still included as last resort
-        // but healthy providers are tried first, avoiding unnecessary timeout waits.
+        // Order providers by (health, trust tier), then round-robin WITHIN the
+        // leading group. The leading group is the healthy providers of the lowest
+        // tier — a NEAR-served model's own attested fleet; requests rotate evenly
+        // among them and only fall through to the next tier (an attested third
+        // party like Chutes) or to demoted providers when the leading group can't
+        // fulfill the request. Rotating within the group (rather than over the full
+        // list before sorting) keeps same-tier load balancing even.
+        //   tier rank: Near (0) < Attested3p (1) < NonAttested (2)
         const MAX_CONSECUTIVE_FAILURES: u32 = 10;
-        let counts = self
-            .provider_failure_counts
-            .read()
-            .unwrap_or_else(|e| e.into_inner());
-        let (mut healthy, mut demoted): (Vec<_>, Vec<_>) =
-            ordered_providers.into_iter().partition(|p| {
-                let key = Arc::as_ptr(p) as *const () as usize;
-                let failures = counts.get(&key).copied().unwrap_or(0);
-                failures < MAX_CONSECUTIVE_FAILURES
-            });
-        drop(counts);
-
-        // Within each health group, order by trust tier so a NEAR-served model
-        // prefers its own attested fleet and only falls back to an attested third
-        // party (Chutes) when the NEAR backends can't fulfill the request. Stable
-        // sort preserves the round-robin order within a tier. A Chutes-only model
-        // has a single provider and never reaches here (early return above).
-        //   Near (0) < Attested3p (1) < NonAttested (2)
         fn tier_rank(p: &Arc<InferenceProviderTrait>) -> u8 {
             match p.tier() {
                 inference_providers::ProviderTier::Near => 0,
@@ -1496,24 +1500,52 @@ impl InferenceProviderPool {
                 inference_providers::ProviderTier::NonAttested => 2,
             }
         }
-        healthy.sort_by_key(tier_rank);
-        demoted.sort_by_key(tier_rank);
+        // (demoted, tier_rank): healthy-before-demoted, NEAR-before-Chutes-before-plaintext.
+        let (mut ordered, group_len) = {
+            let counts = self
+                .provider_failure_counts
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+            let key_of = |p: &Arc<InferenceProviderTrait>| -> (u8, u8) {
+                let failures = counts
+                    .get(&(Arc::as_ptr(p) as *const () as usize))
+                    .copied()
+                    .unwrap_or(0);
+                let demoted = u8::from(failures >= MAX_CONSECUTIVE_FAILURES);
+                (demoted, tier_rank(p))
+            };
+            let mut ordered = providers;
+            ordered.sort_by_key(&key_of); // stable
+            let head_key = key_of(&ordered[0]);
+            let group_len = ordered.iter().take_while(|p| key_of(p) == head_key).count();
+            (ordered, group_len)
+        };
 
-        // Healthy providers first (tier-ordered, round-robin within a tier), then
-        // demoted as last resort. This way, if 1 of 2 providers is down, requests
-        // immediately go to the healthy one instead of waiting 5s for the dead
-        // one's connect timeout.
-        healthy.append(&mut demoted);
-        let ordered_providers = healthy;
+        // Round-robin rotate the leading group so its members share load evenly.
+        if group_len > 1 {
+            let index_key = if let Some(pub_key) = model_pub_key {
+                format!("pubkey:{}", pub_key)
+            } else {
+                format!("id:{}", model_id)
+            };
+            let mut indices = self
+                .load_balancer_index
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            let index = indices.entry(index_key).or_insert(0);
+            let rot = *index % group_len;
+            *index = (*index + 1) % group_len;
+            drop(indices);
+            ordered[..group_len].rotate_left(rot);
+        }
 
         tracing::debug!(
-            index_key = %index_key,
-            providers_count = ordered_providers.len(),
-            selected_index = selected_index,
-            "Prepared providers for fallback with round-robin priority and failure demotion"
+            providers_count = ordered.len(),
+            leading_group = group_len,
+            "Prepared providers for fallback (tier-ordered, round-robin within leading tier)"
         );
 
-        Some(ordered_providers)
+        Some(ordered)
     }
 
     /// Sanitize a CompletionError by preserving its variant structure while sanitizing messages
@@ -1795,6 +1827,72 @@ impl InferenceProviderPool {
         sanitized
     }
 
+    /// Streaming ops: prefer streaming-capable providers. A NEAR-served model's
+    /// Chutes fallback may have streaming disabled (`CHUTES_ENABLE_STREAMING` off);
+    /// keeping it in the list means a retryable NEAR failure falls through to
+    /// Chutes, whose "streaming not enabled" error would overwrite the retryable
+    /// NEAR decision — masking the real error AND suppressing NEAR's backoff retry.
+    /// So when the operation streams and ANY provider can stream, drop the ones that
+    /// can't. If NONE can stream (e.g. a Chutes-only model with streaming off), keep
+    /// the list as-is so the provider's own clear error still surfaces.
+    fn filter_streaming_capable(
+        providers: Vec<Arc<InferenceProviderTrait>>,
+        operation_name: &str,
+    ) -> Vec<Arc<InferenceProviderTrait>> {
+        if operation_name.ends_with("_stream") && providers.iter().any(|p| p.supports_streaming()) {
+            providers
+                .into_iter()
+                .filter(|p| p.supports_streaming())
+                .collect()
+        } else {
+            providers
+        }
+    }
+
+    /// Combine a discovery cycle's per-model provider lists with the out-of-band
+    /// pinned providers, upholding the invariant that DB discovery can never DROP
+    /// or overwrite a pinned (attested, e.g. Chutes) provider:
+    ///   - each discovered model keeps its providers PLUS any pinned providers for
+    ///     it, re-appended and deduped by Arc pointer (`[fresh NEAR..] + [Chutes]`);
+    ///   - each pinned model ABSENT from this discovery cycle is rebuilt from its
+    ///     pinned providers alone, dropping a now-stale discovered backend (NEAR
+    ///     stopped serving it) so the attested fallback serves immediately rather
+    ///     than after ~10 failure-demotions. A Chutes-only id is absent every cycle,
+    ///     so this just re-asserts its pinned-only list.
+    ///
+    /// Pure (no I/O / no locks) so the riskiest refresh logic is unit-testable.
+    /// Callers must only invoke this with a COMPLETE discovery set (the pool does:
+    /// `load_inference_url_models` early-returns on an empty list and
+    /// `fetch_inference_url_models` is an all-or-error DB SELECT), so an absent
+    /// pinned id genuinely is no longer discovery-served.
+    fn merge_discovered_and_pinned(
+        discovered: HashMap<String, Vec<Arc<InferenceProviderTrait>>>,
+        pinned: &HashMap<String, Vec<Arc<InferenceProviderTrait>>>,
+    ) -> Vec<(String, Vec<Arc<InferenceProviderTrait>>)> {
+        let ptr = |p: &Arc<InferenceProviderTrait>| Arc::as_ptr(p) as *const () as usize;
+        let discovered_names: std::collections::HashSet<String> =
+            discovered.keys().cloned().collect();
+        let mut out: Vec<(String, Vec<Arc<InferenceProviderTrait>>)> = Vec::new();
+        for (name, mut providers) in discovered {
+            if let Some(extra) = pinned.get(&name) {
+                let present: std::collections::HashSet<usize> =
+                    providers.iter().map(&ptr).collect();
+                for p in extra {
+                    if !present.contains(&ptr(p)) {
+                        providers.push(p.clone());
+                    }
+                }
+            }
+            out.push((name, providers));
+        }
+        for (name, pin) in pinned {
+            if !discovered_names.contains(name) {
+                out.push((name.clone(), pin.clone()));
+            }
+        }
+        out
+    }
+
     /// Generic retry helper that tries each provider in order with automatic fallback.
     /// Returns both the result and the provider that succeeded (for chat_id mapping).
     /// If model_pub_key is provided, routes to the specific provider by signing public key.
@@ -1863,6 +1961,8 @@ impl InferenceProviderPool {
                 }
             }
         };
+
+        let providers = Self::filter_streaming_capable(providers, operation_name);
 
         tracing::info!(
             model_id = %model_id,
@@ -3377,32 +3477,18 @@ impl InferenceProviderPool {
                 }
             }
 
-            // Never let DB discovery DROP a pinned (out-of-band, attested) provider
-            // — silently substituting the per-request-verified E2EE provider with an
-            // unverified one is the exact attack the pinning prevents. But a pinned
-            // name CAN also be NEAR-served (Chutes as fallback under a canonical id),
-            // so instead of skipping the whole model we rebuild its list as
-            // [fresh discovered NEAR..] + [re-attached pinned providers]. The pinned
-            // providers come from `pinned_providers` (the source of truth), so they
-            // survive every refresh; discovery never produces a Chutes provider, so
-            // it can only ADD/REFRESH the NEAR side, never overwrite the pinned one.
+            // Combine the discovered (NEAR) providers with the out-of-band pinned
+            // (Chutes) ones so discovery can never DROP or overwrite a pinned
+            // provider — see [`Self::merge_discovered_and_pinned`]. This is the exact
+            // substitution-prevention the pinning exists for.
             let pinned_providers = self
                 .pinned_providers
                 .read()
                 .unwrap_or_else(|e| e.into_inner())
                 .clone();
-            for (model_name, mut providers) in model_providers {
-                if let Some(extra) = pinned_providers.get(&model_name) {
-                    let present: std::collections::HashSet<usize> = providers
-                        .iter()
-                        .map(|p| Arc::as_ptr(p) as *const () as usize)
-                        .collect();
-                    for p in extra {
-                        if !present.contains(&(Arc::as_ptr(p) as *const () as usize)) {
-                            providers.push(p.clone());
-                        }
-                    }
-                }
+            for (model_name, providers) in
+                Self::merge_discovered_and_pinned(model_providers, &pinned_providers)
+            {
                 mappings.model_to_providers.insert(model_name, providers);
             }
 
@@ -4844,6 +4930,123 @@ mod tests {
             tiers,
             vec![ProviderTier::Near, ProviderTier::Attested3p],
             "DB NEAR provider and pinned Chutes secondary must coexist, NEAR first"
+        );
+    }
+
+    /// Streaming-capability filter (review #2 / F1): for a streaming op, a Chutes
+    /// fallback with streaming disabled is dropped when a streaming-capable NEAR
+    /// sibling exists — so a NEAR failure doesn't fall through to Chutes' hard
+    /// "streaming disabled" error. A non-streaming op is untouched; a model whose
+    /// only provider can't stream keeps it so the clear error still surfaces.
+    #[test]
+    fn filter_streaming_capable_prefers_streaming_providers() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+
+        let near = Arc::new(MockProvider::new().with_tier(ProviderTier::Near))
+            as Arc<InferenceProviderTrait>;
+        let chutes_no_stream = Arc::new(
+            MockProvider::new()
+                .with_tier(ProviderTier::Attested3p)
+                .with_streaming_support(false),
+        ) as Arc<InferenceProviderTrait>;
+
+        // Streaming op, NEAR can stream + Chutes can't → Chutes dropped.
+        let out = InferenceProviderPool::filter_streaming_capable(
+            vec![near.clone(), chutes_no_stream.clone()],
+            "chat_completion_stream",
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].tier(), ProviderTier::Near);
+
+        // Non-streaming op → no filtering, both kept.
+        let out = InferenceProviderPool::filter_streaming_capable(
+            vec![near.clone(), chutes_no_stream.clone()],
+            "chat_completion",
+        );
+        assert_eq!(out.len(), 2);
+
+        // Streaming op, the ONLY provider can't stream → kept (clear error surfaces).
+        let out = InferenceProviderPool::filter_streaming_capable(
+            vec![chutes_no_stream.clone()],
+            "chat_completion_stream",
+        );
+        assert_eq!(out.len(), 1);
+    }
+
+    /// Refresh merge (review #3 + the highest-risk path): discovery can never DROP
+    /// or overwrite a pinned provider, and a pinned id that falls out of discovery
+    /// is rebuilt pinned-only (stale NEAR dropped).
+    #[test]
+    fn merge_discovered_and_pinned_never_drops_pinned_and_prunes_stale() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::ProviderTier;
+        use std::collections::HashMap;
+
+        let near = Arc::new(MockProvider::new().with_tier(ProviderTier::Near))
+            as Arc<InferenceProviderTrait>;
+        let chutes = Arc::new(MockProvider::new().with_tier(ProviderTier::Attested3p))
+            as Arc<InferenceProviderTrait>;
+
+        let mut pinned: HashMap<String, Vec<Arc<InferenceProviderTrait>>> = HashMap::new();
+        pinned.insert("near+chutes".to_string(), vec![chutes.clone()]);
+        pinned.insert("chutes-only".to_string(), vec![chutes.clone()]);
+
+        // This discovery cycle finds NEAR for "near+chutes" only; "chutes-only" and
+        // the previously-NEAR-served "dropped" id are absent.
+        let mut discovered: HashMap<String, Vec<Arc<InferenceProviderTrait>>> = HashMap::new();
+        discovered.insert("near+chutes".to_string(), vec![near.clone()]);
+
+        let merged: HashMap<String, Vec<ProviderTier>> =
+            InferenceProviderPool::merge_discovered_and_pinned(discovered, &pinned)
+                .into_iter()
+                .map(|(k, v)| (k, v.iter().map(|p| p.tier()).collect()))
+                .collect();
+
+        // NEAR-served pinned id: NEAR refreshed + Chutes re-attached (never dropped).
+        assert_eq!(
+            merged.get("near+chutes"),
+            Some(&vec![ProviderTier::Near, ProviderTier::Attested3p])
+        );
+        // Chutes-only id absent from discovery: rebuilt pinned-only.
+        assert_eq!(
+            merged.get("chutes-only"),
+            Some(&vec![ProviderTier::Attested3p])
+        );
+    }
+
+    /// Fail-closed reservation (review #1): a configured Chutes canonical id is
+    /// reserved BEFORE external load, so a colliding plaintext external/OpenRouter
+    /// row can never register for it — even if the Chutes provider fails to build.
+    /// The model serves only attested providers or fails closed (no plaintext).
+    #[tokio::test]
+    async fn reserved_canonical_id_blocks_plaintext_external_collision() {
+        let pool = InferenceProviderPool::new(
+            None,
+            ExternalProvidersConfig {
+                openai_api_key: Some("sk-test-key".to_string()),
+                timeout_seconds: 60,
+                refresh_interval_secs: 0,
+                ..Default::default()
+            },
+        );
+        let model = "zai-org/GLM-5.1-FP8".to_string();
+
+        // Fail-closed: reserve the canonical id up front (Chutes build may fail, so
+        // no attested provider is ever registered for it).
+        pool.reserve_pinned_models(std::slice::from_ref(&model));
+
+        // A plaintext external row collides on the same canonical id.
+        let _ = pool
+            .load_external_providers(vec![(
+                model.clone(),
+                serde_json::json!({"backend": "openai_compatible", "base_url": "https://api.openai.com/v1"}),
+            )])
+            .await;
+
+        assert!(
+            !pool.has_provider(&model).await,
+            "a reserved (verifiable) canonical id must NOT get a plaintext external provider"
         );
     }
 

--- a/env.example
+++ b/env.example
@@ -238,15 +238,29 @@ BRAVE_SEARCH_PRO_API_KEY=MY_KEY
 # Leave ENABLE_CHUTES unset/false to keep Chutes fully off (no behavior change).
 #   ENABLE_CHUTES=false                       # "true"/"1" to enable
 #   CHUTES_API_KEY=cpk_...                    # secret; or CHUTES_API_KEY_FILE=/path
-#   CHUTES_MODELS=zai-org/GLM-5.1-TEE         # comma-separated model ids to register
+#   CHUTES_MODELS=zai-org/GLM-5.1-FP8=zai-org/GLM-5.1-TEE,moonshotai/Kimi-K2.6-TEE
+#       # Comma-separated `canonical_id=chute_slug` pairs. The CANONICAL id is what
+#       # we expose in /v1/models and route under; the CHUTE SLUG (the `-TEE` form)
+#       # is the internal upstream identity sent to Chutes. Use the NEAR-served id as
+#       # the canonical when NEAR also serves the model (e.g. zai-org/GLM-5.1-FP8),
+#       # else the OpenRouter id. A bare entry (no `=`) means canonical == slug.
 #   CHUTES_ENABLE_STREAMING=false             # opt into streaming (default off; non-streaming is the
 #                                             # honest attested default — streaming has no authenticated frame ordering)
 #   PCCS_URL=...                              # optional Intel PCCS for DCAP collateral
 #                                             # (single source of truth — shared with the NEAR verifier)
-# CATALOG: each CHUTES_MODELS entry needs a row in the model catalog (DB) for
+#
+# ROUTING / FALLBACK: Chutes is registered as a fallback PROVIDER under each
+# canonical id. If NEAR also serves that id, NEAR's own attested fleet is the
+# primary and Chutes is the fallback (per-request, on a retryable NEAR failure);
+# if NEAR does not serve it, Chutes is the only provider (primary). A *verifiable*
+# model (one with any attested provider) NEVER falls back to a non-attested
+# (plaintext) provider — it fails closed instead.
+#
+# CATALOG: each canonical id needs a row in the model catalog (DB) for
 # /v1/chat/completions to route to it AND for usage to be billed (usage rows FK to
 # models.id). On startup we AUTO-SEED a missing row as INACTIVE (is_active=false)
 # with ZERO pricing. To go live you MUST `PATCH /v1/admin/models` with real
 # per-token rates AND is_active=true (one call). The inactive seed makes it
 # impossible to serve — and therefore bill at $0 — before pricing is set. An
-# existing row is respected verbatim (never clobbered); a disabled row stays disabled.
+# existing row (e.g. a NEAR-served canonical id) is respected verbatim (never
+# clobbered); a disabled row stays disabled.


### PR DESCRIPTION
Builds on #758 (Chutes as an attested provider). Turns Chutes from a single pinned provider (registered under its raw `-TEE` slug) into a **fallback fabric across all Chutes TEE models**, under **canonical** ids, with **NEAR-primary** routing and a hard **"verifiable models never serve plaintext"** rule.

## Requirements (from product)
1. Register **all** Chutes TEE models, not one.
2. List them under **canonical** ids — the NEAR-served id when NEAR also serves the model (`zai-org/GLM-5.1-FP8`, **not** `…-TEE`), else the OpenRouter id.
3. Route **NEAR first, Chutes fallback** when NEAR serves the model; **Chutes-primary** when NEAR doesn't.
4. **Do not fall back to a non-attested provider for verifiable models.**
5. (Streaming) enable E2EE streaming — gated on a staging check (below).

## Design decisions (each grounded in the existing pool, with examples)

### 1. Canonical id vs chute slug — decouple them
The Chutes provider used `model_name` as **both** the catalog/public id **and** the upstream `model` it sends to Chutes. We split that:
- **`CHUTES_MODELS`** is now comma-separated **`canonical_id=chute_slug`** pairs (a bare entry → `canonical == slug`), parsed into `Vec<ChutesModelEntry>`.
  - Example: `CHUTES_MODELS=zai-org/GLM-5.1-FP8=zai-org/GLM-5.1-TEE,moonshotai/Kimi-K2.6-TEE`
  - `zai-org/GLM-5.1-FP8` (NEAR-served) is the public/route id; `zai-org/GLM-5.1-TEE` is the upstream chute slug; `moonshotai/Kimi-K2.6-TEE` (Chutes-only) is canonical==slug for now (swap to its OpenRouter id when known).
- The provider is still built with the **chute slug** (`request_body` pins it + `cached_chute_id` resolves it upstream), but seeded/registered under the **canonical id**. So a client calling `zai-org/GLM-5.1-FP8` reaches Chutes with the right `-TEE` slug.

### 2. Wire `ProviderTier` into selection
`ProviderTier{Near, Attested3p, NonAttested}` existed but carried no behavior. Added `fn tier(&self)` to the `InferenceProvider` trait (default `NonAttested`); `nearai::Provider → Near`, `chutes::Provider → Attested3p`.

### 3. Coexistence — Chutes as a *secondary* provider (highest-risk change)
`register_pinned_provider` **overwrote** a model's provider list, and the discovery guards made a pinned name **mutually exclusive** with DB discovery — so NEAR + Chutes couldn't share a canonical id. New `register_pinned_secondary_provider` **pushes** instead, and records the provider in a `pinned_providers` map (the source of truth for the pinned tier). The refresh merge now rebuilds each model's list as **`[fresh discovered NEAR..] + [re-attached pinned Chutes]`** — discovery refreshes/adds the NEAR side but can **never drop or overwrite** the per-request-verified Chutes provider (the security invariant from #758 is preserved: discovery can only ADD an attested provider, never substitute it).

### 4. Tier-ordered selection = NEAR-primary / Chutes-fallback (per-request)
`get_providers_with_fallback` stable-sorts by tier (`Near < Attested3p < NonAttested`) **within each health group**. The existing `retry_with_fallback` then walks that ordered list, so a retryable NEAR failure (5xx/429/connection) falls through to Chutes **within the same request** (a non-retryable client 4xx still fast-returns without spending Chutes quota). A Chutes-only id has a single provider, so it's primary automatically — no special case. NEAR demotion (10 consecutive failures) already moves it below Chutes.

### 5. Verifiable models never fall back to plaintext
If a model has **any** attested provider (`Near` or `Attested3p`), **all `NonAttested` providers are dropped from selection**. A verifiable request thus only ever tries attested providers and **fails closed** rather than silently downgrading to a plaintext backend — defending the case where a Chutes-only canonical id also has a stray external (OpenAI/OpenRouter) row. Pure non-attested models (no attested provider) are unaffected.

### 6. Catalog seeding under the canonical id
Seed/register under the canonical id. A NEAR-served canonical id (e.g. `zai-org/GLM-5.1-FP8`) already has an active, attested row → it's respected verbatim and just gains Chutes as a fallback provider. A Chutes-only canonical id is auto-seeded **inactive / $0** (operator activates + prices via `PATCH /v1/admin/models`, unchanged from #758).

## Streaming
Decoder already implements the exact protocol (single `e2e_init` ML-KEM encapsulation → one HKDF stream key → per-chunk ChaCha20-Poly1305). It stays gated behind `CHUTES_ENABLE_STREAMING` pending a **staging verification** that Chutes emits the `[DONE]` terminator **inside** the encrypted channel (our truncation guard depends on it). Per-chunk AEAD authenticates every byte; frame **reorder** remains undetectable (no sequence numbers) — accepted residual, truncation is caught. No code change needed to flip it on.

## Tests
- **config**: `canonical=slug` pair parsing (+ bare entries, whitespace, dropped empties); empty when unset.
- **pool**: `verifiable_model_prefers_near_then_chutes_and_never_plaintext`; `chutes_only_model_serves_as_single_attested_primary`; `non_verifiable_model_is_served_by_its_non_attested_provider`; `pinned_secondary_chutes_coexists_with_db_near_provider`. Existing `pinned_provider_survives_refresh` still green.
- 297 inference_providers + config tests, 57 pool tests, clippy + fmt clean.

## Follow-ups
- Flip `CHUTES_ENABLE_STREAMING` after the staging inner-`[DONE]` check.
- Supersedes the standalone `zai-org/GLM-5.1-TEE` staging row activated for #758 verification — that should be deactivated; Chutes attaches under `zai-org/GLM-5.1-FP8`.