### PR TITLE
fix(api): pre-flight reject invalid max_tokens/n with 400 instead of masked 502 (#786)

### DIFF
--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -1056,7 +1056,61 @@ use crate::consts::{
 };
 use crate::routes::common::{validate_max_length, validate_non_empty_field};
 
+/// Reject `max_tokens` values the OpenAI API requires to be `>= 1`.
+///
+/// `None` (unset) is valid. Negative or zero values are rejected with a 400
+/// `invalid_request_error` carrying `param: "max_tokens"` instead of falling
+/// through to upstream and surfacing as a masked 502 (nearai/cloud-api #786).
+fn validate_max_tokens(max_tokens: Option<i64>) -> Result<(), ErrorResponse> {
+    if let Some(value) = max_tokens {
+        if value < 1 {
+            return Err(ErrorResponse::with_param(
+                "max_tokens must be at least 1".to_string(),
+                "invalid_request_error".to_string(),
+                "max_tokens".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reject `n` values below 1. `None` (unset) is valid.
+fn validate_n(n: Option<i64>) -> Result<(), ErrorResponse> {
+    if let Some(value) = n {
+        if value < 1 {
+            return Err(ErrorResponse::with_param(
+                "n must be at least 1".to_string(),
+                "invalid_request_error".to_string(),
+                "n".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl ChatCompletionRequest {
+    /// Pre-flight validation that returns a ready-to-serialize OpenAI error
+    /// envelope (`{error:{message,type,param,code}}`) on failure.
+    ///
+    /// This wraps the message-only [`Self::validate`] (temperature/top_p/stop/
+    /// logprobs) and adds the param-bearing sampling checks (`max_tokens`, `n`)
+    /// that would otherwise fall through to upstream and surface as a masked
+    /// 502 instead of a 4xx (nearai/cloud-api #786). All checks reject only
+    /// genuinely-invalid values; valid requests are untouched.
+    ///
+    /// NOTE: context-length validation is intentionally NOT performed here.
+    /// cloud-api has no per-model tokenizer, so the prompt token count is not
+    /// cleanly knowable pre-dispatch; a character-based estimate would risk
+    /// rejecting valid requests. Over-length prompts are still rejected by the
+    /// upstream provider.
+    pub fn validate_request(&self) -> Result<(), ErrorResponse> {
+        self.validate()
+            .map_err(|message| ErrorResponse::new(message, "invalid_request_error".to_string()))?;
+        validate_max_tokens(self.max_tokens)?;
+        validate_n(self.n)?;
+        Ok(())
+    }
+
     pub fn validate(&self) -> Result<(), String> {
         if self.model.is_empty() {
             return Err("model is required".to_string());
@@ -1161,6 +1215,18 @@ impl ChatCompletionRequest {
 }
 
 impl CompletionRequest {
+    /// Pre-flight validation returning a ready-to-serialize OpenAI error
+    /// envelope on failure. See [`ChatCompletionRequest::validate_request`] for
+    /// the rationale (nearai/cloud-api #786); context-length is likewise
+    /// skipped (no pre-dispatch tokenizer).
+    pub fn validate_request(&self) -> Result<(), ErrorResponse> {
+        self.validate()
+            .map_err(|message| ErrorResponse::new(message, "invalid_request_error".to_string()))?;
+        validate_max_tokens(self.max_tokens)?;
+        validate_n(self.n)?;
+        Ok(())
+    }
+
     pub fn validate(&self) -> Result<(), String> {
         if self.model.is_empty() {
             return Err("model is required".to_string());
@@ -4339,6 +4405,116 @@ mod tests {
 
         // String content should pass validation
         assert!(request.validate().is_ok());
+    }
+
+    // ── max_tokens / n pre-flight validation (nearai/cloud-api #786) ──
+
+    /// Build a minimal valid chat request, overriding `max_tokens` and `n`.
+    fn chat_req(max_tokens: Option<i64>, n: Option<i64>) -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: Some(MessageContent::Text("hi".to_string())),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            max_tokens,
+            temperature: None,
+            top_p: None,
+            n,
+            stream: None,
+            stop: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            extra: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn chat_validate_request_accepts_valid_sampling_params() {
+        // Unset, and positive, max_tokens/n all pass.
+        assert!(chat_req(None, None).validate_request().is_ok());
+        assert!(chat_req(Some(1), Some(1)).validate_request().is_ok());
+        assert!(chat_req(Some(4096), Some(3)).validate_request().is_ok());
+    }
+
+    #[test]
+    fn chat_validate_request_rejects_non_positive_max_tokens() {
+        for bad in [-5, 0] {
+            let err = chat_req(Some(bad), None)
+                .validate_request()
+                .expect_err("non-positive max_tokens must be rejected")
+                .error;
+            assert_eq!(err.r#type, "invalid_request_error");
+            assert_eq!(err.param.as_deref(), Some("max_tokens"));
+            assert_eq!(err.message, "max_tokens must be at least 1");
+        }
+    }
+
+    #[test]
+    fn chat_validate_request_rejects_n_below_one() {
+        for bad in [-1, 0] {
+            let err = chat_req(None, Some(bad))
+                .validate_request()
+                .expect_err("n < 1 must be rejected")
+                .error;
+            assert_eq!(err.r#type, "invalid_request_error");
+            assert_eq!(err.param.as_deref(), Some("n"));
+            assert_eq!(err.message, "n must be at least 1");
+        }
+    }
+
+    #[test]
+    fn chat_validate_request_still_enforces_existing_checks() {
+        // temperature out of range still surfaces (no param, matching the
+        // pre-existing message-only path) and as invalid_request_error.
+        let mut req = chat_req(Some(100), Some(1));
+        req.temperature = Some(5.0);
+        let err = req
+            .validate_request()
+            .expect_err("out-of-range temperature must be rejected")
+            .error;
+        assert_eq!(err.r#type, "invalid_request_error");
+        assert_eq!(err.message, "temperature must be between 0 and 2");
+    }
+
+    #[test]
+    fn completion_validate_request_rejects_invalid_sampling_params() {
+        let base = || CompletionRequest {
+            model: "gpt-4".to_string(),
+            prompt: CompletionPrompt::Text("hi".to_string()),
+            max_tokens: Some(16),
+            temperature: None,
+            top_p: None,
+            n: Some(1),
+            stream: None,
+            logprobs: None,
+            echo: None,
+            stop: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            best_of: None,
+            extra: std::collections::HashMap::new(),
+        };
+
+        // Valid passes.
+        assert!(base().validate_request().is_ok());
+
+        // max_tokens <= 0 rejected with param.
+        let mut bad = base();
+        bad.max_tokens = Some(-5);
+        let err = bad.validate_request().expect_err("negative").error;
+        assert_eq!(err.param.as_deref(), Some("max_tokens"));
+        assert_eq!(err.r#type, "invalid_request_error");
+
+        // n: 0 rejected with param.
+        let mut bad = base();
+        bad.n = Some(0);
+        let err = bad.validate_request().expect_err("n zero").error;
+        assert_eq!(err.param.as_deref(), Some("n"));
+        assert_eq!(err.r#type, "invalid_request_error");
     }
 
     #[test]

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1099,15 +1099,8 @@ pub async fn chat_completions(
         request.model, request.stream, api_key.organization.id, api_key.workspace.id.0
     );
     // Validate the request
-    if let Err(error) = request.validate() {
-        return (
-            StatusCode::BAD_REQUEST,
-            ResponseJson(ErrorResponse::new(
-                error,
-                "invalid_request_error".to_string(),
-            )),
-        )
-            .into_response();
+    if let Err(error) = request.validate_request() {
+        return (StatusCode::BAD_REQUEST, ResponseJson(error)).into_response();
     }
 
     // Generate a per-request correlation ID. Reuse the client's X-Request-Id if
@@ -1704,15 +1697,8 @@ pub async fn completions(
     );
 
     // Validate the request
-    if let Err(error) = request.validate() {
-        return (
-            StatusCode::BAD_REQUEST,
-            ResponseJson(ErrorResponse::new(
-                error,
-                "invalid_request_error".to_string(),
-            )),
-        )
-            .into_response();
+    if let Err(error) = request.validate_request() {
+        return (StatusCode::BAD_REQUEST, ResponseJson(error)).into_response();
     }
 
     // Per-request correlation ID: reuse the client's X-Request-Id if present and


### PR DESCRIPTION
## Summary

Closes #786 (HIGH). Invalid client sampling params currently fall through to upstream and the rejection collapses into a generic masked `502 bad_gateway` instead of a proper `4xx`. This mis-signals retryability (clients retry a permanently-bad request) and pollutes outage metrics (real backend outages and client mistakes look identical).

Today only `temperature`/`top_p` are validated up front. This PR adds the **same-style** pre-flight validation for the params that fall through, on the existing validation seam, for **both** `/v1/chat/completions` and `/v1/completions` (cross-cutting across all providers, not Chutes-specific):

- `max_tokens`: reject `< 1` (negative or zero) -> `400 invalid_request_error`, `param: "max_tokens"`.
- `n`: reject `< 1` -> `400 invalid_request_error`, `param: "n"`.

A new `validate_request()` method wraps the existing message-only `validate()` (temperature/top_p/stop/logprobs, unchanged) and adds the param-bearing checks, returning the full OpenAI error envelope `{error:{message,type,param,code}}`. The two handlers now call `validate_request()` and return that envelope directly. The existing `validate()` and all its call sites/tests are untouched, so valid requests and all other endpoints are unaffected.

## Context length: intentionally skipped (per issue)

The issue's third sub-item (reject prompts exceeding a model's max context with `context_length_exceeded`) is **not** implemented: cloud-api has no per-model tokenizer, so the prompt token count is not cleanly knowable pre-dispatch. A character-based estimate would risk rejecting valid requests, violating the "do not change behavior for valid requests" constraint. Over-length prompts continue to be rejected by the upstream provider. This is noted in the code comments.

## Tests

Added unit tests (all green):
- valid (unset / positive) `max_tokens` + `n` pass;
- `max_tokens: -5` and `0` rejected with `400` + `param: "max_tokens"`;
- `n: -1` and `0` rejected with `400` + `param: "n"`;
- existing checks (out-of-range temperature) still surface via the new method;
- the completions (`/v1/completions`) path covered too.

`cargo fmt`, `cargo clippy -p api -p services --all-targets --all-features -- -D warnings`, and the relevant unit tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)