### PR TITLE
Fix batch_upsert_models: merge not replace on partial PATCH (fixes #775)

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -858,7 +858,7 @@ pub async fn init_inference_providers(
     match models_source.fetch_inference_url_models().await {
         Ok(models) if !models.is_empty() => {
             tracing::info!(count = models.len(), "Loading inference_url models");
-            pool.load_inference_url_models(models).await;
+            pool.load_inference_url_models(models, false).await;
         }
         Ok(_) => {
             tracing::info!("No inference_url models found in database");

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -519,7 +519,7 @@ pub async fn batch_upsert_models(
         );
         app_state
             .inference_provider_pool
-            .load_inference_url_models(inference_url_models)
+            .load_inference_url_models(inference_url_models, true)
             .await;
     }
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -3133,12 +3133,13 @@ impl InferenceProviderPool {
     /// * `models` - List of (model_name, inference_url) tuples
     /// Load (or refresh) a set of inference_url models into the provider pool.
     ///
-    /// When `partial = true` (called from the admin PATCH path), only the
-    /// provided models are upserted — existing state for untouched models is
-    /// preserved.  When `partial = false` (called from the periodic sync path
-    /// via `sync_inference_url_models`), the URL-provider cache and fingerprint
-    /// state map are replaced wholesale, pruning entries for models that are no
-    /// longer in the active set.
+    /// The `partial` flag controls whether this is a merge or a replace:
+    ///
+    /// - `partial = true` (admin PATCH path): only the provided models are
+    ///   upserted — existing state for untouched models is preserved.
+    /// - `partial = false` (periodic sync / startup): the URL-provider cache
+    ///   and fingerprint-state map are replaced wholesale, pruning entries for
+    ///   models that are no longer in the active set.
     pub async fn load_inference_url_models(&self, models: Vec<(String, String)>, partial: bool) {
         if models.is_empty() {
             return;
@@ -7046,7 +7047,7 @@ mod tests {
 
         // Pre-seed the URL cache with two "existing" models as if they were
         // loaded during a prior full sync.
-        let untouched_model = "model-untouched".to_string();
+        let _untouched_model = "model-untouched".to_string();
         let untouched_url = "https://untouched.completions.near.ai".to_string();
         let untouched_provider = Arc::new(MockProvider::new());
 

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -3131,7 +3131,15 @@ impl InferenceProviderPool {
     ///
     /// # Arguments
     /// * `models` - List of (model_name, inference_url) tuples
-    pub async fn load_inference_url_models(&self, models: Vec<(String, String)>) {
+    /// Load (or refresh) a set of inference_url models into the provider pool.
+    ///
+    /// When `partial = true` (called from the admin PATCH path), only the
+    /// provided models are upserted — existing state for untouched models is
+    /// preserved.  When `partial = false` (called from the periodic sync path
+    /// via `sync_inference_url_models`), the URL-provider cache and fingerprint
+    /// state map are replaced wholesale, pruning entries for models that are no
+    /// longer in the active set.
+    pub async fn load_inference_url_models(&self, models: Vec<(String, String)>, partial: bool) {
         if models.is_empty() {
             return;
         }
@@ -3808,23 +3816,42 @@ impl InferenceProviderPool {
             "pubkey_to_providers state after update"
         );
 
-        // Update the URL→provider cache
-        *self.inference_url_providers.write().await = new_url_cache;
+        // Update the URL→provider cache.
+        //
+        // Partial mode (admin PATCH): merge new entries into the existing map
+        // so that untouched models keep their warm providers and fingerprint
+        // state.  Full mode (periodic sync): replace the map entirely so that
+        // URLs for models that have been removed are pruned.
+        {
+            let mut cache = self.inference_url_providers.write().await;
+            if partial {
+                // Merge: only insert/replace the URLs we just processed.
+                for (url, provider) in new_url_cache {
+                    cache.insert(url, provider);
+                }
+            } else {
+                *cache = new_url_cache;
+            }
+        }
 
         // Rebuild the URL → FingerprintState map so its key set exactly
         // matches the active inference_url set:
         // - Newly-created URLs take the freshly-discovered state.
         // - Reused URLs keep their existing entries (cumulative discovery
         //   mutated the Arc in place).
-        // - URLs no longer in the active set are pruned — prevents a slow
-        //   leak of stale per-URL state as models are added and removed.
+        // - URLs no longer in the active set are pruned on a full sync —
+        //   prevents a slow leak of stale per-URL state as models are added
+        //   and removed.  On a partial sync we only insert new states and
+        //   leave existing ones untouched.
         {
             let mut states = self.inference_url_fingerprint_states.write().await;
             for (url, state) in new_fingerprint_states {
                 states.insert(url, state);
             }
-            let active_urls = self.inference_url_providers.read().await;
-            states.retain(|url, _| active_urls.contains_key(url));
+            if !partial {
+                let active_urls = self.inference_url_providers.read().await;
+                states.retain(|url, _| active_urls.contains_key(url));
+            }
         }
 
         info!(
@@ -3848,7 +3875,7 @@ impl InferenceProviderPool {
         // load_inference_url_models directly (partial batch, no prune).
         let complete_names: std::collections::HashSet<String> =
             models.iter().map(|(name, _)| name.clone()).collect();
-        self.load_inference_url_models(models).await;
+        self.load_inference_url_models(models, false).await;
         self.prune_stale_pinned(&complete_names).await;
     }
 
@@ -5670,7 +5697,7 @@ mod tests {
 
         // Call load_inference_url_models — the provider should be reused and
         // the self-healing path should detect missing pubkeys and re-fetch them.
-        pool.load_inference_url_models(vec![(model_id.clone(), url)])
+        pool.load_inference_url_models(vec![(model_id.clone(), url)], false)
             .await;
 
         // Verify pubkeys were recovered
@@ -6228,7 +6255,7 @@ mod tests {
         mock_provider.set_fail_attestation(true);
 
         // Load — the provider is reused, pubkeys are missing, re-fetch fails
-        pool.load_inference_url_models(vec![(model_id.clone(), url.clone())])
+        pool.load_inference_url_models(vec![(model_id.clone(), url.clone())], false)
             .await;
 
         // The URL should have been evicted from the cache
@@ -6303,7 +6330,7 @@ mod tests {
                 .insert("pretend-pubkey".to_string(), vec![mock.clone()]);
         }
 
-        pool.load_inference_url_models(vec![(model_id.clone(), url.clone())])
+        pool.load_inference_url_models(vec![(model_id.clone(), url.clone())], false)
             .await;
 
         // Blocked URL evicted from URL cache
@@ -7001,5 +7028,77 @@ mod tests {
         assert_eq!(primary.len(), 1);
         assert!(primary[0].iter().any(|t| t == "provider_tier:near"));
         assert!(primary[0].iter().any(|t| t == "fallback:false"));
+
+    /// When `load_inference_url_models` is called in partial mode (`partial = true`),
+    /// it must merge into the existing URL-provider cache and fingerprint-state map
+    /// rather than replacing them.  Providers for models not in the input set must
+    /// be preserved so they do not need to re-attest on the next periodic refresh.
+    ///
+    /// Regression test for issue #775: `batch_upsert_models` was calling
+    /// `load_inference_url_models` with only the PATCHed models, which caused the
+    /// full URL cache and fingerprint-state map to be replaced by a subset, evicting
+    /// all untouched providers and forcing unnecessary re-attestation.
+    #[tokio::test]
+    async fn test_partial_load_preserves_untouched_providers() {
+        use inference_providers::mock::MockProvider;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+
+        // Pre-seed the URL cache with two "existing" models as if they were
+        // loaded during a prior full sync.
+        let untouched_model = "model-untouched".to_string();
+        let untouched_url = "https://untouched.completions.near.ai".to_string();
+        let untouched_provider = Arc::new(MockProvider::new());
+
+        let patched_model = "model-patched".to_string();
+        let patched_url = "https://patched.completions.near.ai".to_string();
+        let patched_provider = Arc::new(MockProvider::new());
+
+        {
+            let mut cache = pool.inference_url_providers.write().await;
+            cache.insert(
+                untouched_url.clone(),
+                untouched_provider.clone() as Arc<InferenceProviderTrait>,
+            );
+            cache.insert(
+                patched_url.clone(),
+                patched_provider.clone() as Arc<InferenceProviderTrait>,
+            );
+        }
+
+        // Also seed fingerprint states for both.
+        {
+            let mut states = pool.inference_url_fingerprint_states.write().await;
+            states.insert(
+                untouched_url.clone(),
+                Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap)),
+            );
+            states.insert(
+                patched_url.clone(),
+                Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap)),
+            );
+        }
+
+        // Partial load — only the patched model is included.
+        pool.load_inference_url_models(vec![(patched_model.clone(), patched_url.clone())], true)
+            .await;
+
+        // The untouched model's URL must still be present in the URL cache.
+        {
+            let cache = pool.inference_url_providers.read().await;
+            assert!(
+                cache.contains_key(&untouched_url),
+                "partial load must not evict untouched provider from URL cache"
+            );
+        }
+
+        // The untouched model's fingerprint state must also be preserved.
+        {
+            let states = pool.inference_url_fingerprint_states.read().await;
+            assert!(
+                states.contains_key(&untouched_url),
+                "partial load must not prune fingerprint state for untouched provider"
+            );
+        }
     }
 }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -3123,15 +3123,11 @@ impl InferenceProviderPool {
         counts.retain(|ptr, _| live_ptrs.contains(ptr) || !candidate_ptrs.contains(ptr));
     }
 
-    /// Load models with inference_url as nearai::Providers into provider_mappings.
-    ///
-    /// For each model, reuses the existing provider (and its warm TLS connections)
-    /// if the inference_url hasn't changed since last load. Only creates new providers
-    /// for models whose URL changed or that are new.
-    ///
-    /// # Arguments
-    /// * `models` - List of (model_name, inference_url) tuples
     /// Load (or refresh) a set of inference_url models into the provider pool.
+    ///
+    /// Reuses the existing provider (and its warm TLS connections) for each model
+    /// whose inference_url hasn't changed since last load; creates new providers
+    /// only for models whose URL changed or that are new.
     ///
     /// The `partial` flag controls whether this is a merge or a replace.
     /// Pass `partial = true` from the admin PATCH path to upsert only the

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -3133,13 +3133,11 @@ impl InferenceProviderPool {
     /// * `models` - List of (model_name, inference_url) tuples
     /// Load (or refresh) a set of inference_url models into the provider pool.
     ///
-    /// The `partial` flag controls whether this is a merge or a replace:
-    ///
-    /// - `partial = true` (admin PATCH path): only the provided models are
-    ///   upserted — existing state for untouched models is preserved.
-    /// - `partial = false` (periodic sync / startup): the URL-provider cache
-    ///   and fingerprint-state map are replaced wholesale, pruning entries for
-    ///   models that are no longer in the active set.
+    /// The `partial` flag controls whether this is a merge or a replace.
+    /// Pass `partial = true` from the admin PATCH path to upsert only the
+    /// provided models without evicting untouched entries.  Pass
+    /// `partial = false` from the periodic sync / startup paths to replace
+    /// the URL-provider cache wholesale and prune stale entries.
     pub async fn load_inference_url_models(&self, models: Vec<(String, String)>, partial: bool) {
         if models.is_empty() {
             return;

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -650,8 +650,7 @@ impl InferenceProviderPool {
                 {
                     let mut cache = self.inference_url_providers.write().await;
                     cache.retain(|_, p| {
-                        !exclusively_removed
-                            .contains(&(Arc::as_ptr(p) as *const () as usize))
+                        !exclusively_removed.contains(&(Arc::as_ptr(p) as *const () as usize))
                     });
                 }
                 {

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -616,6 +616,20 @@ impl InferenceProviderPool {
                 !providers.is_empty()
             });
 
+            // Check whether any other model still references these providers.
+            // A provider Arc can serve multiple model names (e.g. aliases), so we
+            // must not evict its URL-cache entries if it is still live elsewhere.
+            let still_live_ptrs: std::collections::HashSet<usize> = mappings
+                .model_to_providers
+                .values()
+                .flat_map(|ps| ps.iter().map(|p| Arc::as_ptr(p) as *const () as usize))
+                .collect();
+            let exclusively_removed: std::collections::HashSet<usize> = removed_ptrs
+                .iter()
+                .copied()
+                .filter(|ptr| !still_live_ptrs.contains(ptr))
+                .collect();
+
             // Clean up load balancer index and failure counts for removed providers
             self.load_balancer_index
                 .write()
@@ -625,6 +639,27 @@ impl InferenceProviderPool {
                 .write()
                 .unwrap_or_else(|e| e.into_inner())
                 .retain(|key, _| !removed_ptrs.contains(key));
+
+            // Evict stale URL-cache and fingerprint-state entries for providers that
+            // are no longer referenced by any model.  This prevents a subsequent
+            // partial `load_inference_url_models` call (admin PATCH URL change) from
+            // seeing a warm cache entry for the old URL and skipping re-attestation,
+            // which would leave a stale provider Arc in the cache pointing to a model
+            // that no longer exists.
+            if !exclusively_removed.is_empty() {
+                {
+                    let mut cache = self.inference_url_providers.write().await;
+                    cache.retain(|_, p| {
+                        !exclusively_removed
+                            .contains(&(Arc::as_ptr(p) as *const () as usize))
+                    });
+                }
+                {
+                    let mut states = self.inference_url_fingerprint_states.write().await;
+                    let url_cache = self.inference_url_providers.read().await;
+                    states.retain(|url, _| url_cache.contains_key(url));
+                }
+            }
 
             info!(model = %model_name, "Unregistered provider");
         }
@@ -3706,6 +3741,66 @@ impl InferenceProviderPool {
             new_fingerprint_states.insert(url.clone(), state.clone());
         }
 
+        // In partial mode (admin PATCH), identify stale URL-cache entries for models
+        // whose `inference_url` is changing.  Two cases arise:
+        //
+        // 1. Non-pinned models: the admin route calls `unregister_provider` before
+        //    this function, which already evicts the old URL entries from both caches
+        //    (see the cleanup added to `unregister_provider`).  No further action
+        //    needed here for that case.
+        //
+        // 2. Pinned models: the admin route skips `unregister_provider` for pinned
+        //    models (a model with a Chutes fallback, for example).  For those models
+        //    the old NEAR provider is still in `model_to_providers` when we arrive
+        //    here.  We capture the old provider pointers for models being replaced,
+        //    excluding reused providers, and use them to evict the corresponding old
+        //    URL entries from the caches.
+        //
+        // Lock ordering: we read `provider_mappings` here (before the write below),
+        // drop it, then separately read `inference_url_providers` — no two locks are
+        // held simultaneously.
+        let stale_url_cache_entries: std::collections::HashSet<String> = if partial {
+            let reused_ptrs: std::collections::HashSet<usize> = reused
+                .iter()
+                .map(|(_, _, p)| Arc::as_ptr(p) as *const () as usize)
+                .collect();
+            let new_urls: std::collections::HashSet<&str> =
+                new_url_cache.keys().map(|u| u.as_str()).collect();
+            let old_ptrs: std::collections::HashSet<usize> = {
+                let mappings = self.provider_mappings.read().await;
+                let mut ptrs = std::collections::HashSet::new();
+                for model_name in model_providers.keys() {
+                    if let Some(old) = mappings.model_to_providers.get(model_name) {
+                        for p in old {
+                            let ptr = Arc::as_ptr(p) as *const () as usize;
+                            if !reused_ptrs.contains(&ptr) {
+                                ptrs.insert(ptr);
+                            }
+                        }
+                    }
+                }
+                ptrs
+            };
+            if old_ptrs.is_empty() {
+                std::collections::HashSet::new()
+            } else {
+                let cache = self.inference_url_providers.read().await;
+                cache
+                    .iter()
+                    .filter_map(|(url, p)| {
+                        let ptr = Arc::as_ptr(p) as *const () as usize;
+                        if old_ptrs.contains(&ptr) && !new_urls.contains(url.as_str()) {
+                            Some(url.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            }
+        } else {
+            std::collections::HashSet::new()
+        };
+
         // Atomic update: replace model providers and rebuild pubkey mappings
         {
             let mut mappings = self.provider_mappings.write().await;
@@ -3820,6 +3915,12 @@ impl InferenceProviderPool {
         {
             let mut cache = self.inference_url_providers.write().await;
             if partial {
+                // Evict stale URL entries for models whose inference_url changed.
+                // Without this, the old URL key would stay warm in the cache even
+                // after the model's URL was updated via a PATCH, leaking state.
+                for url in &stale_url_cache_entries {
+                    cache.remove(url);
+                }
                 // Merge: only insert/replace the URLs we just processed.
                 for (url, provider) in new_url_cache {
                     cache.insert(url, provider);
@@ -3837,9 +3938,15 @@ impl InferenceProviderPool {
         // - URLs no longer in the active set are pruned on a full sync —
         //   prevents a slow leak of stale per-URL state as models are added
         //   and removed.  On a partial sync we only insert new states and
-        //   leave existing ones untouched.
+        //   leave existing ones untouched, except stale entries for models
+        //   whose URL changed are evicted to match the URL cache cleanup above.
         {
             let mut states = self.inference_url_fingerprint_states.write().await;
+            if partial {
+                for url in &stale_url_cache_entries {
+                    states.remove(url);
+                }
+            }
             for (url, state) in new_fingerprint_states {
                 states.insert(url, state);
             }
@@ -7093,6 +7200,88 @@ mod tests {
             assert!(
                 states.contains_key(&untouched_url),
                 "partial load must not prune fingerprint state for untouched provider"
+            );
+        }
+    }
+
+    /// When a model's `inference_url` changes via a partial PATCH, the old URL key must
+    /// be evicted from `inference_url_providers` and `inference_url_fingerprint_states`.
+    ///
+    /// Without the fix, the old URL would stay warm in both maps after a URL change,
+    /// pointing to a stale/leaked provider that is no longer registered for any model.
+    ///
+    /// Regression test for the lloydmak99 "changes requested" review on PR #802.
+    #[tokio::test]
+    async fn test_partial_load_evicts_old_url_on_url_change() {
+        use inference_providers::mock::MockProvider;
+
+        let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+
+        let model_name = "my-model".to_string();
+        let old_url = "https://old.completions.near.ai".to_string();
+        let new_url = "https://new.completions.near.ai".to_string();
+
+        // Seed the pool as if a prior full sync registered the model at old_url.
+        let old_provider = Arc::new(MockProvider::new()) as Arc<InferenceProviderTrait>;
+        {
+            let mut cache = pool.inference_url_providers.write().await;
+            cache.insert(old_url.clone(), old_provider.clone());
+        }
+        {
+            let mut states = pool.inference_url_fingerprint_states.write().await;
+            states.insert(
+                old_url.clone(),
+                Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap)),
+            );
+        }
+        {
+            let mut mappings = pool.provider_mappings.write().await;
+            mappings
+                .model_to_providers
+                .insert(model_name.clone(), vec![old_provider.clone()]);
+        }
+
+        // Simulate the admin PATCH path: unregister (removes from model_to_providers),
+        // then call load_inference_url_models in partial mode with the new URL.
+        pool.unregister_provider(&model_name).await;
+
+        // Partial load with the new URL — as if the admin PATCH changed inference_url.
+        pool.load_inference_url_models(vec![(model_name.clone(), new_url.clone())], true)
+            .await;
+
+        // The new URL must be present in the URL cache.
+        {
+            let cache = pool.inference_url_providers.read().await;
+            assert!(
+                cache.contains_key(&new_url),
+                "new URL must be present in the URL cache after a URL change"
+            );
+        }
+
+        // The old URL must have been evicted from the URL cache.
+        {
+            let cache = pool.inference_url_providers.read().await;
+            assert!(
+                !cache.contains_key(&old_url),
+                "old URL must be evicted from the URL cache when inference_url changes"
+            );
+        }
+
+        // The old URL's fingerprint state must also have been evicted.
+        {
+            let states = pool.inference_url_fingerprint_states.read().await;
+            assert!(
+                !states.contains_key(&old_url),
+                "old URL fingerprint state must be evicted when inference_url changes"
+            );
+        }
+
+        // The new URL's fingerprint state must be present (freshly created).
+        {
+            let states = pool.inference_url_fingerprint_states.read().await;
+            assert!(
+                states.contains_key(&new_url),
+                "new URL fingerprint state must be created after a URL change"
             );
         }
     }

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -7129,6 +7129,7 @@ mod tests {
         assert_eq!(primary.len(), 1);
         assert!(primary[0].iter().any(|t| t == "provider_tier:near"));
         assert!(primary[0].iter().any(|t| t == "fallback:false"));
+    }
 
     /// When `load_inference_url_models` is called in partial mode (`partial = true`),
     /// it must merge into the existing URL-provider cache and fingerprint-state map

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -7148,7 +7148,6 @@ mod tests {
 
         // Pre-seed the URL cache with two "existing" models as if they were
         // loaded during a prior full sync.
-        let _untouched_model = "model-untouched".to_string();
         let untouched_url = "https://untouched.completions.near.ai".to_string();
         let untouched_provider = Arc::new(MockProvider::new());
 


### PR DESCRIPTION
## Summary

When `PATCH /v1/admin/models` was called with a subset of models, `load_inference_url_models` was wholesale-replacing `inference_url_providers` and pruning `inference_url_fingerprint_states` down to that subset — evicting provider state for all untouched models and forcing full re-attestation on the next periodic refresh. If discovery transiently failed during that refresh, those models would fail-close despite not having been touched.

The fix adds a `partial: bool` parameter to `load_inference_url_models`:

- **`partial = true`** (admin PATCH path, `batch_upsert_models`): merge-upserts only the provided models into the existing URL-provider cache and fingerprint-state map. Untouched entries are preserved.
- **`partial = false`** (periodic sync via `sync_inference_url_models`, startup load in `lib.rs`): existing replace-all behaviour is preserved so stale entries are pruned as expected.

All three existing call sites outside the periodic sync path (`batch_upsert_models`, startup load in `lib.rs`, and three unit-test direct calls) are updated to compile.

## Test plan
- [x] `cargo build` clean (no errors, no new warnings)
- [x] `cargo test --lib --bins` passes (new test `test_partial_load_preserves_untouched_providers` added)
- [ ] `PATCH /v1/admin/models` on a single model does not evict provider state for other models (staging verification)

Closes #775