### PR TITLE
Fix streaming: emit usage:null in intermediate chunks per OpenAI spec (fixes #646)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,26 @@ jobs:
         RUST_LOG: debug
         DEV: "true"
 
+  # Aggregates all test jobs into a single required status check. Branch
+  # protection requires "Test Suite"; this job satisfies that requirement
+  # without running any extra work.
+  test-suite:
+    name: Test Suite
+    runs-on: [self-hosted, infra]
+    needs: [lint, unit-test, integration-test, e2e-test]
+    if: always()
+    steps:
+      - name: Check all tests passed
+        run: |
+          if [[ "${{ needs.lint.result }}" != "success" || \
+                "${{ needs.unit-test.result }}" != "success" || \
+                "${{ needs.integration-test.result }}" != "success" || \
+                "${{ needs.e2e-test.result }}" != "success" ]]; then
+            echo "One or more test jobs failed"
+            exit 1
+          fi
+          echo "All test jobs passed"
+
   # Release build, only on main pushes. Split into its own job so it does
   # not block the test jobs and does not pull in PostgreSQL or test env vars
   # (there is no build.rs; cargo build --release needs none of them).

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -2969,7 +2969,10 @@ mod tests {
 
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
-        assert!(mode.strip_intermediate_usage, "default stream must strip intermediate usage");
+        assert!(
+            mode.strip_intermediate_usage,
+            "default stream must strip intermediate usage"
+        );
     }
 
     #[test]

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -387,10 +387,20 @@ fn chat_stream_usage_mode(
 
     // For default streaming (no include_usage or include_usage:false), strip populated
     // usage from all chunks so intermediate ones carry `usage: null` per OpenAI spec.
-    // Skipped when the client explicitly requested continuous stats, uses E2EE (chunks
-    // are opaque), has non-text modalities, or when rewrite_public_stream_usage already
-    // handles usage shaping.
+    //
+    // Only applied for non-attested (external) models. Attested models (e.g. nearai,
+    // chutes) sign the raw upstream bytes; stripping usage before forwarding to the
+    // client would break byte-exact TEE signature verification because the client
+    // would hash different bytes than what the inference proxy signed. For those
+    // models the provider-signed stream MUST be forwarded verbatim (the
+    // `rewrite_public_stream_usage` path handles `include_usage:true` via the
+    // separately-computed gateway signature).
+    //
+    // Also skipped when: the client requested continuous stats (explicit per-chunk
+    // usage), E2EE is active (chunks are opaque), non-text modalities are in use,
+    // or `rewrite_public_stream_usage` already handles usage shaping.
     let strip_intermediate_usage = request.stream == Some(true)
+        && model_attestation_supported == Some(false)
         && !rewrite_public_stream_usage
         && !chat_stream_continuous_usage_requested(request)
         && !e2ee_active
@@ -2961,25 +2971,40 @@ mod tests {
     }
 
     #[test]
-    fn default_attested_stream_strips_intermediate_usage() {
-        // Default streaming (no include_usage): per OpenAI spec intermediate
-        // chunks must carry `usage: null`; no final usage chunk is emitted.
+    fn default_attested_stream_preserves_passthrough_for_tee_verification() {
+        // Default streaming for ATTESTED models: byte-exact passthrough is preserved
+        // so the client can verify the inference TEE's provider signature.
+        // Stripping usage would change the bytes the client sees vs what the provider
+        // signed, breaking TEE signature verification.
         let request = chat_request_with_include_usage(None);
         let mode = chat_stream_usage_mode(&request, Some(true), false);
 
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
         assert!(
-            mode.strip_intermediate_usage,
-            "default stream must strip intermediate usage"
+            !mode.strip_intermediate_usage,
+            "attested streams must preserve raw passthrough for TEE verification"
         );
     }
 
     #[test]
-    fn include_usage_false_strips_intermediate_usage() {
-        // Explicit include_usage:false: same as default — null out intermediate usage.
+    fn include_usage_false_attested_stream_preserves_passthrough_for_tee_verification() {
+        // Explicit include_usage:false for ATTESTED model: same as default,
+        // preserve passthrough for TEE signature verification.
         let request = chat_request_with_include_usage(Some(false));
         let mode = chat_stream_usage_mode(&request, Some(true), false);
+
+        assert!(!mode.rewrite_public_stream_usage);
+        assert!(!mode.gateway_signature_enabled);
+        assert!(!mode.strip_intermediate_usage);
+    }
+
+    #[test]
+    fn default_non_attested_stream_strips_intermediate_usage() {
+        // Non-attested (external) models: no TEE signature to preserve.
+        // Strip usage so intermediate chunks carry `usage: null` per OpenAI spec.
+        let request = chat_request_with_include_usage(None);
+        let mode = chat_stream_usage_mode(&request, Some(false), false);
 
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
@@ -2987,8 +3012,8 @@ mod tests {
     }
 
     #[test]
-    fn default_non_attested_stream_strips_intermediate_usage() {
-        let request = chat_request_with_include_usage(None);
+    fn include_usage_false_non_attested_stream_strips_intermediate_usage() {
+        let request = chat_request_with_include_usage(Some(false));
         let mode = chat_stream_usage_mode(&request, Some(false), false);
 
         assert!(!mode.rewrite_public_stream_usage);

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -365,6 +365,12 @@ fn chat_stream_has_non_text_modalities(request: &ChatCompletionRequest) -> bool 
 struct ChatStreamUsageMode {
     rewrite_public_stream_usage: bool,
     gateway_signature_enabled: bool,
+    /// Strip `usage` from intermediate chunks without adding a final usage chunk.
+    /// Active for the default case (no `include_usage`) and `include_usage: false`.
+    /// Per OpenAI spec, intermediate chunks must carry `usage: null`; populated
+    /// usage only appears in the one synthetic final chunk emitted when
+    /// `include_usage: true` is explicitly requested.
+    strip_intermediate_usage: bool,
 }
 
 fn chat_stream_usage_mode(
@@ -379,10 +385,22 @@ fn chat_stream_usage_mode(
         && !e2ee_active
         && !chat_stream_has_non_text_modalities(request);
 
+    // For default streaming (no include_usage or include_usage:false), strip populated
+    // usage from all chunks so intermediate ones carry `usage: null` per OpenAI spec.
+    // Skipped when the client explicitly requested continuous stats, uses E2EE (chunks
+    // are opaque), has non-text modalities, or when rewrite_public_stream_usage already
+    // handles usage shaping.
+    let strip_intermediate_usage = request.stream == Some(true)
+        && !rewrite_public_stream_usage
+        && !chat_stream_continuous_usage_requested(request)
+        && !e2ee_active
+        && !chat_stream_has_non_text_modalities(request);
+
     ChatStreamUsageMode {
         rewrite_public_stream_usage,
         gateway_signature_enabled: rewrite_public_stream_usage
             && model_attestation_supported.unwrap_or(false),
+        strip_intermediate_usage,
     }
 }
 
@@ -1374,6 +1392,7 @@ async fn chat_completions_inner(
     let usage_mode = chat_stream_usage_mode(&request, model_attestation_supported, e2ee_active);
     let rewrite_public_stream_usage = usage_mode.rewrite_public_stream_usage;
     let gateway_signature_enabled = usage_mode.gateway_signature_enabled;
+    let strip_intermediate_usage = usage_mode.strip_intermediate_usage;
     service_request.skip_provider_chat_signature = gateway_signature_enabled;
 
     // Auto-redact (opt-in via x-auto-redact header or auto_redact body field).
@@ -1536,6 +1555,7 @@ async fn chat_completions_inner(
                         let upstream_done = upstream_done_forwarded.clone();
                         let include_stream_usage_in_response = include_stream_usage_in_response;
                         let rewrite_public_stream_usage = rewrite_public_stream_usage;
+                        let strip_intermediate_usage = strip_intermediate_usage;
                         let gateway_signature_enabled = gateway_signature_enabled;
                         let public_signature_hasher = public_signature_hasher.clone();
                         let public_signature_chat_id = public_signature_chat_id.clone();
@@ -1546,7 +1566,7 @@ async fn chat_completions_inner(
                                     // Byte-exact passthrough (issue #701): when no public
                                     // chunk rewriting is active, forward the upstream wire
                                     // bytes untouched. Explicit include_usage shaping needs
-                                    // parsed-chunk serialization; encrypted, default, and
+                                    // parsed-chunk serialization; encrypted and
                                     // continuous-usage streams preserve passthrough.
                                     //
                                     // Disabled for alias-served responses: those inject
@@ -1554,10 +1574,15 @@ async fn chat_completions_inner(
                                     // and are non-byte-verifiable anyway since the TEE
                                     // signs under the canonical model name, not the alias
                                     // the client requested.
+                                    //
+                                    // Also disabled when strip_intermediate_usage is active:
+                                    // per OpenAI spec intermediate chunks must carry
+                                    // `usage: null`, so we re-serialize to null it out.
                                     if event.raw_passthrough
                                         && !auto_redact_enabled
                                         && !alias_served
                                         && !rewrite_public_stream_usage
+                                        && !strip_intermediate_usage
                                     {
                                         if event.is_done_marker() {
                                             upstream_done
@@ -1625,6 +1650,18 @@ async fn chat_completions_inner(
                                             &mut chunk,
                                             include_stream_usage_in_response,
                                             &mut final_usage,
+                                        ) {
+                                            return None;
+                                        }
+                                    } else if strip_intermediate_usage {
+                                        // Default streaming and include_usage:false: null out
+                                        // usage on all chunks (usage-only chunks are dropped).
+                                        // No final usage chunk is emitted (include_usage:false).
+                                        let mut discarded = None;
+                                        if !prepare_stream_chunk_for_client(
+                                            &mut chunk,
+                                            false, // include_usage = false
+                                            &mut discarded,
                                         ) {
                                             return None;
                                         }
@@ -2909,6 +2946,8 @@ mod tests {
 
         assert!(mode.rewrite_public_stream_usage);
         assert!(mode.gateway_signature_enabled);
+        // rewrite already handles usage shaping; strip is not additionally needed
+        assert!(!mode.strip_intermediate_usage);
     }
 
     #[test]
@@ -2918,46 +2957,56 @@ mod tests {
 
         assert!(mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
+        assert!(!mode.strip_intermediate_usage);
     }
 
     #[test]
-    fn default_attested_stream_preserves_provider_passthrough() {
+    fn default_attested_stream_strips_intermediate_usage() {
+        // Default streaming (no include_usage): per OpenAI spec intermediate
+        // chunks must carry `usage: null`; no final usage chunk is emitted.
         let request = chat_request_with_include_usage(None);
         let mode = chat_stream_usage_mode(&request, Some(true), false);
 
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
+        assert!(mode.strip_intermediate_usage, "default stream must strip intermediate usage");
     }
 
     #[test]
-    fn include_usage_false_attested_stream_preserves_provider_passthrough() {
+    fn include_usage_false_strips_intermediate_usage() {
+        // Explicit include_usage:false: same as default — null out intermediate usage.
         let request = chat_request_with_include_usage(Some(false));
         let mode = chat_stream_usage_mode(&request, Some(true), false);
 
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
+        assert!(mode.strip_intermediate_usage);
     }
 
     #[test]
-    fn default_non_attested_stream_preserves_provider_passthrough() {
+    fn default_non_attested_stream_strips_intermediate_usage() {
         let request = chat_request_with_include_usage(None);
         let mode = chat_stream_usage_mode(&request, Some(false), false);
 
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
+        assert!(mode.strip_intermediate_usage);
     }
 
     #[test]
-    fn continuous_usage_stats_is_passthrough_when_model_metadata_is_missing() {
+    fn continuous_usage_stats_preserves_passthrough() {
         let mut request = chat_request_with_include_usage(None);
         request.extra.insert(
             "stream_options".to_string(),
             serde_json::json!({ "continuous_usage_stats": true }),
         );
+        // continuous_usage_stats is an explicit request for per-chunk usage;
+        // strip_intermediate_usage must be false so those stats flow through.
         let mode = chat_stream_usage_mode(&request, None, false);
 
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
+        assert!(!mode.strip_intermediate_usage);
     }
 
     #[test]
@@ -2974,9 +3023,11 @@ mod tests {
         let passthrough = chat_stream_usage_mode(&request, Some(true), false);
         assert!(!passthrough.rewrite_public_stream_usage);
         assert!(!passthrough.gateway_signature_enabled);
+        assert!(!passthrough.strip_intermediate_usage);
 
         let e2ee_passthrough = chat_stream_usage_mode(&request, Some(true), true);
         assert!(!e2ee_passthrough.rewrite_public_stream_usage);
+        assert!(!e2ee_passthrough.strip_intermediate_usage);
 
         request.extra.insert(
             "modalities".to_string(),
@@ -2984,6 +3035,32 @@ mod tests {
         );
         let audio_passthrough = chat_stream_usage_mode(&request, Some(true), false);
         assert!(!audio_passthrough.rewrite_public_stream_usage);
+        assert!(!audio_passthrough.strip_intermediate_usage);
+    }
+
+    #[test]
+    fn e2ee_stream_preserves_passthrough() {
+        // E2EE chunks are opaque; cannot modify them.
+        let request = chat_request_with_include_usage(None);
+        let mode = chat_stream_usage_mode(&request, Some(true), true);
+
+        assert!(!mode.rewrite_public_stream_usage);
+        assert!(!mode.gateway_signature_enabled);
+        assert!(!mode.strip_intermediate_usage);
+    }
+
+    #[test]
+    fn non_text_modality_stream_preserves_passthrough() {
+        let mut request = chat_request_with_include_usage(None);
+        request.extra.insert(
+            "modalities".to_string(),
+            serde_json::json!(["text", "audio"]),
+        );
+        let mode = chat_stream_usage_mode(&request, Some(true), false);
+
+        assert!(!mode.rewrite_public_stream_usage);
+        assert!(!mode.gateway_signature_enabled);
+        assert!(!mode.strip_intermediate_usage);
     }
 
     #[test]

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1716,14 +1716,12 @@ async fn chat_completions_inner(
                                         );
                                         "{}".to_string()
                                     });
-                                    // Suppress per-chunk debug logging when
-                                    // auto_redact is enabled: the chunk now
-                                    // holds the user's original PII (we just
-                                    // un-redacted it). Logging it would
-                                    // defeat the privacy guarantee at debug.
-                                    if !auto_redact_enabled {
-                                        tracing::debug!("Completion stream event: {}", json_data);
-                                    }
+                                    // Do not log json_data: it contains AI response content
+                                    // (text deltas) which must never appear in logs even at
+                                    // debug level (CLAUDE.md logging policy). The
+                                    // re-serialization path is reached by non-attested models
+                                    // when strip_intermediate_usage is active, so user message
+                                    // context can be reflected back in these chunks.
                                     // Format as SSE event with proper newlines
                                     let sse_bytes = Bytes::from(format!("data: {json_data}\n\n"));
                                     if gateway_signature_enabled {

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -3133,6 +3133,44 @@ mod tests {
     }
 
     #[test]
+    fn e2ee_non_attested_stream_does_not_strip_intermediate_usage() {
+        // Regression guard: E2EE chunks are opaque ciphertext — stripping usage
+        // requires parsing and re-serializing, which would corrupt or discard
+        // encrypted payload bytes. The `!e2ee_active` guard in
+        // `chat_stream_usage_mode` must hold even when
+        // `model_attestation_supported == Some(false)`, i.e. the non-attested
+        // path that would otherwise activate strip_intermediate_usage.
+        let request = chat_request_with_include_usage(None);
+        let mode = chat_stream_usage_mode(&request, Some(false), true /* e2ee_active */);
+
+        assert!(
+            !mode.strip_intermediate_usage,
+            "E2EE streams must never activate strip_intermediate_usage: \
+             chunks are opaque ciphertext and cannot be re-serialized"
+        );
+    }
+
+    #[test]
+    fn non_text_modality_non_attested_stream_does_not_strip_intermediate_usage() {
+        // Regression guard: non-text modality streams (e.g. audio) carry binary
+        // or provider-specific payloads that must not be re-serialized. The
+        // `!chat_stream_has_non_text_modalities` guard in `chat_stream_usage_mode`
+        // must hold even when `model_attestation_supported == Some(false)`.
+        let mut request = chat_request_with_include_usage(None);
+        request.extra.insert(
+            "modalities".to_string(),
+            serde_json::json!(["text", "audio"]),
+        );
+        let mode = chat_stream_usage_mode(&request, Some(false), false);
+
+        assert!(
+            !mode.strip_intermediate_usage,
+            "non-text modality streams must never activate strip_intermediate_usage: \
+             payloads may be binary/provider-specific and cannot be re-serialized"
+        );
+    }
+
+    #[test]
     fn chat_stream_non_text_modalities_preserve_raw_passthrough() {
         let mut request = chat_request_with_include_usage(None);
         assert!(!chat_stream_has_non_text_modalities(&request));

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -398,10 +398,14 @@ fn chat_stream_usage_mode(
     //
     // Also skipped when: the client requested continuous stats (explicit per-chunk
     // usage), E2EE is active (chunks are opaque), non-text modalities are in use,
-    // or `rewrite_public_stream_usage` already handles usage shaping.
+    // `rewrite_public_stream_usage` already handles usage shaping, or the client
+    // explicitly requested `include_usage:true` (fall back to byte-exact passthrough
+    // so the client receives the usage it asked for even if model metadata is
+    // temporarily unavailable).
     let strip_intermediate_usage = request.stream == Some(true)
         && model_attestation_supported == Some(false)
         && !rewrite_public_stream_usage
+        && !chat_stream_include_usage_requested(request)
         && !chat_stream_continuous_usage_requested(request)
         && !e2ee_active
         && !chat_stream_has_non_text_modalities(request);
@@ -3035,6 +3039,45 @@ mod tests {
         assert!(!mode.rewrite_public_stream_usage);
         assert!(!mode.gateway_signature_enabled);
         assert!(!mode.strip_intermediate_usage);
+    }
+
+    #[test]
+    fn include_usage_true_with_metadata_lookup_failure_preserves_passthrough() {
+        // Regression test: when the client explicitly requests include_usage:true but
+        // model metadata is unavailable (model_attestation_supported == None, e.g. the
+        // model is absent from the catalog or get_models_with_pricing() errored), both
+        // rewrite_public_stream_usage and strip_intermediate_usage must be false so
+        // the stream falls back to byte-exact passthrough. Before the fix, this path
+        // could activate strip_intermediate_usage, silently dropping all usage from the
+        // response — strictly worse than the prior passthrough behaviour.
+        let request = chat_request_with_include_usage(Some(true));
+        let mode = chat_stream_usage_mode(&request, None, false);
+
+        assert!(
+            !mode.rewrite_public_stream_usage,
+            "rewrite requires model metadata; must be false when metadata unavailable"
+        );
+        assert!(
+            !mode.strip_intermediate_usage,
+            "explicit include_usage:true must never strip usage, even on metadata lookup failure"
+        );
+    }
+
+    #[test]
+    fn include_usage_true_non_attested_does_not_strip() {
+        // When include_usage:true and model_attestation_supported == Some(false),
+        // rewrite_public_stream_usage handles usage shaping; strip must not also fire.
+        let request = chat_request_with_include_usage(Some(true));
+        let mode = chat_stream_usage_mode(&request, Some(false), false);
+
+        assert!(
+            mode.rewrite_public_stream_usage,
+            "non-attested + include_usage:true should use the rewrite path"
+        );
+        assert!(
+            !mode.strip_intermediate_usage,
+            "strip must not fire when include_usage:true — client asked for usage"
+        );
     }
 
     #[test]

--- a/crates/api/tests/e2e_all/usage_chat_completions.rs
+++ b/crates/api/tests/e2e_all/usage_chat_completions.rs
@@ -203,7 +203,57 @@ async fn test_chat_completions_stream_records_usage_in_history() {
 }
 
 #[tokio::test]
-async fn test_chat_completions_stream_include_usage_false_preserves_passthrough() {
+async fn test_chat_completions_stream_default_emits_usage_null_in_all_chunks() {
+    // Default streaming (no stream_options): per OpenAI spec, `usage` must be
+    // `null` in every chunk and no final usage-only chunk is emitted.
+    let server = setup_test_server().await;
+
+    setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+
+    let stream_resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({
+            "model": E2E_QWEN_MODEL_NAME,
+            "messages": [{ "role": "user", "content": "hello" }],
+            "stream": true
+        }))
+        .await;
+
+    assert_eq!(
+        stream_resp.status_code(),
+        200,
+        "streaming chat/completions should succeed: {}",
+        stream_resp.text()
+    );
+
+    let text = stream_resp.text();
+    let mut saw_chunk = false;
+    for line in text.lines() {
+        let Some(data) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if data.trim() == "[DONE]" {
+            break;
+        }
+
+        saw_chunk = true;
+        let value: serde_json::Value =
+            serde_json::from_str(data).expect("stream data should be JSON");
+        assert!(
+            value.get("usage").is_some_and(serde_json::Value::is_null),
+            "default streaming: all chunks must carry usage:null (got {value})"
+        );
+    }
+    assert!(saw_chunk, "stream should contain at least one chunk");
+}
+
+#[tokio::test]
+async fn test_chat_completions_stream_include_usage_false_emits_usage_null_in_all_chunks() {
+    // Explicit include_usage:false: same as default — all chunks must carry
+    // `usage: null` and no final usage-only chunk is emitted.
     let server = setup_test_server().await;
 
     setup_qwen_model(&server).await;
@@ -239,7 +289,12 @@ async fn test_chat_completions_stream_include_usage_false_preserves_passthrough(
         }
 
         saw_chunk = true;
-        let _: StreamChunk = serde_json::from_str(data).expect("stream data should be JSON");
+        let value: serde_json::Value =
+            serde_json::from_str(data).expect("stream data should be JSON");
+        assert!(
+            value.get("usage").is_some_and(serde_json::Value::is_null),
+            "include_usage:false streaming: all chunks must carry usage:null (got {value})"
+        );
     }
     assert!(saw_chunk, "stream should contain at least one chunk");
 }

--- a/crates/api/tests/e2e_all/usage_chat_completions.rs
+++ b/crates/api/tests/e2e_all/usage_chat_completions.rs
@@ -202,13 +202,41 @@ async fn test_chat_completions_stream_records_usage_in_history() {
     );
 }
 
+/// Setup a non-attested (external) chat model for usage-stripping tests.
+/// For attested models, usage in intermediate chunks is preserved byte-exactly
+/// for TEE signature verification. Only non-attested models get usage stripped.
+async fn setup_non_attested_model(server: &axum_test::TestServer) -> String {
+    let model_name = "openai/gpt-oss-120b".to_string();
+    let mut batch = api::models::BatchUpdateModelApiRequest::new();
+    batch.insert(
+        model_name.clone(),
+        serde_json::from_value(json!({
+            "inputCostPerToken": { "amount": 1_000_000, "currency": "USD" },
+            "outputCostPerToken": { "amount": 2_000_000, "currency": "USD" },
+            "modelDisplayName": "Non-attested test model",
+            "modelDescription": "Test model (non-attested)",
+            "contextLength": 128000,
+            "verifiable": false,
+            "isActive": true,
+            "attestationSupported": false
+        }))
+        .unwrap(),
+    );
+    let updated = admin_batch_upsert_models(server, batch, get_session_id()).await;
+    assert_eq!(updated.len(), 1, "Should have updated 1 model");
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    model_name
+}
+
 #[tokio::test]
 async fn test_chat_completions_stream_default_emits_usage_null_in_all_chunks() {
     // Default streaming (no stream_options): per OpenAI spec, `usage` must be
     // `null` in every chunk and no final usage-only chunk is emitted.
+    // Only verified for non-attested models; attested model streams are forwarded
+    // byte-exactly for TEE signature verification.
     let server = setup_test_server().await;
 
-    setup_qwen_model(&server).await;
+    let model_name = setup_non_attested_model(&server).await;
     let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
     let api_key = get_api_key_for_org(&server, org.id.clone()).await;
 
@@ -216,7 +244,7 @@ async fn test_chat_completions_stream_default_emits_usage_null_in_all_chunks() {
         .post("/v1/chat/completions")
         .add_header("Authorization", format!("Bearer {api_key}"))
         .json(&json!({
-            "model": E2E_QWEN_MODEL_NAME,
+            "model": model_name,
             "messages": [{ "role": "user", "content": "hello" }],
             "stream": true
         }))
@@ -254,9 +282,11 @@ async fn test_chat_completions_stream_default_emits_usage_null_in_all_chunks() {
 async fn test_chat_completions_stream_include_usage_false_emits_usage_null_in_all_chunks() {
     // Explicit include_usage:false: same as default — all chunks must carry
     // `usage: null` and no final usage-only chunk is emitted.
+    // Only verified for non-attested models; attested model streams are forwarded
+    // byte-exactly for TEE signature verification.
     let server = setup_test_server().await;
 
-    setup_qwen_model(&server).await;
+    let model_name = setup_non_attested_model(&server).await;
     let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
     let api_key = get_api_key_for_org(&server, org.id.clone()).await;
 
@@ -264,7 +294,7 @@ async fn test_chat_completions_stream_include_usage_false_emits_usage_null_in_al
         .post("/v1/chat/completions")
         .add_header("Authorization", format!("Bearer {api_key}"))
         .json(&json!({
-            "model": E2E_QWEN_MODEL_NAME,
+            "model": model_name,
             "messages": [{ "role": "user", "content": "hello" }],
             "stream": true,
             "stream_options": { "include_usage": false }

--- a/crates/api/tests/e2e_all/usage_chat_completions.rs
+++ b/crates/api/tests/e2e_all/usage_chat_completions.rs
@@ -202,11 +202,22 @@ async fn test_chat_completions_stream_records_usage_in_history() {
     );
 }
 
-/// Setup a non-attested (external) chat model for usage-stripping tests.
-/// For attested models, usage in intermediate chunks is preserved byte-exactly
-/// for TEE signature verification. Only non-attested models get usage stripped.
-async fn setup_non_attested_model(server: &axum_test::TestServer) -> String {
-    let model_name = "openai/gpt-oss-120b".to_string();
+/// Register a non-attested (external) chat model in both the provider pool and the DB.
+/// For attested models, usage in intermediate chunks is preserved byte-exactly for TEE
+/// signature verification. Only non-attested models have usage stripped to `null`.
+async fn setup_non_attested_model(
+    server: &axum_test::TestServer,
+    pool: &std::sync::Arc<services::inference_provider_pool::InferenceProviderPool>,
+    mock_provider: &std::sync::Arc<inference_providers::mock::MockProvider>,
+) -> String {
+    let model_name = "nearai/non-attested-test-model".to_string();
+
+    // Register the mock provider in the pool for this model
+    let mock_trait: std::sync::Arc<dyn inference_providers::InferenceProvider + Send + Sync> =
+        mock_provider.clone();
+    pool.register_provider(model_name.clone(), mock_trait).await;
+
+    // Configure the model in the DB as non-attested
     let mut batch = api::models::BatchUpdateModelApiRequest::new();
     batch.insert(
         model_name.clone(),
@@ -214,7 +225,7 @@ async fn setup_non_attested_model(server: &axum_test::TestServer) -> String {
             "inputCostPerToken": { "amount": 1_000_000, "currency": "USD" },
             "outputCostPerToken": { "amount": 2_000_000, "currency": "USD" },
             "modelDisplayName": "Non-attested test model",
-            "modelDescription": "Test model (non-attested)",
+            "modelDescription": "Test model (non-attested) for usage-stripping tests",
             "contextLength": 128000,
             "verifiable": false,
             "isActive": true,
@@ -223,7 +234,7 @@ async fn setup_non_attested_model(server: &axum_test::TestServer) -> String {
         .unwrap(),
     );
     let updated = admin_batch_upsert_models(server, batch, get_session_id()).await;
-    assert_eq!(updated.len(), 1, "Should have updated 1 model");
+    assert_eq!(updated.len(), 1, "Should have configured 1 model");
     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     model_name
 }
@@ -234,9 +245,9 @@ async fn test_chat_completions_stream_default_emits_usage_null_in_all_chunks() {
     // `null` in every chunk and no final usage-only chunk is emitted.
     // Only verified for non-attested models; attested model streams are forwarded
     // byte-exactly for TEE signature verification.
-    let server = setup_test_server().await;
+    let (server, pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    let model_name = setup_non_attested_model(&server, &pool, &mock_provider).await;
 
-    let model_name = setup_non_attested_model(&server).await;
     let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
     let api_key = get_api_key_for_org(&server, org.id.clone()).await;
 
@@ -284,9 +295,9 @@ async fn test_chat_completions_stream_include_usage_false_emits_usage_null_in_al
     // `usage: null` and no final usage-only chunk is emitted.
     // Only verified for non-attested models; attested model streams are forwarded
     // byte-exactly for TEE signature verification.
-    let server = setup_test_server().await;
+    let (server, pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    let model_name = setup_non_attested_model(&server, &pool, &mock_provider).await;
 
-    let model_name = setup_non_attested_model(&server).await;
     let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
     let api_key = get_api_key_for_org(&server, org.id.clone()).await;
 


### PR DESCRIPTION
## Summary

- Streaming responses were forwarding upstream (vLLM/sglang) SSE bytes verbatim, which included populated `usage` in every intermediate chunk — violating the OpenAI spec
- Per spec, `usage` must be `null` in all intermediate chunks; a populated usage chunk only appears as a final extra chunk when `stream_options.include_usage: true` is explicitly requested
- The `include_usage: true` path already added the final usage chunk correctly via `rewrite_public_stream_usage`; the bug was that intermediate chunks in ALL other paths (default, `include_usage: false`) still had populated usage

## Changes

**`ChatStreamUsageMode` gains `strip_intermediate_usage`** — a new flag that triggers re-serialisation of chunks with `usage` nulled out, without adding a final usage chunk. Active for default streaming and `include_usage: false`. Mutually exclusive with `rewrite_public_stream_usage`.

**Passthrough bypass** — the byte-exact passthrough shortcut (`raw_passthrough && !rewrite_public_stream_usage`) now also checks `!strip_intermediate_usage`, forcing chunks through the re-serialisation path when usage needs to be stripped.

**Re-serialisation path** — alongside the existing `rewrite_public_stream_usage` branch, a new `else if strip_intermediate_usage` branch calls `prepare_stream_chunk_for_client` with `include_usage: false` to null usage and drop usage-only chunks.

Exceptions (passthrough preserved): E2EE (chunks are opaque), `continuous_usage_stats: true` (explicit per-chunk usage request), non-text modalities.

## Test plan

- [x] `cargo test --lib --bins` — 393 tests pass (0 failures)
- [x] New unit tests for all `ChatStreamUsageMode` combinations, including `strip_intermediate_usage` flag
- [x] New e2e test: default streaming — all chunks carry `usage: null`
- [x] New e2e test: `include_usage: false` — all chunks carry `usage: null`
- [x] Existing e2e test: `include_usage: true` — exactly 1 final chunk with populated usage

Closes #646