### PR TITLE
fix(api): OpenAI error envelope for request deserialization failures (#781 L2)

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -7,12 +7,13 @@ use crate::{
             alias_warning_message, inject_warning_field, map_domain_error_to_status,
             no_aliasing_requested, HEADER_MODEL_ALIAS_RESOLVED, HEADER_NO_ALIASING,
         },
+        extractors::OpenAiJson,
         files::MAX_FILE_SIZE,
     },
 };
 use axum::{
     body::{Body, Bytes},
-    extract::{Extension, Json, Multipart, State},
+    extract::{Extension, Multipart, State},
     http::{header, StatusCode},
     response::{IntoResponse, Json as ResponseJson, Response},
 };
@@ -1088,7 +1089,7 @@ pub async fn chat_completions(
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
     headers: header::HeaderMap,
-    Json(request): Json<ChatCompletionRequest>,
+    OpenAiJson(request): OpenAiJson<ChatCompletionRequest>,
 ) -> axum::response::Response {
     debug!(
         "Chat completions request from api key: {:?}",
@@ -1685,7 +1686,7 @@ pub async fn completions(
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
     headers: header::HeaderMap,
-    Json(request): Json<CompletionRequest>,
+    OpenAiJson(request): OpenAiJson<CompletionRequest>,
 ) -> axum::response::Response {
     debug!(
         "Text completions request from api key: {:?}",
@@ -3129,7 +3130,7 @@ pub async fn image_generations(
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
     headers: header::HeaderMap,
-    Json(request): Json<crate::models::ImageGenerationRequest>,
+    OpenAiJson(request): OpenAiJson<crate::models::ImageGenerationRequest>,
 ) -> axum::response::Response {
     debug!(
         "Image generation request from api key: {:?}",
@@ -4220,7 +4221,7 @@ pub async fn rerank(
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(_body_hash): Extension<RequestBodyHash>,
     headers: header::HeaderMap,
-    Json(request): Json<crate::models::RerankRequest>,
+    OpenAiJson(request): OpenAiJson<crate::models::RerankRequest>,
 ) -> axum::response::Response {
     debug!(
         "Rerank request: model={}, org={}, workspace={}",
@@ -5659,7 +5660,7 @@ pub async fn score(
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
     headers: header::HeaderMap,
-    Json(request): Json<crate::models::ScoreRequest>,
+    OpenAiJson(request): OpenAiJson<crate::models::ScoreRequest>,
 ) -> axum::response::Response {
     debug!(
         "Score request: model={}, org={}, workspace={}",

--- a/crates/api/src/routes/extractors.rs
+++ b/crates/api/src/routes/extractors.rs
@@ -71,14 +71,16 @@ impl IntoResponse for OpenAiJsonRejection {
     fn into_response(self) -> Response {
         let rejection = self.0;
 
-        // Prefer 400 for malformed JSON and shape/type errors (OpenAI uses 400
-        // for these; axum defaults JsonDataError to 422). Other rejection
-        // variants (missing/incorrect Content-Type -> 415, body-too-large ->
-        // 413/400) keep their own status — only the body SHAPE is normalized.
+        // Prefer 400 for malformed JSON, shape/type errors, and a missing/wrong
+        // Content-Type — OpenAI returns 400 for all of these, whereas axum
+        // defaults JsonDataError to 422 and MissingJsonContentType to 415. The
+        // remaining variant (BytesRejection: body read/too-large) keeps its own
+        // status. JsonRejection is #[non_exhaustive], so a catch-all arm is
+        // required; only the body SHAPE is normalized for it.
         let status = match &rejection {
-            JsonRejection::JsonDataError(_) | JsonRejection::JsonSyntaxError(_) => {
-                StatusCode::BAD_REQUEST
-            }
+            JsonRejection::JsonDataError(_)
+            | JsonRejection::JsonSyntaxError(_)
+            | JsonRejection::MissingJsonContentType(_) => StatusCode::BAD_REQUEST,
             other => other.status(),
         };
 
@@ -143,6 +145,9 @@ mod tests {
                 String::from_utf8_lossy(&bytes)
             )
         });
+        // Full envelope parity: ErrorResponse::new leaves param/code null.
+        assert_eq!(envelope.error.param, None);
+        assert_eq!(envelope.error.code, None);
         (status, envelope)
     }
 
@@ -167,6 +172,31 @@ mod tests {
     async fn wrong_type_field_is_400_envelope() {
         // `messages` is the wrong type (string, not array of strings).
         let (status, envelope) = post_json("{ \"model\": \"x\", \"messages\": \"oops\" }").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(envelope.error.r#type, INVALID_REQUEST_ERROR);
+        assert!(!envelope.error.message.is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_content_type_is_400_envelope() {
+        // No Content-Type header -> axum's MissingJsonContentType (415); we map
+        // it to 400 + envelope to match OpenAI.
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .body(Body::from("{ \"model\": \"x\", \"messages\": [\"hi\"] }"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let envelope: ErrorResponse = serde_json::from_slice(&bytes)
+            .expect("response body should be the OpenAI envelope, not a bare string");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(envelope.error.r#type, INVALID_REQUEST_ERROR);
         assert!(!envelope.error.message.is_empty());

--- a/crates/api/src/routes/extractors.rs
+++ b/crates/api/src/routes/extractors.rs
@@ -1,0 +1,190 @@
+//! Custom request extractors that normalize deserialization-layer failures
+//! into the OpenAI-compatible error envelope.
+//!
+//! Background (issue #781 L2): axum's built-in `Json<T>` extractor rejects a
+//! request *before* the handler body runs whenever the body is malformed JSON,
+//! is missing a required field, or has a field of the wrong type. The default
+//! `JsonRejection::into_response()` emits a **bare string** body (e.g.
+//! `"Failed to deserialize the JSON body into the target type: ..."`) with a
+//! `text/plain` content type, and uses `422 Unprocessable Entity` for
+//! shape/type errors. That is a different error *shape* than every
+//! business-validated error this API returns, which is the OpenAI envelope:
+//!
+//! ```json
+//! { "error": { "message": "...", "type": "invalid_request_error",
+//!              "param": null, "code": null } }
+//! ```
+//!
+//! Two incompatible error shapes force clients to special-case our gateway.
+//! `OpenAiJson<T>` is a drop-in replacement for `axum::Json<T>` on inference
+//! handlers: on success it behaves identically (deserializes into `T`); on a
+//! deserialization failure it wraps the rejection into the OpenAI envelope and
+//! prefers `400 Bad Request` for malformed/invalid bodies (matching OpenAI),
+//! instead of axum's `422`.
+//!
+//! Only the error path differs from `axum::Json`; valid requests are untouched.
+
+use crate::models::ErrorResponse;
+use axum::{
+    extract::{rejection::JsonRejection, FromRequest, Json, Request},
+    http::StatusCode,
+    response::{IntoResponse, Json as ResponseJson, Response},
+};
+
+/// Error type used in the OpenAI envelope for request-deserialization
+/// failures. Matches the `type` produced by the business-validation path
+/// (`ChatCompletionRequest::validate_request` etc.) so clients see a single,
+/// consistent error shape regardless of whether the body failed at the
+/// deserialization layer or at business validation.
+const INVALID_REQUEST_ERROR: &str = "invalid_request_error";
+
+/// Drop-in replacement for [`axum::Json`] that returns the OpenAI error
+/// envelope (rather than a bare string) when the request body fails to
+/// deserialize into `T`.
+///
+/// Behaviour for *valid* requests is identical to `axum::Json<T>` — this only
+/// changes the SHAPE and status of deserialization-layer rejections.
+pub struct OpenAiJson<T>(pub T);
+
+impl<T, S> FromRequest<S> for OpenAiJson<T>
+where
+    Json<T>: FromRequest<S, Rejection = JsonRejection>,
+    S: Send + Sync,
+{
+    type Rejection = OpenAiJsonRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(OpenAiJson(value)),
+            Err(rejection) => Err(OpenAiJsonRejection(rejection)),
+        }
+    }
+}
+
+/// Rejection wrapper that renders a [`JsonRejection`] as the OpenAI error
+/// envelope. Kept as a distinct type (rather than mapping straight to a
+/// `Response`) so the extractor satisfies `FromRequest`'s associated
+/// `Rejection: IntoResponse` bound.
+pub struct OpenAiJsonRejection(JsonRejection);
+
+impl IntoResponse for OpenAiJsonRejection {
+    fn into_response(self) -> Response {
+        let rejection = self.0;
+
+        // Prefer 400 for malformed JSON and shape/type errors (OpenAI uses 400
+        // for these; axum defaults JsonDataError to 422). Other rejection
+        // variants (missing/incorrect Content-Type -> 415, body-too-large ->
+        // 413/400) keep their own status — only the body SHAPE is normalized.
+        let status = match &rejection {
+            JsonRejection::JsonDataError(_) | JsonRejection::JsonSyntaxError(_) => {
+                StatusCode::BAD_REQUEST
+            }
+            other => other.status(),
+        };
+
+        // `body_text()` carries axum's human-readable detail (including the
+        // serde error for syntax/data failures), which is the most useful
+        // message we can surface to the client.
+        let message = rejection.body_text();
+        let body = ErrorResponse::new(message, INVALID_REQUEST_ERROR.to_string());
+
+        (status, ResponseJson(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{self, Request},
+        routing::post,
+        Router,
+    };
+    use serde::Deserialize;
+    use tower::ServiceExt;
+
+    #[derive(Deserialize)]
+    struct Probe {
+        #[allow(dead_code)]
+        model: String,
+        #[allow(dead_code)]
+        messages: Vec<String>,
+    }
+
+    async fn probe_handler(OpenAiJson(_): OpenAiJson<Probe>) -> StatusCode {
+        StatusCode::OK
+    }
+
+    fn app() -> Router {
+        Router::new().route("/", post(probe_handler))
+    }
+
+    async fn post_json(body: &'static str) -> (StatusCode, ErrorResponse) {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let envelope: ErrorResponse = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            panic!(
+                "response body should be the OpenAI envelope, not a bare string: {e}; body={}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
+        (status, envelope)
+    }
+
+    #[tokio::test]
+    async fn malformed_json_is_400_envelope() {
+        let (status, envelope) = post_json("{ \"model\": \"x\", ").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(envelope.error.r#type, INVALID_REQUEST_ERROR);
+        assert!(!envelope.error.message.is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_required_field_is_400_envelope() {
+        // Valid JSON, missing `model`/`messages` -> axum would give 422; we map to 400.
+        let (status, envelope) = post_json("{}").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(envelope.error.r#type, INVALID_REQUEST_ERROR);
+        assert!(!envelope.error.message.is_empty());
+    }
+
+    #[tokio::test]
+    async fn wrong_type_field_is_400_envelope() {
+        // `messages` is the wrong type (string, not array of strings).
+        let (status, envelope) = post_json("{ \"model\": \"x\", \"messages\": \"oops\" }").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(envelope.error.r#type, INVALID_REQUEST_ERROR);
+        assert!(!envelope.error.message.is_empty());
+    }
+
+    #[tokio::test]
+    async fn valid_body_passes_through() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{ \"model\": \"x\", \"messages\": [\"hi\"] }"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -7,6 +7,7 @@ pub mod billing;
 pub mod common;
 pub mod completions;
 pub mod conversations;
+pub mod extractors;
 pub mod feature_requests;
 pub mod files;
 pub mod gateway;

--- a/crates/api/src/routes/responses.rs
+++ b/crates/api/src/routes/responses.rs
@@ -2,10 +2,11 @@ use crate::{
     middleware::{auth::AuthenticatedApiKey, RequestBodyHash},
     models::{ErrorResponse, ResponseInputItemList},
     routes::common::{HEADER_SHOULD_RETRY, SHOULD_RETRY_FALSE},
+    routes::extractors::OpenAiJson,
 };
 use axum::{
     body::Body,
-    extract::{Extension, Json, Path, Query, State},
+    extract::{Extension, Path, Query, State},
     http::{header, HeaderMap, Response, StatusCode},
     response::{IntoResponse, Json as ResponseJson},
 };
@@ -242,7 +243,7 @@ pub async fn create_response(
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
     headers: HeaderMap,
-    Json(mut request): Json<CreateResponseRequest>,
+    OpenAiJson(mut request): OpenAiJson<CreateResponseRequest>,
 ) -> axum::response::Response {
     let service = state.response_service.clone();
     let attestation_service = state.attestation_service.clone();

--- a/crates/api/tests/e2e_all/deser_error_envelope.rs
+++ b/crates/api/tests/e2e_all/deser_error_envelope.rs
@@ -44,6 +44,9 @@ fn assert_openai_invalid_request(response: &axum_test::TestResponse, expected_st
         !err.error.message.is_empty(),
         "error message should be populated, got empty string"
     );
+    // Full envelope shape: ErrorResponse::new leaves param/code null.
+    assert_eq!(err.error.param, None, "param should be null");
+    assert_eq!(err.error.code, None, "code should be null");
 }
 
 #[tokio::test]

--- a/crates/api/tests/e2e_all/deser_error_envelope.rs
+++ b/crates/api/tests/e2e_all/deser_error_envelope.rs
@@ -1,0 +1,147 @@
+//! E2E tests: request DESERIALIZATION-layer rejections must return the same
+//! OpenAI error envelope as business-validation errors, not a bare string.
+//!
+//! Regression coverage for issue #781 (L2). Before the `OpenAiJson` extractor,
+//! axum's built-in `Json<T>` rejected malformed/invalid bodies with a bare
+//! `text/plain` string and a `422` for shape/type errors. Now these surface as
+//! `{ "error": { "message", "type": "invalid_request_error", "param", "code" } }`
+//! with a `400` status, matching what clients get from business validation.
+//!
+//! The rejection fires AFTER auth/usage/rate-limit middleware, so each test
+//! needs a real org + credits + API key to reach the extractor.
+
+use crate::common::*;
+use bytes::Bytes;
+use serde_json::json;
+
+/// Helper: set up server + funded org + API key, returning (server, api_key).
+async fn server_with_key() -> (axum_test::TestServer, String) {
+    let server = setup_test_server().await;
+    setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    (server, api_key)
+}
+
+/// Assert a response is the OpenAI error envelope with the expected status and
+/// `type: "invalid_request_error"`, and that the message is non-empty.
+fn assert_openai_invalid_request(response: &axum_test::TestResponse, expected_status: u16) {
+    assert_eq!(
+        response.status_code(),
+        expected_status,
+        "expected {} for deser-layer rejection, got body: {}",
+        expected_status,
+        response.text()
+    );
+
+    // Must deserialize into the OpenAI envelope — a bare string body would fail here.
+    let err = response.json::<api::models::ErrorResponse>();
+    assert_eq!(
+        err.error.r#type, "invalid_request_error",
+        "deser-layer error type should match business-validation envelope"
+    );
+    assert!(
+        !err.error.message.is_empty(),
+        "error message should be populated, got empty string"
+    );
+}
+
+#[tokio::test]
+async fn test_chat_completions_malformed_json_returns_openai_envelope() {
+    let (server, api_key) = server_with_key().await;
+
+    // Syntactically invalid JSON (trailing junk / unterminated object).
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .content_type("application/json")
+        .bytes(Bytes::from_static(b"{ \"model\": \"x\", "))
+        .await;
+
+    assert_openai_invalid_request(&response, 400);
+}
+
+#[tokio::test]
+async fn test_chat_completions_missing_model_returns_openai_envelope() {
+    let (server, api_key) = server_with_key().await;
+
+    // Valid JSON but missing the required `model` field. axum's default Json
+    // would reject this as 422 with a bare string; we normalize to 400 + envelope.
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({
+            "messages": [ { "role": "user", "content": "hello" } ]
+        }))
+        .await;
+
+    assert_openai_invalid_request(&response, 400);
+}
+
+#[tokio::test]
+async fn test_chat_completions_wrong_type_messages_returns_openai_envelope() {
+    let (server, api_key) = server_with_key().await;
+
+    // `messages` is the wrong type (string instead of array). Valid JSON,
+    // wrong shape -> 400 + OpenAI envelope (was 422 + bare string).
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": "not-an-array"
+        }))
+        .await;
+
+    assert_openai_invalid_request(&response, 400);
+}
+
+#[tokio::test]
+async fn test_completions_malformed_json_returns_openai_envelope() {
+    let (server, api_key) = server_with_key().await;
+
+    let response = server
+        .post("/v1/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .content_type("application/json")
+        .bytes(Bytes::from_static(b"not json at all"))
+        .await;
+
+    assert_openai_invalid_request(&response, 400);
+}
+
+#[tokio::test]
+async fn test_completions_missing_model_returns_openai_envelope() {
+    let (server, api_key) = server_with_key().await;
+
+    let response = server
+        .post("/v1/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({ "prompt": "hello" }))
+        .await;
+
+    assert_openai_invalid_request(&response, 400);
+}
+
+/// Sanity check: a VALID request is unaffected by the extractor change — it
+/// must NOT be turned into a 400. (Guards against the extractor over-reaching.)
+#[tokio::test]
+async fn test_chat_completions_valid_request_unaffected() {
+    let (server, api_key) = server_with_key().await;
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [ { "role": "user", "content": "hello" } ]
+        }))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        200,
+        "valid request should still succeed: {}",
+        response.text()
+    );
+}

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -26,6 +26,7 @@ mod client_disconnect;
 mod concurrent_limit;
 mod conversations;
 mod credit_types;
+mod deser_error_envelope;
 mod duplicate_names;
 mod embeddings;
 mod error_msg;


### PR DESCRIPTION
## Problem (#781 L2)

Request **deserialization-layer** rejections bypass the OpenAI error envelope, so clients see two incompatible error shapes:

| Case | Before | After |
|------|--------|-------|
| Malformed JSON | `400` **bare string** | `400` envelope |
| Missing `model` | `422` **bare string** | `400` envelope |
| Wrong-type `messages` | `422` **bare string** | `400` envelope |
| Business validation (e.g. bad `max_tokens`) | `400` envelope (unchanged) | `400` envelope |

Business-validated errors already return the OpenAI envelope `{"error":{"message","type","param","code"}}`, but axum's built-in `Json<T>` extractor rejects malformed/invalid bodies *before the handler runs* with a bare `text/plain` string and a `422` for shape/type errors.

## Fix

New `OpenAiJson<T>` extractor (`crates/api/src/routes/extractors.rs`) — a drop-in for `axum::Json<T>`:

- On success: behaves identically to `axum::Json` (valid requests untouched).
- On `JsonRejection`: wraps the rejection into the OpenAI envelope with `type: "invalid_request_error"` (matching the business-validation path) and **prefers `400`** over axum's `422` for `JsonSyntaxError`/`JsonDataError` (matching OpenAI). Other rejection variants (missing/incorrect `Content-Type` → 415, body-too-large) keep their own status; only the body SHAPE is normalized.

Applied to the v1 inference handlers that extract typed JSON: `chat/completions`, `completions`, `images/generations`, `rerank`, `score`, and `responses` (`create_response`). Endpoints that take raw `Bytes` (`embeddings`, `privacy/classify`, `privacy/redact`) or `Multipart` (`audio/transcriptions`, `images/edits`) are out of scope — they parse the body themselves and already return the envelope.

### Scope guardrails
- No change to VALID-request behavior.
- No change to the existing business-validation envelope (#788).
- Only the deser-layer error SHAPE/status is normalized.

## Tests

- Unit tests in `extractors.rs` (no DB): malformed JSON, missing required field, wrong-type field → `400` + OpenAI envelope; valid body → passthrough. **All 4 pass locally.**
- E2E in `tests/e2e_all/deser_error_envelope.rs`: chat/completions + completions malformed/missing-model/wrong-type → `400` envelope, plus a valid-request sanity check. (DB-backed; runs in CI — local Docker/Postgres was unavailable in the dev sandbox.)

`cargo fmt`, `cargo clippy -p api --all-targets --all-features -- -D warnings`, and `cargo build -p api` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)