### PR TITLE
feat(pool): logging + metric for Chutes-fallback visibility

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -295,6 +295,11 @@ pub async fn init_domain_services_with_pool(
     inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
     metrics_service: Arc<dyn services::metrics::MetricsServiceTrait>,
 ) -> DomainServices {
+    // Give the provider pool the metrics sink so it can emit the per-tier /
+    // fallback counter (cloud_api.provider.requests) from the one layer that
+    // knows which trust tier served each request.
+    inference_provider_pool.set_metrics_service(metrics_service.clone());
+
     // Create shared repositories
     let conversation_repo = Arc::new(database::PgConversationRepository::new(
         database.pool().clone(),

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -145,6 +145,15 @@ impl ProviderTier {
     pub fn is_attested(self) -> bool {
         matches!(self, ProviderTier::Near | ProviderTier::Attested3p)
     }
+
+    /// Stable, lowercase label for logs and metric tags (low cardinality).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProviderTier::Near => "near",
+            ProviderTier::Attested3p => "attested_3p",
+            ProviderTier::NonAttested => "non_attested",
+        }
+    }
 }
 
 /// Creates a verified `reqwest::Client` with an H2 connection to a specific backend.

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -241,6 +241,11 @@ pub struct InferenceProviderPool {
     /// Distinct from [`Self::pinned_models`] (just the name set the no-overwrite /
     /// no-evict / no-stale-remove guards consult).
     pinned_providers: Arc<std::sync::RwLock<HashMap<String, Vec<Arc<InferenceProviderTrait>>>>>,
+    /// Optional metrics sink for tiered-routing visibility (set once after
+    /// construction via [`Self::set_metrics_service`]; absent in tests). The pool
+    /// is the only layer that knows which trust tier served a request and whether
+    /// it was a fallback, so the per-tier / fallback counter is emitted from here.
+    metrics_service: std::sync::OnceLock<Arc<dyn crate::metrics::MetricsServiceTrait>>,
 }
 
 /// Backend verifier that creates verified reqwest clients by connecting to a backend,
@@ -511,7 +516,17 @@ impl InferenceProviderPool {
             attestation_verifier: Arc::new(AttestationVerifier::near_with_pccs(pccs_url)),
             pinned_models: Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
             pinned_providers: Arc::new(std::sync::RwLock::new(HashMap::new())),
+            metrics_service: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Attach a metrics sink for tiered-routing/fallback visibility. Set once
+    /// during app setup (the pool is shared as `Arc` immediately, so this uses
+    /// interior mutability rather than a `new()` arg — keeping the many test
+    /// `InferenceProviderPool::new(...)` call sites untouched). A second call is
+    /// a no-op.
+    pub fn set_metrics_service(&self, metrics: Arc<dyn crate::metrics::MetricsServiceTrait>) {
+        let _ = self.metrics_service.set(metrics);
     }
 
     /// Load external providers (OpenAI, Anthropic, Gemini, etc.) into provider_mappings.
@@ -2143,13 +2158,38 @@ impl InferenceProviderPool {
                             let key = Arc::as_ptr(provider) as *const () as usize;
                             counts.insert(key, 0);
                         }
+                        // Visibility into tiered routing: which trust tier actually
+                        // served, and whether we fell back off the primary. `attempt`
+                        // is the 0-based index into the tier-ordered provider list, so
+                        // anything past index 0 means the leading (primary, e.g. NEAR)
+                        // tier failed and a fallback (e.g. Chutes) served the request.
+                        let tier = provider.tier();
+                        let is_fallback = attempt > 0;
                         tracing::info!(
                             model_id = %model_id,
                             attempt = attempt + 1,
                             retry = retry_count,
                             operation = operation_name,
+                            provider_tier = tier.as_str(),
+                            is_fallback,
                             "Successfully completed request with provider"
                         );
+                        // Emit a fallback counter (every served request, tagged) so
+                        // dashboards can show Chutes-served traffic and the
+                        // NEAR→fallback rate per model. Recorded here — the only point
+                        // that knows the serving provider's tier and the attempt index.
+                        if let Some(metrics) = self.metrics_service.get() {
+                            metrics.record_count(
+                                crate::metrics::consts::METRIC_PROVIDER_REQUESTS,
+                                1,
+                                &[
+                                    &format!("model:{model_id}"),
+                                    &format!("provider_tier:{}", tier.as_str()),
+                                    &format!("fallback:{is_fallback}"),
+                                    &format!("operation:{operation_name}"),
+                                ],
+                            );
+                        }
                         return Ok((result, provider.clone()));
                     }
                     Err(e) => {
@@ -6885,5 +6925,81 @@ mod tests {
             chutes.last_chat_params().await.is_none(),
             "Chutes must NOT be tried for a genuine client 4xx"
         );
+    }
+
+    /// Observability: the pool emits `cloud_api.provider.requests` tagged with the
+    /// serving tier and a `fallback` flag, so dashboards can see Chutes-served
+    /// traffic and the NEAR→fallback rate. A NEAR-5xx→Chutes request must record
+    /// `provider_tier:attested_3p, fallback:true`; a healthy NEAR primary must
+    /// record `provider_tier:near, fallback:false`.
+    #[tokio::test]
+    async fn provider_requests_metric_tags_tier_and_fallback() {
+        use crate::metrics::capturing::{CapturingMetricsService, MetricValue};
+        use crate::metrics::consts::METRIC_PROVIDER_REQUESTS;
+        use inference_providers::mock::{MockProvider, RequestMatcher, ResponseTemplate};
+        use inference_providers::{CompletionError, ProviderTier};
+
+        // Helper: run one request through a pool wired with capturing metrics and
+        // return the recorded provider-requests tag sets.
+        async fn served_tags(near_fails: bool) -> Vec<Vec<String>> {
+            let pool = InferenceProviderPool::new(None, ExternalProvidersConfig::default());
+            let metrics = Arc::new(CapturingMetricsService::new());
+            pool.set_metrics_service(metrics.clone());
+            let model_id = "z-ai/glm-5.1".to_string();
+
+            let near = Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Near));
+            if near_fails {
+                near.set_error_override(Some(CompletionError::HttpError {
+                    status_code: 503,
+                    message: "overloaded".to_string(),
+                    is_external: true,
+                }))
+                .await;
+            } else {
+                near.when(RequestMatcher::Any)
+                    .respond_with(ResponseTemplate::new("near"))
+                    .await;
+            }
+            let chutes =
+                Arc::new(MockProvider::new_accept_all().with_tier(ProviderTier::Attested3p));
+            chutes
+                .when(RequestMatcher::Any)
+                .respond_with(ResponseTemplate::new("chutes"))
+                .await;
+            {
+                let mut m = pool.provider_mappings.write().await;
+                m.model_to_providers.insert(
+                    model_id.clone(),
+                    vec![
+                        near.clone() as Arc<InferenceProviderTrait>,
+                        chutes.clone() as Arc<InferenceProviderTrait>,
+                    ],
+                );
+            }
+            pool.chat_completion(fallback_params(&model_id), "h".to_string())
+                .await
+                .expect("served");
+
+            metrics
+                .get_metrics()
+                .into_iter()
+                .filter(|m| m.name == METRIC_PROVIDER_REQUESTS)
+                .inspect(|m| assert!(matches!(m.value, MetricValue::Count(1))))
+                .map(|m| m.tags)
+                .collect()
+        }
+
+        // NEAR 5xx → served by Chutes fallback.
+        let fb = served_tags(true).await;
+        assert_eq!(fb.len(), 1, "exactly one provider-requests metric");
+        assert!(fb[0].iter().any(|t| t == "provider_tier:attested_3p"));
+        assert!(fb[0].iter().any(|t| t == "fallback:true"));
+        assert!(fb[0].iter().any(|t| t == "model:z-ai/glm-5.1"));
+
+        // Healthy NEAR → served by primary, no fallback.
+        let primary = served_tags(false).await;
+        assert_eq!(primary.len(), 1);
+        assert!(primary[0].iter().any(|t| t == "provider_tier:near"));
+        assert!(primary[0].iter().any(|t| t == "fallback:false"));
     }
 }

--- a/crates/services/src/metrics/consts.rs
+++ b/crates/services/src/metrics/consts.rs
@@ -20,6 +20,12 @@ pub const METRIC_REQUEST_COUNT: &str = "cloud_api.request.count";
 pub const METRIC_TOKENS_INPUT: &str = "cloud_api.tokens.input";
 pub const METRIC_TOKENS_OUTPUT: &str = "cloud_api.tokens.output";
 
+// Tiered-routing visibility: one increment per served request, tagged with
+// `model`, `provider_tier` (near|attested_3p|non_attested), `fallback`
+// (true when the primary tier failed and a fallback served), and `operation`.
+// Lets dashboards show Chutes-served traffic and the NEAR->fallback rate.
+pub const METRIC_PROVIDER_REQUESTS: &str = "cloud_api.provider.requests";
+
 // Error metrics
 pub const METRIC_REQUEST_ERRORS: &str = "cloud_api.request.errors";
 

--- a/crates/services/src/metrics/mod.rs
+++ b/crates/services/src/metrics/mod.rs
@@ -92,6 +92,9 @@ impl MetricsServiceTrait for OtlpMetricsService {
         let counter = counters.entry(name.to_string()).or_insert_with(|| {
             let description = match name {
                 consts::METRIC_REQUEST_COUNT => "Total number of API requests",
+                consts::METRIC_PROVIDER_REQUESTS => {
+                    "Served requests by provider tier + fallback (Chutes-served traffic, NEAR->fallback rate)"
+                }
                 consts::METRIC_TOKENS_INPUT => "Input tokens consumed",
                 consts::METRIC_TOKENS_OUTPUT => "Output tokens generated",
                 consts::METRIC_VERIFICATION_SUCCESS => "Successful verification operations",


### PR DESCRIPTION
Follow-up to #795/#798: there was no clean way to see **when a request is served by the Chutes fallback vs the NEAR primary**. The closest signal (`attempt > 1` on the success log) didn't name the tier and missed Chutes-primary models. This adds proper logging + a metric, emitted from the provider pool's retry loop — the only layer that knows the serving tier and the attempt index.

## Logging
The "Successfully completed request with provider" log now carries:
- `provider_tier` — `near` | `attested_3p` | `non_attested` (new `ProviderTier::as_str()`)
- `is_fallback` — `true` when the leading/primary tier failed and a fallback served

DD: `service:cloud-api @fields.provider_tier:attested_3p` = Chutes-served; `@fields.is_fallback:true` = a genuine NEAR→fallback.

## Metric
`cloud_api.provider.requests` — counter, **+1 per served request**, tagged `{model, provider_tier, fallback, operation}`. Enables:
- Chutes-served traffic over time (`provider_tier:attested_3p`)
- NEAR→fallback **rate** per model (`fallback:true` / total) — alert on spikes
- works for both fallback (NEAR-primary models) and Chutes-primary models

## Wiring (non-invasive)
The pool gains an optional metrics sink set once via `set_metrics_service` (interior-mutable `OnceLock`), so the many `InferenceProviderPool::new(...)` call sites (incl. tests) are **untouched**; wired in `init_domain_services_with_pool`. Absent → no-op.

## Test (green; fmt + clippy clean)
`provider_requests_metric_tags_tier_and_fallback` (via `CapturingMetricsService`): NEAR-5xx→Chutes records `provider_tier:attested_3p, fallback:true`; healthy NEAR records `provider_tier:near, fallback:false`. Existing fallback/model-not-found tests still pass.