### PR TITLE
feat: add revenue density percentile endpoint

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1844,9 +1844,9 @@ pub fn build_admin_routes(
         get_organization as get_admin_organization, get_organization_concurrent_limit,
         get_organization_limits_history, get_organization_metrics, get_organization_timeseries,
         get_performance_timeseries, get_platform_metrics, get_platform_timeseries,
-        list_admin_access_tokens, list_invitation_email_deliveries, list_model_pricing_changes,
-        list_models as admin_list_models, list_organization_members, list_organizations,
-        list_users, preview_model_deprecation, preview_model_pricing_changes,
+        get_revenue_density, list_admin_access_tokens, list_invitation_email_deliveries,
+        list_model_pricing_changes, list_models as admin_list_models, list_organization_members,
+        list_organizations, list_users, preview_model_deprecation, preview_model_pricing_changes,
         resend_invitation_email, update_organization_concurrent_limit, update_organization_limits,
         update_service, AdminAppState,
     };
@@ -1997,6 +1997,10 @@ pub fn build_admin_routes(
         .route(
             "/admin/platform/performance-timeseries",
             axum::routing::get(get_performance_timeseries),
+        )
+        .route(
+            "/admin/platform/revenue-density",
+            axum::routing::get(get_revenue_density),
         )
         .route(
             "/admin/invitation-email-deliveries",

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3623,6 +3623,53 @@ pub async fn get_performance_timeseries(
     Ok(ResponseJson(result))
 }
 
+/// Query params for the revenue density endpoint
+#[derive(Debug, serde::Deserialize)]
+pub struct RevenueDensityParams {
+    pub start: Option<String>,
+    pub end: Option<String>,
+}
+
+/// Get revenue density percentiles (Admin only)
+///
+/// Buckets usage into 1-minute windows, computes revenue/second per bucket,
+/// then returns P50/P95/P99/peak over active buckets — platform-wide and per model.
+/// Use the annualized figures to estimate potential revenue if a given demand
+/// rate were sustained continuously.
+pub async fn get_revenue_density(
+    State(app_state): State<AdminAppState>,
+    Query(params): Query<RevenueDensityParams>,
+    Extension(_admin_user): Extension<AdminUser>,
+) -> Result<
+    ResponseJson<services::admin::RevenueDensityReport>,
+    (StatusCode, ResponseJson<ErrorResponse>),
+> {
+    // Default to last 30 days; cap at 90 days (43k–129k minute-buckets).
+    let (start, end) = crate::routes::common::parse_metrics_range(
+        params.start.as_deref(),
+        params.end.as_deref(),
+        None,
+        90,
+    )?;
+
+    let result = app_state
+        .analytics_service
+        .get_revenue_density(services::admin::RevenueDensityQuery { start, end })
+        .await
+        .map_err(|e| {
+            error!("Failed to get revenue density: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponseJson(ErrorResponse::new(
+                    format!("Failed to retrieve revenue density: {e}"),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+
+    Ok(ResponseJson(result))
+}
+
 /// Get time series metrics for an organization (Admin only)
 ///
 /// Returns daily/weekly/hourly aggregations for charting:

--- a/crates/database/src/repositories/analytics.rs
+++ b/crates/database/src/repositories/analytics.rs
@@ -11,8 +11,9 @@ use services::admin::{
     ModelMetrics, ModelRevenueEntry, ModelRevenueQuery, ModelRevenueReport, OrgRevenueEntry,
     OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics, PerformancePoint,
     PerformanceTimeseries, PerformanceTimeseriesQuery, PlatformMetrics, PlatformTimeSeriesMetrics,
-    PlatformTimeSeriesPoint, RevenueSort, TimeSeriesMetrics, TimeSeriesPoint, TopModelMetrics,
-    TopOrganizationMetrics, WorkspaceMetrics,
+    PlatformTimeSeriesPoint, RevenueDensityModelRow, RevenueDensityQuery, RevenueDensityReport,
+    RevenueSort, TimeSeriesMetrics, TimeSeriesPoint, TopModelMetrics, TopOrganizationMetrics,
+    WorkspaceMetrics,
 };
 use services::common::RepositoryError;
 use std::collections::BTreeMap;
@@ -1062,6 +1063,144 @@ impl AnalyticsRepository for PgAnalyticsRepository {
             granularity: query.granularity,
             model_filter: query.model_name,
             data,
+        })
+    }
+
+    async fn get_revenue_density(
+        &self,
+        query: RevenueDensityQuery,
+    ) -> Result<RevenueDensityReport, RepositoryError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| RepositoryError::PoolError(e.into()))?;
+
+        // ── Platform-wide percentiles ─────────────────────────────────────────
+        // Inner CTE: one row per minute bucket with sum(cost)/60 = nano-USD/s.
+        // Outer query: PERCENTILE_CONT + MAX over active minutes only (cost > 0).
+        let platform_row = client
+            .query_one(
+                r#"
+                WITH per_minute AS (
+                    SELECT
+                        DATE_TRUNC('minute', created_at)    AS bucket,
+                        SUM(total_cost)::float8 / 60.0      AS revenue_per_sec
+                    FROM organization_usage_log
+                    WHERE created_at >= $1
+                      AND created_at < $2
+                    GROUP BY 1
+                )
+                SELECT
+                    COALESCE(
+                        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY revenue_per_sec)
+                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                    )::float8 AS p50,
+                    COALESCE(
+                        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY revenue_per_sec)
+                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                    )::float8 AS p95,
+                    COALESCE(
+                        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY revenue_per_sec)
+                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                    )::float8 AS p99,
+                    COALESCE(MAX(revenue_per_sec), 0.0)::float8              AS peak,
+                    COUNT(*) FILTER (WHERE revenue_per_sec > 0)::bigint       AS active_minutes,
+                    COUNT(*)::bigint                                           AS sampled_minutes
+                FROM per_minute
+                "#,
+                &[&query.start, &query.end],
+            )
+            .await
+            .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
+
+        let p50_nano: f64 = platform_row.get(0);
+        let p95_nano: f64 = platform_row.get(1);
+        let p99_nano: f64 = platform_row.get(2);
+        let peak_nano: f64 = platform_row.get(3);
+        let active_minutes: i64 = platform_row.get(4);
+        let sampled_minutes: i64 = platform_row.get(5);
+
+        const NANO_TO_USD: f64 = 1.0 / 1_000_000_000.0;
+        const YEAR_SECONDS: f64 = 86400.0 * 365.0;
+
+        let p50 = p50_nano * NANO_TO_USD;
+        let p95 = p95_nano * NANO_TO_USD;
+        let p99 = p99_nano * NANO_TO_USD;
+        let peak = peak_nano * NANO_TO_USD;
+
+        // ── Per-model percentiles ─────────────────────────────────────────────
+        let model_rows = client
+            .query(
+                r#"
+                WITH per_minute AS (
+                    SELECT
+                        model_name,
+                        DATE_TRUNC('minute', created_at)    AS bucket,
+                        SUM(total_cost)::float8 / 60.0      AS revenue_per_sec
+                    FROM organization_usage_log
+                    WHERE created_at >= $1
+                      AND created_at < $2
+                    GROUP BY 1, 2
+                )
+                SELECT
+                    model_name,
+                    COALESCE(
+                        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY revenue_per_sec)
+                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                    )::float8 AS p50,
+                    COALESCE(
+                        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY revenue_per_sec)
+                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                    )::float8 AS p95,
+                    COALESCE(
+                        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY revenue_per_sec)
+                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                    )::float8 AS p99,
+                    COALESCE(MAX(revenue_per_sec), 0.0)::float8              AS peak,
+                    COUNT(*) FILTER (WHERE revenue_per_sec > 0)::bigint       AS active_minutes,
+                    SUM(revenue_per_sec * 60.0)::float8                       AS total_cost_nano
+                FROM per_minute
+                GROUP BY model_name
+                ORDER BY total_cost_nano DESC
+                "#,
+                &[&query.start, &query.end],
+            )
+            .await
+            .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
+
+        let by_model: Vec<RevenueDensityModelRow> = model_rows
+            .iter()
+            .map(|row| {
+                let model_p50 = row.get::<_, f64>(1) * NANO_TO_USD;
+                let model_p95 = row.get::<_, f64>(2) * NANO_TO_USD;
+                let model_p99 = row.get::<_, f64>(3) * NANO_TO_USD;
+                let model_peak = row.get::<_, f64>(4) * NANO_TO_USD;
+                RevenueDensityModelRow {
+                    model_name: row.get(0),
+                    p50_usd_per_sec: model_p50,
+                    p95_usd_per_sec: model_p95,
+                    p99_usd_per_sec: model_p99,
+                    peak_usd_per_sec: model_peak,
+                    p99_annualized_usd: model_p99 * YEAR_SECONDS,
+                    peak_annualized_usd: model_peak * YEAR_SECONDS,
+                    active_minutes: row.get(5),
+                }
+            })
+            .collect();
+
+        Ok(RevenueDensityReport {
+            period_start: query.start,
+            period_end: query.end,
+            sampled_minutes,
+            active_minutes,
+            p50_usd_per_sec: p50,
+            p95_usd_per_sec: p95,
+            p99_usd_per_sec: p99,
+            peak_usd_per_sec: peak,
+            p99_annualized_usd: p99 * YEAR_SECONDS,
+            peak_annualized_usd: peak * YEAR_SECONDS,
+            by_model,
         })
     }
 }

--- a/crates/services/src/admin/analytics.rs
+++ b/crates/services/src/admin/analytics.rs
@@ -420,6 +420,57 @@ pub struct PerformanceTimeseries {
     pub data: Vec<PerformancePoint>,
 }
 
+/// Per-model revenue density row.
+///
+/// All rate fields are in USD/second, derived from 1-minute buckets.
+/// Percentiles are computed over **active minutes only** (buckets with >0 revenue)
+/// to reflect the rate during actual serving windows, not idle time.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RevenueDensityModelRow {
+    pub model_name: String,
+    /// P50 revenue rate during active minutes, USD/s
+    pub p50_usd_per_sec: f64,
+    /// P95 revenue rate during active minutes, USD/s
+    pub p95_usd_per_sec: f64,
+    /// P99 revenue rate during active minutes, USD/s
+    pub p99_usd_per_sec: f64,
+    /// Maximum observed revenue rate, USD/s
+    pub peak_usd_per_sec: f64,
+    /// Annualized revenue if p99 rate were constant: p99 × 86400 × 365, USD
+    pub p99_annualized_usd: f64,
+    /// Annualized revenue if peak rate were constant: peak × 86400 × 365, USD
+    pub peak_annualized_usd: f64,
+    /// Number of 1-minute buckets with revenue > 0 in the period
+    pub active_minutes: i64,
+}
+
+/// Platform-wide revenue density report with per-model breakdown.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RevenueDensityReport {
+    pub period_start: DateTime<Utc>,
+    pub period_end: DateTime<Utc>,
+    /// Total 1-minute buckets sampled in the period
+    pub sampled_minutes: i64,
+    /// Buckets with any revenue > 0
+    pub active_minutes: i64,
+    // Platform-wide percentiles (over active minutes, all models combined)
+    pub p50_usd_per_sec: f64,
+    pub p95_usd_per_sec: f64,
+    pub p99_usd_per_sec: f64,
+    pub peak_usd_per_sec: f64,
+    pub p99_annualized_usd: f64,
+    pub peak_annualized_usd: f64,
+    /// Per-model breakdown, sorted by total consumed cost DESC
+    pub by_model: Vec<RevenueDensityModelRow>,
+}
+
+/// Query params for the revenue density endpoint.
+#[derive(Debug, Clone)]
+pub struct RevenueDensityQuery {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+}
+
 /// Query params for the performance timeseries endpoint.
 #[derive(Debug, Clone)]
 pub struct PerformanceTimeseriesQuery {
@@ -492,6 +543,13 @@ pub trait AnalyticsRepository: Send + Sync {
         &self,
         query: PerformanceTimeseriesQuery,
     ) -> Result<PerformanceTimeseries, RepositoryError>;
+
+    /// Revenue density percentiles (p50/p95/p99/peak USD/s) over 1-minute buckets,
+    /// platform-wide and per-model.
+    async fn get_revenue_density(
+        &self,
+        query: RevenueDensityQuery,
+    ) -> Result<RevenueDensityReport, RepositoryError>;
 }
 
 /// Analytics service implementation
@@ -618,6 +676,17 @@ impl AnalyticsService {
     ) -> Result<PerformanceTimeseries, super::AdminError> {
         self.repository
             .get_performance_timeseries(query)
+            .await
+            .map_err(|e| super::AdminError::InternalError(e.to_string()))
+    }
+
+    /// Revenue density percentiles (p50/p95/p99/peak USD/s)
+    pub async fn get_revenue_density(
+        &self,
+        query: RevenueDensityQuery,
+    ) -> Result<RevenueDensityReport, super::AdminError> {
+        self.repository
+            .get_revenue_density(query)
             .await
             .map_err(|e| super::AdminError::InternalError(e.to_string()))
     }

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -7,8 +7,9 @@ pub use analytics::{
     ModelConsumptionTimeseriesQuery, ModelMetrics, ModelRevenueEntry, ModelRevenueQuery,
     ModelRevenueReport, OrgRevenueEntry, OrgRevenueQuery, OrgRevenueReport, OrganizationMetrics,
     PerformancePoint, PerformanceTimeseries, PerformanceTimeseriesQuery, PlatformMetrics,
-    PlatformTimeSeriesMetrics, PlatformTimeSeriesPoint, RevenueSort, TimeSeriesMetrics,
-    TimeSeriesPoint, TopModelMetrics, TopOrganizationMetrics, WorkspaceMetrics,
+    PlatformTimeSeriesMetrics, PlatformTimeSeriesPoint, RevenueDensityModelRow,
+    RevenueDensityQuery, RevenueDensityReport, RevenueSort, TimeSeriesMetrics, TimeSeriesPoint,
+    TopModelMetrics, TopOrganizationMetrics, WorkspaceMetrics,
 };
 pub mod infra;
 pub mod pricing_scheduler;


### PR DESCRIPTION
## Summary
- New `GET /admin/platform/revenue-density` endpoint (90-day cap)
- Buckets `organization_usage_log` into 1-minute windows; computes `revenue_per_sec = SUM(total_cost) / 60`
- Returns P50 / P95 / P99 / peak USD/s over **active minutes only** (buckets with any revenue), platform-wide and per model
- Includes annualized projections (`p99_annualized_usd = p99 × 86400 × 365`) — "if this demand rate were constant, what is annual revenue?"
- Returns `active_minutes` and `sampled_minutes` so callers can compute utilization fraction
- Uses existing covering index `V0062` — index-only scan, ≤43,200 intermediate rows per 30-day window; lighter than the performance-timeseries query

## Schema additions
```rust
RevenueDensityModelRow { model_name, p50/p95/p99/peak_usd_per_sec, p99/peak_annualized_usd, active_minutes }
RevenueDensityReport   { period_start/end, sampled_minutes, active_minutes, platform-wide percentiles, by_model }
RevenueDensityQuery    { start, end }
```

## Test plan
- [ ] `cargo test --lib --bins` passes
- [ ] `cargo test --test e2e_test` passes
- [ ] `cargo fmt --check` passes
- [ ] `GET /admin/platform/revenue-density` returns valid JSON on staging
- [ ] 90-day date cap enforced (range > 90 days → 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)