### PR TITLE
fix(anthropic): forward cache_control and surface cache-read tokens in usage (#666)

### DIFF
--- a/crates/api/src/conversions.rs
+++ b/crates/api/src/conversions.rs
@@ -1019,6 +1019,143 @@ mod tests {
         assert_eq!(domain.stop, Some(vec!["a".to_string(), "b".to_string()]));
     }
 
+    /// END-TO-END (#666): cache_control must survive the REAL public path —
+    /// `api::models::Message` (deserialized from the HTTP body) -> `From<Message>
+    /// for ChatMessage` (which re-serializes the converted content into
+    /// `ChatMessage.content`) -> the Anthropic converter's `convert_messages`.
+    ///
+    /// Before the Part-1 change, `MessageContentPart::Text`/`ImageUrl` had no
+    /// `cache_control` field, so serde dropped the breakpoint at deserialization
+    /// and the re-serialize produced cache-control-free content; this test would
+    /// then find a bare-string `system` and no breakpoint, and fail. With the
+    /// field present, the breakpoint rides through to the Anthropic request.
+    #[test]
+    fn cache_control_survives_message_to_anthropic_request() {
+        use inference_providers::non_attested::external::anthropic::converter::{
+            convert_messages, AnthropicContentPart, AnthropicMessageContent, AnthropicSystem,
+        };
+
+        // Deserialize from a wire body so the WHOLE path is exercised: the HTTP
+        // JSON -> `MessageContentPart` (the enum the reviewer flagged) -> the rest.
+        let system: crate::models::Message = serde_json::from_value(serde_json::json!({
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Large shared preamble",
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ]
+        }))
+        .expect("system message should deserialize");
+        let user: crate::models::Message = serde_json::from_value(serde_json::json!({
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Cached context",
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"}
+                },
+                {"type": "text", "text": "Volatile question"}
+            ]
+        }))
+        .expect("user message should deserialize");
+
+        // The REAL From impl: re-serializes converted content into ChatMessage.content.
+        let chat_messages: Vec<ChatMessage> = vec![system.into(), user.into()];
+
+        let (anthropic_system, anthropic_messages) = convert_messages(&chat_messages);
+
+        // `system` must be the block-array form carrying the verbatim breakpoint.
+        match anthropic_system.expect("system present") {
+            AnthropicSystem::Blocks(blocks) => {
+                assert_eq!(blocks.len(), 1);
+                assert_eq!(blocks[0].text, "Large shared preamble");
+                assert_eq!(
+                    blocks[0].cache_control,
+                    Some(serde_json::json!({"type": "ephemeral"}))
+                );
+            }
+            other => panic!("expected block-array system, got {other:?}"),
+        }
+
+        // The user turn must carry the breakpoint on the cached text block only.
+        assert_eq!(anthropic_messages.len(), 1);
+        let blocks = match &anthropic_messages[0].content {
+            AnthropicMessageContent::Blocks(b) => b,
+            AnthropicMessageContent::Text(t) => {
+                panic!("cache_control should force the block form, got text: {t}")
+            }
+        };
+        assert_eq!(blocks.len(), 2);
+        match &blocks[0] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Cached context");
+                assert_eq!(
+                    *cache_control,
+                    Some(serde_json::json!({"type": "ephemeral", "ttl": "1h"}))
+                );
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+        match &blocks[1] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Volatile question");
+                assert!(
+                    cache_control.is_none(),
+                    "breakpoint must not bleed onto the volatile part"
+                );
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+    }
+
+    /// Companion guard: the SAME public path must NOT leak cache_control toward a
+    /// non-Anthropic upstream. `strip_cache_control` (called by the vLLM /
+    /// openai_compatible / Chutes backends) removes the breakpoint from the
+    /// re-serialized `ChatMessage.content`, restoring the exact pre-#666 bytes
+    /// those upstreams used to receive.
+    #[test]
+    fn cache_control_stripped_for_non_anthropic_path() {
+        let user: crate::models::Message = serde_json::from_value(serde_json::json!({
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Cached context",
+                    "cache_control": {"type": "ephemeral"}
+                },
+                {"type": "text", "text": "Volatile question"}
+            ]
+        }))
+        .unwrap();
+
+        let mut chat_messages: Vec<ChatMessage> = vec![user.into()];
+        // Sanity: the breakpoint is present before stripping (Part-1 preserved it).
+        let before = serde_json::to_string(&chat_messages).unwrap();
+        assert!(
+            before.contains("cache_control"),
+            "cache_control must reach ChatMessage.content before stripping"
+        );
+
+        inference_providers::strip_cache_control(&mut chat_messages);
+
+        let after = serde_json::to_string(&chat_messages).unwrap();
+        assert!(
+            !after.contains("cache_control"),
+            "cache_control must be stripped before a non-Anthropic upstream sees it"
+        );
+        // The actual content/text is untouched — only the breakpoint is gone.
+        assert!(after.contains("Cached context"));
+        assert!(after.contains("Volatile question"));
+    }
+
     /// The mechanistic-interpretability workflow sends `return_hidden_states`
     /// / `layers` on the chat-completions request. We deliberately do NOT
     /// model these as typed fields: they ride the flattened `extra` catch-all

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -71,12 +71,27 @@ pub enum MessageContent {
 #[serde(tag = "type")]
 pub enum MessageContentPart {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        /// Anthropic prompt-caching breakpoint (`{"type":"ephemeral"}`), forwarded
+        /// verbatim (#666). Without this field serde drops the breakpoint at
+        /// deserialization, so it never survives the re-serialize in
+        /// `From<Message> for ChatMessage` to reach the Anthropic converter.
+        /// Stripped before any non-Anthropic upstream sees it (see
+        /// `inference_providers::strip_cache_control`). Omitted on the wire when
+        /// absent so the common (uncached) request is byte-identical to before.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<serde_json::Value>,
+    },
     #[serde(rename = "image_url")]
     ImageUrl {
         image_url: MessageImageUrl,
         #[serde(skip_serializing_if = "Option::is_none")]
         detail: Option<String>,
+        /// Prompt-caching breakpoint on an image content part (#666). Same
+        /// verbatim forwarding and same non-Anthropic stripping as `Text`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<serde_json::Value>,
     },
     // OpenAI format: input_audio with data + format
     #[serde(rename = "input_audio")]
@@ -4351,9 +4366,11 @@ mod tests {
                 content: Some(MessageContent::Parts(vec![
                     MessageContentPart::Text {
                         text: "Hello".to_string(),
+                        cache_control: None,
                     },
                     MessageContentPart::Text {
                         text: "World".to_string(),
+                        cache_control: None,
                     },
                 ])),
                 name: None,
@@ -4531,12 +4548,14 @@ mod tests {
                 content: Some(MessageContent::Parts(vec![
                     MessageContentPart::Text {
                         text: "What's in this image?".to_string(),
+                        cache_control: None,
                     },
                     MessageContentPart::ImageUrl {
                         image_url: MessageImageUrl::String(
                             "data:image/jpeg;base64,/9j/4AAQSkZJRg==".to_string(),
                         ),
                         detail: Some("low".to_string()),
+                        cache_control: None,
                     },
                 ])),
                 name: None,

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -1341,10 +1341,15 @@ impl InferenceProvider for Provider {
 
     async fn chat_completion(
         &self,
-        params: ChatCompletionParams,
+        mut params: ChatCompletionParams,
         _request_hash: String,
     ) -> Result<ChatCompletionResponseWithBytes, CompletionError> {
         reject_client_e2ee(&params)?;
+        // #666: Chutes serializes `ChatMessage.content` verbatim into the (E2EE)
+        // request body, so drop Anthropic prompt-caching breakpoints before
+        // `request_body` — the upstream may 400 on an unknown `cache_control`
+        // content-part field (it only matters on the Anthropic upstream).
+        crate::strip_cache_control(&mut params.messages);
         let body = request_body(&self.model_name, &params, false)
             .map_err(CompletionError::CompletionError)?;
         let prep = self.verify_and_prepare(&body).await?;
@@ -1415,7 +1420,7 @@ impl InferenceProvider for Provider {
 
     async fn chat_completion_stream(
         &self,
-        params: ChatCompletionParams,
+        mut params: ChatCompletionParams,
         _request_hash: String,
     ) -> Result<StreamingResult, CompletionError> {
         // Streaming is off by default: Chutes' stream protocol has no
@@ -1433,6 +1438,9 @@ impl InferenceProvider for Provider {
             ));
         }
         reject_client_e2ee(&params)?;
+        // #666: drop Anthropic prompt-caching breakpoints before serialization
+        // (see the non-streaming path for the rationale).
+        crate::strip_cache_control(&mut params.messages);
         // Capture the CLIENT's usage intent before `request_body` force-sets
         // `include_usage: true` upstream (we always request usage so billing sees
         // it; #781 L1 gates what the client receives). A client opts in via

--- a/crates/inference_providers/src/attested/nearai/mod.rs
+++ b/crates/inference_providers/src/attested/nearai/mod.rs
@@ -1401,6 +1401,11 @@ impl InferenceProvider for Fleet {
 
         // Ensure streaming and token usage are enabled
         let mut streaming_params = params;
+        // #666: self-hosted vLLM serves a verbatim copy of `ChatMessage.content`,
+        // so drop Anthropic prompt-caching breakpoints before routing and
+        // serialization — vLLM may 400 on an unknown `cache_control` content-part
+        // field (the breakpoint only matters on the Anthropic upstream).
+        crate::strip_cache_control(&mut streaming_params.messages);
         streaming_params.stream = Some(true);
         streaming_params.stream_options = Some(StreamOptions {
             include_usage: Some(true),
@@ -1532,6 +1537,9 @@ impl InferenceProvider for Fleet {
         let url = format!("{}/v1/chat/completions", self.config.base_url);
 
         let mut non_streaming_params = params;
+        // #666: drop Anthropic prompt-caching breakpoints before forwarding to
+        // self-hosted vLLM (see the streaming path for the rationale).
+        crate::strip_cache_control(&mut non_streaming_params.messages);
 
         let mut headers = self
             .build_headers()

--- a/crates/inference_providers/src/lib.rs
+++ b/crates/inference_providers/src/lib.rs
@@ -79,6 +79,7 @@ use tokio_stream::StreamExt;
 
 // Re-export commonly used types for convenience
 pub use mock::MockProvider;
+pub use models::strip_cache_control;
 pub use models::{
     is_client_audio_input_status, AudioOutput, AudioTranscriptionError, AudioTranscriptionParams,
     AudioTranscriptionResponse, ChatCompletionParams, ChatCompletionResponse,

--- a/crates/inference_providers/src/models.rs
+++ b/crates/inference_providers/src/models.rs
@@ -16,6 +16,34 @@ pub struct ChatMessage {
     pub tool_calls: Option<Vec<ToolCall>>,
 }
 
+/// Remove every `cache_control` breakpoint from a chat message's content parts.
+///
+/// #666: the API model now preserves `cache_control` on text/image content parts
+/// so it survives the re-serialize into [`ChatMessage::content`] and reaches the
+/// Anthropic converter. Every OTHER upstream (self-hosted vLLM, openai_compatible,
+/// gemini, Chutes) serializes `ChatMessage.content` verbatim into its outgoing
+/// request, and those APIs may 400 on an unknown `cache_control` field on a
+/// content part. Pre-#666 the breakpoint was silently dropped at deserialization,
+/// so it never reached them; this restores that exact behaviour for the
+/// non-Anthropic paths. Anthropic must NOT call this — it reads `cache_control`
+/// off the content to build its native breakpoints.
+///
+/// Only touches array-shaped content (the OpenAI content-parts form); a bare
+/// string content never carries a breakpoint and is left untouched, so the
+/// common (uncached / string-content) request stays byte-identical to before.
+pub fn strip_cache_control(messages: &mut [ChatMessage]) {
+    for msg in messages.iter_mut() {
+        let Some(serde_json::Value::Array(parts)) = msg.content.as_mut() else {
+            continue;
+        };
+        for part in parts.iter_mut() {
+            if let Some(obj) = part.as_object_mut() {
+                obj.remove("cache_control");
+            }
+        }
+    }
+}
+
 /// Delta message in streaming chat completions
 /// All fields are optional as they may not be present in every chunk
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1166,6 +1194,63 @@ pub fn detect_audio_content_type(filename: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #666 NO-LEAK: `strip_cache_control` removes the breakpoint from each
+    /// content part so the JSON serialized toward a non-Anthropic upstream
+    /// (vLLM / openai_compatible / Chutes) carries no `cache_control` — restoring
+    /// the exact bytes those upstreams received before #666.
+    #[test]
+    fn test_strip_cache_control_removes_breakpoints_from_parts() {
+        let mut messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "Cached context",
+                    "cache_control": {"type": "ephemeral"}
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/a.png"},
+                    "cache_control": {"type": "ephemeral"}
+                },
+                {"type": "text", "text": "Volatile"}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        strip_cache_control(&mut messages);
+
+        let json = serde_json::to_string(&messages).unwrap();
+        assert!(
+            !json.contains("cache_control"),
+            "no cache_control may reach a non-Anthropic upstream: {json}"
+        );
+        // Content survives intact — only the breakpoint is removed.
+        assert!(json.contains("Cached context"));
+        assert!(json.contains("Volatile"));
+        assert!(json.contains("https://example.com/a.png"));
+    }
+
+    /// String content never carries a breakpoint and must be left untouched, so
+    /// the common (uncached / string-content) request stays byte-identical.
+    #[test]
+    fn test_strip_cache_control_leaves_string_content_untouched() {
+        let original = ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::Value::String("Hello".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        };
+        let mut messages = vec![original.clone()];
+        let before = serde_json::to_string(&messages).unwrap();
+        strip_cache_control(&mut messages);
+        let after = serde_json::to_string(&messages).unwrap();
+        assert_eq!(before, after, "string content must be byte-identical");
+    }
 
     #[test]
     fn test_chat_completion_response_deserialization() {

--- a/crates/inference_providers/src/non_attested/external/anthropic/converter.rs
+++ b/crates/inference_providers/src/non_attested/external/anthropic/converter.rs
@@ -323,6 +323,21 @@ fn per_part_cache_controls(content: &serde_json::Value) -> Vec<Option<serde_json
     }
 }
 
+/// The `cache_control` breakpoint to attach to a single, flattened text block
+/// (the assistant turn rebuilds all text parts into one block via
+/// `text_from_content`). Anthropic allows a cache breakpoint on an assistant
+/// content block, so a cached prefix that ends at an assistant turn must keep
+/// its breakpoint (#666). When several text parts each carry a breakpoint, the
+/// LAST one is the prefix boundary, so we surface that — attaching it to the one
+/// block that represents the concatenated text. Returns `None` when no text part
+/// carries a breakpoint (the common case stays the bare-string form).
+fn flattened_text_cache_control(content: &serde_json::Value) -> Option<serde_json::Value> {
+    per_part_cache_controls(content)
+        .into_iter()
+        .flatten()
+        .next_back()
+}
+
 /// Build the Anthropic `system` value from a raw OpenAI system message content.
 ///
 /// Uses a bare string in the common case (no cache_control) so the request is
@@ -449,6 +464,14 @@ pub fn convert_messages(
                 }
             }
             MessageRole::Assistant => {
+                // Per-part cache_control, aligned the same way the user branch
+                // does — Anthropic allows a breakpoint on an assistant content
+                // block, so a cached prefix ending at an assistant turn keeps it
+                // (#666). The assistant text is flattened into a single block, so
+                // we attach the last (prefix-boundary) breakpoint to that block.
+                let text_cache_control =
+                    msg.content.as_ref().and_then(flattened_text_cache_control);
+
                 // Check if the assistant message contains tool calls
                 if let Some(tool_calls) = &msg.tool_calls {
                     if !tool_calls.is_empty() {
@@ -460,7 +483,7 @@ pub fn convert_messages(
                             if !text.is_empty() {
                                 blocks.push(AnthropicContentPart::Text {
                                     text,
-                                    cache_control: None,
+                                    cache_control: text_cache_control,
                                 });
                             }
                         }
@@ -487,16 +510,32 @@ pub fn convert_messages(
                     }
                 }
 
-                // No tool calls - just text content
+                // No tool calls - just text content.
                 let content = msg
                     .content
                     .as_ref()
                     .map(&extract_content)
                     .unwrap_or_default();
-                anthropic_messages.push(AnthropicMessage {
-                    role: "assistant".to_string(),
-                    content: AnthropicMessageContent::Text(content),
-                });
+                // A bare string can't carry a breakpoint, so when this turn has a
+                // cache_control we emit the block-array form (mirroring the user
+                // branch). The common (uncached) case keeps the bare string so the
+                // request is byte-identical to before.
+                if let Some(cache_control) = text_cache_control {
+                    anthropic_messages.push(AnthropicMessage {
+                        role: "assistant".to_string(),
+                        content: AnthropicMessageContent::Blocks(vec![
+                            AnthropicContentPart::Text {
+                                text: content,
+                                cache_control: Some(cache_control),
+                            },
+                        ]),
+                    });
+                } else {
+                    anthropic_messages.push(AnthropicMessage {
+                        role: "assistant".to_string(),
+                        content: AnthropicMessageContent::Text(content),
+                    });
+                }
             }
             MessageRole::Tool => {
                 // Tool results need special formatting for Anthropic
@@ -1217,6 +1256,123 @@ mod tests {
                 );
             }
             other => panic!("expected text block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cache_control_on_assistant_text_part_forwards_breakpoint() {
+        // #666: Anthropic allows a cache breakpoint on an assistant
+        // content block, so a prefix ending at an assistant turn must keep it.
+        // A plain-text assistant turn carrying cache_control must become the
+        // block-array form with the breakpoint on the rebuilt text block.
+        let messages = vec![ChatMessage {
+            role: MessageRole::Assistant,
+            content: Some(serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "Assistant prefix to cache",
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, anthropic_messages) = convert_messages(&messages);
+        assert_eq!(anthropic_messages.len(), 1);
+        let blocks = match &anthropic_messages[0].content {
+            AnthropicMessageContent::Blocks(b) => b,
+            AnthropicMessageContent::Text(t) => {
+                panic!("assistant cache_control should force the block form, got text: {t}")
+            }
+        };
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Assistant prefix to cache");
+                assert_eq!(
+                    *cache_control,
+                    Some(serde_json::json!({"type": "ephemeral"}))
+                );
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+
+        // Serialized assistant message carries the verbatim breakpoint.
+        let json = serde_json::to_string(&anthropic_messages[0]).unwrap();
+        assert!(json.contains("\"cache_control\""));
+        assert!(json.contains("\"role\":\"assistant\""));
+    }
+
+    #[test]
+    fn test_cache_control_on_assistant_with_tool_calls_forwards_breakpoint() {
+        // Assistant turn with BOTH text (carrying a breakpoint) and tool calls:
+        // the breakpoint must land on the text block, the tool_use blocks follow.
+        let messages = vec![ChatMessage {
+            role: MessageRole::Assistant,
+            content: Some(serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "Let me look that up.",
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: Some(vec![ToolCall {
+                id: Some("call_1".to_string()),
+                type_: Some("function".to_string()),
+                function: FunctionCall {
+                    name: Some("search".to_string()),
+                    arguments: Some("{\"q\":\"x\"}".to_string()),
+                },
+                index: None,
+                thought_signature: None,
+            }]),
+        }];
+
+        let (_system, anthropic_messages) = convert_messages(&messages);
+        let blocks = match &anthropic_messages[0].content {
+            AnthropicMessageContent::Blocks(b) => b,
+            AnthropicMessageContent::Text(t) => panic!("expected block form, got text: {t}"),
+        };
+        assert_eq!(blocks.len(), 2, "text block + tool_use block");
+        match &blocks[0] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Let me look that up.");
+                assert_eq!(
+                    *cache_control,
+                    Some(serde_json::json!({"type": "ephemeral"}))
+                );
+            }
+            other => panic!("expected text block first, got {other:?}"),
+        }
+        assert!(matches!(blocks[1], AnthropicContentPart::ToolUse { .. }));
+    }
+
+    #[test]
+    fn test_assistant_without_cache_control_stays_bare_string() {
+        // Regression guard: an assistant turn with no breakpoint keeps the
+        // bare-string form (byte-identical to pre-#666).
+        let messages = vec![ChatMessage {
+            role: MessageRole::Assistant,
+            content: Some(serde_json::Value::String("Plain answer".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, anthropic_messages) = convert_messages(&messages);
+        match &anthropic_messages[0].content {
+            AnthropicMessageContent::Text(t) => assert_eq!(t, "Plain answer"),
+            other => panic!("expected bare-string assistant content, got {other:?}"),
         }
     }
 

--- a/crates/inference_providers/src/non_attested/external/anthropic/converter.rs
+++ b/crates/inference_providers/src/non_attested/external/anthropic/converter.rs
@@ -37,7 +37,14 @@ pub enum AnthropicMessageContent {
 #[serde(tag = "type")]
 pub enum AnthropicContentPart {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        /// Anthropic prompt-caching breakpoint, forwarded verbatim from the
+        /// caller's OpenAI content part (`{"type":"ephemeral"}` shape, #666).
+        /// Omitted when absent so the common (uncached) request is unchanged.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<serde_json::Value>,
+    },
     #[serde(rename = "tool_use")]
     ToolUse {
         id: String,
@@ -50,7 +57,13 @@ pub enum AnthropicContentPart {
         content: String,
     },
     #[serde(rename = "image")]
-    Image { source: AnthropicImageSource },
+    Image {
+        source: AnthropicImageSource,
+        /// Prompt-caching breakpoint on an image block (#666). Same verbatim
+        /// forwarding as `Text::cache_control`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<serde_json::Value>,
+    },
 }
 
 /// Anthropic image source. Anthropic accepts either inline base64 bytes
@@ -66,6 +79,29 @@ pub enum AnthropicImageSource {
     },
     #[serde(rename = "url")]
     Url { url: String },
+}
+
+/// Anthropic `system` prompt. Anthropic accepts either a bare string or an
+/// array of text blocks; the array form is required to attach a
+/// `cache_control` breakpoint to the system prompt (#666). We keep the bare
+/// string for the common (uncached) case so that request is byte-identical to
+/// before, and only switch to the block array when a cache_control is present.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum AnthropicSystem {
+    Text(String),
+    Blocks(Vec<AnthropicSystemBlock>),
+}
+
+/// A `text` block inside the `system` array, optionally carrying a
+/// prompt-caching breakpoint.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AnthropicSystemBlock {
+    #[serde(rename = "type")]
+    pub type_: &'static str,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<serde_json::Value>,
 }
 
 /// Anthropic tool definition
@@ -93,7 +129,7 @@ pub struct AnthropicRequest {
     pub messages: Vec<AnthropicMessage>,
     pub max_tokens: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
+    pub system: Option<AnthropicSystem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -210,6 +246,15 @@ pub struct AnthropicUsage {
     pub input_tokens: i32,
     #[serde(default)]
     pub output_tokens: i32,
+    /// Tokens served from the prompt cache (cache hit). Reported by Anthropic
+    /// SEPARATELY from `input_tokens` (#666). Defaults to 0 when the field is
+    /// absent (no caching, or older API versions).
+    #[serde(default)]
+    pub cache_read_input_tokens: i32,
+    /// Tokens written to the prompt cache on this request (cache miss/creation).
+    /// Also reported separately from `input_tokens`.
+    #[serde(default)]
+    pub cache_creation_input_tokens: i32,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -236,8 +281,99 @@ pub struct AnthropicResponse {
 // Conversion Functions
 // =============================================================================
 
+/// Pull the raw `cache_control` object (if any) out of a single OpenAI content
+/// part. Anthropic accepts the breakpoint object verbatim
+/// (`{"type":"ephemeral"}`), so we forward it untouched rather than inventing
+/// our own shape (#666). The shared `parse_content` discards unknown fields, so
+/// we read this directly from the raw JSON here in the Anthropic converter
+/// instead of widening the shared `ContentPart` enum.
+fn cache_control_of(item: &serde_json::Value) -> Option<serde_json::Value> {
+    item.as_object()
+        .and_then(|obj| obj.get("cache_control"))
+        .filter(|v| !v.is_null())
+        .cloned()
+}
+
+/// Whether a string content value carries any per-part `cache_control`. A bare
+/// JSON string never does; an array might on one of its parts.
+fn content_has_cache_control(content: &serde_json::Value) -> bool {
+    matches!(content, serde_json::Value::Array(items)
+        if items.iter().any(|item| cache_control_of(item).is_some()))
+}
+
+/// Extract `cache_control` for each content part, aligned 1:1 with the parts
+/// `parse_content` produces. We reuse `parse_content_part` (the exact per-part
+/// recogniser `parse_content` is built from) as the filter, so a part counts
+/// here iff it produces a `ContentPart` there. This keeps the indices in lockstep
+/// even for malformed parts (e.g. a `text` part whose `text` is missing/non-string,
+/// which `parse_content_part` drops), so the caller always attaches each breakpoint
+/// to the correct block (#666). A bare string yields a single `None` (matching the
+/// single `ContentPart::Text`).
+fn per_part_cache_controls(content: &serde_json::Value) -> Vec<Option<serde_json::Value>> {
+    use crate::non_attested::external::content::parse_content_part;
+
+    match content {
+        serde_json::Value::Array(items) => items
+            .iter()
+            .filter(|item| parse_content_part(item).is_some())
+            .map(cache_control_of)
+            .collect(),
+        // A plain string (or any non-array) parses to exactly one text part.
+        _ => vec![None],
+    }
+}
+
+/// Build the Anthropic `system` value from a raw OpenAI system message content.
+///
+/// Uses a bare string in the common case (no cache_control) so the request is
+/// byte-identical to the pre-#666 behaviour. If any part carries a
+/// `cache_control`, emit the block-array form Anthropic requires for caching,
+/// carrying the breakpoint on the matching text block.
+fn build_system(content: &serde_json::Value) -> AnthropicSystem {
+    use crate::non_attested::external::content::text_from_content as extract_content;
+
+    if !content_has_cache_control(content) {
+        return AnthropicSystem::Text(extract_content(content));
+    }
+
+    // Array form with at least one cache_control: emit one text block per
+    // `text` part, attaching its breakpoint. Image parts in a system prompt are
+    // dropped (matching the text-only flattening this path already did).
+    let serde_json::Value::Array(items) = content else {
+        // Not an array but flagged as having cache_control is impossible
+        // (content_has_cache_control only returns true for arrays), but be safe.
+        return AnthropicSystem::Text(extract_content(content));
+    };
+
+    let mut blocks = Vec::new();
+    for item in items {
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+        if obj.get("type").and_then(|t| t.as_str()) != Some("text") {
+            continue;
+        }
+        let Some(text) = obj.get("text").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        blocks.push(AnthropicSystemBlock {
+            type_: "text",
+            text: text.to_string(),
+            cache_control: cache_control_of(item),
+        });
+    }
+
+    if blocks.is_empty() {
+        AnthropicSystem::Text(extract_content(content))
+    } else {
+        AnthropicSystem::Blocks(blocks)
+    }
+}
+
 /// Convert OpenAI messages to Anthropic format
-pub fn convert_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<AnthropicMessage>) {
+pub fn convert_messages(
+    messages: &[ChatMessage],
+) -> (Option<AnthropicSystem>, Vec<AnthropicMessage>) {
     use crate::non_attested::external::content::{
         parse_content, text_from_content as extract_content, ContentPart,
     };
@@ -249,7 +385,7 @@ pub fn convert_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<Anthro
         match msg.role {
             MessageRole::System => {
                 if let Some(content) = &msg.content {
-                    system_message = Some(extract_content(content));
+                    system_message = Some(build_system(content));
                 }
             }
             MessageRole::User => {
@@ -259,24 +395,39 @@ pub fn convert_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<Anthro
                 let parts = msg.content.as_ref().map(parse_content).unwrap_or_default();
 
                 let has_image = parts.iter().any(|p| !matches!(p, ContentPart::Text(_)));
+                // Per-part cache_control breakpoints, forwarded verbatim (#666).
+                // When present we must emit content blocks (the bare-string form
+                // can't carry a breakpoint), even with no image part.
+                let cache_controls = msg
+                    .content
+                    .as_ref()
+                    .map(per_part_cache_controls)
+                    .unwrap_or_default();
+                let has_cache_control = cache_controls.iter().any(Option::is_some);
 
-                if has_image {
+                if has_image || has_cache_control {
                     let mut blocks = Vec::with_capacity(parts.len());
-                    for part in parts {
+                    for (idx, part) in parts.into_iter().enumerate() {
+                        let cc = cache_controls.get(idx).cloned().flatten();
                         match part {
                             ContentPart::Text(text) => {
                                 if !text.is_empty() {
-                                    blocks.push(AnthropicContentPart::Text { text });
+                                    blocks.push(AnthropicContentPart::Text {
+                                        text,
+                                        cache_control: cc,
+                                    });
                                 }
                             }
                             ContentPart::ImageBase64 { media_type, data } => {
                                 blocks.push(AnthropicContentPart::Image {
                                     source: AnthropicImageSource::Base64 { media_type, data },
+                                    cache_control: cc,
                                 });
                             }
                             ContentPart::ImageUrl { url } => {
                                 blocks.push(AnthropicContentPart::Image {
                                     source: AnthropicImageSource::Url { url },
+                                    cache_control: cc,
                                 });
                             }
                         }
@@ -307,7 +458,10 @@ pub fn convert_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<Anthro
                         // Add text content if present
                         if let Some(text) = msg.content.as_ref().map(&extract_content) {
                             if !text.is_empty() {
-                                blocks.push(AnthropicContentPart::Text { text });
+                                blocks.push(AnthropicContentPart::Text {
+                                    text,
+                                    cache_control: None,
+                                });
                             }
                         }
 
@@ -479,6 +633,12 @@ pub struct AnthropicParserState {
     pub created: i64,
     pub input_tokens: i32,
     pub output_tokens: i32,
+    /// Prompt-cache tokens (read + creation) Anthropic charged us for. Reported
+    /// separately from `input_tokens` by Anthropic; we fold them into
+    /// `prompt_tokens` and surface the read portion as `cached_tokens` so the
+    /// existing OpenAI-shaped billing path bills cache reads (#666).
+    cache_read_tokens: i32,
+    cache_creation_tokens: i32,
     tool_calls: HashMap<i64, ActiveToolCall>,
     tool_call_counter: i64,
 }
@@ -491,8 +651,33 @@ impl AnthropicParserState {
             created: chrono::Utc::now().timestamp(),
             input_tokens: 0,
             output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
             tool_calls: HashMap::new(),
             tool_call_counter: 0,
+        }
+    }
+
+    /// Build the prompt-token usage for a streaming chunk.
+    ///
+    /// CRITICAL accounting (#666): Anthropic reports cache reads/creation
+    /// SEPARATELY from `input_tokens`, whereas OpenAI's `cached_tokens` is a
+    /// SUBSET of `prompt_tokens` (and `TokenUsage::cached_tokens()` caps it to
+    /// `[0, prompt_tokens]`). To both preserve that OpenAI invariant AND bill
+    /// the cache-read cost, we ADD the cache tokens into `prompt_tokens` and
+    /// report the read portion as `cached_tokens`.
+    fn prompt_tokens(&self) -> i32 {
+        self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens
+    }
+
+    /// `prompt_tokens_details` for a chunk: `cached_tokens` when there was a
+    /// cache read, else `None` (so an uncached stream is byte-identical to
+    /// before).
+    fn prompt_tokens_details(&self) -> Option<serde_json::Value> {
+        if self.cache_read_tokens > 0 {
+            Some(serde_json::json!({ "cached_tokens": self.cache_read_tokens }))
+        } else {
+            None
         }
     }
 
@@ -522,6 +707,11 @@ impl SSEEventParser for AnthropicEventParser {
             AnthropicStreamEvent::MessageStart { message } => {
                 state.message_id = Some(message.id);
                 state.input_tokens = message.usage.input_tokens;
+                // Cache-token counts are known up front (message_start), like
+                // input_tokens (#666). Capture them so an interrupted stream is
+                // still billed for the cache reads Anthropic charged us for.
+                state.cache_read_tokens = message.usage.cache_read_input_tokens;
+                state.cache_creation_tokens = message.usage.cache_creation_input_tokens;
                 let ctx = state.chunk_context();
                 // Anthropic reports input tokens up front in `message_start`, but
                 // completion tokens only in the final `message_delta`. Carry the
@@ -529,11 +719,12 @@ impl SSEEventParser for AnthropicEventParser {
                 // still billed for the prompt tokens Anthropic charged us for
                 // (completion tokens stay 0 until the final chunk). On a clean
                 // stream the final chunk's full usage overwrites this.
+                let prompt_tokens = state.prompt_tokens();
                 let early_usage = TokenUsage {
-                    prompt_tokens: state.input_tokens,
+                    prompt_tokens,
                     completion_tokens: 0,
-                    total_tokens: state.input_tokens,
-                    prompt_tokens_details: None,
+                    total_tokens: prompt_tokens,
+                    prompt_tokens_details: state.prompt_tokens_details(),
                 };
                 Ok(Some(StreamChunk::Chat(
                     ctx.role_chunk_with_usage(Some(early_usage)),
@@ -593,13 +784,23 @@ impl SSEEventParser for AnthropicEventParser {
 
             AnthropicStreamEvent::MessageDelta { delta, usage } => {
                 state.output_tokens = usage.output_tokens;
+                // The final message_delta usage may also restate the cache
+                // counts; prefer non-zero values so the final chunk carries the
+                // authoritative figures even if message_start was missed (#666).
+                if usage.cache_read_input_tokens > 0 {
+                    state.cache_read_tokens = usage.cache_read_input_tokens;
+                }
+                if usage.cache_creation_input_tokens > 0 {
+                    state.cache_creation_tokens = usage.cache_creation_input_tokens;
+                }
                 let ctx = state.chunk_context();
                 let finish_reason = map_finish_reason(delta.stop_reason);
+                let prompt_tokens = state.prompt_tokens();
                 let token_usage = TokenUsage {
-                    prompt_tokens: state.input_tokens,
+                    prompt_tokens,
                     completion_tokens: state.output_tokens,
-                    total_tokens: state.input_tokens + state.output_tokens,
-                    prompt_tokens_details: None,
+                    total_tokens: prompt_tokens + state.output_tokens,
+                    prompt_tokens_details: state.prompt_tokens_details(),
                 };
                 Ok(Some(StreamChunk::Chat(
                     ctx.finish_chunk(finish_reason, token_usage),
@@ -645,7 +846,11 @@ mod tests {
 
         let (system, anthropic_messages) = convert_messages(&messages);
 
-        assert_eq!(system, Some("You are helpful.".to_string()));
+        // No cache_control -> bare string form (unchanged from pre-#666).
+        match system {
+            Some(AnthropicSystem::Text(s)) => assert_eq!(s, "You are helpful."),
+            other => panic!("expected bare-string system, got {other:?}"),
+        }
         assert_eq!(anthropic_messages.len(), 1);
     }
 
@@ -684,12 +889,13 @@ mod tests {
         assert_eq!(blocks.len(), 2, "expected text + image blocks");
 
         match &blocks[0] {
-            AnthropicContentPart::Text { text } => assert_eq!(text, "Describe this image."),
+            AnthropicContentPart::Text { text, .. } => assert_eq!(text, "Describe this image."),
             other => panic!("expected text block first, got {other:?}"),
         }
         match &blocks[1] {
             AnthropicContentPart::Image {
                 source: AnthropicImageSource::Base64 { media_type, data },
+                ..
             } => {
                 assert_eq!(media_type, "image/png");
                 assert_eq!(data, &payload, "base64 payload must be byte-identical");
@@ -728,6 +934,7 @@ mod tests {
         match &blocks[0] {
             AnthropicContentPart::Image {
                 source: AnthropicImageSource::Url { url },
+                ..
             } => assert_eq!(url, "https://example.com/cat.jpg"),
             other => panic!("expected url image source, got {other:?}"),
         }
@@ -845,5 +1052,285 @@ mod tests {
         assert_eq!(usage.completion_tokens, 0);
         assert_eq!(usage.total_tokens, 42);
         assert_eq!(state.input_tokens, 42);
+    }
+
+    // ── #666: prompt-caching cache_control passthrough + cache-stat surfacing ──
+
+    /// Read `prompt_tokens_details.cached_tokens` off a usage object, or 0.
+    fn cached_tokens_of(usage: &TokenUsage) -> i64 {
+        usage
+            .prompt_tokens_details
+            .as_ref()
+            .and_then(|d| d.get("cached_tokens"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn test_cache_control_on_system_emits_block_array() {
+        // A system message whose text part carries cache_control must serialize
+        // `system` as an array of text blocks with the breakpoint, not a string.
+        let messages = vec![ChatMessage {
+            role: MessageRole::System,
+            content: Some(serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "Large shared preamble",
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (system, _msgs) = convert_messages(&messages);
+        let system = system.expect("system should be present");
+        match &system {
+            AnthropicSystem::Blocks(blocks) => {
+                assert_eq!(blocks.len(), 1);
+                assert_eq!(blocks[0].text, "Large shared preamble");
+                assert_eq!(
+                    blocks[0].cache_control,
+                    Some(serde_json::json!({"type": "ephemeral"}))
+                );
+            }
+            other => panic!("expected block-array system, got {other:?}"),
+        }
+
+        // Serialized request: `system` is an array with the verbatim breakpoint.
+        let json = serde_json::to_value(&system).unwrap();
+        assert!(json.is_array(), "system must serialize as an array");
+        assert_eq!(json[0]["type"], "text");
+        assert_eq!(json[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn test_cache_control_on_user_text_part_appears_in_request() {
+        // A user text part with cache_control forces the block form (even with
+        // no image) and forwards the breakpoint verbatim.
+        let messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "Cached context",
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"}
+                },
+                {"type": "text", "text": "Volatile question"}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, anthropic_messages) = convert_messages(&messages);
+        assert_eq!(anthropic_messages.len(), 1);
+        let blocks = match &anthropic_messages[0].content {
+            AnthropicMessageContent::Blocks(b) => b,
+            AnthropicMessageContent::Text(t) => {
+                panic!("cache_control should force the block form, got text: {t}")
+            }
+        };
+        assert_eq!(blocks.len(), 2);
+        match &blocks[0] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Cached context");
+                assert_eq!(
+                    *cache_control,
+                    Some(serde_json::json!({"type": "ephemeral", "ttl": "1h"}))
+                );
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+        // The volatile part keeps no breakpoint.
+        match &blocks[1] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Volatile question");
+                assert!(cache_control.is_none());
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+
+        // The serialized outgoing request carries the breakpoint verbatim.
+        let json = serde_json::to_string(&anthropic_messages[0]).unwrap();
+        assert!(json.contains("\"cache_control\""));
+        assert!(json.contains("\"ttl\":\"1h\""));
+    }
+
+    #[test]
+    fn test_cache_control_alignment_survives_malformed_part() {
+        // Alignment guard (#666): a malformed `text` part (no `text` field) is
+        // dropped by `parse_content`, so the cache_control list must drop it too —
+        // otherwise the breakpoint would be misattached to the wrong block. The
+        // breakpoint here belongs to "Cached", and "Volatile" must keep none.
+        let messages = vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!([
+                {"type": "text"}, // malformed: dropped by parse_content
+                {
+                    "type": "text",
+                    "text": "Cached",
+                    "cache_control": {"type": "ephemeral"}
+                },
+                {"type": "text", "text": "Volatile"}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        let (_system, anthropic_messages) = convert_messages(&messages);
+        let blocks = match &anthropic_messages[0].content {
+            AnthropicMessageContent::Blocks(b) => b,
+            AnthropicMessageContent::Text(t) => panic!("expected block form, got text: {t}"),
+        };
+        assert_eq!(blocks.len(), 2);
+        match &blocks[0] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Cached");
+                assert_eq!(
+                    *cache_control,
+                    Some(serde_json::json!({"type": "ephemeral"}))
+                );
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+        match &blocks[1] {
+            AnthropicContentPart::Text {
+                text,
+                cache_control,
+            } => {
+                assert_eq!(text, "Volatile");
+                assert!(
+                    cache_control.is_none(),
+                    "breakpoint must not bleed onto the volatile part"
+                );
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_no_cache_control_keeps_bare_string_system() {
+        // Regression guard: a request with NO cache_control must still serialize
+        // `system` as a bare string (no #666 regression for the common case).
+        let messages = vec![
+            ChatMessage {
+                role: MessageRole::System,
+                content: Some(serde_json::Value::String("You are helpful.".to_string())),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+            ChatMessage {
+                role: MessageRole::User,
+                content: Some(serde_json::Value::String("Hello".to_string())),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+        ];
+
+        let (system, anthropic_messages) = convert_messages(&messages);
+        let system = system.expect("system present");
+        assert_eq!(
+            system,
+            AnthropicSystem::Text("You are helpful.".to_string())
+        );
+        let json = serde_json::to_value(&system).unwrap();
+        assert!(
+            json.is_string(),
+            "system must stay a bare string when uncached"
+        );
+
+        // The user message stays the bare-string form too (no block array).
+        match &anthropic_messages[0].content {
+            AnthropicMessageContent::Text(t) => assert_eq!(t, "Hello"),
+            other => panic!("expected bare-string user content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_anthropic_usage_deserializes_cache_fields() {
+        let json = r#"{"input_tokens":100,"output_tokens":20,"cache_read_input_tokens":80,"cache_creation_input_tokens":40}"#;
+        let usage: AnthropicUsage = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 20);
+        assert_eq!(usage.cache_read_input_tokens, 80);
+        assert_eq!(usage.cache_creation_input_tokens, 40);
+    }
+
+    #[test]
+    fn test_anthropic_usage_cache_fields_default_to_zero() {
+        // Absent cache fields default to 0 (older API versions / no caching).
+        let json = r#"{"input_tokens":100,"output_tokens":20}"#;
+        let usage: AnthropicUsage = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.cache_read_input_tokens, 0);
+        assert_eq!(usage.cache_creation_input_tokens, 0);
+    }
+
+    #[test]
+    fn test_streaming_final_chunk_carries_cached_tokens() {
+        // message_start surfaces cache reads; the final message_delta restates
+        // them. Both fold the cache tokens into prompt_tokens and report the
+        // read portion as cached_tokens, preserving cached <= prompt.
+        let mut state = AnthropicParserState::new("claude-test".to_string());
+
+        let start = r#"{"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10,"cache_read_input_tokens":80,"cache_creation_input_tokens":5}}}"#;
+        let chunk = AnthropicEventParser::parse_event(&mut state, start)
+            .unwrap()
+            .expect("message_start should produce a chunk");
+        let StreamChunk::Chat(chat) = chunk else {
+            panic!("expected a chat chunk");
+        };
+        let usage = chat.usage.expect("early usage");
+        // prompt_tokens = input + cache_read + cache_creation = 10 + 80 + 5 = 95.
+        assert_eq!(usage.prompt_tokens, 95);
+        assert_eq!(cached_tokens_of(&usage), 80);
+        assert!(
+            cached_tokens_of(&usage) <= usage.prompt_tokens as i64,
+            "cached_tokens must not exceed prompt_tokens"
+        );
+
+        let delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":30}}"#;
+        let chunk = AnthropicEventParser::parse_event(&mut state, delta)
+            .unwrap()
+            .expect("message_delta should produce a chunk");
+        let StreamChunk::Chat(chat) = chunk else {
+            panic!("expected a chat chunk");
+        };
+        let usage = chat.usage.expect("final usage");
+        assert_eq!(usage.prompt_tokens, 95);
+        assert_eq!(usage.completion_tokens, 30);
+        assert_eq!(usage.total_tokens, 125);
+        assert_eq!(cached_tokens_of(&usage), 80);
+        assert!(cached_tokens_of(&usage) <= usage.prompt_tokens as i64);
+    }
+
+    #[test]
+    fn test_streaming_no_cache_omits_prompt_tokens_details() {
+        // No cache reads -> prompt_tokens_details stays None (no regression).
+        let mut state = AnthropicParserState::new("claude-test".to_string());
+        let start =
+            r#"{"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":42}}}"#;
+        let chunk = AnthropicEventParser::parse_event(&mut state, start)
+            .unwrap()
+            .unwrap();
+        let StreamChunk::Chat(chat) = chunk else {
+            panic!("expected a chat chunk");
+        };
+        let usage = chat.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, 42);
+        assert!(usage.prompt_tokens_details.is_none());
     }
 }

--- a/crates/inference_providers/src/non_attested/external/anthropic/mod.rs
+++ b/crates/inference_providers/src/non_attested/external/anthropic/mod.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use converter::{
     convert_messages, convert_tool_choice, convert_tools, extract_response_content,
     map_finish_reason_string, AnthropicEventParser, AnthropicParserState, AnthropicRequest,
-    AnthropicResponse,
+    AnthropicResponse, AnthropicUsage,
 };
 use futures_util::Stream;
 use reqwest::{header::HeaderValue, Client};
@@ -83,6 +83,33 @@ fn strip_json_code_fence(content: &str) -> String {
         return content.to_string();
     };
     inner.trim().to_string()
+}
+
+/// Map a non-streaming Anthropic `usage` block to OpenAI-shaped [`TokenUsage`].
+///
+/// #666: surface Anthropic prompt-cache stats so the existing billing path
+/// (which reads `usage.cached_tokens()` and bills `cache_read_tokens`) lights
+/// up. CRITICAL accounting: Anthropic reports cache reads and cache creation
+/// SEPARATELY from `input_tokens`, whereas OpenAI's `cached_tokens` is a SUBSET
+/// of `prompt_tokens` (and `TokenUsage::cached_tokens()` caps it to
+/// `[0, prompt_tokens]`). To preserve that invariant AND bill the cache-read
+/// cost, we ADD both cache figures into `prompt_tokens` and report the read
+/// portion as `cached_tokens`. When there is no cache read, `prompt_tokens_details`
+/// stays `None` so an uncached response is byte-identical to before.
+fn map_usage(usage: &AnthropicUsage) -> TokenUsage {
+    let prompt_tokens =
+        usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+    let prompt_tokens_details = if usage.cache_read_input_tokens > 0 {
+        Some(serde_json::json!({ "cached_tokens": usage.cache_read_input_tokens }))
+    } else {
+        None
+    };
+    TokenUsage {
+        prompt_tokens,
+        completion_tokens: usage.output_tokens,
+        total_tokens: prompt_tokens + usage.output_tokens,
+        prompt_tokens_details,
+    }
 }
 
 /// Pick the allowlisted reasoning-control fields out of `extra`.
@@ -347,13 +374,7 @@ impl ExternalBackend for AnthropicBackend {
             }],
             service_tier: None,
             system_fingerprint: None,
-            usage: TokenUsage {
-                prompt_tokens: anthropic_response.usage.input_tokens,
-                completion_tokens: anthropic_response.usage.output_tokens,
-                total_tokens: anthropic_response.usage.input_tokens
-                    + anthropic_response.usage.output_tokens,
-                prompt_tokens_details: None,
-            },
+            usage: map_usage(&anthropic_response.usage),
             prompt_logprobs: None,
             prompt_token_ids: None,
             kv_transfer_params: None,
@@ -730,6 +751,47 @@ mod tests {
     fn test_strip_json_code_fence_passes_through_raw_json() {
         let raw = "{\"city\":\"Paris\"}";
         assert_eq!(strip_json_code_fence(raw), raw);
+    }
+
+    // ── #666: non-streaming usage maps cache reads -> cached_tokens ──────────
+
+    #[test]
+    fn test_map_usage_folds_cache_into_prompt_tokens() {
+        // Anthropic reports cache reads/creation separately from input_tokens.
+        // map_usage adds them into prompt_tokens and reports the read portion as
+        // cached_tokens, so cached <= prompt holds and the cache read is billed.
+        let usage = AnthropicUsage {
+            input_tokens: 10,
+            output_tokens: 30,
+            cache_read_input_tokens: 80,
+            cache_creation_input_tokens: 5,
+        };
+        let mapped = map_usage(&usage);
+
+        // prompt_tokens = 10 + 80 + 5 = 95.
+        assert_eq!(mapped.prompt_tokens, 95);
+        assert_eq!(mapped.completion_tokens, 30);
+        assert_eq!(mapped.total_tokens, 125);
+        // cached_tokens surfaced via prompt_tokens_details, and clamped helper
+        // confirms the invariant cached <= prompt.
+        assert_eq!(mapped.cached_tokens(), 80);
+        assert!(mapped.cached_tokens() <= mapped.prompt_tokens);
+    }
+
+    #[test]
+    fn test_map_usage_no_cache_omits_details() {
+        // No cache reads -> prompt_tokens_details stays None (no regression).
+        let usage = AnthropicUsage {
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+        };
+        let mapped = map_usage(&usage);
+        assert_eq!(mapped.prompt_tokens, 100);
+        assert_eq!(mapped.total_tokens, 120);
+        assert!(mapped.prompt_tokens_details.is_none());
+        assert_eq!(mapped.cached_tokens(), 0);
     }
 
     #[tokio::test]

--- a/crates/inference_providers/src/non_attested/external/anthropic/mod.rs
+++ b/crates/inference_providers/src/non_attested/external/anthropic/mod.rs
@@ -3,7 +3,7 @@
 //! This backend handles HTTP communication with Anthropic's Messages API.
 //! Format conversion is handled by the `anthropic_converter` module.
 
-mod converter;
+pub mod converter;
 
 use super::backend::{BackendConfig, ExternalBackend};
 use crate::{

--- a/crates/inference_providers/src/non_attested/external/content.rs
+++ b/crates/inference_providers/src/non_attested/external/content.rs
@@ -60,7 +60,7 @@ pub fn parse_content(value: &serde_json::Value) -> Vec<ContentPart> {
     }
 }
 
-fn parse_content_part(item: &serde_json::Value) -> Option<ContentPart> {
+pub(crate) fn parse_content_part(item: &serde_json::Value) -> Option<ContentPart> {
     let obj = item.as_object()?;
 
     match obj.get("type").and_then(|t| t.as_str()) {

--- a/crates/inference_providers/src/non_attested/external/openai_compatible.rs
+++ b/crates/inference_providers/src/non_attested/external/openai_compatible.rs
@@ -182,6 +182,10 @@ impl ExternalBackend for OpenAiCompatibleBackend {
 
         // Ensure streaming and usage are enabled
         let mut streaming_params = params;
+        // #666: drop Anthropic prompt-caching breakpoints — they ride on the API
+        // model's content parts but openai_compatible upstreams (OpenAI, Azure,
+        // Together, …) may 400 on an unknown `cache_control` content-part field.
+        crate::strip_cache_control(&mut streaming_params.messages);
         streaming_params.model = model.to_string();
         streaming_params.stream = Some(true);
         streaming_params.stream_options = Some(StreamOptions {
@@ -251,6 +255,9 @@ impl ExternalBackend for OpenAiCompatibleBackend {
 
         // Ensure non-streaming
         let mut non_streaming_params = params;
+        // #666: drop Anthropic prompt-caching breakpoints before forwarding (see
+        // the streaming path for the rationale).
+        crate::strip_cache_control(&mut non_streaming_params.messages);
         non_streaming_params.model = model.to_string();
         non_streaming_params.stream = Some(false);
 
@@ -1007,6 +1014,41 @@ mod tests {
         ));
         // malformed URL → not OpenAI-source (and never panics)
         assert!(!is_openai_source("not a url"));
+    }
+
+    /// #666 NO-LEAK at the openai_compatible serialization boundary: the strip
+    /// the backend applies before `.json(&params)` must leave NO `cache_control`
+    /// in the bytes sent to an openai_compatible upstream (OpenAI may 400 on an
+    /// unknown content-part field). Build params with a breakpoint, strip, then
+    /// serialize exactly as the backend does.
+    #[test]
+    fn test_cache_control_stripped_before_serializing_to_openai() {
+        let mut params = make_chat_params(None, None);
+        params.messages = vec![crate::ChatMessage {
+            role: crate::MessageRole::User,
+            content: Some(serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "Cached context",
+                    "cache_control": {"type": "ephemeral"}
+                },
+                {"type": "text", "text": "Volatile"}
+            ])),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+
+        // The exact strip the backend runs before `.json(&streaming_params)`.
+        crate::strip_cache_control(&mut params.messages);
+
+        let wire = serde_json::to_string(&params).unwrap();
+        assert!(
+            !wire.contains("cache_control"),
+            "cache_control must not reach an openai_compatible upstream: {wire}"
+        );
+        assert!(wire.contains("Cached context"));
+        assert!(wire.contains("Volatile"));
     }
 
     /// A look-alike host must keep the sampling knobs (we only strip for the


### PR DESCRIPTION
## Summary

Fixes #666. Anthropic prompt caching was silently broken in the external Anthropic backend: incoming `cache_control` breakpoints were dropped on the request side, and Anthropic's cache-usage stats were never surfaced in the response usage. The billing/pricing plumbing already records `cache_read_tokens` from `usage.cached_tokens()` (issue #601), so this only needed the converter to populate `prompt_tokens_details.cached_tokens`.

## Request side
- Add an optional `cache_control` to `AnthropicContentPart::Text` and `::Image`, forwarded **verbatim** from the caller's OpenAI content part (Anthropic's `{"type":"ephemeral"}` shape). Parsed locally from the raw message JSON in the converter rather than widening the shared `ContentPart` enum (keeps the Gemini path untouched).
- `system`: emit an array of text blocks (with `cache_control`) when the system message carries a breakpoint; keep the bare-string form otherwise so the common uncached request is **byte-identical** to before.
- Per-part breakpoints are aligned 1:1 with the parsed content blocks by reusing `parse_content_part` as the recognizer, so alignment holds even for malformed parts.

## Response side
- Extend `AnthropicUsage` with `cache_read_input_tokens` / `cache_creation_input_tokens` (default 0).
- Non-streaming and streaming both fold the cache tokens into `prompt_tokens` and report the read portion as `prompt_tokens_details.cached_tokens`. Anthropic reports cache reads **separately** from `input_tokens`, whereas OpenAI's `cached_tokens` is a **subset** of `prompt_tokens`; folding them in preserves the `cached <= prompt` invariant (which `TokenUsage::cached_tokens()` clamps to) and bills the cache-read cost via the existing path.

## Tests
11 new unit tests (cache_control on system + user text parts, malformed-part alignment regression, usage deserialization/defaults, non-streaming + streaming cached-token mapping, and the no-regression bare-string system case). Full crate suite green; clippy `-D warnings` clean.

```
cargo test  -p inference_providers   # 353 passed / 0 failed / 1 ignored
cargo clippy -p inference_providers --all-targets --all-features -- -D warnings   # clean
cargo build -p inference_providers && cargo build -p api   # ok
```

## Notes / out of scope
- Surfacing Anthropic reasoning/`thinking` output as `reasoning_content`, and OpenAI `completion_tokens_details.reasoning_tokens` — separate concerns, left out.
- `cache_creation_input_tokens` is folded into `prompt_tokens` (billed at the normal input rate). There is no OpenAI-shaped slot for cache-write tokens; surfacing cache-write cost at Anthropic's premium rate would require billing-side changes and is left as a follow-up.
