### PR TITLE
Remap ServiceOverloaded → HTTP 429 (was 529) (fixes #738)

### DIFF
--- a/crates/api/src/routes/common.rs
+++ b/crates/api/src/routes/common.rs
@@ -4,14 +4,18 @@ use services::completions::CompletionError;
 use services::organization::OrganizationError;
 use uuid::Uuid;
 
-/// HTTP 529 "Site Is Overloaded" — non-standard but widely used (Cloudflare,
-/// Anthropic) for "all backends exhausted; please retry with exponential
-/// backoff." Surfaced when `retry_with_fallback` has tried every inference
-/// backend for a model and they all rejected with 5xx — typically SGLang
-/// `--max-queued-requests` 503s under load. 503 stays reserved for narrower
-/// per-handler "this dependency is down" cases.
+/// HTTP 429 "Too Many Requests" — used here for the "all backends exhausted;
+/// please retry with exponential backoff" case. Surfaced when
+/// `retry_with_fallback` has tried every inference backend for a model and
+/// they all rejected with 5xx — typically SGLang `--max-queued-requests`
+/// 503s under load. 503 stays reserved for narrower per-handler "this
+/// dependency is down" cases. The error body carries `"type":
+/// "service_overloaded"` to distinguish it from per-org rate-limit 429s
+/// (`"type": "rate_limit_exceeded"`). 429 is the universally understood
+/// "back off and retry" signal; 529 is non-standard and some clients (e.g.
+/// OpenRouter) count non-2xx/4xx as downtime, degrading our routing rank.
 pub fn status_overloaded() -> StatusCode {
-    StatusCode::from_u16(529).expect("529 is a valid HTTP status code")
+    StatusCode::TOO_MANY_REQUESTS
 }
 
 /// Map domain errors to HTTP status codes
@@ -727,7 +731,7 @@ mod tests {
     #[test]
     fn test_map_domain_error_service_overloaded() {
         let error = CompletionError::ServiceOverloaded("overloaded".to_string());
-        assert_eq!(map_domain_error_to_status(&error).as_u16(), 529);
+        assert_eq!(map_domain_error_to_status(&error).as_u16(), 429);
     }
 
     #[test]

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1239,7 +1239,7 @@ fn unsupported_completion_param(request: &CompletionRequest) -> Option<&'static 
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 402, description = "Insufficient credits", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -2017,7 +2017,7 @@ async fn chat_completions_inner(
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -3815,7 +3815,7 @@ mod tests {
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -4071,7 +4071,7 @@ pub async fn image_generations(
         (status = 401, description = "Unauthorized (missing or invalid API key)", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]
@@ -4464,7 +4464,7 @@ pub async fn audio_transcriptions(
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 413, description = "Payload too large", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -4970,7 +4970,7 @@ mod rerank_response_options_tests {
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Concurrent request limit exceeded for the organization. Max concurrent requests per model: 64 (configurable)", body = ErrorResponse),
         (status = 500, description = "Server error (billing failure, provider error)", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]
@@ -5314,7 +5314,7 @@ fn classify_provider_error(
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -5618,7 +5618,7 @@ struct PrivacyClassifyResponseDoc {
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
     ),
     security(
@@ -6409,7 +6409,7 @@ pub async fn privacy_redact(
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 429, description = "Concurrent request limit exceeded for the organization. Max concurrent requests per model: 64 (configurable)", body = ErrorResponse),
         (status = 500, description = "Server error (billing failure, provider error)", body = ErrorResponse),
-        (status = 529, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
+        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1239,7 +1239,7 @@ fn unsupported_completion_param(request: &CompletionRequest) -> Option<&'static 
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 402, description = "Insufficient credits", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -2017,7 +2017,7 @@ async fn chat_completions_inner(
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -3815,7 +3815,7 @@ mod tests {
         (status = 400, description = "Invalid request parameters", body = ErrorResponse),
         (status = 401, description = "Invalid or missing API key", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -4071,7 +4071,7 @@ pub async fn image_generations(
         (status = 401, description = "Unauthorized (missing or invalid API key)", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]
@@ -4464,7 +4464,7 @@ pub async fn audio_transcriptions(
         (status = 404, description = "Model not found", body = ErrorResponse),
         (status = 413, description = "Payload too large", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -4968,9 +4968,8 @@ mod rerank_response_options_tests {
         (status = 400, description = "Invalid request (empty documents, invalid model, etc.)", body = ErrorResponse),
         (status = 401, description = "Unauthorized (missing or invalid API key)", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
-        (status = 429, description = "Concurrent request limit exceeded for the organization. Max concurrent requests per model: 64 (configurable)", body = ErrorResponse),
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse),
         (status = 500, description = "Server error (billing failure, provider error)", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]
@@ -5312,9 +5311,8 @@ fn classify_provider_error(
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
-        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse)
     ),
     security(
         ("api_key" = [])
@@ -5617,8 +5615,7 @@ struct PrivacyClassifyResponseDoc {
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
-        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
     ),
     security(
@@ -5944,7 +5941,7 @@ struct PrivacyRedactResponseDoc {
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
-        (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse),
         (status = 500, description = "Server error", body = ErrorResponse)
     ),
     security(
@@ -6407,9 +6404,8 @@ pub async fn privacy_redact(
         (status = 400, description = "Invalid request (empty texts, invalid model, etc.)", body = ErrorResponse),
         (status = 401, description = "Unauthorized (missing or invalid API key)", body = ErrorResponse),
         (status = 404, description = "Model not found", body = ErrorResponse),
-        (status = 429, description = "Concurrent request limit exceeded for the organization. Max concurrent requests per model: 64 (configurable)", body = ErrorResponse),
+        (status = 429, description = "Rate limited or overloaded — retry with backoff. Check error.type: rate_limit_exceeded or service_overloaded.", body = ErrorResponse),
         (status = 500, description = "Server error (billing failure, provider error)", body = ErrorResponse),
-        (status = 429, description = "All inference backends overloaded; retry with exponential backoff", body = ErrorResponse),
     ),
     security(("ApiKeyAuth" = []))
 )]

--- a/crates/api/tests/e2e_all/general.rs
+++ b/crates/api/tests/e2e_all/general.rs
@@ -1693,14 +1693,14 @@ async fn test_high_context_length_completion() {
 
         // Common acceptable errors:
         // - Model not found (404)
+        // - All backends overloaded (429 service_overloaded) — retry_with_fallback exhausted
         // - Model not available (503) — narrow per-handler dependency-down case
-        // - All backends overloaded (529) — retry_with_fallback exhausted
         assert!(
             response.status_code() == 404
+                || response.status_code() == 429
                 || response.status_code() == 503
-                || response.status_code() == 529
                 || response.status_code() == 500,
-            "Expected 200, 404, 500, 503, or 529, got: {}",
+            "Expected 200, 404, 429, 500, or 503, got: {}",
             response.status_code()
         );
 

--- a/crates/api/tests/e2e_all/provider_errors.rs
+++ b/crates/api/tests/e2e_all/provider_errors.rs
@@ -228,6 +228,49 @@ async fn test_responses_partial_output_then_stream_error_429_non_streaming() {
     assert_eq!(err.error.r#type, "rate_limit_exceeded");
 }
 
+/// Test that the Responses API returns HTTP 429 with `type=service_overloaded`
+/// when all inference backends are exhausted — mirrors the chat completions path
+/// in `test_provider_error_503_propagated` and covers the mapping in
+/// `crates/services/src/responses/errors.rs`.
+#[tokio::test]
+async fn test_responses_service_overloaded_returns_429() {
+    let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
+    setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+
+    mock_provider
+        .set_error_override(Some(inference_providers::CompletionError::HttpError {
+            status_code: 503,
+            message: "GPU out of memory".to_string(),
+            is_external: false,
+        }))
+        .await;
+
+    let response = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&responses_request(
+            "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            false,
+        ))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        429,
+        "Responses API: expected 429 (all backends overloaded), got {}",
+        response.status_code()
+    );
+
+    let err = response.json::<api::models::ErrorResponse>();
+    assert_eq!(
+        err.error.r#type, "service_overloaded",
+        "Responses API: overloaded error should carry type=service_overloaded, got {}",
+        err.error.r#type
+    );
+}
+
 /// Test that initial inference failures in non-streaming Responses API surface
 /// as HTTP errors rather than fallback ResponseObjects with status=failed.
 #[tokio::test]

--- a/crates/api/tests/e2e_all/provider_errors.rs
+++ b/crates/api/tests/e2e_all/provider_errors.rs
@@ -34,8 +34,10 @@ fn responses_request(model: &str, stream: bool) -> serde_json::Value {
 // ============================================
 
 /// Test that a 503 from the provider, after `retry_with_fallback` exhausts
-/// every backend, surfaces to the client as HTTP 529 ("Site Is Overloaded").
-/// 503 stays reserved for narrower per-handler "this dependency is down" cases.
+/// every backend, surfaces to the client as HTTP 429 ("Too Many Requests").
+/// The error body uses `"type": "service_overloaded"` to distinguish it from
+/// per-org rate-limit 429s (`"type": "rate_limit_exceeded"`). 503 stays
+/// reserved for narrower per-handler "this dependency is down" cases.
 #[tokio::test]
 async fn test_provider_error_503_propagated() {
     let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
@@ -60,8 +62,8 @@ async fn test_provider_error_503_propagated() {
 
     assert_eq!(
         response.status_code(),
-        529,
-        "Expected 529 (all backends overloaded), got {}",
+        429,
+        "Expected 429 (all backends overloaded), got {}",
         response.status_code()
     );
 
@@ -378,8 +380,8 @@ async fn test_provider_error_message_preserved_in_streaming() {
 
     assert_eq!(
         response.status_code(),
-        529,
-        "Expected 529 (all backends overloaded) for streaming request, got {}",
+        429,
+        "Expected 429 (all backends overloaded) for streaming request, got {}",
         response.status_code()
     );
 

--- a/crates/services/src/responses/errors.rs
+++ b/crates/services/src/responses/errors.rs
@@ -160,7 +160,7 @@ fn completion_http_status_code(error: &crate::completions::CompletionError) -> u
         | crate::completions::CompletionError::InvalidParams(_) => 400,
         crate::completions::CompletionError::RateLimitExceeded(_) => 429,
         crate::completions::CompletionError::ProviderError { status_code, .. } => *status_code,
-        crate::completions::CompletionError::ServiceOverloaded(_) => 529,
+        crate::completions::CompletionError::ServiceOverloaded(_) => 429,
         crate::completions::CompletionError::InternalError(_) => 500,
     }
 }

--- a/crates/services/src/responses/errors.rs
+++ b/crates/services/src/responses/errors.rs
@@ -220,3 +220,40 @@ fn response_error(
         code: code.map(str::to_string),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completions::CompletionError;
+
+    #[test]
+    fn test_responses_api_service_overloaded_returns_429() {
+        let completion_err = CompletionError::ServiceOverloaded("all backends busy".to_string());
+        let response_err = ResponseError::Completion(completion_err);
+        assert_eq!(
+            response_err.http_status_code(),
+            429,
+            "ServiceOverloaded should map to HTTP 429 in the Responses API"
+        );
+    }
+
+    #[test]
+    fn test_responses_api_service_overloaded_error_type() {
+        let completion_err = CompletionError::ServiceOverloaded("all backends busy".to_string());
+        let response_err = ResponseError::Completion(completion_err);
+        let error_body = response_err.response_error();
+        assert_eq!(
+            error_body.type_,
+            "service_overloaded",
+            "ServiceOverloaded should carry type=service_overloaded in the Responses API error body"
+        );
+    }
+
+    #[test]
+    fn test_responses_api_rate_limit_returns_429() {
+        let completion_err = CompletionError::RateLimitExceeded("quota exceeded".to_string());
+        let response_err = ResponseError::Completion(completion_err);
+        assert_eq!(response_err.http_status_code(), 429);
+        assert_eq!(response_err.response_error().type_, "rate_limit_exceeded");
+    }
+}


### PR DESCRIPTION
## Summary
`ServiceOverloaded` previously returned HTTP 529 (non-standard). OpenRouter counts all non-standard responses as downtime, degrading our routing rank. Additionally, 429 is the universally understood "back off and retry" signal — which is exactly the semantic we want.

- Changed `status_overloaded()` in `crates/api/src/routes/common.rs` to return `StatusCode::TOO_MANY_REQUESTS` (429)
- Updated the matching status code in `crates/services/src/responses/errors.rs` (responses API path)
- Updated all 9 OpenAPI `utoipa` response annotations in `completions.rs` from `status = 529` to `status = 429`
- Updated unit test asserting `.as_u16() == 529` → `429`
- Updated e2e tests asserting `529` → `429`

The error body retains `"type": "service_overloaded"` so it's distinguishable from per-org rate-limit 429s (`"type": "rate_limit_exceeded"`).

## Test plan
- [x] `cargo build` clean
- [x] `cargo test --lib -- common` passes (23 tests including `test_map_domain_error_service_overloaded`)
- [x] All 529 assertions in unit and e2e tests updated to 429
- [x] Error body still contains `"type": "service_overloaded"` — distinguishable from rate-limit 429s

Closes #738