### PR TITLE
fix(chutes): post-merge review polish (#768 follow-up)

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -465,11 +465,10 @@ pub async fn batch_upsert_models(
         // that has a Chutes fallback (it's `is_pinned`). So a PATCH that changes its
         // `inference_url` skips the eager `unregister_provider` here, but the NEW url
         // is still re-registered below and `load_inference_url_models`' atomic update
-        // already drops the replaced provider from `model_to_providers` and prunes
-        // its `pubkey_to_providers` entries — only the per-provider failure-counter
-        // entry lingers until the next periodic refresh. Behavior stays safe (pubkey
-        // intersection + catalog `is_active` gating); the residual is just that one
-        // stale counter, not the provider or its routing.
+        // drops the replaced provider from `model_to_providers`, prunes its
+        // `pubkey_to_providers` entries, and prunes its per-provider failure-counter
+        // entry — so the refresh leaves no stale routing or counter state behind.
+        // Behavior stays safe (pubkey intersection + catalog `is_active` gating).
         if app_state.inference_provider_pool.is_pinned(model_name) {
             continue;
         }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -463,12 +463,13 @@ pub async fn batch_upsert_models(
         //
         // NOTE: with tiered fallback this now also covers a NEAR-served canonical id
         // that has a Chutes fallback (it's `is_pinned`). So a PATCH that changes its
-        // `inference_url` or deactivates it skips the eager `unregister_provider`
-        // cleanup here: the NEW url is still re-registered below (the merge keeps
-        // Chutes), but the stale OLD-url NEAR provider + its pubkey/failure-counter
-        // entries linger until the next periodic refresh prunes them. Behavior stays
-        // safe (pubkey intersection + catalog `is_active` gating); it just isn't
-        // instantaneously clean for a runtime url change on a Chutes-fallback model.
+        // `inference_url` skips the eager `unregister_provider` here, but the NEW url
+        // is still re-registered below and `load_inference_url_models`' atomic update
+        // already drops the replaced provider from `model_to_providers` and prunes
+        // its `pubkey_to_providers` entries — only the per-provider failure-counter
+        // entry lingers until the next periodic refresh. Behavior stays safe (pubkey
+        // intersection + catalog `is_active` gating); the residual is just that one
+        // stale counter, not the provider or its routing.
         if app_state.inference_provider_pool.is_pinned(model_name) {
             continue;
         }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -465,10 +465,12 @@ pub async fn batch_upsert_models(
         // that has a Chutes fallback (it's `is_pinned`). So a PATCH that changes its
         // `inference_url` skips the eager `unregister_provider` here, but the NEW url
         // is still re-registered below and `load_inference_url_models`' atomic update
-        // drops the replaced provider from `model_to_providers`, prunes its
-        // `pubkey_to_providers` entries, and prunes its per-provider failure-counter
-        // entry — so the refresh leaves no stale routing or counter state behind.
-        // Behavior stays safe (pubkey intersection + catalog `is_active` gating).
+        // drops the *replaced* NEAR provider from `model_to_providers`, prunes its
+        // `pubkey_to_providers` entries, and prunes its per-provider failure counter
+        // (the prune is filtered against still-live pointers, so the coexisting
+        // pinned Chutes fallback keeps its counter) — no stale routing or counter
+        // state for the replaced provider is left behind. Behavior stays safe (pubkey
+        // intersection + catalog `is_active` gating).
         if app_state.inference_provider_pool.is_pinned(model_name) {
             continue;
         }

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -1183,6 +1183,12 @@ impl ExternalProvidersConfig {
                     continue;
                 }
                 if !seen.insert(entry.canonical_id.clone()) {
+                    // `eprintln!` (not `tracing::warn!`) on purpose: the `config`
+                    // crate has no `tracing` dependency, and `from_env` runs during
+                    // startup config parsing — potentially before the tracing
+                    // subscriber is installed, where a `tracing::warn!` would be
+                    // dropped. stderr is always captured by the container log
+                    // pipeline. Consistent with the sibling CHUTES_API_KEY_FILE warn.
                     eprintln!(
                         "WARN: duplicate CHUTES_MODELS canonical id '{}' ignored (first wins)",
                         entry.canonical_id

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -376,13 +376,14 @@ const INTERNAL_KEYS: &[&str] = {
 /// alias-served paths — so leaving the slug there would still leak it). Only
 /// touches chunk-bearing data lines; control events ([DONE], blanks, the keyed
 /// init) have no chunk and pass through unchanged. On any parse failure the event
-/// is returned as-is (never drop a chunk over a rewrite).
+/// is returned as-is (never drop a chunk over a rewrite). The rewrite is ATOMIC:
+/// we compute the rewritten `raw_bytes` first and bail (returning the event
+/// unchanged) on any failure, mutating the parsed `chunk` only once that succeeds —
+/// so the event can never end up with `chunk` carrying the canonical id while
+/// `raw_bytes` still leaks the slug.
 fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: &str) -> SSEEvent {
     if ev.chunk.is_none() {
         return ev;
-    }
-    if let Some(StreamChunk::Chat(c)) = &mut ev.chunk {
-        c.model = canonical.to_string();
     }
     let Ok(s) = std::str::from_utf8(&ev.raw_bytes) else {
         return ev;
@@ -394,6 +395,10 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: &str) -> SSEEvent {
     let Ok(json) = String::from_utf8(rewritten) else {
         return ev;
     };
+    // raw_bytes rewrite succeeded — now mutate the parsed chunk to match.
+    if let Some(StreamChunk::Chat(c)) = &mut ev.chunk {
+        c.model = canonical.to_string();
+    }
     SSEEvent {
         raw_bytes: bytes::Bytes::from(format!("data: {json}\n\n")),
         chunk: ev.chunk,

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -947,6 +947,39 @@ mod tests {
     }
 
     #[test]
+    fn rewrite_sse_event_model_leaves_chunk_bearing_event_untouched_on_rewrite_failure() {
+        use crate::{ChatCompletionChunk, StreamChunk};
+        // Pins the ATOMIC invariant: if the raw_bytes rewrite fails (here the
+        // payload isn't a JSON object so set_model_in_json returns None), the event
+        // is returned fully unchanged — raw_bytes AND the parsed chunk's model both
+        // keep their original value. Guards against a future refactor reintroducing
+        // a half-rewritten state (chunk mutated to canonical while raw_bytes still
+        // leaks the slug). This failure path is unreachable in practice (the decoder
+        // only sets chunk: Some when raw_bytes parsed as valid JSON) but is cheap to
+        // pin and the only thing the atomicity reorder protects.
+        let chunk: ChatCompletionChunk = serde_json::from_value(json!({
+            "id":"c","object":"chat.completion.chunk","created":0,
+            "model":"zai-org/GLM-5.1-TEE","choices":[]
+        }))
+        .unwrap();
+        let ev = SSEEvent {
+            // Non-object JSON → set_model_in_json returns None → rewrite bails.
+            raw_bytes: bytes::Bytes::from_static(b"data: [1,2,3]\n\n"),
+            chunk: Some(StreamChunk::Chat(chunk)),
+            raw_passthrough: true,
+        };
+        let out = rewrite_sse_event_model(ev, "zai-org/GLM-5.1-FP8");
+        // raw_bytes untouched (no canonical id introduced, no reframing).
+        assert_eq!(&out.raw_bytes[..], b"data: [1,2,3]\n\n");
+        // The parsed chunk's model must NOT have been mutated to canonical.
+        match &out.chunk {
+            Some(StreamChunk::Chat(c)) => assert_eq!(c.model, "zai-org/GLM-5.1-TEE"),
+            other => panic!("expected the original Chat chunk, got {other:?}"),
+        }
+        assert!(out.raw_passthrough, "raw_passthrough preserved");
+    }
+
+    #[test]
     fn request_body_pins_model_and_stream() {
         let params: ChatCompletionParams = serde_json::from_value(json!({
             "model": "ignored", "messages": [{"role":"user","content":"hi"}]

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -3605,6 +3605,19 @@ impl InferenceProviderPool {
                     });
                     !providers.is_empty()
                 });
+                // Prune the per-provider failure counters for the replaced providers
+                // too. The map is keyed by Arc pointer address; leaving a replaced
+                // provider's entry would let a future provider allocated at a
+                // recycled address inherit its (possibly demotion-level) count — for
+                // a tiered model that could start a fresh NEAR provider deprioritized
+                // below its Chutes fallback until its first success resets it. This
+                // mirrors the `pubkey_to_providers` prune above and honors this
+                // struct's "cleaned up on refresh" contract for the replace-in-place
+                // case (remove_stale_providers only covers models dropped entirely).
+                self.provider_failure_counts
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .retain(|key, _| !old_provider_ptrs.contains(key));
             }
 
             for (key, provider) in pub_key_updates {

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -2978,6 +2978,24 @@ impl InferenceProviderPool {
         }
     }
 
+    /// Drop the per-provider failure counters for providers replaced this refresh.
+    ///
+    /// `candidate_ptrs` is the over-approximate "replaced" set built from the old
+    /// `model_to_providers` (it can include a pinned provider, which is never in the
+    /// URL-cache reused set). `live_ptrs` is the set of pointers still backing some
+    /// model after the merge. A counter is pruned only when its provider is a
+    /// candidate AND no longer live — so a still-served pinned fallback, or an Arc
+    /// shared by another still-served model, keeps its consecutive-failure counter
+    /// and can stay demoted. Pure so the invariant is unit-testable without driving
+    /// the (network/attestation-bound) refresh path.
+    fn prune_replaced_failure_counts(
+        counts: &mut HashMap<usize, u32>,
+        candidate_ptrs: &std::collections::HashSet<usize>,
+        live_ptrs: &std::collections::HashSet<usize>,
+    ) {
+        counts.retain(|ptr, _| live_ptrs.contains(ptr) || !candidate_ptrs.contains(ptr));
+    }
+
     /// Load models with inference_url as nearai::Providers into provider_mappings.
     ///
     /// For each model, reuses the existing provider (and its warm TLS connections)
@@ -3605,19 +3623,32 @@ impl InferenceProviderPool {
                     });
                     !providers.is_empty()
                 });
-                // Prune the per-provider failure counters for the replaced providers
-                // too. The map is keyed by Arc pointer address; leaving a replaced
-                // provider's entry would let a future provider allocated at a
-                // recycled address inherit its (possibly demotion-level) count — for
-                // a tiered model that could start a fresh NEAR provider deprioritized
-                // below its Chutes fallback until its first success resets it. This
-                // mirrors the `pubkey_to_providers` prune above and honors this
-                // struct's "cleaned up on refresh" contract for the replace-in-place
-                // case (remove_stale_providers only covers models dropped entirely).
-                self.provider_failure_counts
-                    .write()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .retain(|key, _| !old_provider_ptrs.contains(key));
+                // Prune the per-provider failure counters for genuinely-replaced
+                // providers. `old_provider_ptrs` OVER-approximates "replaced": a
+                // pinned (Chutes) provider is collected into it on every refresh — it
+                // isn't in the URL-cache `reused_provider_ptrs` set — yet it is
+                // re-merged into `model_to_providers` just above, and one Arc can back
+                // several models. So filter against the post-merge live pointers
+                // (mirrors `prune_stale_pinned`'s shared-Arc guard): a counter is
+                // dropped only when its provider is replaced AND no longer referenced.
+                // Without this the prune would reset a still-served pinned fallback's
+                // consecutive-failure counter every refresh, so it could never stay
+                // demoted (demotion needs >=10 consecutive failures); the map is also
+                // keyed by Arc pointer address, so a stale entry could let a future
+                // provider at a recycled address inherit a demotion-level count.
+                let live_ptrs: std::collections::HashSet<usize> = mappings
+                    .model_to_providers
+                    .values()
+                    .flat_map(|ps| ps.iter().map(|p| Arc::as_ptr(p) as *const () as usize))
+                    .collect();
+                Self::prune_replaced_failure_counts(
+                    &mut self
+                        .provider_failure_counts
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner()),
+                    &old_provider_ptrs,
+                    &live_ptrs,
+                );
             }
 
             for (key, provider) in pub_key_updates {
@@ -5156,6 +5187,51 @@ mod tests {
         // the partial-batch safety the admin PATCH path depends on.
         assert!(!merged.contains_key("other-pinned"));
         assert_eq!(merged.len(), 1);
+    }
+
+    /// The refresh failure-counter prune (review round 3, Pierre's blocking) must
+    /// NOT reset a still-served pinned (Chutes) fallback's consecutive-failure
+    /// counter. `old_provider_ptrs` over-approximates "replaced" — a pinned provider
+    /// lands in it every refresh (it's never in the URL-cache reused set) yet stays
+    /// in `model_to_providers` — so the prune is filtered against the post-merge live
+    /// pointers. Without that filter a persistently-failing Chutes fallback would be
+    /// re-promoted every ~5 min and could never stay demoted.
+    #[test]
+    fn prune_replaced_failure_counts_keeps_live_pinned_and_shared_drops_replaced() {
+        use std::collections::{HashMap, HashSet};
+
+        // 1 = replaced NEAR provider: a candidate, no longer live  -> pruned
+        // 2 = pinned Chutes fallback: a candidate (not in reused set) but STILL live
+        //     after the merge                                       -> kept
+        // 3 = Arc shared with another still-served model: candidate but live -> kept
+        // 4 = untouched provider for an unrelated model: not a candidate    -> kept
+        let mut counts: HashMap<usize, u32> = [(1usize, 12u32), (2, 9), (3, 7), (4, 3)]
+            .into_iter()
+            .collect();
+        let candidates: HashSet<usize> = [1usize, 2, 3].into_iter().collect();
+        let live: HashSet<usize> = [2usize, 3, 4].into_iter().collect();
+
+        InferenceProviderPool::prune_replaced_failure_counts(&mut counts, &candidates, &live);
+
+        assert!(
+            !counts.contains_key(&1),
+            "a genuinely-replaced provider's counter must be pruned"
+        );
+        assert_eq!(
+            counts.get(&2),
+            Some(&9),
+            "a still-served pinned fallback must keep its counter (would have caught the round-3 bug)"
+        );
+        assert_eq!(
+            counts.get(&3),
+            Some(&7),
+            "a still-referenced shared Arc must keep its counter"
+        );
+        assert_eq!(
+            counts.get(&4),
+            Some(&3),
+            "an untouched provider's counter must survive"
+        );
     }
 
     /// Complete-set stale-prune (review round 2): on the refresh path, a pinned id


### PR DESCRIPTION
Addresses the four non-blocking observations from Pierre's final review on #768 (merged). No behavior change in the default posture; all unreachable-today but worth tightening.

- **`rewrite_sse_event_model` atomicity** — compute the rewritten `raw_bytes` first and return the event unchanged on any failure, mutating the parsed `chunk` only after that succeeds. Prevents an event ever carrying `chunk` = canonical id while `raw_bytes` still leaks the `-TEE` slug (only reachable if the raw rewrite failed on a chunk it parsed, which the decoder makes impossible — but the function now fails atomically regardless).
- **config `eprintln!` rationale** — comment why the duplicate-`CHUTES_MODELS` warning uses `eprintln!` not `tracing::warn!`: `config` has no `tracing` dep and `from_env` can run before the subscriber is installed (a `tracing::warn!` would be dropped); stderr is captured by the container log pipeline; consistent with the sibling `CHUTES_API_KEY_FILE` warning.
- **admin `is_pinned`-guard comment corrected** — a runtime `inference_url` change on a pinned model re-registers the new url, and `load_inference_url_models`' atomic update already drops the replaced provider from `model_to_providers` and prunes its `pubkey_to_providers` entries; only the per-provider failure-counter lingers until the next refresh. The previous comment overstated the lingering.

The two larger follow-ups are tracked separately: #769 (attestation/signature for fallback-served responses) and #770 (per-op capability filter for rerank/embeddings/score).

`cargo test -p inference_providers --lib` 299 · clippy `-D warnings` + fmt clean.