### PR TITLE
Strip Chutes-internal/serving response fields (#780)

### DIFF
--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -370,18 +370,60 @@ const INTERNAL_KEYS: &[&str] = {
     ]
 };
 
-/// Rewrite the `model` field of a decrypted OpenAI SSE event to the canonical id —
-/// in BOTH `raw_bytes` (the byte-exact passthrough path) AND the parsed `chunk`
-/// (the route re-serializes from `chunk`, not `raw_bytes`, on the auto-redact /
-/// alias-served paths — so leaving the slug there would still leak it). Only
-/// touches chunk-bearing data lines; control events ([DONE], blanks, the keyed
-/// init) have no chunk and pass through unchanged. On any parse failure the event
-/// is returned as-is (never drop a chunk over a rewrite). The rewrite is ATOMIC:
-/// we compute the rewritten `raw_bytes` first and bail (returning the event
-/// unchanged) on any failure, mutating the parsed `chunk` only once that succeeds —
-/// so the event can never end up with `chunk` carrying the canonical id while
-/// `raw_bytes` still leaks the slug.
-fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: &str) -> SSEEvent {
+/// Chutes-internal / serving fields that must be stripped from the decrypted
+/// response before it reaches a client (#780). `prompt_sha256` is the genuine
+/// privacy concern — a deterministic SHA-256 fingerprint of the rendered user
+/// prompt — while the others are sglang/serving internals that a NEAR/Anthropic/
+/// OpenAI response on the same endpoint never carries.
+///
+/// `chutes_verification` (the attestation receipt) is deliberately NOT listed —
+/// it's kept untouched. We strip ONLY these named keys, so unmodeled fields the
+/// repo intentionally passes through (e.g. `hidden_states`) survive.
+const STRIPPED_TOP_LEVEL_FIELDS: &[&str] = &["prompt_sha256", "template_sha256", "metadata"];
+
+/// Per-choice serving internal stripped from every element of `choices` (#780):
+/// sglang's matched stop-token id.
+const STRIPPED_CHOICE_FIELDS: &[&str] = &["matched_stop"];
+
+/// Remove the Chutes-internal/serving fields ([`STRIPPED_TOP_LEVEL_FIELDS`] at the
+/// top level + [`STRIPPED_CHOICE_FIELDS`] inside each `choices` element) from a
+/// decrypted response JSON, in place. Surgical by design: it touches ONLY the named
+/// keys, so `chutes_verification` and any unmodeled passthrough field (e.g.
+/// `hidden_states`) are left exactly as-is. A no-op on a non-object value (the
+/// caller keeps such bodies verbatim). Used on both non-stream paths and per
+/// `data:` chunk on the stream path (the chunk shape — `choices[].delta` — also
+/// carries `matched_stop` per choice at the final chunk).
+fn strip_internal_response_fields(v: &mut Value) {
+    let Some(obj) = v.as_object_mut() else {
+        return;
+    };
+    for k in STRIPPED_TOP_LEVEL_FIELDS {
+        obj.remove(*k);
+    }
+    if let Some(choices) = obj.get_mut("choices").and_then(Value::as_array_mut) {
+        for choice in choices {
+            if let Some(choice_obj) = choice.as_object_mut() {
+                for k in STRIPPED_CHOICE_FIELDS {
+                    choice_obj.remove(*k);
+                }
+            }
+        }
+    }
+}
+
+/// Rewrite the `model` field of a decrypted OpenAI SSE event to the canonical id
+/// (when `canonical` is `Some`) AND strip the Chutes-internal/serving fields
+/// (#780) — in BOTH `raw_bytes` (the byte-exact passthrough path) AND the parsed
+/// `chunk` (the route re-serializes from `chunk`, not `raw_bytes`, on the
+/// auto-redact / alias-served paths — so leaving the slug/internal fields there
+/// would still leak them). Only touches chunk-bearing data lines; control events
+/// ([DONE], blanks, the keyed init) have no chunk and pass through unchanged. On
+/// any parse failure the event is returned as-is (never drop a chunk over a
+/// rewrite). The rewrite is ATOMIC: we compute the rewritten `raw_bytes` first and
+/// bail (returning the event unchanged) on any failure, mutating the parsed `chunk`
+/// only once that succeeds — so the event can never end up with `chunk` carrying
+/// the canonical id while `raw_bytes` still leaks the slug.
+fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: Option<&str>) -> SSEEvent {
     if ev.chunk.is_none() {
         return ev;
     }
@@ -389,14 +431,14 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: &str) -> SSEEvent {
         return ev;
     };
     let content = s.strip_prefix("data:").map(str::trim).unwrap_or(s.trim());
-    let Some(rewritten) = set_model_in_json(content.as_bytes(), canonical) else {
+    let Some(rewritten) = transform_response_json(content.as_bytes(), canonical) else {
         return ev;
     };
     let Ok(json) = String::from_utf8(rewritten) else {
         return ev;
     };
     // raw_bytes rewrite succeeded — now mutate the parsed chunk to match.
-    if let Some(StreamChunk::Chat(c)) = &mut ev.chunk {
+    if let (Some(canonical), Some(StreamChunk::Chat(c))) = (canonical, &mut ev.chunk) {
         c.model = canonical.to_string();
     }
     SSEEvent {
@@ -406,13 +448,18 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: &str) -> SSEEvent {
     }
 }
 
-/// Set `model` to `canonical` in an OpenAI JSON body, preserving every other field
-/// (so unmodeled provider fields survive). Returns the re-serialized bytes, or
-/// `None` if the body isn't a JSON object or (de)serialization fails.
-fn set_model_in_json(bytes: &[u8], canonical: &str) -> Option<Vec<u8>> {
+/// Transform a decrypted OpenAI JSON body: optionally set `model` to `canonical`,
+/// then strip the Chutes-internal/serving fields (#780). Preserves every other
+/// field (so unmodeled provider fields like `hidden_states` survive). Returns the
+/// re-serialized bytes, or `None` if the body isn't a JSON object or
+/// (de)serialization fails.
+fn transform_response_json(bytes: &[u8], canonical: Option<&str>) -> Option<Vec<u8>> {
     let mut v: Value = serde_json::from_slice(bytes).ok()?;
-    v.as_object_mut()?
-        .insert("model".to_string(), Value::String(canonical.to_string()));
+    let obj = v.as_object_mut()?;
+    if let Some(canonical) = canonical {
+        obj.insert("model".to_string(), Value::String(canonical.to_string()));
+    }
+    strip_internal_response_fields(&mut v);
     serde_json::to_vec(&v).ok()
 }
 
@@ -524,30 +571,25 @@ impl InferenceProvider for Provider {
         // The upstream body carries the chute SLUG in `model`. When the canonical id
         // differs (NEAR-served / OpenRouter-id case), rewrite `model` to the
         // canonical id so the slug never leaks to clients and `response.model`
-        // matches an id listable in /v1/models. We rewrite the JSON *value* (not the
-        // typed struct) so any unmodeled provider fields survive. When canonical ==
-        // slug, keep the plaintext verbatim (byte-exact, preserves unmodeled fields
-        // like `hidden_states`). No signature is sacrificed — Chutes responses aren't
-        // separately signed (`supports_chat_signatures == false`).
-        if self.canonical_id != self.model_name {
-            let raw_bytes = set_model_in_json(&plaintext, &self.canonical_id).ok_or_else(|| {
-                CompletionError::CompletionError(
-                    "failed to rewrite Chutes response model to the canonical id".to_string(),
-                )
-            })?;
-            let response: ChatCompletionResponse = serde_json::from_slice(&raw_bytes)
-                .map_err(|e| CompletionError::CompletionError(format!("parse response: {e}")))?;
-            return Ok(ChatCompletionResponseWithBytes {
-                response,
-                raw_bytes,
-            });
-        }
-
-        let response: ChatCompletionResponse = serde_json::from_slice(&plaintext)
+        // matches an id listable in /v1/models. In BOTH cases we also strip the
+        // Chutes-internal/serving fields (#780: `prompt_sha256` — a user-prompt
+        // fingerprint — plus `template_sha256`/`metadata`/`choices[].matched_stop`)
+        // so a Chutes response matches the clean shape returned for first-party /
+        // Anthropic / OpenAI models. We transform the JSON *value* (not the typed
+        // struct), removing ONLY those named keys — so `chutes_verification` (the
+        // attestation receipt) and any unmodeled passthrough field (e.g.
+        // `hidden_states`) survive. No signature is sacrificed — Chutes responses
+        // aren't separately signed (`supports_chat_signatures == false`).
+        let canonical =
+            (self.canonical_id != self.model_name).then_some(self.canonical_id.as_str());
+        let raw_bytes = transform_response_json(&plaintext, canonical).ok_or_else(|| {
+            CompletionError::CompletionError("failed to sanitize Chutes response body".to_string())
+        })?;
+        let response: ChatCompletionResponse = serde_json::from_slice(&raw_bytes)
             .map_err(|e| CompletionError::CompletionError(format!("parse response: {e}")))?;
         Ok(ChatCompletionResponseWithBytes {
             response,
-            raw_bytes: plaintext,
+            raw_bytes,
         })
     }
 
@@ -598,16 +640,15 @@ impl InferenceProvider for Provider {
             r.map_err(|e| CompletionError::CompletionError(format!("Chutes stream transport: {e}")))
         });
         let decoded = e2ee_stream::decrypt_e2ee_sse(Box::pin(byte_stream), prep.session);
-        // Same canonical-id rewrite as the non-stream path: when the canonical id
-        // differs from the chute slug, rewrite `model` in each decrypted `data:`
-        // line so streamed chunks never leak the slug to clients. No-op (and no
-        // per-chunk re-serialization) when canonical == slug.
-        if self.canonical_id == self.model_name {
-            return Ok(decoded);
-        }
-        let canonical = self.canonical_id.clone();
+        // Per-chunk transform, mirroring the non-stream path: strip the
+        // Chutes-internal/serving fields (#780) from every decrypted `data:` line,
+        // and — only when the canonical id differs from the chute slug — also rewrite
+        // `model` so streamed chunks never leak the slug. We ALWAYS run the strip
+        // (even when canonical == slug), since `prompt_sha256`/`template_sha256`/
+        // `metadata`/`choices[].matched_stop` can appear on the stream regardless.
+        let canonical = (self.canonical_id != self.model_name).then(|| self.canonical_id.clone());
         Ok(Box::pin(decoded.map(move |item| {
-            item.map(|ev| rewrite_sse_event_model(ev, &canonical))
+            item.map(|ev| rewrite_sse_event_model(ev, canonical.as_deref()))
         })))
     }
 
@@ -890,19 +931,82 @@ mod tests {
     }
 
     #[test]
-    fn set_model_in_json_rewrites_model_and_preserves_other_fields() {
+    fn transform_response_json_rewrites_model_and_preserves_other_fields() {
         // The canonical-id rewrite that keeps the chute slug out of `response.model`
         // while preserving every other (incl. unmodeled) field.
         let body =
             br#"{"id":"x","model":"zai-org/GLM-5.1-TEE","choices":[],"hidden_states":[1,2]}"#;
-        let out = set_model_in_json(body, "zai-org/GLM-5.1-FP8").expect("rewrite");
+        let out = transform_response_json(body, Some("zai-org/GLM-5.1-FP8")).expect("rewrite");
         let v: Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(v["model"], "zai-org/GLM-5.1-FP8");
         assert_eq!(v["id"], "x");
         // Unmodeled provider field survives the rewrite.
         assert_eq!(v["hidden_states"], json!([1, 2]));
         // Non-object body → None (left untouched by callers).
-        assert!(set_model_in_json(b"[1,2,3]", "x").is_none());
+        assert!(transform_response_json(b"[1,2,3]", Some("x")).is_none());
+        // With canonical == None, `model` is left as-is (strip-only mode).
+        let out = transform_response_json(body, None).expect("strip-only");
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["model"], "zai-org/GLM-5.1-TEE");
+        assert_eq!(v["hidden_states"], json!([1, 2]));
+    }
+
+    #[test]
+    fn transform_response_json_strips_internal_fields_keeps_verification_and_hidden_states() {
+        // A Chutes-shaped non-stream body (#780): internal/serving fields present.
+        let body = br#"{
+            "id":"x",
+            "model":"zai-org/GLM-5.1-TEE",
+            "prompt_sha256":"deadbeef",
+            "template_sha256":"cafef00d",
+            "metadata":{"weight_version":"v3"},
+            "chutes_verification":{"quote":"abc","instance_id":"i"},
+            "hidden_states":[1,2,3],
+            "choices":[
+                {"index":0,"matched_stop":151643,"message":{"role":"assistant","content":"hi"}}
+            ]
+        }"#;
+        // Strip-only mode (canonical == slug) and rewrite mode (canonical != slug)
+        // must BOTH remove the internal fields.
+        for canonical in [None, Some("zai-org/GLM-5.1-FP8")] {
+            let out = transform_response_json(body, canonical).expect("transform");
+            let v: Value = serde_json::from_slice(&out).unwrap();
+            // The genuine privacy concern and the serving internals are gone.
+            assert!(
+                v.get("prompt_sha256").is_none(),
+                "prompt_sha256 must be stripped"
+            );
+            assert!(
+                v.get("template_sha256").is_none(),
+                "template_sha256 must be stripped"
+            );
+            assert!(v.get("metadata").is_none(), "metadata must be stripped");
+            // The attestation receipt is KEPT untouched.
+            assert_eq!(v["chutes_verification"]["quote"], "abc");
+            assert_eq!(v["chutes_verification"]["instance_id"], "i");
+            // Unmodeled passthrough field survives.
+            assert_eq!(v["hidden_states"], json!([1, 2, 3]));
+            // Per-choice serving internal removed; other choice fields kept.
+            assert!(
+                v["choices"][0].get("matched_stop").is_none(),
+                "choices[].matched_stop must be stripped"
+            );
+            assert_eq!(v["choices"][0]["index"], 0);
+            assert_eq!(v["choices"][0]["message"]["content"], "hi");
+        }
+    }
+
+    #[test]
+    fn strip_internal_response_fields_is_noop_on_non_object() {
+        // The caller keeps non-object bodies verbatim; the helper must not panic.
+        let mut v = json!([1, 2, 3]);
+        strip_internal_response_fields(&mut v);
+        assert_eq!(v, json!([1, 2, 3]));
+        // No `choices` array → only top-level keys removed, no panic.
+        let mut v = json!({"id":"x","prompt_sha256":"d","choices":"not-an-array"});
+        strip_internal_response_fields(&mut v);
+        assert!(v.get("prompt_sha256").is_none());
+        assert_eq!(v["choices"], "not-an-array");
     }
 
     #[test]
@@ -920,7 +1024,7 @@ mod tests {
             chunk: Some(StreamChunk::Chat(chunk)),
             raw_passthrough: true,
         };
-        let out = rewrite_sse_event_model(ev, "zai-org/GLM-5.1-FP8");
+        let out = rewrite_sse_event_model(ev, Some("zai-org/GLM-5.1-FP8"));
         let s = std::str::from_utf8(&out.raw_bytes).unwrap();
         assert!(
             s.contains("zai-org/GLM-5.1-FP8"),
@@ -943,8 +1047,50 @@ mod tests {
             chunk: None,
             raw_passthrough: true,
         };
-        let out = rewrite_sse_event_model(ctrl, "zai-org/GLM-5.1-FP8");
+        let out = rewrite_sse_event_model(ctrl, Some("zai-org/GLM-5.1-FP8"));
         assert_eq!(&out.raw_bytes[..], b"data: [DONE]\n\n");
+    }
+
+    #[test]
+    fn rewrite_sse_event_model_strips_internal_fields_per_chunk() {
+        use crate::{ChatCompletionChunk, StreamChunk};
+        // A final stream chunk carrying the Chutes-internal/serving fields (#780).
+        // canonical == None (slug == canonical) is the strip-only mode that the
+        // stream path uses for a Chutes-only model.
+        let raw = br#"data: {"id":"c","object":"chat.completion.chunk","created":0,"model":"zai-org/GLM-5.1-TEE","prompt_sha256":"deadbeef","template_sha256":"cafef00d","metadata":{"weight_version":"v3"},"chutes_verification":{"quote":"abc"},"hidden_states":[7,8],"choices":[{"index":0,"matched_stop":151643,"delta":{}}]}"#;
+        let mut full = raw.to_vec();
+        full.extend_from_slice(b"\n\n");
+        let chunk: ChatCompletionChunk = serde_json::from_value(json!({
+            "id":"c","object":"chat.completion.chunk","created":0,
+            "model":"zai-org/GLM-5.1-TEE","choices":[]
+        }))
+        .unwrap();
+        let ev = SSEEvent {
+            raw_bytes: bytes::Bytes::from(full),
+            chunk: Some(StreamChunk::Chat(chunk)),
+            raw_passthrough: true,
+        };
+        let out = rewrite_sse_event_model(ev, None);
+        let s = std::str::from_utf8(&out.raw_bytes).unwrap();
+        let payload = s.strip_prefix("data: ").unwrap().trim_end();
+        let v: Value = serde_json::from_str(payload).unwrap();
+        // Internal/serving fields stripped from the streamed chunk.
+        assert!(v.get("prompt_sha256").is_none(), "prompt_sha256 stripped");
+        assert!(
+            v.get("template_sha256").is_none(),
+            "template_sha256 stripped"
+        );
+        assert!(v.get("metadata").is_none(), "metadata stripped");
+        assert!(
+            v["choices"][0].get("matched_stop").is_none(),
+            "choices[].matched_stop stripped"
+        );
+        // canonical == None → `model` (the slug here) is left as-is by this helper;
+        // the strip happened regardless of any model rewrite.
+        assert_eq!(v["model"], "zai-org/GLM-5.1-TEE");
+        // Attestation receipt + unmodeled passthrough survive.
+        assert_eq!(v["chutes_verification"]["quote"], "abc");
+        assert_eq!(v["hidden_states"], json!([7, 8]));
     }
 
     #[test]
@@ -969,7 +1115,7 @@ mod tests {
             chunk: Some(StreamChunk::Chat(chunk)),
             raw_passthrough: true,
         };
-        let out = rewrite_sse_event_model(ev, "zai-org/GLM-5.1-FP8");
+        let out = rewrite_sse_event_model(ev, Some("zai-org/GLM-5.1-FP8"));
         // raw_bytes untouched (no canonical id introduced, no reframing).
         assert_eq!(&out.raw_bytes[..], b"data: [1,2,3]\n\n");
         // The parsed chunk's model must NOT have been mutated to canonical.

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -387,16 +387,14 @@ const STRIPPED_CHOICE_FIELDS: &[&str] = &["matched_stop"];
 
 /// Remove the Chutes-internal/serving fields ([`STRIPPED_TOP_LEVEL_FIELDS`] at the
 /// top level + [`STRIPPED_CHOICE_FIELDS`] inside each `choices` element) from a
-/// decrypted response JSON, in place. Surgical by design: it touches ONLY the named
-/// keys, so `chutes_verification` and any unmodeled passthrough field (e.g.
-/// `hidden_states`) are left exactly as-is. A no-op on a non-object value (the
-/// caller keeps such bodies verbatim). Used on both non-stream paths and per
-/// `data:` chunk on the stream path (the chunk shape — `choices[].delta` — also
-/// carries `matched_stop` per choice at the final chunk).
-fn strip_internal_response_fields(v: &mut Value) {
-    let Some(obj) = v.as_object_mut() else {
-        return;
-    };
+/// decrypted response object, in place. Surgical by design: it touches ONLY the
+/// named keys, so `chutes_verification` and any unmodeled passthrough field (e.g.
+/// `hidden_states`) are left exactly as-is. Takes the object map directly — the
+/// caller has already established it's a JSON object (a non-object body is kept
+/// verbatim). Used on both non-stream paths and per `data:` chunk on the stream
+/// path (the chunk shape — `choices[].delta` — also carries `matched_stop` per
+/// choice at the final chunk).
+fn strip_internal_response_fields(obj: &mut serde_json::Map<String, Value>) {
     for k in STRIPPED_TOP_LEVEL_FIELDS {
         obj.remove(*k);
     }
@@ -416,13 +414,20 @@ fn strip_internal_response_fields(v: &mut Value) {
 /// (#780) — in BOTH `raw_bytes` (the byte-exact passthrough path) AND the parsed
 /// `chunk` (the route re-serializes from `chunk`, not `raw_bytes`, on the
 /// auto-redact / alias-served paths — so leaving the slug/internal fields there
-/// would still leak them). Only touches chunk-bearing data lines; control events
-/// ([DONE], blanks, the keyed init) have no chunk and pass through unchanged. On
+/// would still leak them). The chunk-side strip targets `ChatCompletionChunk::extra`,
+/// the `#[serde(flatten)]` catch-all that captures exactly the stripped top-level
+/// keys (`matched_stop` has no slot on `ChatChoice` and is dropped on parse, so the
+/// per-choice strip is `raw_bytes`-only). Only touches chunk-bearing data lines;
+/// control events ([DONE], blanks, the keyed init) have no chunk and pass through
+/// unchanged. As a cheap fast path, an event that needs neither a model rewrite
+/// (`canonical == None`) nor any strip (none of the stripped keys appear as a
+/// substring in the raw line) is returned verbatim without a JSON round-trip. On
 /// any parse failure the event is returned as-is (never drop a chunk over a
 /// rewrite). The rewrite is ATOMIC: we compute the rewritten `raw_bytes` first and
 /// bail (returning the event unchanged) on any failure, mutating the parsed `chunk`
 /// only once that succeeds — so the event can never end up with `chunk` carrying
-/// the canonical id while `raw_bytes` still leaks the slug.
+/// the canonical id (or the stripped keys) while `raw_bytes` is already clean, or
+/// vice versa.
 fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: Option<&str>) -> SSEEvent {
     if ev.chunk.is_none() {
         return ev;
@@ -430,6 +435,11 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: Option<&str>) -> SSEEven
     let Ok(s) = std::str::from_utf8(&ev.raw_bytes) else {
         return ev;
     };
+    // Fast path: nothing to rewrite (already canonical) and a cheap substring scan
+    // finds none of the stripped keys → pure passthrough, no JSON round-trip.
+    if canonical.is_none() && !contains_any_stripped_key(s) {
+        return ev;
+    }
     let content = s.strip_prefix("data:").map(str::trim).unwrap_or(s.trim());
     let Some(rewritten) = transform_response_json(content.as_bytes(), canonical) else {
         return ev;
@@ -437,15 +447,35 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: Option<&str>) -> SSEEven
     let Ok(json) = String::from_utf8(rewritten) else {
         return ev;
     };
-    // raw_bytes rewrite succeeded — now mutate the parsed chunk to match.
-    if let (Some(canonical), Some(StreamChunk::Chat(c))) = (canonical, &mut ev.chunk) {
-        c.model = canonical.to_string();
+    // raw_bytes rewrite succeeded — now mutate the parsed chunk to match, so the
+    // re-serialized-chunk route paths emit the same sanitized payload. The strip
+    // runs regardless of `canonical`: `ChatCompletionChunk::extra` holds exactly
+    // the stripped top-level keys.
+    if let Some(StreamChunk::Chat(c)) = &mut ev.chunk {
+        if let Some(canonical) = canonical {
+            c.model = canonical.to_string();
+        }
+        for k in STRIPPED_TOP_LEVEL_FIELDS {
+            c.extra.remove(*k);
+        }
     }
     SSEEvent {
         raw_bytes: bytes::Bytes::from(format!("data: {json}\n\n")),
         chunk: ev.chunk,
         raw_passthrough: ev.raw_passthrough,
     }
+}
+
+/// Cheap substring scan over a raw SSE line for any stripped key, used to skip the
+/// JSON round-trip when there's nothing to strip and no model rewrite is needed. A
+/// false positive (the key name appears inside string content) only costs a
+/// round-trip that produces identical output; a false negative is impossible since
+/// a present key must appear literally. Per-choice keys are included too.
+fn contains_any_stripped_key(raw: &str) -> bool {
+    STRIPPED_TOP_LEVEL_FIELDS
+        .iter()
+        .chain(STRIPPED_CHOICE_FIELDS)
+        .any(|k| raw.contains(*k))
 }
 
 /// Transform a decrypted OpenAI JSON body: optionally set `model` to `canonical`,
@@ -459,7 +489,7 @@ fn transform_response_json(bytes: &[u8], canonical: Option<&str>) -> Option<Vec<
     if let Some(canonical) = canonical {
         obj.insert("model".to_string(), Value::String(canonical.to_string()));
     }
-    strip_internal_response_fields(&mut v);
+    strip_internal_response_fields(obj);
     serde_json::to_vec(&v).ok()
 }
 
@@ -997,16 +1027,15 @@ mod tests {
     }
 
     #[test]
-    fn strip_internal_response_fields_is_noop_on_non_object() {
-        // The caller keeps non-object bodies verbatim; the helper must not panic.
-        let mut v = json!([1, 2, 3]);
-        strip_internal_response_fields(&mut v);
-        assert_eq!(v, json!([1, 2, 3]));
-        // No `choices` array → only top-level keys removed, no panic.
+    fn strip_internal_response_fields_handles_missing_choices() {
+        // No `choices` array → only top-level keys removed, no panic. (The
+        // non-object case is the caller's concern — `transform_response_json`
+        // returns `None` and the body is kept verbatim; covered above.)
         let mut v = json!({"id":"x","prompt_sha256":"d","choices":"not-an-array"});
-        strip_internal_response_fields(&mut v);
-        assert!(v.get("prompt_sha256").is_none());
-        assert_eq!(v["choices"], "not-an-array");
+        let obj = v.as_object_mut().unwrap();
+        strip_internal_response_fields(obj);
+        assert!(obj.get("prompt_sha256").is_none());
+        assert_eq!(obj["choices"], "not-an-array");
     }
 
     #[test]
@@ -1053,28 +1082,27 @@ mod tests {
 
     #[test]
     fn rewrite_sse_event_model_strips_internal_fields_per_chunk() {
-        use crate::{ChatCompletionChunk, StreamChunk};
+        use crate::StreamChunk;
         // A final stream chunk carrying the Chutes-internal/serving fields (#780).
         // canonical == None (slug == canonical) is the strip-only mode that the
         // stream path uses for a Chutes-only model.
-        let raw = br#"data: {"id":"c","object":"chat.completion.chunk","created":0,"model":"zai-org/GLM-5.1-TEE","prompt_sha256":"deadbeef","template_sha256":"cafef00d","metadata":{"weight_version":"v3"},"chutes_verification":{"quote":"abc"},"hidden_states":[7,8],"choices":[{"index":0,"matched_stop":151643,"delta":{}}]}"#;
-        let mut full = raw.to_vec();
-        full.extend_from_slice(b"\n\n");
-        let chunk: ChatCompletionChunk = serde_json::from_value(json!({
-            "id":"c","object":"chat.completion.chunk","created":0,
-            "model":"zai-org/GLM-5.1-TEE","choices":[]
-        }))
-        .unwrap();
+        let payload = r#"{"id":"c","object":"chat.completion.chunk","created":0,"model":"zai-org/GLM-5.1-TEE","prompt_sha256":"deadbeef","template_sha256":"cafef00d","metadata":{"weight_version":"v3"},"chutes_verification":{"quote":"abc"},"hidden_states":[7,8],"choices":[{"index":0,"matched_stop":151643,"delta":{}}]}"#;
+        // Build the parsed `chunk` from the SAME raw payload that production
+        // deserializes (e2ee_stream), so the catch-all `extra` map actually
+        // captures the internal fields — otherwise the chunk-side leak is invisible.
+        let chunk: StreamChunk =
+            StreamChunk::Chat(serde_json::from_str(payload).expect("parse chunk"));
         let ev = SSEEvent {
-            raw_bytes: bytes::Bytes::from(full),
-            chunk: Some(StreamChunk::Chat(chunk)),
+            raw_bytes: bytes::Bytes::from(format!("data: {payload}\n\n")),
+            chunk: Some(chunk),
             raw_passthrough: true,
         };
         let out = rewrite_sse_event_model(ev, None);
+
+        // raw_bytes: internal/serving fields stripped from the streamed line.
         let s = std::str::from_utf8(&out.raw_bytes).unwrap();
-        let payload = s.strip_prefix("data: ").unwrap().trim_end();
-        let v: Value = serde_json::from_str(payload).unwrap();
-        // Internal/serving fields stripped from the streamed chunk.
+        let raw_payload = s.strip_prefix("data: ").unwrap().trim_end();
+        let v: Value = serde_json::from_str(raw_payload).unwrap();
         assert!(v.get("prompt_sha256").is_none(), "prompt_sha256 stripped");
         assert!(
             v.get("template_sha256").is_none(),
@@ -1088,29 +1116,59 @@ mod tests {
         // canonical == None → `model` (the slug here) is left as-is by this helper;
         // the strip happened regardless of any model rewrite.
         assert_eq!(v["model"], "zai-org/GLM-5.1-TEE");
-        // Attestation receipt + unmodeled passthrough survive.
+        // Attestation receipt + unmodeled passthrough survive in raw_bytes.
         assert_eq!(v["chutes_verification"]["quote"], "abc");
         assert_eq!(v["hidden_states"], json!([7, 8]));
+
+        // PARSED chunk: the route re-serializes from `chunk` (not raw_bytes) on the
+        // auto-redact / alias-served paths, so the chunk MUST be sanitized too. Its
+        // `extra` catch-all captured the internal top-level keys at parse time.
+        let Some(StreamChunk::Chat(c)) = &out.chunk else {
+            panic!("expected a Chat chunk");
+        };
+        let cv = serde_json::to_value(c).expect("serialize chunk");
+        assert!(
+            cv.get("prompt_sha256").is_none(),
+            "prompt_sha256 must be stripped from the parsed chunk (extra)"
+        );
+        assert!(
+            cv.get("template_sha256").is_none(),
+            "template_sha256 must be stripped from the parsed chunk (extra)"
+        );
+        assert!(
+            cv.get("metadata").is_none(),
+            "metadata must be stripped from the parsed chunk (extra)"
+        );
+        // matched_stop has no slot on ChatChoice and is dropped on parse, so it's
+        // already absent from the chunk regardless of the strip.
+        assert!(
+            cv["choices"][0].get("matched_stop").is_none(),
+            "choices[].matched_stop absent from parsed chunk"
+        );
+        // The attestation receipt + unmodeled passthrough survive on the chunk too
+        // (both land in `extra` and are deliberately NOT stripped).
+        assert_eq!(cv["chutes_verification"]["quote"], "abc");
+        assert_eq!(cv["hidden_states"], json!([7, 8]));
     }
 
     #[test]
     fn rewrite_sse_event_model_leaves_chunk_bearing_event_untouched_on_rewrite_failure() {
         use crate::{ChatCompletionChunk, StreamChunk};
         // Pins the ATOMIC invariant: if the raw_bytes rewrite fails (here the
-        // payload isn't a JSON object so set_model_in_json returns None), the event
-        // is returned fully unchanged — raw_bytes AND the parsed chunk's model both
-        // keep their original value. Guards against a future refactor reintroducing
-        // a half-rewritten state (chunk mutated to canonical while raw_bytes still
-        // leaks the slug). This failure path is unreachable in practice (the decoder
-        // only sets chunk: Some when raw_bytes parsed as valid JSON) but is cheap to
-        // pin and the only thing the atomicity reorder protects.
+        // payload isn't a JSON object so transform_response_json returns None), the
+        // event is returned fully unchanged — raw_bytes AND the parsed chunk both
+        // keep their original value (model unchanged, no strip applied). Guards
+        // against a future refactor reintroducing a half-rewritten state (chunk
+        // mutated while raw_bytes still leaks). This failure path is unreachable in
+        // practice (the decoder only sets chunk: Some when raw_bytes parsed as valid
+        // JSON) but is cheap to pin and the only thing the atomicity reorder protects.
         let chunk: ChatCompletionChunk = serde_json::from_value(json!({
             "id":"c","object":"chat.completion.chunk","created":0,
             "model":"zai-org/GLM-5.1-TEE","choices":[]
         }))
         .unwrap();
         let ev = SSEEvent {
-            // Non-object JSON → set_model_in_json returns None → rewrite bails.
+            // Non-object JSON → transform_response_json returns None → rewrite bails.
             raw_bytes: bytes::Bytes::from_static(b"data: [1,2,3]\n\n"),
             chunk: Some(StreamChunk::Chat(chunk)),
             raw_passthrough: true,

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -386,14 +386,16 @@ const STRIPPED_TOP_LEVEL_FIELDS: &[&str] = &["prompt_sha256", "template_sha256",
 const STRIPPED_CHOICE_FIELDS: &[&str] = &["matched_stop"];
 
 /// Remove the Chutes-internal/serving fields ([`STRIPPED_TOP_LEVEL_FIELDS`] at the
-/// top level + [`STRIPPED_CHOICE_FIELDS`] inside each `choices` element) from a
-/// decrypted response object, in place. Surgical by design: it touches ONLY the
-/// named keys, so `chutes_verification` and any unmodeled passthrough field (e.g.
-/// `hidden_states`) are left exactly as-is. Takes the object map directly — the
-/// caller has already established it's a JSON object (a non-object body is kept
-/// verbatim). Used on both non-stream paths and per `data:` chunk on the stream
-/// path (the chunk shape — `choices[].delta` — also carries `matched_stop` per
-/// choice at the final chunk).
+/// top level + [`STRIPPED_CHOICE_FIELDS`] inside each `choices` element, AND inside
+/// each `choices[].delta` on the stream shape) from a decrypted response object, in
+/// place. Surgical by design: it touches ONLY the named keys, so
+/// `chutes_verification` and any unmodeled passthrough field (e.g. `hidden_states`)
+/// are left exactly as-is. Takes the object map directly — the caller has already
+/// established it's a JSON object (a non-object body is kept verbatim). Used on both
+/// non-stream paths and per `data:` chunk on the stream path. sglang currently emits
+/// `matched_stop` at the choice level, but stripping the `delta` too is cheap
+/// defense-in-depth (`ChatDelta` also has a `#[serde(flatten)]` catch-all, so a
+/// delta-nested `matched_stop` would otherwise survive re-serialization).
 fn strip_internal_response_fields(obj: &mut serde_json::Map<String, Value>) {
     for k in STRIPPED_TOP_LEVEL_FIELDS {
         obj.remove(*k);
@@ -403,6 +405,13 @@ fn strip_internal_response_fields(obj: &mut serde_json::Map<String, Value>) {
             if let Some(choice_obj) = choice.as_object_mut() {
                 for k in STRIPPED_CHOICE_FIELDS {
                     choice_obj.remove(*k);
+                }
+                // Defense-in-depth: also strip from `delta` (the stream shape).
+                if let Some(delta_obj) = choice_obj.get_mut("delta").and_then(Value::as_object_mut)
+                {
+                    for k in STRIPPED_CHOICE_FIELDS {
+                        delta_obj.remove(*k);
+                    }
                 }
             }
         }
@@ -416,12 +425,14 @@ fn strip_internal_response_fields(obj: &mut serde_json::Map<String, Value>) {
 /// auto-redact / alias-served paths — so leaving the slug/internal fields there
 /// would still leak them). The chunk-side strip targets `ChatCompletionChunk::extra`,
 /// the `#[serde(flatten)]` catch-all that captures exactly the stripped top-level
-/// keys (`matched_stop` has no slot on `ChatChoice` and is dropped on parse, so the
-/// per-choice strip is `raw_bytes`-only). Only touches chunk-bearing data lines;
-/// control events ([DONE], blanks, the keyed init) have no chunk and pass through
-/// unchanged. As a cheap fast path, an event that needs neither a model rewrite
-/// (`canonical == None`) nor any strip (none of the stripped keys appear as a
-/// substring in the raw line) is returned verbatim without a JSON round-trip. On
+/// keys, plus each `choices[].delta.extra` for the per-choice keys (`matched_stop`
+/// has no slot on `ChatChoice` and is dropped on parse, so the choice-level strip is
+/// `raw_bytes`-only; the `delta` strip is cheap defense-in-depth). Only touches
+/// chunk-bearing data lines; control events ([DONE], blanks, the keyed init) have no
+/// chunk and pass through unchanged. We ALWAYS round-trip a chunk-bearing line
+/// through the JSON sanitizer rather than guarding with a substring scan: this is a
+/// privacy-critical control and a unicode-escaped key (e.g. `"prompt_sha256"`)
+/// would defeat a literal-substring fast path while still parsing into `extra`. On
 /// any parse failure the event is returned as-is (never drop a chunk over a
 /// rewrite). The rewrite is ATOMIC: we compute the rewritten `raw_bytes` first and
 /// bail (returning the event unchanged) on any failure, mutating the parsed `chunk`
@@ -435,11 +446,6 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: Option<&str>) -> SSEEven
     let Ok(s) = std::str::from_utf8(&ev.raw_bytes) else {
         return ev;
     };
-    // Fast path: nothing to rewrite (already canonical) and a cheap substring scan
-    // finds none of the stripped keys → pure passthrough, no JSON round-trip.
-    if canonical.is_none() && !contains_any_stripped_key(s) {
-        return ev;
-    }
     let content = s.strip_prefix("data:").map(str::trim).unwrap_or(s.trim());
     let Some(rewritten) = transform_response_json(content.as_bytes(), canonical) else {
         return ev;
@@ -449,8 +455,8 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: Option<&str>) -> SSEEven
     };
     // raw_bytes rewrite succeeded — now mutate the parsed chunk to match, so the
     // re-serialized-chunk route paths emit the same sanitized payload. The strip
-    // runs regardless of `canonical`: `ChatCompletionChunk::extra` holds exactly
-    // the stripped top-level keys.
+    // runs regardless of `canonical`: `ChatCompletionChunk::extra` holds the stripped
+    // top-level keys, and each `delta.extra` can hold a per-choice key.
     if let Some(StreamChunk::Chat(c)) = &mut ev.chunk {
         if let Some(canonical) = canonical {
             c.model = canonical.to_string();
@@ -458,24 +464,19 @@ fn rewrite_sse_event_model(mut ev: SSEEvent, canonical: Option<&str>) -> SSEEven
         for k in STRIPPED_TOP_LEVEL_FIELDS {
             c.extra.remove(*k);
         }
+        for choice in &mut c.choices {
+            if let Some(delta) = &mut choice.delta {
+                for k in STRIPPED_CHOICE_FIELDS {
+                    delta.extra.remove(*k);
+                }
+            }
+        }
     }
     SSEEvent {
         raw_bytes: bytes::Bytes::from(format!("data: {json}\n\n")),
         chunk: ev.chunk,
         raw_passthrough: ev.raw_passthrough,
     }
-}
-
-/// Cheap substring scan over a raw SSE line for any stripped key, used to skip the
-/// JSON round-trip when there's nothing to strip and no model rewrite is needed. A
-/// false positive (the key name appears inside string content) only costs a
-/// round-trip that produces identical output; a false negative is impossible since
-/// a present key must appear literally. Per-choice keys are included too.
-fn contains_any_stripped_key(raw: &str) -> bool {
-    STRIPPED_TOP_LEVEL_FIELDS
-        .iter()
-        .chain(STRIPPED_CHOICE_FIELDS)
-        .any(|k| raw.contains(*k))
 }
 
 /// Transform a decrypted OpenAI JSON body: optionally set `model` to `canonical`,
@@ -1086,7 +1087,10 @@ mod tests {
         // A final stream chunk carrying the Chutes-internal/serving fields (#780).
         // canonical == None (slug == canonical) is the strip-only mode that the
         // stream path uses for a Chutes-only model.
-        let payload = r#"{"id":"c","object":"chat.completion.chunk","created":0,"model":"zai-org/GLM-5.1-TEE","prompt_sha256":"deadbeef","template_sha256":"cafef00d","metadata":{"weight_version":"v3"},"chutes_verification":{"quote":"abc"},"hidden_states":[7,8],"choices":[{"index":0,"matched_stop":151643,"delta":{}}]}"#;
+        // `matched_stop` appears BOTH at the choice level (no slot on `ChatChoice`,
+        // dropped on parse) and nested in `delta` (captured by `ChatDelta::extra`) to
+        // pin the defense-in-depth delta strip.
+        let payload = r#"{"id":"c","object":"chat.completion.chunk","created":0,"model":"zai-org/GLM-5.1-TEE","prompt_sha256":"deadbeef","template_sha256":"cafef00d","metadata":{"weight_version":"v3"},"chutes_verification":{"quote":"abc"},"hidden_states":[7,8],"choices":[{"index":0,"matched_stop":151643,"delta":{"matched_stop":151643,"content":"hi"}}]}"#;
         // Build the parsed `chunk` from the SAME raw payload that production
         // deserializes (e2ee_stream), so the catch-all `extra` map actually
         // captures the internal fields — otherwise the chunk-side leak is invisible.
@@ -1113,6 +1117,12 @@ mod tests {
             v["choices"][0].get("matched_stop").is_none(),
             "choices[].matched_stop stripped"
         );
+        assert!(
+            v["choices"][0]["delta"].get("matched_stop").is_none(),
+            "choices[].delta.matched_stop stripped (defense-in-depth)"
+        );
+        // The legitimate delta content survives the strip.
+        assert_eq!(v["choices"][0]["delta"]["content"], "hi");
         // canonical == None → `model` (the slug here) is left as-is by this helper;
         // the strip happened regardless of any model rewrite.
         assert_eq!(v["model"], "zai-org/GLM-5.1-TEE");
@@ -1145,10 +1155,49 @@ mod tests {
             cv["choices"][0].get("matched_stop").is_none(),
             "choices[].matched_stop absent from parsed chunk"
         );
+        // The delta-nested matched_stop IS captured by ChatDelta::extra, so the
+        // defense-in-depth strip must remove it from the parsed chunk too.
+        assert!(
+            cv["choices"][0]["delta"].get("matched_stop").is_none(),
+            "choices[].delta.matched_stop must be stripped from the parsed chunk"
+        );
+        assert_eq!(cv["choices"][0]["delta"]["content"], "hi");
         // The attestation receipt + unmodeled passthrough survive on the chunk too
         // (both land in `extra` and are deliberately NOT stripped).
         assert_eq!(cv["chutes_verification"]["quote"], "abc");
         assert_eq!(cv["hidden_states"], json!([7, 8]));
+    }
+
+    #[test]
+    fn transform_response_json_strips_unicode_escaped_key() {
+        // A JSON key whose first char is unicode-escaped — "prompt_sha256" —
+        // decodes to the plain field name `prompt_sha256`, so it must still be
+        // stripped. The strip is by parsed key, not literal substring. This pins the
+        // correctness reason we always round-trip rather than guarding with a cheap
+        // substring scan, which such an escaped key would defeat. (Note: `\\u` here is
+        // a single backslash in the Rust string, i.e. a real JSON `\u` escape.)
+        let body = format!(
+            r#"{{"id":"x","{}":"deadbeef","choices":[]}}"#,
+            "\\u0070rompt_sha256"
+        );
+        // Sanity: the escaped key really does decode to the plain field name, and
+        // the literal `prompt_sha256` substring is NOT present in the raw bytes.
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+        assert!(
+            parsed.get("prompt_sha256").is_some(),
+            "escape decodes to key"
+        );
+        assert!(
+            !body.contains("prompt_sha256"),
+            "a literal-substring fast path would miss this key"
+        );
+        let out = transform_response_json(body.as_bytes(), None).expect("transform");
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert!(
+            v.get("prompt_sha256").is_none(),
+            "unicode-escaped prompt_sha256 must be stripped"
+        );
+        assert_eq!(v["id"], "x");
     }
 
     #[test]


### PR DESCRIPTION
## What

Strip Chutes-internal / serving fields from the decrypted response so they don't leak to clients. Closes #780.

Chutes responses carried top-level/extra fields absent from non-Chutes (Anthropic/OpenAI) responses on the same endpoint, passed through verbatim by cloud-api:

- **`prompt_sha256`** — a deterministic SHA-256 fingerprint of the rendered user prompt. The genuine privacy concern: it links identical prompts and lets an observer confirm/guess prompt contents.
- `template_sha256`, `metadata` — serving internals (e.g. `metadata.weight_version`).
- `choices[].matched_stop` — sglang stop-token id.

## How

One shared helper, `strip_internal_response_fields(&mut serde_json::Map<String, Value>)`, removes exactly the named keys (top-level `prompt_sha256`/`template_sha256`/`metadata`, and `matched_stop` from each `choices[]` element **and** each `choices[].delta`). It is folded into:

- `transform_response_json` (renamed from `set_model_in_json`, now `Option<&str>` canonical) — used on **both** non-stream paths: the `canonical_id != model_name` model-rewrite path (which re-serializes) **and** the previously byte-verbatim `canonical_id == model_name` path (now also sanitized).
- `rewrite_sse_event_model` — applied per `data:` chunk on the stream path. This path runs **always** (even when `canonical == slug`), so the strip happens on streamed chunks regardless of whether a model rewrite is needed; the model field is only rewritten when `canonical != slug`.

### Streaming chunk-side strip (the key correctness point)

The route re-serializes from the **parsed chunk**, not `raw_bytes`, on the auto-redact / alias-served paths. `ChatCompletionChunk` has a `#[serde(flatten)] extra` catch-all that captures exactly the stripped top-level keys, so a `raw_bytes`-only strip would still leak them there. `rewrite_sse_event_model` therefore also removes `STRIPPED_TOP_LEVEL_FIELDS` from `chunk.extra` (and `STRIPPED_CHOICE_FIELDS` from each `delta.extra` as defense-in-depth — `ChatDelta` also has a flatten catch-all). `matched_stop` has no slot on `ChatChoice` and is dropped on parse, so the choice-level strip is `raw_bytes`-only.

The strip is **always** a full JSON round-trip — there is no substring fast path: a unicode-escaped key (`prompt_sha256`) decodes to `prompt_sha256` and lands in `extra` while defeating a literal-substring scan, so for a privacy-critical control we always parse.

## Safety / scope

- Strips **only** the named fields. Unmodeled fields like **`hidden_states`** still pass through untouched — the deliberate hidden-states passthrough design is preserved.
- **`chutes_verification`** (the attestation receipt) is left **untouched**.
- Non-object bodies cause `transform_response_json` to return `None`; the caller keeps such bodies verbatim (never drop a chunk over a sanitize failure). The rewrite is atomic: `raw_bytes` is computed first and the parsed chunk is mutated only once that succeeds.

### Behavioral note: non-stream `raw_bytes` key ordering

The previously byte-verbatim non-stream path (`canonical_id == model_name`) now round-trips through `serde_json::Value` (no `preserve_order`), so response keys come back alphabetically sorted in `raw_bytes`. This is semantically identical JSON. Nothing in-repo depends on byte-exact `raw_bytes` for Chutes — `supports_chat_signatures() == false`, so no hash/signature path is affected, matching how other external providers already return synthetic `raw_bytes`. Flagging it because the old code documented byte-exactness as a property; it would only matter to an external byte-level comparison.

## Tests

New / updated unit tests (reusing the existing helpers in the module):
- internal fields removed on both strip-only and rewrite modes; `hidden_states` + `chutes_verification` survive;
- `choices[].matched_stop` removed, plus the delta-nested `matched_stop` defense-in-depth;
- per-chunk strip on the stream path, asserting on the **serialized parsed chunk** (built from the same raw payload production deserializes) — verified to fail without the `chunk.extra` strip;
- unicode-escaped key still stripped (pins the always-round-trip rationale);
- missing-`choices` no-op.

`cargo fmt`, `cargo clippy -p inference_providers --all-targets --all-features -D warnings`, and the full `inference_providers` suite (69 chutes tests pass, live Chutes probe ignored) all green.
