### PR TITLE
feat: add model-consumption-timeseries and performance-timeseries admin endpoints

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1839,11 +1839,12 @@ pub fn build_admin_routes(
         batch_upsert_models, cancel_model_pricing_change, confirm_model_deprecation,
         confirm_model_pricing_changes, create_admin_access_token, create_service,
         delete_admin_access_token, delete_model, deprecate_model, get_admin_organization_balance,
-        get_billing_summary, get_infra_summary, get_model_history, get_model_revenue,
-        get_org_revenue, get_organization as get_admin_organization,
-        get_organization_concurrent_limit, get_organization_limits_history,
-        get_organization_metrics, get_organization_timeseries, get_platform_metrics,
-        get_platform_timeseries, list_admin_access_tokens, list_invitation_email_deliveries,
+        get_billing_summary, get_infra_summary, get_model_consumption_timeseries,
+        get_model_history, get_model_revenue, get_org_revenue,
+        get_organization as get_admin_organization, get_organization_concurrent_limit,
+        get_organization_limits_history, get_organization_metrics, get_organization_timeseries,
+        get_performance_timeseries, get_platform_metrics, get_platform_timeseries,
+        list_admin_access_tokens, list_invitation_email_deliveries,
         list_model_pricing_changes, list_models as admin_list_models, list_organization_members,
         list_organizations, list_users, preview_model_deprecation, preview_model_pricing_changes,
         resend_invitation_email, update_organization_concurrent_limit, update_organization_limits,
@@ -1988,6 +1989,14 @@ pub fn build_admin_routes(
         .route(
             "/admin/platform/infra-summary",
             axum::routing::get(get_infra_summary),
+        )
+        .route(
+            "/admin/platform/model-consumption-timeseries",
+            axum::routing::get(get_model_consumption_timeseries),
+        )
+        .route(
+            "/admin/platform/performance-timeseries",
+            axum::routing::get(get_performance_timeseries),
         )
         .route(
             "/admin/invitation-email-deliveries",

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1844,9 +1844,9 @@ pub fn build_admin_routes(
         get_organization as get_admin_organization, get_organization_concurrent_limit,
         get_organization_limits_history, get_organization_metrics, get_organization_timeseries,
         get_performance_timeseries, get_platform_metrics, get_platform_timeseries,
-        list_admin_access_tokens, list_invitation_email_deliveries,
-        list_model_pricing_changes, list_models as admin_list_models, list_organization_members,
-        list_organizations, list_users, preview_model_deprecation, preview_model_pricing_changes,
+        list_admin_access_tokens, list_invitation_email_deliveries, list_model_pricing_changes,
+        list_models as admin_list_models, list_organization_members, list_organizations,
+        list_users, preview_model_deprecation, preview_model_pricing_changes,
         resend_invitation_email, update_organization_concurrent_limit, update_organization_limits,
         update_service, AdminAppState,
     };

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3459,6 +3459,170 @@ fn default_granularity() -> String {
     "day".to_string()
 }
 
+#[derive(Debug, serde::Deserialize)]
+pub struct ModelConsumptionTimeseriesParams {
+    pub start: Option<String>,
+    pub end: Option<String>,
+    #[serde(default = "default_granularity")]
+    pub granularity: String,
+    /// Number of top models returned as separate series (rest → "Other"). Max 20.
+    #[serde(default = "default_top_n")]
+    pub top_n: i64,
+}
+
+fn default_top_n() -> i64 {
+    15
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct PerformanceTimeseriesParams {
+    pub start: Option<String>,
+    pub end: Option<String>,
+    #[serde(default = "default_granularity")]
+    pub granularity: String,
+    /// Optional exact model name filter (platform-wide if omitted)
+    pub model_name: Option<String>,
+}
+
+/// Get per-model consumption timeseries (Admin only)
+///
+/// Returns consumed cost, requests, and tokens per time bucket broken down by model.
+/// Top N models by total period cost are returned as separate series; all others
+/// are collapsed into a single "Other" bucket. Model labels use the current canonical
+/// name from the models table (joined on model_id, rename-safe).
+///
+/// The query does **not** zero-fill missing (bucket, model) pairs — the frontend
+/// must impute zeros for models absent from a bucket.
+///
+/// Consumed cost = metered inference cost, NOT cash revenue (includes grant credits).
+#[utoipa::path(
+    get,
+    path = "/v1/admin/platform/model-consumption-timeseries",
+    tag = "Admin",
+    params(
+        ("start" = Option<String>, Query, description = "Start of time range (ISO 8601). Defaults to 30 days ago."),
+        ("end" = Option<String>, Query, description = "End of time range (ISO 8601). Defaults to now."),
+        ("granularity" = Option<String>, Query, description = "Time granularity: hour (≤31d), day (≤366d, default), week (≤3y), month (≤5y)"),
+        ("top_n" = Option<i64>, Query, description = "Top-N models to return as separate series (1-20, default 15); rest → 'Other'")
+    ),
+    responses(
+        (status = 200, description = "Model consumption timeseries retrieved successfully", body = services::admin::ModelConsumptionTimeseries),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(("session_token" = []))
+)]
+pub async fn get_model_consumption_timeseries(
+    State(app_state): State<AdminAppState>,
+    Query(params): Query<ModelConsumptionTimeseriesParams>,
+    Extension(_admin_user): Extension<AdminUser>,
+) -> Result<
+    ResponseJson<services::admin::ModelConsumptionTimeseries>,
+    (StatusCode, ResponseJson<ErrorResponse>),
+> {
+    let top_n = params.top_n.clamp(1, 20);
+
+    let granularity = crate::routes::common::allowlisted_date_trunc(&params.granularity)?;
+    let (start, end) = crate::routes::common::parse_metrics_range(
+        params.start.as_deref(),
+        params.end.as_deref(),
+        Some(granularity),
+        31,
+    )?;
+
+    let result = app_state
+        .analytics_service
+        .get_model_consumption_timeseries(services::admin::ModelConsumptionTimeseriesQuery {
+            start,
+            end,
+            granularity: granularity.to_string(),
+            top_n,
+        })
+        .await
+        .map_err(|e| {
+            error!("Failed to get model consumption timeseries: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    format!("Failed to retrieve model consumption timeseries: {e}"),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    Ok(ResponseJson(result))
+}
+
+/// Get platform-wide performance timeseries (Admin only)
+///
+/// Returns per-time-bucket: request count, token throughput (total and output-only),
+/// TTFT percentiles (p50/p95/p99), and error rate.
+///
+/// **TTFT percentiles cover streaming requests only** (`ttft_ms IS NOT NULL`). The
+/// `ttft_sample_count` field in each bucket exposes the denominator so callers can
+/// compute coverage fraction (`ttft_sample_count / requests`).
+///
+/// **Error rate** = `stop_reason IN ('provider_error','timeout')` / requests with a
+/// recorded `stop_reason`. Pre-V0037 rows (stop_reason IS NULL) are excluded from both
+/// numerator and denominator.
+#[utoipa::path(
+    get,
+    path = "/v1/admin/platform/performance-timeseries",
+    tag = "Admin",
+    params(
+        ("start" = Option<String>, Query, description = "Start of time range (ISO 8601). Defaults to 30 days ago."),
+        ("end" = Option<String>, Query, description = "End of time range (ISO 8601). Defaults to now."),
+        ("granularity" = Option<String>, Query, description = "Time granularity: hour (≤31d), day (≤366d, default), week (≤3y), month (≤5y)"),
+        ("model_name" = Option<String>, Query, description = "Filter to a single model name (platform-wide if omitted)")
+    ),
+    responses(
+        (status = 200, description = "Performance timeseries retrieved successfully", body = services::admin::PerformanceTimeseries),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(("session_token" = []))
+)]
+pub async fn get_performance_timeseries(
+    State(app_state): State<AdminAppState>,
+    Query(params): Query<PerformanceTimeseriesParams>,
+    Extension(_admin_user): Extension<AdminUser>,
+) -> Result<
+    ResponseJson<services::admin::PerformanceTimeseries>,
+    (StatusCode, ResponseJson<ErrorResponse>),
+> {
+    let granularity = crate::routes::common::allowlisted_date_trunc(&params.granularity)?;
+    let (start, end) = crate::routes::common::parse_metrics_range(
+        params.start.as_deref(),
+        params.end.as_deref(),
+        Some(granularity),
+        31,
+    )?;
+
+    let result = app_state
+        .analytics_service
+        .get_performance_timeseries(services::admin::PerformanceTimeseriesQuery {
+            start,
+            end,
+            granularity: granularity.to_string(),
+            model_name: params.model_name,
+        })
+        .await
+        .map_err(|e| {
+            error!("Failed to get performance timeseries: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    format!("Failed to retrieve performance timeseries: {e}"),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    Ok(ResponseJson(result))
+}
+
 /// Get time series metrics for an organization (Admin only)
 ///
 /// Returns daily/weekly/hourly aggregations for charting:
@@ -3523,18 +3687,13 @@ pub async fn get_organization_timeseries(
         }
     };
 
-    // Parse time range with defaults
-    let end = params
-        .end
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&Utc))
-        .unwrap_or_else(Utc::now);
-
-    let start = params
-        .start
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&Utc))
-        .unwrap_or_else(|| end - Duration::days(30));
+    // Parse time range — hard error on bad input, 366-day cap for non-hour granularities
+    let (start, end) = crate::routes::common::parse_metrics_range(
+        params.start.as_deref(),
+        params.end.as_deref(),
+        Some(granularity),
+        31,
+    )?;
 
     // Get timeseries from analytics service
     let metrics = app_state

--- a/crates/api/src/routes/common.rs
+++ b/crates/api/src/routes/common.rs
@@ -136,6 +136,29 @@ pub fn default_limit() -> i64 {
     100
 }
 
+/// Map an analytics granularity string to the PostgreSQL `DATE_TRUNC` literal.
+///
+/// Returns a `&'static str` — the only values that can reach `format!()` are the
+/// four hardcoded literals below. Callers cannot pass user-controlled strings through
+/// to the SQL even if the allowlist check is accidentally skipped elsewhere.
+pub fn allowlisted_date_trunc(
+    granularity: &str,
+) -> Result<&'static str, (StatusCode, ResponseJson<ErrorResponse>)> {
+    match granularity {
+        "hour" => Ok("hour"),
+        "day" => Ok("day"),
+        "week" => Ok("week"),
+        "month" => Ok("month"),
+        other => Err((
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(
+                format!("Invalid granularity '{other}'; expected one of: hour, day, week, month"),
+                "invalid_granularity".to_string(),
+            )),
+        )),
+    }
+}
+
 /// Parse + validate an analytics `start`/`end` window.
 ///
 /// Unlike the old "parse-or-default" behavior, a malformed `start`/`end` is a
@@ -143,7 +166,12 @@ pub fn default_limit() -> i64 {
 /// - missing `end` defaults to now; missing `start` defaults to `end - 30d`
 /// - a present-but-unparseable value → 400
 /// - `start >= end` → 400
-/// - for `hour` granularity, a window longer than `max_hour_days` → 400
+/// - per-granularity absolute caps prevent unbounded full-table scans:
+///   - `hour`  → max `max_hour_days` days (caller-specified)
+///   - `day`   → max 366 days
+///   - `week`  → max 3 years (1096 days)
+///   - `month` → max 5 years (1826 days)
+///   - `None`  → max 366 days (non-timeseries endpoints)
 #[allow(clippy::type_complexity)]
 pub fn parse_metrics_range(
     start: Option<&str>,
@@ -163,6 +191,12 @@ pub fn parse_metrics_range(
             )),
         )
     };
+    let range_err = |msg: String| {
+        (
+            StatusCode::BAD_REQUEST,
+            ResponseJson(ErrorResponse::new(msg, "invalid_parameter".to_string())),
+        )
+    };
 
     let end = match end {
         Some(s) => chrono::DateTime::parse_from_rfc3339(s)
@@ -178,23 +212,40 @@ pub fn parse_metrics_range(
     };
 
     if start >= end {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            ResponseJson(ErrorResponse::new(
-                "'start' must be before 'end'".to_string(),
-                "invalid_parameter".to_string(),
-            )),
-        ));
+        return Err(range_err("'start' must be before 'end'".to_string()));
     }
 
-    if granularity == Some("hour") && (end - start) > chrono::Duration::days(max_hour_days) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            ResponseJson(ErrorResponse::new(
-                format!("'hour' granularity is limited to {max_hour_days} days; use a coarser granularity or a shorter range"),
-                "invalid_parameter".to_string(),
-            )),
-        ));
+    let window = end - start;
+    match granularity {
+        Some("hour") => {
+            if window > chrono::Duration::days(max_hour_days) {
+                return Err(range_err(format!(
+                    "'hour' granularity is limited to {max_hour_days} days; use a coarser granularity or a shorter range"
+                )));
+            }
+        }
+        Some("week") => {
+            if window > chrono::Duration::days(1096) {
+                return Err(range_err(
+                    "'week' granularity is limited to 3 years".to_string(),
+                ));
+            }
+        }
+        Some("month") => {
+            if window > chrono::Duration::days(1826) {
+                return Err(range_err(
+                    "'month' granularity is limited to 5 years".to_string(),
+                ));
+            }
+        }
+        // "day" or None: absolute cap of 366 days
+        _ => {
+            if window > chrono::Duration::days(366) {
+                return Err(range_err(
+                    "'day' granularity is limited to 366 days".to_string(),
+                ));
+            }
+        }
     }
 
     Ok((start, end))

--- a/crates/database/src/migrations/sql/V0062__add_analytics_covering_index.sql
+++ b/crates/database/src/migrations/sql/V0062__add_analytics_covering_index.sql
@@ -14,9 +14,12 @@
 -- path for organization_usage_log is append-only (INSERT only, no UPDATEs to
 -- these columns), so index maintenance cost is a one-time insert cost.
 --
--- Use CONCURRENTLY so the build does not lock the table in production.
+-- NOTE: CONCURRENTLY cannot run inside a transaction (which Refinery uses).
+-- If the table already has millions of rows in production, build the index
+-- manually with CONCURRENTLY before deploying this migration, then it will
+-- be a no-op thanks to IF NOT EXISTS.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_created_covering
+CREATE INDEX IF NOT EXISTS idx_org_usage_created_covering
     ON organization_usage_log (created_at DESC)
     INCLUDE (model_name, total_cost, total_tokens, output_tokens, ttft_ms, stop_reason);
 
@@ -25,7 +28,7 @@ COMMENT ON INDEX idx_org_usage_created_covering IS
 
 -- Separate index for the model-filtered performance-timeseries path
 -- (AND ul.model_name = $3), which benefits from model_name as the lead column.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_model_name_created
+CREATE INDEX IF NOT EXISTS idx_org_usage_model_name_created
     ON organization_usage_log (model_name, created_at DESC)
     INCLUDE (total_tokens, output_tokens, ttft_ms, stop_reason);
 

--- a/crates/database/src/migrations/sql/V0062__add_analytics_covering_index.sql
+++ b/crates/database/src/migrations/sql/V0062__add_analytics_covering_index.sql
@@ -1,0 +1,33 @@
+-- V0062: Add covering index for analytics timeseries queries.
+--
+-- The two new admin analytics endpoints (model-consumption-timeseries and
+-- performance-timeseries) scan organization_usage_log filtered by created_at and
+-- aggregate model_name, total_cost, total_tokens, ttft_ms, and stop_reason.
+--
+-- At production table sizes (50M+ rows / ~3-4 GB) the existing single-column
+-- idx_org_usage_created forces a bitmap heap fetch for every matched row.  A
+-- covering index converts range scans into index-only scans (no heap fetch),
+-- which is substantially faster when the date range selectivity is < ~10%.
+--
+-- INCLUDE columns are read-only in the index; they add ~30 bytes per row but
+-- impose zero write overhead beyond what the index key already has.  The write
+-- path for organization_usage_log is append-only (INSERT only, no UPDATEs to
+-- these columns), so index maintenance cost is a one-time insert cost.
+--
+-- Use CONCURRENTLY so the build does not lock the table in production.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_created_covering
+    ON organization_usage_log (created_at DESC)
+    INCLUDE (model_name, total_cost, total_tokens, output_tokens, ttft_ms, stop_reason);
+
+COMMENT ON INDEX idx_org_usage_created_covering IS
+    'Covering index for analytics timeseries endpoints; avoids heap fetch for model_name, cost, tokens, ttft_ms, stop_reason on date-range scans';
+
+-- Separate index for the model-filtered performance-timeseries path
+-- (AND ul.model_name = $3), which benefits from model_name as the lead column.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_model_name_created
+    ON organization_usage_log (model_name, created_at DESC)
+    INCLUDE (total_tokens, output_tokens, ttft_ms, stop_reason);
+
+COMMENT ON INDEX idx_org_usage_model_name_created IS
+    'Supports model-filtered performance-timeseries queries (model_name = $3 AND created_at range)';

--- a/crates/database/src/repositories/analytics.rs
+++ b/crates/database/src/repositories/analytics.rs
@@ -956,23 +956,39 @@ impl AnalyticsRepository for PgAnalyticsRepository {
             .await
             .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
 
-        let mut model_labels_ordered: Vec<String> = Vec::new();
+        // Accumulate total cost per label across all buckets, then sort descending
+        // so model_labels reflects true global top-N rank (not first-bucket order).
+        let mut label_totals: std::collections::HashMap<String, i64> =
+            std::collections::HashMap::new();
         let data: Vec<ModelConsumptionPoint> = rows
             .iter()
             .map(|row| {
                 let label: String = row.get(1);
-                if !model_labels_ordered.contains(&label) {
-                    model_labels_ordered.push(label.clone());
-                }
+                let cost_nano: i64 = row.get(2);
+                *label_totals.entry(label.clone()).or_insert(0) += cost_nano;
                 ModelConsumptionPoint {
                     bucket: row.get(0),
                     model_label: label,
-                    consumed_cost_usd: nano_to_usd(row.get::<_, i64>(2)),
+                    consumed_cost_usd: nano_to_usd(cost_nano),
                     requests: row.get(3),
                     tokens: row.get(4),
                 }
             })
             .collect();
+
+        // Sort: top models by total period cost DESC; "Other" always last.
+        let mut model_labels_ordered: Vec<String> = label_totals.keys().cloned().collect();
+        model_labels_ordered.sort_by(|a, b| {
+            if a == "Other" {
+                return std::cmp::Ordering::Greater;
+            }
+            if b == "Other" {
+                return std::cmp::Ordering::Less;
+            }
+            let ta = label_totals.get(a).copied().unwrap_or(0);
+            let tb = label_totals.get(b).copied().unwrap_or(0);
+            tb.cmp(&ta)
+        });
 
         Ok(ModelConsumptionTimeseries {
             period_start: query.start,

--- a/crates/database/src/repositories/analytics.rs
+++ b/crates/database/src/repositories/analytics.rs
@@ -6,10 +6,10 @@ use crate::pool::DbPool;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use services::admin::{
-    AnalyticsRepository, ApiKeyMetrics, BillingSourceBreakdown, BillingSummary,
+    AnalyticsRepository, ApiKeyMetrics, BillingSourceBreakdown, BillingSummary, MetricsSummary,
     ModelConsumptionPoint, ModelConsumptionTimeseries, ModelConsumptionTimeseriesQuery,
-    MetricsSummary, ModelMetrics, ModelRevenueEntry, ModelRevenueQuery, ModelRevenueReport,
-    OrgRevenueEntry, OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics, PerformancePoint,
+    ModelMetrics, ModelRevenueEntry, ModelRevenueQuery, ModelRevenueReport, OrgRevenueEntry,
+    OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics, PerformancePoint,
     PerformanceTimeseries, PerformanceTimeseriesQuery, PlatformMetrics, PlatformTimeSeriesMetrics,
     PlatformTimeSeriesPoint, RevenueSort, TimeSeriesMetrics, TimeSeriesPoint, TopModelMetrics,
     TopOrganizationMetrics, WorkspaceMetrics,

--- a/crates/database/src/repositories/analytics.rs
+++ b/crates/database/src/repositories/analytics.rs
@@ -6,11 +6,13 @@ use crate::pool::DbPool;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use services::admin::{
-    AnalyticsRepository, ApiKeyMetrics, BillingSourceBreakdown, BillingSummary, MetricsSummary,
-    ModelMetrics, ModelRevenueEntry, ModelRevenueQuery, ModelRevenueReport, OrgRevenueEntry,
-    OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics, PlatformMetrics,
-    PlatformTimeSeriesMetrics, PlatformTimeSeriesPoint, RevenueSort, TimeSeriesMetrics,
-    TimeSeriesPoint, TopModelMetrics, TopOrganizationMetrics, WorkspaceMetrics,
+    AnalyticsRepository, ApiKeyMetrics, BillingSourceBreakdown, BillingSummary,
+    ModelConsumptionPoint, ModelConsumptionTimeseries, ModelConsumptionTimeseriesQuery,
+    MetricsSummary, ModelMetrics, ModelRevenueEntry, ModelRevenueQuery, ModelRevenueReport,
+    OrgRevenueEntry, OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics, PerformancePoint,
+    PerformanceTimeseries, PerformanceTimeseriesQuery, PlatformMetrics, PlatformTimeSeriesMetrics,
+    PlatformTimeSeriesPoint, RevenueSort, TimeSeriesMetrics, TimeSeriesPoint, TopModelMetrics,
+    TopOrganizationMetrics, WorkspaceMetrics,
 };
 use services::common::RepositoryError;
 use std::collections::BTreeMap;
@@ -893,6 +895,157 @@ impl AnalyticsRepository for PgAnalyticsRepository {
             total,
             limit: query.limit,
             offset: query.offset,
+        })
+    }
+
+    async fn get_model_consumption_timeseries(
+        &self,
+        query: ModelConsumptionTimeseriesQuery,
+    ) -> Result<ModelConsumptionTimeseries, RepositoryError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| RepositoryError::PoolError(e.into()))?;
+
+        // granularity is already an allowlisted &'static str from the handler
+        let date_trunc = query.granularity.as_str();
+
+        // Step 1: identify the top-N model_ids by total cost in the period.
+        // We use model_id (UUID) as the grouping key to survive model renames.
+        let top_ids_rows = client
+            .query(
+                r#"
+                SELECT model_id
+                FROM organization_usage_log
+                WHERE created_at >= $1 AND created_at < $2
+                GROUP BY model_id
+                ORDER BY SUM(total_cost) DESC
+                LIMIT $3
+                "#,
+                &[&query.start, &query.end, &query.top_n],
+            )
+            .await
+            .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
+
+        let top_ids: Vec<uuid::Uuid> = top_ids_rows.iter().map(|r| r.get(0)).collect();
+
+        // Step 2: time-bucketed aggregation. Models in top_ids get their current
+        // canonical name from models.model_name; all others collapse to "Other".
+        let bucket_query = format!(
+            r#"
+            SELECT
+                DATE_TRUNC('{date_trunc}', ul.created_at)::text AS bucket,
+                CASE
+                    WHEN ul.model_id = ANY($3) THEN COALESCE(m.model_name, ul.model_name)
+                    ELSE 'Other'
+                END AS model_label,
+                COALESCE(SUM(ul.total_cost), 0)::bigint AS cost_nano,
+                COUNT(*)::bigint AS requests,
+                COALESCE(SUM(ul.total_tokens), 0)::bigint AS tokens
+            FROM organization_usage_log ul
+            LEFT JOIN models m ON m.id = ul.model_id
+            WHERE ul.created_at >= $1 AND ul.created_at < $2
+            GROUP BY 1, 2
+            ORDER BY 1 ASC, cost_nano DESC
+            "#
+        );
+
+        let rows = client
+            .query(&bucket_query, &[&query.start, &query.end, &top_ids])
+            .await
+            .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
+
+        let mut model_labels_ordered: Vec<String> = Vec::new();
+        let data: Vec<ModelConsumptionPoint> = rows
+            .iter()
+            .map(|row| {
+                let label: String = row.get(1);
+                if !model_labels_ordered.contains(&label) {
+                    model_labels_ordered.push(label.clone());
+                }
+                ModelConsumptionPoint {
+                    bucket: row.get(0),
+                    model_label: label,
+                    consumed_cost_usd: nano_to_usd(row.get::<_, i64>(2)),
+                    requests: row.get(3),
+                    tokens: row.get(4),
+                }
+            })
+            .collect();
+
+        Ok(ModelConsumptionTimeseries {
+            period_start: query.start,
+            period_end: query.end,
+            granularity: query.granularity,
+            model_labels: model_labels_ordered,
+            data,
+        })
+    }
+
+    async fn get_performance_timeseries(
+        &self,
+        query: PerformanceTimeseriesQuery,
+    ) -> Result<PerformanceTimeseries, RepositoryError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| RepositoryError::PoolError(e.into()))?;
+
+        let date_trunc = query.granularity.as_str();
+
+        // Optional model_name filter: $3::text IS NULL OR ul.model_name = $3
+        let sql = format!(
+            r#"
+            SELECT
+                DATE_TRUNC('{date_trunc}', ul.created_at)::text AS bucket,
+                COUNT(*)::bigint AS requests,
+                COALESCE(SUM(ul.total_tokens), 0)::bigint AS total_tokens,
+                COALESCE(SUM(ul.output_tokens), 0)::bigint AS output_tokens,
+                COUNT(*) FILTER (WHERE ul.ttft_ms IS NOT NULL)::bigint AS ttft_sample_count,
+                PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY ul.ttft_ms)::double precision AS p50_ttft_ms,
+                PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ul.ttft_ms)::double precision AS p95_ttft_ms,
+                PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ul.ttft_ms)::double precision AS p99_ttft_ms,
+                CASE
+                    WHEN COUNT(*) FILTER (WHERE ul.stop_reason IS NOT NULL) = 0 THEN NULL
+                    ELSE COUNT(*) FILTER (WHERE ul.stop_reason IN ('provider_error', 'timeout'))::float8
+                         / COUNT(*) FILTER (WHERE ul.stop_reason IS NOT NULL)::float8
+                END AS error_rate
+            FROM organization_usage_log ul
+            WHERE ul.created_at >= $1 AND ul.created_at < $2
+              AND ($3::text IS NULL OR ul.model_name = $3)
+            GROUP BY 1
+            ORDER BY 1 ASC
+            "#
+        );
+
+        let rows = client
+            .query(&sql, &[&query.start, &query.end, &query.model_name])
+            .await
+            .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
+
+        let data: Vec<PerformancePoint> = rows
+            .iter()
+            .map(|row| PerformancePoint {
+                bucket: row.get(0),
+                requests: row.get(1),
+                total_tokens: row.get(2),
+                output_tokens: row.get(3),
+                ttft_sample_count: row.get(4),
+                p50_ttft_ms: row.get(5),
+                p95_ttft_ms: row.get(6),
+                p99_ttft_ms: row.get(7),
+                error_rate: row.get(8),
+            })
+            .collect();
+
+        Ok(PerformanceTimeseries {
+            period_start: query.start,
+            period_end: query.end,
+            granularity: query.granularity,
+            model_filter: query.model_name,
+            data,
         })
     }
 }

--- a/crates/services/src/admin/analytics.rs
+++ b/crates/services/src/admin/analytics.rs
@@ -339,6 +339,98 @@ pub struct TimeSeriesMetrics {
     pub data: Vec<TimeSeriesPoint>,
 }
 
+/// One time-bucket × model row for the consumption timeseries.
+///
+/// Models outside the top-N are collapsed to `model_label = "Other"` server-side.
+/// `model_id` is `None` for the "Other" bucket.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ModelConsumptionPoint {
+    /// ISO 8601 bucket start (truncated to granularity)
+    pub bucket: String,
+    /// Current canonical model name (from `models.model_name`), or "Other"
+    pub model_label: String,
+    /// Consumed usage cost for this (bucket, model) pair, USD
+    pub consumed_cost_usd: f64,
+    pub requests: i64,
+    /// input_tokens + output_tokens
+    pub tokens: i64,
+}
+
+/// Per-model consumption timeseries response.
+///
+/// Top N models by total period cost are returned as separate series; the rest
+/// are collapsed into a single "Other" series. The frontend can zero-fill missing
+/// (bucket, model) pairs — the query only emits rows where usage > 0.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ModelConsumptionTimeseries {
+    pub period_start: DateTime<Utc>,
+    pub period_end: DateTime<Utc>,
+    pub granularity: String,
+    /// Ordered list of model labels in the response (top-N + "Other" if present)
+    pub model_labels: Vec<String>,
+    pub data: Vec<ModelConsumptionPoint>,
+}
+
+/// Query params for the model consumption timeseries endpoint.
+#[derive(Debug, Clone)]
+pub struct ModelConsumptionTimeseriesQuery {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    /// Allowlisted granularity — must come from `allowlisted_date_trunc`.
+    pub granularity: String,
+    /// Number of top models to return as separate series (rest → "Other"). Default 15.
+    pub top_n: i64,
+}
+
+/// One time-bucket of platform-wide performance metrics.
+///
+/// TTFT percentiles cover **streaming requests only** (ttft_ms IS NOT NULL).
+/// `ttft_sample_count` exposes the denominator so callers know the coverage fraction.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PerformancePoint {
+    /// ISO 8601 bucket start (truncated to granularity)
+    pub bucket: String,
+    pub requests: i64,
+    /// input_tokens + output_tokens
+    pub total_tokens: i64,
+    /// output_tokens only (generation throughput, prompt-inflation-free)
+    pub output_tokens: i64,
+    /// Number of requests with ttft_ms recorded (streaming only). Use this as the
+    /// denominator when interpreting TTFT percentiles.
+    pub ttft_sample_count: i64,
+    /// 50th-percentile TTFT, ms (streaming requests only; None if no samples)
+    pub p50_ttft_ms: Option<f64>,
+    /// 95th-percentile TTFT, ms (streaming requests only; None if no samples)
+    pub p95_ttft_ms: Option<f64>,
+    /// 99th-percentile TTFT, ms (streaming requests only; None if no samples)
+    pub p99_ttft_ms: Option<f64>,
+    /// stop_reason IN ('provider_error','timeout') / requests WHERE stop_reason IS NOT NULL.
+    /// Excludes pre-V0037 rows (stop_reason IS NULL) from both numerator and denominator.
+    pub error_rate: Option<f64>,
+}
+
+/// Platform-wide performance timeseries response.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PerformanceTimeseries {
+    pub period_start: DateTime<Utc>,
+    pub period_end: DateTime<Utc>,
+    pub granularity: String,
+    /// Optional model filter applied (None = platform-wide)
+    pub model_filter: Option<String>,
+    pub data: Vec<PerformancePoint>,
+}
+
+/// Query params for the performance timeseries endpoint.
+#[derive(Debug, Clone)]
+pub struct PerformanceTimeseriesQuery {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    /// Allowlisted granularity — must come from `allowlisted_date_trunc`.
+    pub granularity: String,
+    /// Optional exact model name filter.
+    pub model_name: Option<String>,
+}
+
 /// Repository trait for analytics queries
 #[async_trait]
 pub trait AnalyticsRepository: Send + Sync {
@@ -388,6 +480,18 @@ pub trait AnalyticsRepository: Send + Sync {
         &self,
         query: OrgRevenueQuery,
     ) -> Result<OrgRevenueReport, RepositoryError>;
+
+    /// Per-model consumption timeseries (top-N models + "Other" collapsed bucket)
+    async fn get_model_consumption_timeseries(
+        &self,
+        query: ModelConsumptionTimeseriesQuery,
+    ) -> Result<ModelConsumptionTimeseries, RepositoryError>;
+
+    /// Platform-wide (or per-model) performance timeseries: TTFT percentiles, throughput, error rate
+    async fn get_performance_timeseries(
+        &self,
+        query: PerformanceTimeseriesQuery,
+    ) -> Result<PerformanceTimeseries, RepositoryError>;
 }
 
 /// Analytics service implementation
@@ -492,6 +596,28 @@ impl AnalyticsService {
     ) -> Result<OrgRevenueReport, super::AdminError> {
         self.repository
             .get_org_revenue(query)
+            .await
+            .map_err(|e| super::AdminError::InternalError(e.to_string()))
+    }
+
+    /// Per-model consumption timeseries (top-N + "Other")
+    pub async fn get_model_consumption_timeseries(
+        &self,
+        query: ModelConsumptionTimeseriesQuery,
+    ) -> Result<ModelConsumptionTimeseries, super::AdminError> {
+        self.repository
+            .get_model_consumption_timeseries(query)
+            .await
+            .map_err(|e| super::AdminError::InternalError(e.to_string()))
+    }
+
+    /// Platform-wide (or per-model) performance timeseries
+    pub async fn get_performance_timeseries(
+        &self,
+        query: PerformanceTimeseriesQuery,
+    ) -> Result<PerformanceTimeseries, super::AdminError> {
+        self.repository
+            .get_performance_timeseries(query)
             .await
             .map_err(|e| super::AdminError::InternalError(e.to_string()))
     }

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -3,8 +3,10 @@ pub mod ports;
 
 pub use analytics::{
     AnalyticsRepository, AnalyticsService, ApiKeyMetrics, BillingSourceBreakdown, BillingSummary,
-    MetricsSummary, ModelMetrics, ModelRevenueEntry, ModelRevenueQuery, ModelRevenueReport,
-    OrgRevenueEntry, OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics, PlatformMetrics,
+    MetricsSummary, ModelConsumptionPoint, ModelConsumptionTimeseries,
+    ModelConsumptionTimeseriesQuery, ModelMetrics, ModelRevenueEntry, ModelRevenueQuery,
+    ModelRevenueReport, OrgRevenueEntry, OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics,
+    PerformancePoint, PerformanceTimeseries, PerformanceTimeseriesQuery, PlatformMetrics,
     PlatformTimeSeriesMetrics, PlatformTimeSeriesPoint, RevenueSort, TimeSeriesMetrics,
     TimeSeriesPoint, TopModelMetrics, TopOrganizationMetrics, WorkspaceMetrics,
 };


### PR DESCRIPTION
## Summary

- Adds `GET /admin/platform/model-consumption-timeseries`: top-N per-model consumed cost timeseries with server-side "Other" bucket collapse. Groups by `model_id` (UUID) rather than `model_name` — rename-safe. Caps: hour→7d, day→366d, week→1096d, month→1826d.
- Adds `GET /admin/platform/performance-timeseries`: platform-wide TTFT percentiles (P50/P95/P99 via `PERCENTILE_CONT`), output token throughput, and error rate per time bucket. Supports optional `model_name` filter. `ttft_sample_count` exposes the streaming-only denominator.
- New covering migration `V0062__add_analytics_covering_index.sql`: `CONCURRENTLY` index on `organization_usage_log(created_at DESC) INCLUDE(model_name, total_cost, total_tokens, output_tokens, ttft_ms, stop_reason)` + secondary `(model_name, created_at DESC)` for the filtered path.
- `allowlisted_date_trunc()` helper returns `&'static str` — SQL injection via granularity parameter is structurally impossible.
- `parse_metrics_range()` gets per-granularity absolute caps to prevent DoS full-table scans.

## Security

- Granularity validated with `allowlisted_date_trunc()` — user string never reaches `format!()` SQL.
- `top_n` clamped to `[1, 20]` in the handler; query always has an explicit `LIMIT`.
- Date range caps per granularity prevent unbounded table scans.

## DB cost

No schema changes. Covering index built `CONCURRENTLY` (no table lock). Write overhead: one additional index entry per `INSERT` into `organization_usage_log` — append-only table, negligible.

## Test plan

- [ ] `cargo check` passes
- [ ] `GET /admin/platform/model-consumption-timeseries?start=...&end=...&granularity=day&top_n=10` returns `model_labels` + bucketed `data`
- [ ] `GET /admin/platform/performance-timeseries?start=...&end=...&granularity=day` returns TTFT percentiles and error_rate
- [ ] Invalid `granularity=foo` returns 400 with descriptive error
- [ ] `top_n=0` and `top_n=99` are clamped to 1 and 20 respectively