### PR TITLE
test(pool): end-to-end NEAR→Chutes per-request fallback

### DIFF
--- a/crates/database/src/patroni_discovery.rs
+++ b/crates/database/src/patroni_discovery.rs
@@ -44,8 +44,43 @@ pub struct ClusterMember {
     pub timeline: Option<i64>,
 }
 
+/// Patroni lists a node as a member as soon as it registers in the DCS — which
+/// happens *before* it publishes its `conn_url`. So a replica mid-creation (or
+/// an uninitialized node) appears without `host`/`port`/`api_url`. Those fields
+/// are required on `ClusterMember`, so a strict `Vec<ClusterMember>` parse fails
+/// the ENTIRE `/cluster` response with `missing field \`host\`` over one
+/// half-registered member — freezing topology discovery for every consumer
+/// (cloud-api + chat-api) whenever a new postgres instance is being added.
+///
+/// Parse each member independently and drop any that don't fully deserialize; a
+/// member with no connection info is not a usable leader/replica target anyway,
+/// and the next refresh picks it up once it finishes registering. Same
+/// resilience philosophy as `deserialize_lag` — one bad member must not poison
+/// the whole cluster view.
+fn deserialize_members<'de, D>(deserializer: D) -> Result<Vec<ClusterMember>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    let mut members = Vec::with_capacity(raw.len());
+    for value in raw {
+        match serde_json::from_value::<ClusterMember>(value.clone()) {
+            Ok(member) => members.push(member),
+            Err(e) => {
+                let name = value
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("<unknown>");
+                warn!("Skipping not-yet-ready cluster member {name}: {e}");
+            }
+        }
+    }
+    Ok(members)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClusterInfo {
+    #[serde(deserialize_with = "deserialize_members")]
     pub members: Vec<ClusterMember>,
     #[serde(default)]
     pub scope: Option<String>,
@@ -367,6 +402,40 @@ mod tests {
         let member: ClusterMember = serde_json::from_str(json).unwrap();
         assert_eq!(member.state, "stopped");
         assert!(member.lag.is_none());
+    }
+
+    #[test]
+    fn test_initializing_member_does_not_poison_parse() {
+        // Regression: a replica mid-creation is registered in the DCS before it
+        // publishes its conn_url, so Patroni omits host/port/api_url. Previously
+        // this failed the whole parse with `missing field \`host\``, breaking
+        // discovery for cloud-api + chat-api whenever a postgres instance was
+        // added. The not-yet-ready member must be dropped, not poison the rest.
+        let json = r#"{"members": [
+          {"name":"leader1","role":"leader","state":"running","host":"postgres-a.dstack.internal","port":5432,"timeline":3},
+          {"name":"newrep","role":"replica","state":"creating replica","timeline":3}
+        ],"scope":"pg-cluster"}"#;
+        let info: ClusterInfo = serde_json::from_str(json).expect("must parse despite half-registered member");
+        assert_eq!(info.members.len(), 1, "the not-yet-ready member should be dropped");
+        assert_eq!(info.members[0].name, "leader1");
+        assert_eq!(info.members[0].role, "leader");
+    }
+
+    #[test]
+    fn test_full_cluster_with_initializing_replica_parses() {
+        // Real staging /cluster shape with an extra member mid-creation appended
+        // (no host/port/api_url). The 4 ready members must still parse and the
+        // leader must still be discoverable.
+        let json = r#"{"members": [
+          {"name":"a","role":"replica","state":"streaming","api_url":"http://[postgres-staging-5hbt5t4n.dstack.internal:8008]:8008/patroni","host":"postgres-staging-5hbt5t4n.dstack.internal","port":5432,"timeline":3,"lag":0},
+          {"name":"b","role":"replica","state":"streaming","host":"postgres-yr6k7rmo.dstack.internal","port":5432,"timeline":3,"lag":0},
+          {"name":"newrep","role":"replica","state":"creating replica","timeline":3},
+          {"name":"leader","role":"leader","state":"running","host":"postgres-ew3zj5pk.dstack.internal","port":5432,"timeline":3}
+        ],"scope":"pg-cluster"}"#;
+        let info: ClusterInfo = serde_json::from_str(json).expect("must parse");
+        assert_eq!(info.members.len(), 3, "only the 3 fully-registered members survive");
+        assert!(info.members.iter().any(|m| m.role == "leader"));
+        assert!(info.members.iter().all(|m| m.name != "newrep"));
     }
 
     #[test]

--- a/crates/database/src/patroni_discovery.rs
+++ b/crates/database/src/patroni_discovery.rs
@@ -415,8 +415,13 @@ mod tests {
           {"name":"leader1","role":"leader","state":"running","host":"postgres-a.dstack.internal","port":5432,"timeline":3},
           {"name":"newrep","role":"replica","state":"creating replica","timeline":3}
         ],"scope":"pg-cluster"}"#;
-        let info: ClusterInfo = serde_json::from_str(json).expect("must parse despite half-registered member");
-        assert_eq!(info.members.len(), 1, "the not-yet-ready member should be dropped");
+        let info: ClusterInfo =
+            serde_json::from_str(json).expect("must parse despite half-registered member");
+        assert_eq!(
+            info.members.len(),
+            1,
+            "the not-yet-ready member should be dropped"
+        );
         assert_eq!(info.members[0].name, "leader1");
         assert_eq!(info.members[0].role, "leader");
     }
@@ -433,7 +438,11 @@ mod tests {
           {"name":"leader","role":"leader","state":"running","host":"postgres-ew3zj5pk.dstack.internal","port":5432,"timeline":3}
         ],"scope":"pg-cluster"}"#;
         let info: ClusterInfo = serde_json::from_str(json).expect("must parse");
-        assert_eq!(info.members.len(), 3, "only the 3 fully-registered members survive");
+        assert_eq!(
+            info.members.len(),
+            3,
+            "only the 3 fully-registered members survive"
+        );
         assert!(info.members.iter().any(|m| m.role == "leader"));
         assert!(info.members.iter().all(|m| m.name != "newrep"));
     }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -6735,7 +6735,10 @@ mod tests {
             .await
             .expect("healthy NEAR must serve");
         let body = String::from_utf8_lossy(&resp.raw_bytes);
-        assert!(body.contains("served-by-near-primary"), "NEAR must serve, got: {body}");
+        assert!(
+            body.contains("served-by-near-primary"),
+            "NEAR must serve, got: {body}"
+        );
         assert!(
             chutes.last_chat_params().await.is_none(),
             "Chutes must NOT be invoked when the NEAR primary succeeds"

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -6544,4 +6544,201 @@ mod tests {
             other => panic!("Expected RequestFailed, got: {:?}", other),
         }
     }
+
+    // ==================== Per-request NEAR→Chutes fallback ====================
+    //
+    // These exercise the END-TO-END per-request fallback through
+    // `chat_completion` (→ `retry_with_fallback_caps`), the behavior a staging
+    // backend-drain could NOT validate: cloud-api holds sticky keepalive
+    // connections to NEAR backends, so a model-proxy registry change never makes
+    // the live request fail. The fallback only triggers on a genuine
+    // request-level failure, which is deterministic to inject with a mock.
+
+    fn fallback_params(model: &str) -> inference_providers::ChatCompletionParams {
+        inference_providers::ChatCompletionParams {
+            model: model.to_string(),
+            messages: vec![inference_providers::ChatMessage {
+                role: inference_providers::MessageRole::User,
+                content: Some(serde_json::Value::String("hello".to_string())),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            stop: None,
+            stream: Some(false),
+            tools: None,
+            max_completion_tokens: None,
+            n: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            logit_bias: None,
+            logprobs: None,
+            top_logprobs: None,
+            user: None,
+            seed: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            metadata: None,
+            store: None,
+            stream_options: None,
+            modalities: None,
+            extra: std::collections::HashMap::new(),
+        }
+    }
+
+    /// A retryable NEAR primary failure (upstream 5xx) MUST fall through to the
+    /// Chutes (Attested3p) provider within the SAME request — the client sees a
+    /// success, not the NEAR error. Also asserts NEAR is attempted first (it's
+    /// the primary tier) and that the fallback is immediate (no long backoff
+    /// before trying the next tier).
+    #[tokio::test]
+    async fn near_5xx_falls_back_to_chutes_within_one_request() {
+        use inference_providers::mock::{MockProvider, RequestMatcher, ResponseTemplate};
+        use inference_providers::{CompletionError, ProviderTier};
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model_id = "z-ai/glm-5.1".to_string();
+
+        // NEAR primary: always returns a retryable upstream 5xx.
+        let near = Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Near));
+        near.set_error_override(Some(CompletionError::HttpError {
+            status_code: 503,
+            message: "backend overloaded".to_string(),
+            is_external: true,
+        }))
+        .await;
+
+        // Chutes fallback: healthy, returns a recognizable response.
+        let chutes = Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Attested3p));
+        chutes
+            .when(RequestMatcher::Any)
+            .respond_with(ResponseTemplate::new("served-by-chutes-fallback"))
+            .await;
+
+        {
+            let mut m = pool.provider_mappings.write().await;
+            m.model_to_providers.insert(
+                model_id.clone(),
+                vec![
+                    near.clone() as Arc<InferenceProviderTrait>,
+                    chutes.clone() as Arc<InferenceProviderTrait>,
+                ],
+            );
+        }
+
+        let started = std::time::Instant::now();
+        let resp = pool
+            .chat_completion(fallback_params(&model_id), "test-hash".to_string())
+            .await
+            .expect("NEAR 5xx must fall back to Chutes, not fail the client request");
+        let elapsed = started.elapsed();
+
+        // NEAR was attempted first (primary tier), not skipped.
+        assert!(
+            near.last_chat_params().await.is_some(),
+            "NEAR (primary) must be attempted before falling back"
+        );
+        // Chutes actually served the request.
+        assert!(
+            chutes.last_chat_params().await.is_some(),
+            "Chutes must serve the fallback after the NEAR 5xx"
+        );
+        let body = String::from_utf8_lossy(&resp.raw_bytes);
+        assert!(
+            body.contains("served-by-chutes-fallback"),
+            "response must be the Chutes one, got: {body}"
+        );
+        // Fallback is within the same round (next provider tried immediately) —
+        // no client-facing retry/backoff latency.
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "fallback should be immediate, took {elapsed:?}"
+        );
+    }
+
+    /// When the NEAR primary AND the Chutes fallback both fail with a retryable
+    /// 5xx, the error must SURFACE to the client — the pool must not invent a
+    /// false success once every provider is exhausted.
+    #[tokio::test]
+    async fn all_providers_5xx_surfaces_error() {
+        use inference_providers::mock::MockProvider;
+        use inference_providers::{CompletionError, ProviderTier};
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model_id = "z-ai/glm-5.1".to_string();
+        let err = || CompletionError::HttpError {
+            status_code: 503,
+            message: "down".to_string(),
+            is_external: true,
+        };
+
+        let near = Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Near));
+        near.set_error_override(Some(err())).await;
+        let chutes = Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Attested3p));
+        chutes.set_error_override(Some(err())).await;
+
+        {
+            let mut m = pool.provider_mappings.write().await;
+            m.model_to_providers.insert(
+                model_id.clone(),
+                vec![
+                    near.clone() as Arc<InferenceProviderTrait>,
+                    chutes.clone() as Arc<InferenceProviderTrait>,
+                ],
+            );
+        }
+
+        let result = pool
+            .chat_completion(fallback_params(&model_id), "test-hash".to_string())
+            .await;
+        assert!(
+            result.is_err(),
+            "all providers failing must surface an error, not a false success"
+        );
+        // Both tiers were genuinely attempted.
+        assert!(near.last_chat_params().await.is_some());
+        assert!(chutes.last_chat_params().await.is_some());
+    }
+
+    /// A healthy NEAR primary serves the request itself; the Chutes fallback must
+    /// NOT be invoked when the primary succeeds (no needless fallback / billing).
+    #[tokio::test]
+    async fn healthy_near_serves_without_invoking_chutes() {
+        use inference_providers::mock::{MockProvider, RequestMatcher, ResponseTemplate};
+        use inference_providers::ProviderTier;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+        let model_id = "z-ai/glm-5.1".to_string();
+
+        let near = Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Near));
+        near.when(RequestMatcher::Any)
+            .respond_with(ResponseTemplate::new("served-by-near-primary"))
+            .await;
+        let chutes = Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Attested3p));
+
+        {
+            let mut m = pool.provider_mappings.write().await;
+            m.model_to_providers.insert(
+                model_id.clone(),
+                vec![
+                    near.clone() as Arc<InferenceProviderTrait>,
+                    chutes.clone() as Arc<InferenceProviderTrait>,
+                ],
+            );
+        }
+
+        let resp = pool
+            .chat_completion(fallback_params(&model_id), "test-hash".to_string())
+            .await
+            .expect("healthy NEAR must serve");
+        let body = String::from_utf8_lossy(&resp.raw_bytes);
+        assert!(body.contains("served-by-near-primary"), "NEAR must serve, got: {body}");
+        assert!(
+            chutes.last_chat_params().await.is_none(),
+            "Chutes must NOT be invoked when the NEAR primary succeeds"
+        );
+    }
 }


### PR DESCRIPTION
Adds deterministic integration tests for the **per-request NEAR→Chutes fallback** through `chat_completion` → `retry_with_fallback_caps`.

## Why
We tried to validate the fallback on staging by draining the NEAR backend at the model-proxy. It **couldn't** be validated that way: cloud-api holds **sticky keepalive connections** to NEAR backends through the L4 proxy, so a registry change never makes the *live* request fail — the fallback only fires on a genuine **request-level** failure. That's deterministic to inject with `MockProvider`, so it belongs in a unit/integration test rather than a fragile infra experiment.

## Tests (all green, 3.7s)
- **`near_5xx_falls_back_to_chutes_within_one_request`** — NEAR primary returns a retryable upstream `503`; the request falls through to the Chutes (`Attested3p`) provider and **succeeds**. Asserts NEAR was attempted first, Chutes served (response body check), and the fallback is **immediate** (`< 5s`, i.e. next-provider-in-same-round, no client-facing backoff — addresses the timeout we saw in the staging poke).
- **`all_providers_5xx_surfaces_error`** — NEAR + Chutes both `503` → error **surfaces** (no false success).
- **`healthy_near_serves_without_invoking_chutes`** — healthy NEAR serves itself; Chutes is **never invoked** (no needless fallback/billing).

Complements the existing component tests (`verifiable_model_drops_nonattested_and_orders_tiers`, `filter_streaming_capable_*`, `merge_discovered_and_pinned_*`) with the end-to-end behavior.