### PR TITLE
perf(users): fix N+1 queries in GET /v1/users/me (fixes #757)

### DIFF
--- a/crates/api/src/routes/users.rs
+++ b/crates/api/src/routes/users.rs
@@ -113,63 +113,53 @@ pub async fn get_current_user(
         }
     };
 
-    // Get user's organizations with roles
+    // Get user's organizations with roles — single JOIN query (replaces prior N+1 pattern of
+    // list_organizations_for_user + N × get_user_role).
     let organizations = match app_state
         .organization_service
-        .list_organizations_for_user(user_id.clone(), 100, 0, None, None)
+        .list_organizations_with_roles_for_user(user_id.clone(), 100, 0, None, None)
         .await
     {
-        Ok(orgs) => {
-            let mut user_orgs = Vec::new();
-            for org in orgs {
-                // Get user's role in this organization
-                if let Ok(Some(role)) = app_state
-                    .organization_service
-                    .get_user_role(org.id.clone(), user_id.clone())
-                    .await
-                {
-                    user_orgs.push(crate::models::UserOrganizationResponse {
-                        id: org.id.0.to_string(),
-                        name: org.name,
-                        description: org.description,
-                        role: crate::conversions::services_role_to_api_role(role),
-                        is_active: org.is_active,
-                        created_at: org.created_at,
-                    });
-                }
-            }
-            user_orgs
-        }
+        Ok(orgs) => orgs
+            .into_iter()
+            .map(|org_with_role| crate::models::UserOrganizationResponse {
+                id: org_with_role.organization.id.0.to_string(),
+                name: org_with_role.organization.name,
+                description: org_with_role.organization.description,
+                role: crate::conversions::services_role_to_api_role(org_with_role.role),
+                is_active: org_with_role.organization.is_active,
+                created_at: org_with_role.organization.created_at,
+            })
+            .collect(),
         Err(_) => {
             error!("Failed to list organizations for user");
             Vec::new()
         }
     };
 
-    // Get user's workspaces from all their organizations
-    let mut workspaces = Vec::new();
-    for org_response in &organizations {
-        let org_id = match Uuid::parse_str(&org_response.id) {
-            Ok(id) => services::organization::OrganizationId(id),
-            Err(_) => continue,
-        };
-
-        if let Ok(org_workspaces) = app_state
-            .workspace_service
-            .list_workspaces_for_organization(org_id.clone(), user_id.clone())
-            .await
-        {
-            for workspace in org_workspaces {
-                workspaces.push(crate::models::UserWorkspaceResponse {
-                    id: workspace.id.0.to_string(),
-                    name: workspace.name,
-                    organization_id: workspace.organization_id.0.to_string(),
-                    is_active: workspace.is_active,
-                    created_at: workspace.created_at,
-                });
-            }
+    // Get user's workspaces across all their organizations — single JOIN query (replaces prior
+    // N+1 pattern of iterating over orgs and calling list_workspaces_for_organization per org,
+    // which also triggered an is_member check per org).
+    let workspaces = match app_state
+        .workspace_service
+        .list_workspaces_for_user(user_id.clone(), 500)
+        .await
+    {
+        Ok(ws) => ws
+            .into_iter()
+            .map(|workspace| crate::models::UserWorkspaceResponse {
+                id: workspace.id.0.to_string(),
+                name: workspace.name,
+                organization_id: workspace.organization_id.0.to_string(),
+                is_active: workspace.is_active,
+                created_at: workspace.created_at,
+            })
+            .collect(),
+        Err(_) => {
+            error!("Failed to list workspaces for user");
+            Vec::new()
         }
-    }
+    };
 
     // Build response with all data
     let response = crate::conversions::services_user_to_api_user_with_relations(

--- a/crates/database/src/migrations/sql/V0063__add_workspaces_org_active_index.sql
+++ b/crates/database/src/migrations/sql/V0063__add_workspaces_org_active_index.sql
@@ -1,0 +1,6 @@
+-- Covering index for the /v1/users/me workspaces JOIN query.
+-- The query joins workspaces → organization_members on organization_id,
+-- then filters is_active = true. A composite index on (organization_id, is_active)
+-- lets Postgres satisfy both the join and the filter with a single index scan.
+CREATE INDEX IF NOT EXISTS idx_workspaces_org_active
+    ON workspaces (organization_id, is_active);

--- a/crates/database/src/repositories/workspace.rs
+++ b/crates/database/src/repositories/workspace.rs
@@ -554,6 +554,48 @@ impl services::workspace::ports::WorkspaceRepository for WorkspaceRepository {
     ) -> Result<i64, RepositoryError> {
         self.count_by_organization(organization_id.0).await
     }
+
+    async fn list_by_user(
+        &self,
+        user_id: services::auth::ports::UserId,
+        limit: i64,
+    ) -> Result<Vec<services::workspace::Workspace>, RepositoryError> {
+        let rows = retry_db!("list_workspaces_by_user_across_orgs", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            // Single query: join workspaces → organizations → organization_members
+            // to fetch all workspaces the user can access across all their orgs.
+            client
+                .query(
+                    r#"
+                    SELECT w.*
+                    FROM workspaces w
+                    INNER JOIN organization_members om
+                        ON w.organization_id = om.organization_id
+                    WHERE om.user_id = $1
+                      AND w.is_active = true
+                    ORDER BY w.created_at ASC
+                    LIMIT $2
+                    "#,
+                    &[&user_id.0, &limit],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        rows.into_iter()
+            .map(|row| {
+                self.row_to_workspace(row)
+                    .map(db_workspace_to_workspace_service)
+                    .map_err(RepositoryError::DataConversionError)
+            })
+            .collect()
+    }
 }
 
 // Conversion function for workspace service

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -931,6 +931,13 @@ mod tests {
         async fn count_by_organization(&self, _: OrganizationId) -> Result<i64, RepositoryError> {
             unimplemented!()
         }
+        async fn list_by_user(
+            &self,
+            _: UserId,
+            _: i64,
+        ) -> Result<Vec<Workspace>, RepositoryError> {
+            unimplemented!()
+        }
     }
 
     struct StubOrgService;

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -931,11 +931,7 @@ mod tests {
         async fn count_by_organization(&self, _: OrganizationId) -> Result<i64, RepositoryError> {
             unimplemented!()
         }
-        async fn list_by_user(
-            &self,
-            _: UserId,
-            _: i64,
-        ) -> Result<Vec<Workspace>, RepositoryError> {
+        async fn list_by_user(&self, _: UserId, _: i64) -> Result<Vec<Workspace>, RepositoryError> {
             unimplemented!()
         }
     }

--- a/crates/services/src/workspace/mod.rs
+++ b/crates/services/src/workspace/mod.rs
@@ -477,6 +477,17 @@ impl WorkspaceServiceTrait for WorkspaceServiceImpl {
             .map_err(Self::map_repository_error)
     }
 
+    async fn list_workspaces_for_user(
+        &self,
+        user_id: UserId,
+        limit: i64,
+    ) -> Result<Vec<Workspace>, WorkspaceError> {
+        self.workspace_repository
+            .list_by_user(user_id, limit)
+            .await
+            .map_err(Self::map_repository_error)
+    }
+
     async fn count_workspaces_by_organization(
         &self,
         organization_id: OrganizationId,

--- a/crates/services/src/workspace/ports.rs
+++ b/crates/services/src/workspace/ports.rs
@@ -166,6 +166,13 @@ pub trait WorkspaceRepository: Send + Sync {
         &self,
         organization_id: OrganizationId,
     ) -> Result<i64, RepositoryError>;
+
+    /// List all workspaces accessible to a user across all their organizations in a single query
+    async fn list_by_user(
+        &self,
+        user_id: UserId,
+        limit: i64,
+    ) -> Result<Vec<Workspace>, RepositoryError>;
 }
 
 // Repository trait for API key data access
@@ -343,6 +350,16 @@ pub trait WorkspaceServiceTrait: Send + Sync {
         workspace_id: WorkspaceId,
         requester_id: UserId,
     ) -> Result<bool, WorkspaceError>;
+
+    /// List all workspaces accessible to a user across all their organizations in a single query.
+    ///
+    /// This is the efficient replacement for the N+1 pattern of looping over orgs and calling
+    /// `list_workspaces_for_organization` for each one.
+    async fn list_workspaces_for_user(
+        &self,
+        user_id: UserId,
+        limit: i64,
+    ) -> Result<Vec<Workspace>, WorkspaceError>;
 
     /// Count workspaces for an organization with permission checking
     async fn count_workspaces_by_organization(


### PR DESCRIPTION
## Summary

`/v1/users/me` was measuring ~1.7s in prod, dominating the authenticated load on cloud.near.ai.

**Root cause: 1 + N + 2N database queries per request.**

The handler was:
1. `get_user` — 1 query ✓
2. `list_organizations_for_user` — 1 query to get org list
3. For each org: `get_user_role` — **N extra queries** (N+1)
4. For each org: `list_workspaces_for_organization` — **N queries**, each of which also called `is_member` internally (**another N queries**)

With a user in just 2 orgs: 1 + 1 + 2 + 4 = 8 sequential DB round-trips.

## Fix

- **Orgs**: Replace `list_organizations_for_user` + N×`get_user_role` with `list_organizations_with_roles_for_user` (already existed in the repository layer; uses a single JOIN query that returns orgs+roles together).
- **Workspaces**: Add `WorkspaceRepository::list_by_user` and `WorkspaceServiceTrait::list_workspaces_for_user` — a single JOIN across `workspaces × organization_members` to fetch all user workspaces across all orgs in one query.
- **Index**: Migration V0063 adds `idx_workspaces_org_active` on `workspaces(organization_id, is_active)` — lets Postgres satisfy the join condition + `is_active = true` filter with a single index scan.

**Result**: GET `/v1/users/me` now performs exactly **3 DB queries** regardless of how many orgs/workspaces the user belongs to (was O(3N+2)).

## Test plan
- [x] `cargo test --lib --bins` passes (391 tests)
- [x] `cargo build` succeeds
- [x] `cargo clippy -- -D warnings` clean
- [x] N+1 eliminated (verified via code inspection — no loops over orgs making per-org DB calls)

Closes #757