### PR TITLE
fix(db): auto-reap idle sessions to prevent connection-pool exhaustion (V0062)

### DIFF
--- a/crates/database/src/migrations/sql/V0062__set_idle_session_timeout.sql
+++ b/crates/database/src/migrations/sql/V0062__set_idle_session_timeout.sql
@@ -1,0 +1,37 @@
+-- Auto-reap idle client sessions at the server so connections orphaned by a
+-- crashed or recycled cloud-api instance do not accumulate and exhaust the
+-- cluster's max_connections.
+--
+-- Incident 2026-06-15: after a prod deploy, crash-looping/recycled instances
+-- left behind dozens of `idle` client backends (no server-side idle timeout +
+-- dead-peer TCP backends linger for minutes). The leader filled to
+-- max_connections, so even a single healthy instance could not acquire a
+-- connection ("FATAL: sorry, too many clients already"). These settings make
+-- Postgres close abandoned sessions on its own.
+--
+-- Safe with our pooling: deadpool re-validates a connection on checkout
+-- (Fast recycling -> is_closed()), so a warm pooled connection that the server
+-- reaps after going idle is simply discarded and re-created on next use — no
+-- error surfaces to the app. 300s is well above normal inter-query gaps under
+-- load, so only genuinely-abandoned sessions get reaped.
+--
+-- idle_session_timeout requires PostgreSQL >= 14 (the cluster is PG16/Spilo-16);
+-- the version guard keeps this migration a no-op rather than an error on any
+-- older node, so it can never wedge startup.
+DO $$
+BEGIN
+    IF current_setting('server_version_num')::int >= 140000 THEN
+        EXECUTE format(
+            'ALTER DATABASE %I SET idle_session_timeout = %L',
+            current_database(), '300s'
+        );
+    END IF;
+
+    -- Available since PG 9.6; reaps sessions stuck idle-in-transaction
+    -- (the classic connection leak) much sooner.
+    EXECUTE format(
+        'ALTER DATABASE %I SET idle_in_transaction_session_timeout = %L',
+        current_database(), '60s'
+    );
+END
+$$;


### PR DESCRIPTION
## Incident context (2026-06-15)
After a prod deploy, crash-looping / recycled cloud-api instances left dozens of `idle` client backends behind — there's **no server-side idle timeout**, and dead-peer TCP backends linger for minutes. The Patroni **leader filled to `max_connections`**, so even a single healthy instance got `FATAL: sorry, too many clients already` and panicked at `init_database` (`lib.rs:108`), crash-looping.

## What this does
Adds migration **V0062** setting, on the application database:
- `idle_session_timeout = 300s` — Postgres closes abandoned idle client sessions on its own (the orphaned-connection reaper this incident needed).
- `idle_in_transaction_session_timeout = 60s` — reaps the classic idle-in-transaction leak sooner.

## Why it's safe
- **With our pooling:** deadpool uses Fast recycling (`is_closed()` check on checkout), so a warm pooled connection the server reaps after it goes idle is simply discarded and re-created on next use — no error reaches the app. `300s` is well above normal inter-query gaps under load, so only genuinely-abandoned sessions are reaped.
- **Won't wedge startup:** `idle_session_timeout` is PG14+; the cluster is PG16/Spilo-16, but the migration is version-guarded (`server_version_num >= 140000`) so it's a no-op rather than an error on any older node. `ALTER DATABASE … SET` is transaction-safe (runs fine under refinery).

## ⚠️ Scope — this is the *recurrence* fix, not the live-outage fix
- It runs at `run_migrations()` (`lib.rs:114`), **after** the initial pool connect that fails during the outage — so it cannot clear an active pileup.
- It only affects **new** sessions; existing zombie backends are unaffected.
- Pair it with: (1) a manual `pg_terminate_backend` of idle backends to restore service now, and (2) a `DATABASE_MAX_CONNECTIONS` reduction (32→16) so `instances × (write+read) pools` fit under the server `max_connections` (currently the default ~100).

## Follow-ups worth filing
- cloud-api **panics** at boot instead of retrying when the DB is briefly full (`lib.rs:108` `.expect`) — should back off and retry.
- Pool sizing (`max_write/read_connections`) isn't bounded against the server `max_connections` for the instance count.