### PR TITLE
test(chutes): live probe confirms inner-[DONE] streaming terminus

### DIFF
--- a/crates/inference_providers/src/attested/chutes/e2ee_stream.rs
+++ b/crates/inference_providers/src/attested/chutes/e2ee_stream.rs
@@ -21,11 +21,16 @@
 //! as a clean terminus; a *plaintext outer* `[DONE]` is forgeable (the gateway
 //! could inject it after dropping frames) and is ignored, so a truncated stream
 //! surfaces an error instead of a fake success. Frame *ordering* is still not
-//! cryptographically guaranteed. **Open (verify on staging):** confirm Chutes
-//! emits the terminator *inside* the encrypted channel; if it only sends the
-//! outer plaintext `[DONE]`, the terminator is forgeable — add it to the tracked
-//! Chutes asks (alongside missing frame sequence numbers + unsigned measurements)
-//! and reconsider exposing streaming as attested.
+//! cryptographically guaranteed.
+//!
+//! **Terminator confirmed (2026-06-11):** a live round-trip against GLM-5.1-TEE
+//! (see the `live_chutes_streaming_done_probe` test in `super`) showed Chutes
+//! emits the terminator *inside* the encrypted channel — the stream ends on an
+//! authenticated inner `[DONE]`, so the inner-terminus assumption holds and
+//! streaming can be exposed as attested. The remaining residual is frame
+//! *reorder* (undetectable without sequence numbers — an accepted limitation;
+//! truncation IS caught). Sequence numbers + signed measurements stay on the
+//! tracked Chutes asks.
 
 use async_stream::try_stream;
 use base64::Engine;

--- a/crates/inference_providers/src/attested/chutes/e2ee_stream.rs
+++ b/crates/inference_providers/src/attested/chutes/e2ee_stream.rs
@@ -26,11 +26,15 @@
 //! **Terminator confirmed (2026-06-11):** a live round-trip against GLM-5.1-TEE
 //! (see the `live_chutes_streaming_done_probe` test in `super`) showed Chutes
 //! emits the terminator *inside* the encrypted channel — the stream ends on an
-//! authenticated inner `[DONE]`, so the inner-terminus assumption holds and
-//! streaming can be exposed as attested. The remaining residual is frame
-//! *reorder* (undetectable without sequence numbers — an accepted limitation;
-//! truncation IS caught). Sequence numbers + signed measurements stay on the
-//! tracked Chutes asks.
+//! authenticated inner `[DONE]`. This narrowly establishes that an EOF *without*
+//! an inner `[DONE]` is detected (surfaced as a truncation error). It does **not**
+//! make streaming tamper-evident: because content frames carry no sequence
+//! numbers, an on-path gateway can still **drop** encrypted content frames and
+//! forward the (authenticated) inner `[DONE]`, or **reorder** / **replay** frames,
+//! and the decoder cannot detect any of it. So drop, reorder, replay, and
+//! truncation-*with*-a-forwarded-inner-`[DONE]` all remain **undetectable** until
+//! Chutes adds sequence numbers or a transcript MAC — these stay on the tracked
+//! Chutes asks. The only guarantee added here is "no inner `[DONE]` ⇒ error".
 
 use async_stream::try_stream;
 use base64::Engine;
@@ -104,8 +108,8 @@ fn handle_outer_payload(
         // frames to fake a successful-but-truncated stream. Ignore it: only the
         // **authenticated inner** `[DONE]` (decrypted from an `e2e` frame, handled
         // in `inner_event`) is a valid terminus. If no inner `[DONE]` arrives, the
-        // stream ends as truncation. (If staging shows Chutes terminates only with
-        // the outer `[DONE]`, that's a forgeable terminator — see the module note.)
+        // stream ends as truncation. Chutes is confirmed to emit the inner
+        // terminator (see the module note), so ignoring the outer one is safe.
         return Ok(None);
     }
     let v: serde_json::Value = match serde_json::from_str(payload) {

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -552,10 +552,11 @@ impl InferenceProvider for Provider {
         _request_hash: String,
     ) -> Result<StreamingResult, CompletionError> {
         // Streaming is off by default: Chutes' stream protocol has no
-        // authenticated frame ordering (a gateway could drop/reorder AEAD-valid
-        // frames undetectably), so it isn't honestly attested until Chutes adds
-        // sequence numbers and the inner-terminator behavior is confirmed on
-        // staging. Opt in with CHUTES_ENABLE_STREAMING. Non-streaming is attested.
+        // authenticated frame ordering (content frames carry no sequence numbers),
+        // so an on-path gateway could drop, reorder, or replay AEAD-valid frames
+        // undetectably. It isn't honestly attested until Chutes adds sequence
+        // numbers or a transcript MAC. Opt in with CHUTES_ENABLE_STREAMING.
+        // Non-streaming is attested.
         if !self.allow_streaming {
             return Err(CompletionError::CompletionError(
                 "Chutes streaming is not enabled as an attested path (frame ordering is not \
@@ -1075,13 +1076,13 @@ mod tests {
     /// Uses the real E2EE path with a stub verifier (we're testing the stream
     /// protocol, not re-verifying attestation — the encaps pubkey still comes from
     /// the live discovered instance). Run:
-    ///   CHUTES_KEY=cpk_... cargo test -p inference_providers --lib \
+    ///   CHUTES_API_KEY=cpk_... cargo test -p inference_providers --lib \
     ///     attested::chutes::tests::live_chutes_streaming_done_probe -- --ignored --nocapture
     #[tokio::test]
-    #[ignore = "live Chutes streaming probe; needs CHUTES_KEY + network"]
+    #[ignore = "live Chutes streaming probe; needs CHUTES_API_KEY + network"]
     async fn live_chutes_streaming_done_probe() {
         use futures_util::StreamExt;
-        let key = std::env::var("CHUTES_KEY").expect("set CHUTES_KEY for the live probe");
+        let key = std::env::var("CHUTES_API_KEY").expect("set CHUTES_API_KEY for the live probe");
         let provider = Provider::new(
             Config::new(key, "zai-org/GLM-5.1-TEE".to_string(), 120).with_streaming(true),
             Arc::new(StubVerifier { ok: true }),
@@ -1107,11 +1108,15 @@ mod tests {
             match item {
                 Ok(ev) => {
                     events += 1;
-                    let s = String::from_utf8_lossy(&ev.raw_bytes).to_string();
-                    if s.contains("[DONE]") {
+                    // The decoder filters the forgeable *outer* `[DONE]`
+                    // (`handle_outer_payload` returns `Ok(None)`), so the only
+                    // yielded done-marker is the authenticated inner one. Use the
+                    // precise predicate rather than a raw-bytes substring scan,
+                    // which model text containing "[DONE]" could false-positive.
+                    if ev.is_done_marker() {
                         inner_done = true;
                     }
-                    last = s;
+                    last = String::from_utf8_lossy(&ev.raw_bytes).to_string();
                 }
                 Err(e) => {
                     err = Some(format!("{e}"));

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -1075,7 +1075,9 @@ mod tests {
     ///
     /// Uses the real E2EE path with a stub verifier (we're testing the stream
     /// protocol, not re-verifying attestation — the encaps pubkey still comes from
-    /// the live discovered instance). Run:
+    /// the live discovered instance). The model defaults to `zai-org/GLM-5.1-TEE`
+    /// but can be overridden via `CHUTES_PROBE_MODEL` so re-running the probe after
+    /// that model is decommissioned needs no code edit. Run:
     ///   CHUTES_API_KEY=cpk_... cargo test -p inference_providers --lib \
     ///     attested::chutes::tests::live_chutes_streaming_done_probe -- --ignored --nocapture
     #[tokio::test]
@@ -1083,13 +1085,15 @@ mod tests {
     async fn live_chutes_streaming_done_probe() {
         use futures_util::StreamExt;
         let key = std::env::var("CHUTES_API_KEY").expect("set CHUTES_API_KEY for the live probe");
+        let model =
+            std::env::var("CHUTES_PROBE_MODEL").unwrap_or_else(|_| "zai-org/GLM-5.1-TEE".into());
         let provider = Provider::new(
-            Config::new(key, "zai-org/GLM-5.1-TEE".to_string(), 120).with_streaming(true),
+            Config::new(key, model.clone(), 120).with_streaming(true),
             Arc::new(StubVerifier { ok: true }),
         )
         .unwrap();
         let params: ChatCompletionParams = serde_json::from_value(json!({
-            "model": "zai-org/GLM-5.1-TEE",
+            "model": model,
             "messages": [{"role": "user", "content": "Count: 1 2 3, then stop."}],
             "max_tokens": 64,
             "temperature": 0,

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -1065,4 +1065,71 @@ mod tests {
     async fn get_signature_is_unsupported() {
         assert!(provider().get_signature("c", None).await.is_err());
     }
+
+    /// LIVE probe (ignored) — the open question gating `CHUTES_ENABLE_STREAMING`:
+    /// does Chutes terminate a stream with an **authenticated inner `[DONE]`**
+    /// (decrypted from an `e2e` frame → our decoder yields it and ends cleanly) or
+    /// only an **outer plaintext `[DONE]`** (which the decoder ignores as forgeable
+    /// → EOF without an inner terminus → a fatal truncation error)?
+    ///
+    /// Uses the real E2EE path with a stub verifier (we're testing the stream
+    /// protocol, not re-verifying attestation — the encaps pubkey still comes from
+    /// the live discovered instance). Run:
+    ///   CHUTES_KEY=cpk_... cargo test -p inference_providers --lib \
+    ///     attested::chutes::tests::live_chutes_streaming_done_probe -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "live Chutes streaming probe; needs CHUTES_KEY + network"]
+    async fn live_chutes_streaming_done_probe() {
+        use futures_util::StreamExt;
+        let key = std::env::var("CHUTES_KEY").expect("set CHUTES_KEY for the live probe");
+        let provider = Provider::new(
+            Config::new(key, "zai-org/GLM-5.1-TEE".to_string(), 120).with_streaming(true),
+            Arc::new(StubVerifier { ok: true }),
+        )
+        .unwrap();
+        let params: ChatCompletionParams = serde_json::from_value(json!({
+            "model": "zai-org/GLM-5.1-TEE",
+            "messages": [{"role": "user", "content": "Count: 1 2 3, then stop."}],
+            "max_tokens": 64,
+            "temperature": 0,
+            "stream": true
+        }))
+        .unwrap();
+        let mut stream = provider
+            .chat_completion_stream(params, "probe".to_string())
+            .await
+            .expect("stream should start");
+        let mut events = 0usize;
+        let mut inner_done = false;
+        let mut err: Option<String> = None;
+        let mut last = String::new();
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(ev) => {
+                    events += 1;
+                    let s = String::from_utf8_lossy(&ev.raw_bytes).to_string();
+                    if s.contains("[DONE]") {
+                        inner_done = true;
+                    }
+                    last = s;
+                }
+                Err(e) => {
+                    err = Some(format!("{e}"));
+                    break;
+                }
+            }
+        }
+        eprintln!("PROBE: events={events} inner_done={inner_done} err={err:?}");
+        eprintln!("PROBE last_event: {last}");
+        assert!(
+            err.is_none(),
+            "stream errored before a clean terminus — Chutes likely sends only an \
+             outer plaintext [DONE] (truncation): {err:?}"
+        );
+        assert!(
+            inner_done,
+            "stream ended without an inner [DONE] — streaming can't be honestly \
+             attested until Chutes emits the terminator inside the channel"
+        );
+    }
 }


### PR DESCRIPTION
Resolves the open question that gated `CHUTES_ENABLE_STREAMING` (flagged across #758/#768 and in the `e2ee_stream` module note): **does Chutes terminate a stream with an authenticated inner `[DONE]`, or only a forgeable outer plaintext one?**

Our decoder only accepts an **inner** `[DONE]` (decrypted from an `e2e` frame) as a clean terminus — it ignores the outer plaintext `[DONE]` (a gateway could inject it after dropping frames) and treats EOF-without-inner-`[DONE]` as a fatal truncation. So if Chutes only sent the outer one, attested streaming would always error.

**Verified it doesn't.** New `#[ignore]` live probe `live_chutes_streaming_done_probe` streams a real request to `zai-org/GLM-5.1-TEE` over the full E2EE path (stub verifier — testing the *stream protocol*, not re-verifying attestation; the encaps pubkey still comes from the live discovered instance):

```
PROBE: events=22 inner_done=true err=None
PROBE last_event: data: [DONE]
```

22 frames, clean inner-`[DONE]` terminus, no error → **Chutes emits the terminator inside the encrypted channel**, so the decoder completes cleanly. The `e2ee_stream` module note now records this with a *narrowed* claim: the probe only establishes that EOF **without** an inner `[DONE]` is detected (surfaced as a truncation error). It does **not** make streaming tamper-evident — drop, reorder, replay, and truncation-*with*-a-forwarded-inner-`[DONE]` all remain **undetectable** until Chutes adds sequence numbers or a transcript MAC, and stay on the tracked Chutes asks alongside signed measurements.

Run the probe (model overridable via `CHUTES_PROBE_MODEL`, defaults to `zai-org/GLM-5.1-TEE`):
`CHUTES_API_KEY=cpk_... cargo test -p inference_providers --lib attested::chutes::tests::live_chutes_streaming_done_probe -- --ignored --nocapture`

Docs-only + an ignored live test (CI skips it). Flipping `CHUTES_ENABLE_STREAMING` on staging is a separate cvm-ansible vars change (note: a separate measurement-allowlist bug, #773, currently 502s non-H200 Chutes models before any stream starts, so end-to-end staging streaming has not yet been exercised).
