### PR TITLE
feat(chutes): accept the full v1.3.0 hardware family in golden measurements

### DIFF
--- a/crates/services/src/attestation/chutes.rs
+++ b/crates/services/src/attestation/chutes.rs
@@ -206,24 +206,63 @@ impl ChutesInstanceVerifier for ChutesBackendVerifier {
 }
 
 /// A vetted snapshot of Chutes' published golden measurements (from the public
-/// `GET https://api.chutes.ai/servers/tee/measurements`), confirmed 2026-06-10 to
-/// match the live GLM-5.1-TEE fleet byte-for-byte on MRTD + RTMR0-2 (boot chain)
-/// **and the runtime RTMR3** (`runtime_rtmrs.RTMR3`, 6/6 live quotes) — i.e. the
-/// full software identity, boot + running app/IMA layer. This is the
-/// software-identity anchor for the staging rollout; expand (or make
-/// config-driven) as more configs are independently vetted. Fail-closed: anything
-/// not listed here is rejected.
+/// `GET https://api.chutes.ai/servers/tee/measurements`) for the **v1.3.0**
+/// software release across all of Chutes' GPU hardware platforms.
+///
+/// Within v1.3.0 the five rows below are byte-identical on MRTD (firmware),
+/// RTMR1 (kernel), RTMR2 (cmdline/initrd) **and the runtime RTMR3**
+/// (`runtime_rtmrs.RTMR3`, the running app/IMA layer) — i.e. the full *software*
+/// identity is one and the same. They differ **only in RTMR0**, the TD-HOB/ACPI/
+/// VM-config layer that varies with the GPU SKU and VM sizing (8×H200,
+/// 8×RTX PRO 6000, 8×B200, 8×B200-eth, 8×B300). Pinning each published RTMR0
+/// lets a request land on any of Chutes' vetted hardware platforms while still
+/// authenticating the full software stack against a single, fixed identity.
+///
+/// Live cross-checks against genuine, DCAP-signature-verified, report-data-bound
+/// quotes (the measurement check runs only *after* the Intel signature chain and
+/// the nonce/e2e-key/SPKI bindings pass, so observed registers are trustworthy):
+///   - `8xh200 v1.3.0`         — GLM-5.1-TEE, 6/6 quotes (2026-06-10); and
+///                               kimi-k2.5 / deepseek-v3.2 / minimax-m2.5 served
+///                               live over E2EE (2026-06-11).
+///   - `8xRTX_PRO_6000 v1.3.0` — Qwen3-32B-TEE, observed register set matched the
+///                               published row byte-for-byte (2026-06-11).
+/// The remaining Blackwell rows (b200 / b200-eth / b300) are taken from the same
+/// published v1.3.0 release and carry the identical software identity; they are
+/// accepted so a model scheduled onto Blackwell hardware serves without a
+/// per-SKU re-vet. The cryptographic root of trust is the Intel DCAP signature,
+/// not the transparency endpoint — these rows merely enumerate which genuine
+/// software identities we accept.
+///
+/// NOT included (fail-closed): the v1.0.0–v1.2.0 rows publish RTMR3 = all-zeros
+/// (a boot template, never matchable against a live extended RTMR3), and v1.3.1
+/// is a distinct firmware/kernel (different MRTD/RTMR1) with no live instance yet
+/// — add it once Chutes upgrades and a live quote cross-checks. Anything not
+/// listed here is rejected.
 pub fn vetted_golden_measurements() -> ChutesMeasurementPolicy {
-    ChutesMeasurementPolicy::new(vec![ExpectedMeasurement::new(
-        "8xh200",
-        "1.3.0",
-        "ddc6efcdd2309e10837f8a7f64b71272b7ef003b129460410fe715bdfffec38c7c0c1686dddb2a23d4fd623d145e8455",
-        "2864b11878e8129095d62a5dd7c3e3aae178d3a077606a825617324768f189ad05aed08376947df92d6c75865d915cbf",
-        "f858ed2aecba4ecd29084352c6b5c6e403c0bec89b8c852f90fa5a8cee796ffa095518c5cd8b92c25c1856e932a95877",
-        "7719f4fde518994a5dd6767a8b8b87a38168cc0f3480e7498d4ace99e49319be6a7fed26c21ad43310d2d488fc68ab1c",
-        // runtime RTMR3 (runtime_rtmrs.RTMR3) — the running app/IMA layer.
-        "bfac8bbe97148d00c0bc5dea273ccd926e2415511f08f5dedaa96d3c19e824d2bf01fae86e8987ff509fd3ad31374a60",
-    )])
+    // v1.3.0 software identity — shared across every hardware row below.
+    const MRTD: &str = "ddc6efcdd2309e10837f8a7f64b71272b7ef003b129460410fe715bdfffec38c7c0c1686dddb2a23d4fd623d145e8455";
+    const RTMR1: &str = "f858ed2aecba4ecd29084352c6b5c6e403c0bec89b8c852f90fa5a8cee796ffa095518c5cd8b92c25c1856e932a95877";
+    const RTMR2: &str = "7719f4fde518994a5dd6767a8b8b87a38168cc0f3480e7498d4ace99e49319be6a7fed26c21ad43310d2d488fc68ab1c";
+    // runtime RTMR3 (runtime_rtmrs.RTMR3) — the running app/IMA layer.
+    const RTMR3: &str = "bfac8bbe97148d00c0bc5dea273ccd926e2415511f08f5dedaa96d3c19e824d2bf01fae86e8987ff509fd3ad31374a60";
+
+    // (config name, RTMR0) — the per-hardware boot/VM-config register.
+    let hardware_rows = [
+        ("8xh200", "2864b11878e8129095d62a5dd7c3e3aae178d3a077606a825617324768f189ad05aed08376947df92d6c75865d915cbf"),
+        ("8xRTX_PRO_6000", "5064826bfd530ca9f823ceecb74899d7dbd014b60897a77317a14200c8706f2368ecbbc0a04cec8ceef90474b8c955e1"),
+        ("8xb200", "734628b9a715ec492c2b14b409907f32d91847f439ba8bac2fa985b41c01245536348fefb2e021ed574c290c8c50347a"),
+        ("8xb200-eth", "724c1d0d20c11a479d2874fa543b0f1b920be32f2a5b9707fa5bcf6176fff31aeac9436e541e1125f78a0b61f7c2e165"),
+        ("8xb300", "31f6446add906b7d56132c600549270a8ea780193e0c89586f784b20b25136de441ca715d5ecf86ae72f0b40f7a47f39"),
+    ];
+
+    ChutesMeasurementPolicy::new(
+        hardware_rows
+            .iter()
+            .map(|&(name, rtmr0)| {
+                ExpectedMeasurement::new(name, "1.3.0", MRTD, rtmr0, RTMR1, RTMR2, RTMR3)
+            })
+            .collect(),
+    )
 }
 
 #[cfg(test)]
@@ -289,5 +328,88 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ChutesVerifyError::Transform(_)));
+    }
+
+    mod golden {
+        use super::*;
+        use inference_providers::attested::chutes::measurements::REGISTER_LEN;
+
+        fn reg(h: &str) -> [u8; REGISTER_LEN] {
+            let v = hex::decode(h).expect("valid hex register");
+            assert_eq!(v.len(), REGISTER_LEN, "register must be 48 bytes");
+            let mut a = [0u8; REGISTER_LEN];
+            a.copy_from_slice(&v);
+            a
+        }
+
+        // The v1.3.0 software identity, shared across every hardware row.
+        const MRTD: &str = "ddc6efcdd2309e10837f8a7f64b71272b7ef003b129460410fe715bdfffec38c7c0c1686dddb2a23d4fd623d145e8455";
+        const RTMR1: &str = "f858ed2aecba4ecd29084352c6b5c6e403c0bec89b8c852f90fa5a8cee796ffa095518c5cd8b92c25c1856e932a95877";
+        const RTMR2: &str = "7719f4fde518994a5dd6767a8b8b87a38168cc0f3480e7498d4ace99e49319be6a7fed26c21ad43310d2d488fc68ab1c";
+        const RTMR3: &str = "bfac8bbe97148d00c0bc5dea273ccd926e2415511f08f5dedaa96d3c19e824d2bf01fae86e8987ff509fd3ad31374a60";
+        // Per-hardware RTMR0 (the only register that differs within v1.3.0).
+        const RTMR0_H200: &str = "2864b11878e8129095d62a5dd7c3e3aae178d3a077606a825617324768f189ad05aed08376947df92d6c75865d915cbf";
+        const RTMR0_RTX_PRO_6000: &str = "5064826bfd530ca9f823ceecb74899d7dbd014b60897a77317a14200c8706f2368ecbbc0a04cec8ceef90474b8c955e1";
+
+        #[test]
+        fn covers_the_full_v130_hardware_family() {
+            // All five published v1.3.0 hardware platforms are accepted.
+            assert_eq!(vetted_golden_measurements().len(), 5);
+        }
+
+        #[test]
+        fn accepts_rtx_pro_6000_the_config_qwen3_32b_runs_on() {
+            // Regression guard: before the v1.3.0-family expansion only 8xh200 was
+            // pinned, so a Qwen3-32B-TEE instance scheduled on RTX PRO 6000 hardware
+            // — a genuine, signature-verified, nonce-bound quote — was rejected with
+            // "observed measurements match no accepted Chutes config". These are its
+            // live-observed registers; they must now verify.
+            let policy = vetted_golden_measurements();
+            let matched = policy
+                .verify(
+                    &reg(MRTD),
+                    &reg(RTMR0_RTX_PRO_6000),
+                    &reg(RTMR1),
+                    &reg(RTMR2),
+                    &reg(RTMR3),
+                )
+                .expect("RTX PRO 6000 v1.3.0 must be accepted after the family expansion");
+            assert_eq!(matched.name, "8xRTX_PRO_6000");
+            assert_eq!(matched.version, "1.3.0");
+        }
+
+        #[test]
+        fn still_accepts_h200_the_original_glm_config() {
+            let policy = vetted_golden_measurements();
+            let matched = policy
+                .verify(
+                    &reg(MRTD),
+                    &reg(RTMR0_H200),
+                    &reg(RTMR1),
+                    &reg(RTMR2),
+                    &reg(RTMR3),
+                )
+                .expect("the original 8xh200 v1.3.0 row must keep matching");
+            assert_eq!(matched.name, "8xh200");
+        }
+
+        #[test]
+        fn rejects_v130_software_on_an_unpublished_rtmr0() {
+            // Same vetted software identity but a fabricated hardware register that
+            // matches no published row — fail-closed, never a soft pass.
+            let mut bogus_rtmr0 = reg(RTMR0_H200);
+            bogus_rtmr0[0] ^= 0xff;
+            let policy = vetted_golden_measurements();
+            let err = policy
+                .verify(
+                    &reg(MRTD),
+                    &bogus_rtmr0,
+                    &reg(RTMR1),
+                    &reg(RTMR2),
+                    &reg(RTMR3),
+                )
+                .unwrap_err();
+            assert!(matches!(err, MeasurementError::NoMatch { .. }));
+        }
     }
 }

--- a/crates/services/src/attestation/chutes.rs
+++ b/crates/services/src/attestation/chutes.rs
@@ -221,11 +221,12 @@ impl ChutesInstanceVerifier for ChutesBackendVerifier {
 /// Live cross-checks against genuine, DCAP-signature-verified, report-data-bound
 /// quotes (the measurement check runs only *after* the Intel signature chain and
 /// the nonce/e2e-key/SPKI bindings pass, so observed registers are trustworthy):
-///   - `8xh200 v1.3.0`         — GLM-5.1-TEE, 6/6 quotes (2026-06-10); and
-///                               kimi-k2.5 / deepseek-v3.2 / minimax-m2.5 served
-///                               live over E2EE (2026-06-11).
-///   - `8xRTX_PRO_6000 v1.3.0` — Qwen3-32B-TEE, observed register set matched the
-///                               published row byte-for-byte (2026-06-11).
+///
+/// - `8xh200 v1.3.0` — GLM-5.1-TEE, 6/6 quotes (2026-06-10); and kimi-k2.5 /
+///   deepseek-v3.2 / minimax-m2.5 served live over E2EE (2026-06-11).
+/// - `8xRTX_PRO_6000 v1.3.0` — Qwen3-32B-TEE, observed register set matched the
+///   published row byte-for-byte (2026-06-11).
+///
 /// The remaining Blackwell rows (b200 / b200-eth / b300) are taken from the same
 /// published v1.3.0 release and carry the identical software identity; they are
 /// accepted so a model scheduled onto Blackwell hardware serves without a
@@ -257,8 +258,8 @@ pub fn vetted_golden_measurements() -> ChutesMeasurementPolicy {
 
     ChutesMeasurementPolicy::new(
         hardware_rows
-            .iter()
-            .map(|&(name, rtmr0)| {
+            .into_iter()
+            .map(|(name, rtmr0)| {
                 ExpectedMeasurement::new(name, "1.3.0", MRTD, rtmr0, RTMR1, RTMR2, RTMR3)
             })
             .collect(),
@@ -350,11 +351,60 @@ mod tests {
         // Per-hardware RTMR0 (the only register that differs within v1.3.0).
         const RTMR0_H200: &str = "2864b11878e8129095d62a5dd7c3e3aae178d3a077606a825617324768f189ad05aed08376947df92d6c75865d915cbf";
         const RTMR0_RTX_PRO_6000: &str = "5064826bfd530ca9f823ceecb74899d7dbd014b60897a77317a14200c8706f2368ecbbc0a04cec8ceef90474b8c955e1";
+        const RTMR0_B200: &str = "734628b9a715ec492c2b14b409907f32d91847f439ba8bac2fa985b41c01245536348fefb2e021ed574c290c8c50347a";
+        const RTMR0_B200_ETH: &str = "724c1d0d20c11a479d2874fa543b0f1b920be32f2a5b9707fa5bcf6176fff31aeac9436e541e1125f78a0b61f7c2e165";
+        const RTMR0_B300: &str = "31f6446add906b7d56132c600549270a8ea780193e0c89586f784b20b25136de441ca715d5ecf86ae72f0b40f7a47f39";
+
+        // Accept the v1.3.0 software identity on `rtmr0`, asserting the matched
+        // row is `name`. Drives the full register set through `verify()`.
+        fn accepts(rtmr0: &str, name: &str) {
+            let policy = vetted_golden_measurements();
+            let matched = policy
+                .verify(
+                    &reg(MRTD),
+                    &reg(rtmr0),
+                    &reg(RTMR1),
+                    &reg(RTMR2),
+                    &reg(RTMR3),
+                )
+                .unwrap_or_else(|e| panic!("{name} v1.3.0 must be accepted: {e}"));
+            assert_eq!(matched.name, name);
+            assert_eq!(matched.version, "1.3.0");
+        }
+
+        #[test]
+        fn every_vetted_row_is_well_formed_48_byte_hex() {
+            // Guards against a transcription typo (wrong length / non-hex char) in
+            // any pinned row — especially the three Blackwell rows whose RTMR0 is
+            // only exercised positively by the per-SKU tests below. `verify()`
+            // runs `assert_enforceable()` per-request, so an InvalidGolden row
+            // would otherwise only surface in production as a fail-closed reject.
+            vetted_golden_measurements()
+                .assert_enforceable()
+                .expect("all pinned golden rows must be valid 48-byte hex");
+        }
 
         #[test]
         fn covers_the_full_v130_hardware_family() {
-            // All five published v1.3.0 hardware platforms are accepted.
+            // All five published v1.3.0 hardware platforms are accepted — by name,
+            // so swapping a row for a different config (count unchanged) still fails.
             assert_eq!(vetted_golden_measurements().len(), 5);
+            accepts(RTMR0_H200, "8xh200");
+            accepts(RTMR0_RTX_PRO_6000, "8xRTX_PRO_6000");
+            accepts(RTMR0_B200, "8xb200");
+            accepts(RTMR0_B200_ETH, "8xb200-eth");
+            accepts(RTMR0_B300, "8xb300");
+        }
+
+        #[test]
+        fn accepts_the_three_blackwell_rows() {
+            // The b200 / b200-eth / b300 rows have no live signature-verified
+            // cross-check yet (documented trade-off); these assert the pinned
+            // RTMR0 literals were copied correctly and map to the right SKU, so a
+            // typo fails a specific test rather than only the count check.
+            accepts(RTMR0_B200, "8xb200");
+            accepts(RTMR0_B200_ETH, "8xb200-eth");
+            accepts(RTMR0_B300, "8xb300");
         }
 
         #[test]


### PR DESCRIPTION
## Problem

`vetted_golden_measurements()` pinned only **`8xh200 v1.3.0`**. Every Chutes TEE model scheduled onto other hardware (RTX PRO 6000 / B200 / B300) presents a different **RTMR0** and is rejected:

```
attestation failed: measurement register-pin: observed measurements match no
accepted Chutes config (mrtd=ddc6efc…, rtmr0=5064826b…, …)
```

…surfaced to the client as a 502 *"The model is currently unavailable."* On staging only models that happened to land on an H200 instance served. **Qwen3-32B-TEE runs on RTX PRO 6000 → every request failed.** (Found while bringing up the full Chutes inventory on `cloud-stg-api`.)

## Root cause

The register-pin requires **all five** registers (MRTD + RTMR0-2 + runtime RTMR3) to equal one config row. Across Chutes' published **v1.3.0** release, the five hardware rows are **byte-identical** on MRTD (firmware), RTMR1 (kernel), RTMR2 (cmdline) and **RTMR3** (the running app/IMA layer — the security-relevant software identity). They differ **only in RTMR0**, which tracks the TD-HOB/ACPI/VM-config (GPU SKU + VM sizing).

| register | varies within v1.3.0? | meaning |
|---|---|---|
| MRTD, RTMR1, RTMR2, **RTMR3** | ❌ identical | firmware + kernel + cmdline + **app/IMA software identity** |
| RTMR0 | ✅ 5 distinct | GPU SKU / VM-config (h200, RTX_PRO_6000, b200, b200-eth, b300) |

## Fix

Enumerate all five published **v1.3.0** hardware rows. A request can now land on any vetted Chutes hardware platform while still authenticating the full software stack against one fixed identity.

**Trust chain is unbroken:** the Intel DCAP signature remains the cryptographic root of trust. The measurement check runs **only after** the signature chain *and* the `report_data` bindings (nonce ‖ e2e_pubkey, cert SPKI) pass — so every register we accept comes from a genuine, fresh, nonce-bound quote. The transparency endpoint only *enumerates* which genuine software identities we accept; it is not itself trusted.

Values copied byte-for-byte from `GET https://api.chutes.ai/servers/tee/measurements`.

### Live cross-checks (genuine, signature-verified, nonce-bound quotes)
- **`8xh200 v1.3.0`** — GLM-5.1-TEE 6/6 quotes (2026-06-10); kimi-k2.5 / deepseek-v3.2 / minimax-m2.5 served live over E2EE (2026-06-11).
- **`8xRTX_PRO_6000 v1.3.0`** — Qwen3-32B-TEE observed register set matched the published row byte-for-byte (2026-06-11).
- The Blackwell rows (b200 / b200-eth / b300) carry the identical v1.3.0 software identity and are accepted so a model scheduled onto Blackwell serves without a per-SKU re-vet.

### Excluded (fail-closed)
- **v1.0.0–v1.2.0**: publish `RTMR3 = all-zeros` (boot templates, never matchable against a live extended RTMR3).
- **v1.3.1**: distinct firmware/kernel (different MRTD/RTMR1), no live instance yet — add on the next Chutes upgrade once a live quote cross-checks.

Anything not listed is rejected.

## Tests
- `accepts_rtx_pro_6000_the_config_qwen3_32b_runs_on` — regression guard for the exact 502.
- `still_accepts_h200_the_original_glm_config`, `covers_the_full_v130_hardware_family`.
- `rejects_v130_software_on_an_unpublished_rtmr0` — fabricated RTMR0 still fails closed.

## Follow-up (separate)
Chutes `/e2e/instances` rate-limits (429) under burst and is masked as a generic 502 — should map to a retryable 503 and/or cache instance discovery. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)