### PR TITLE
fix(anthropic): return requested model name in non-streaming responses for transport consistency (#632)

### DIFF
--- a/crates/inference_providers/src/non_attested/external/anthropic/converter.rs
+++ b/crates/inference_providers/src/non_attested/external/anthropic/converter.rs
@@ -227,6 +227,13 @@ pub struct AnthropicError {
 pub struct AnthropicResponse {
     pub id: String,
     pub content: Vec<AnthropicContentBlock>,
+    // #632: Anthropic returns the upstream dated canonical name here (e.g.
+    // `claude-haiku-4-5-20251001`). We deserialize it for completeness/parity
+    // with the wire payload, but intentionally do NOT surface it on our
+    // response: the non-streaming path echoes the requested/sent model name to
+    // stay consistent with the streaming path (which never sees this field).
+    // Hence it is read only in tests; allow dead_code in non-test builds.
+    #[allow(dead_code)]
     pub model: String,
     pub stop_reason: Option<String>,
     pub usage: AnthropicUsage,

--- a/crates/inference_providers/src/non_attested/external/anthropic/mod.rs
+++ b/crates/inference_providers/src/non_attested/external/anthropic/mod.rs
@@ -95,6 +95,77 @@ fn extract_passthrough(
         .collect()
 }
 
+/// Build our normalized OpenAI-shaped response from a parsed Anthropic
+/// non-streaming response.
+///
+/// `sent_model` is the model name cloud-api sent to Anthropic (the `model`
+/// argument threaded through the backend call), NOT `anthropic_response.model`.
+///
+/// #632: the response `model` field uses the requested/sent model name to stay
+/// consistent with the streaming path, which seeds its chunk model from the
+/// same sent name (see `AnthropicParserState::new` in `converter.rs`).
+/// Upstream's dated canonical name (e.g. `claude-haiku-4-5-20251001`) is
+/// intentionally NOT surfaced, so both transports echo the same value for an
+/// identical request.
+fn build_openai_response(
+    anthropic_response: AnthropicResponse,
+    sent_model: &str,
+    wants_json: bool,
+) -> ChatCompletionResponse {
+    // Convert to OpenAI format using the converter
+    let (content, tool_calls) = extract_response_content(&anthropic_response.content);
+
+    // #668: Anthropic has no native JSON-output mode, so when the caller
+    // requested `response_format: json_object`/`json_schema` it tends to
+    // wrap the JSON in a markdown ```json … ``` fence, breaking
+    // `JSON.parse`. Strip that fence so the content is raw parseable JSON.
+    let content = if wants_json {
+        content.map(|c| strip_json_code_fence(&c))
+    } else {
+        content
+    };
+
+    ChatCompletionResponse {
+        id: anthropic_response.id,
+        object: "chat.completion".to_string(),
+        created: chrono::Utc::now().timestamp(),
+        // #632: echo the requested/sent model name (not upstream's dated name)
+        // so non-streaming matches the streaming path for the same request.
+        model: sent_model.to_string(),
+        choices: vec![ChatCompletionResponseChoice {
+            index: 0,
+            message: ChatResponseMessage {
+                role: MessageRole::Assistant,
+                content,
+                refusal: None,
+                annotations: None,
+                audio: None,
+                function_call: None,
+                tool_calls,
+                reasoning_content: None,
+                reasoning: None,
+            },
+            logprobs: None,
+            finish_reason: map_finish_reason_string(anthropic_response.stop_reason),
+            token_ids: None,
+            extra: Default::default(),
+        }],
+        service_tier: None,
+        system_fingerprint: None,
+        usage: TokenUsage {
+            prompt_tokens: anthropic_response.usage.input_tokens,
+            completion_tokens: anthropic_response.usage.output_tokens,
+            total_tokens: anthropic_response.usage.input_tokens
+                + anthropic_response.usage.output_tokens,
+            prompt_tokens_details: None,
+        },
+        prompt_logprobs: None,
+        prompt_token_ids: None,
+        kv_transfer_params: None,
+        extra: Default::default(),
+    }
+}
+
 /// Anthropic backend - handles HTTP communication with Anthropic's API
 pub struct AnthropicBackend {
     client: Client,
@@ -309,56 +380,8 @@ impl ExternalBackend for AnthropicBackend {
                 CompletionError::CompletionError(format!("Failed to parse response: {e}"))
             })?;
 
-        // Convert to OpenAI format using the converter
-        let (content, tool_calls) = extract_response_content(&anthropic_response.content);
-
-        // #668: Anthropic has no native JSON-output mode, so when the caller
-        // requested `response_format: json_object`/`json_schema` it tends to
-        // wrap the JSON in a markdown ```json … ``` fence, breaking
-        // `JSON.parse`. Strip that fence so the content is raw parseable JSON.
-        let content = if wants_json_output(&params.extra) {
-            content.map(|c| strip_json_code_fence(&c))
-        } else {
-            content
-        };
-
-        let openai_response = ChatCompletionResponse {
-            id: anthropic_response.id,
-            object: "chat.completion".to_string(),
-            created: chrono::Utc::now().timestamp(),
-            model: anthropic_response.model,
-            choices: vec![ChatCompletionResponseChoice {
-                index: 0,
-                message: ChatResponseMessage {
-                    role: MessageRole::Assistant,
-                    content,
-                    refusal: None,
-                    annotations: None,
-                    audio: None,
-                    function_call: None,
-                    tool_calls,
-                    reasoning_content: None,
-                    reasoning: None,
-                },
-                logprobs: None,
-                finish_reason: map_finish_reason_string(anthropic_response.stop_reason),
-                token_ids: None,
-                extra: Default::default(),
-            }],
-            service_tier: None,
-            system_fingerprint: None,
-            usage: TokenUsage {
-                prompt_tokens: anthropic_response.usage.input_tokens,
-                completion_tokens: anthropic_response.usage.output_tokens,
-                total_tokens: anthropic_response.usage.input_tokens
-                    + anthropic_response.usage.output_tokens,
-                prompt_tokens_details: None,
-            },
-            prompt_logprobs: None,
-            prompt_token_ids: None,
-            kv_transfer_params: None,
-            extra: Default::default(),
-        };
+        let openai_response =
+            build_openai_response(anthropic_response, model, wants_json_output(&params.extra));
 
         // Serialize our normalized response. We intentionally overwrite fields
         // like `usage` (and any future cost-related fields derived from it) instead of passing
@@ -730,6 +753,65 @@ mod tests {
     fn test_strip_json_code_fence_passes_through_raw_json() {
         let raw = "{\"city\":\"Paris\"}";
         assert_eq!(strip_json_code_fence(raw), raw);
+    }
+
+    // ── #632: non-streaming response echoes the SENT model name ─────────────
+
+    /// Build a minimal Anthropic non-streaming response whose `model` field is
+    /// the upstream dated canonical name, as Anthropic actually returns.
+    fn make_anthropic_response(upstream_dated_model: &str) -> AnthropicResponse {
+        serde_json::from_value(serde_json::json!({
+            "id": "msg_test_632",
+            "model": upstream_dated_model,
+            "stop_reason": "end_turn",
+            "content": [{ "type": "text", "text": "Hello" }],
+            "usage": { "input_tokens": 3, "output_tokens": 1 }
+        }))
+        .expect("test AnthropicResponse should deserialize")
+    }
+
+    #[test]
+    fn test_non_streaming_response_model_is_sent_name_not_upstream_dated() {
+        // For the SAME request, streaming echoes the SENT name (the `model` arg
+        // threaded into the backend, seeded into AnthropicParserState), while
+        // Anthropic's non-streaming JSON carries the UPSTREAM dated name. Plan A
+        // for #632 makes non-streaming match streaming: the response `model`
+        // must be the sent name, not the upstream dated name.
+        let sent = "claude-haiku-4-5";
+        let upstream_dated = "claude-haiku-4-5-20251001";
+
+        let anthropic_response = make_anthropic_response(upstream_dated);
+        // Sanity: the parsed upstream payload really carries the dated name, so
+        // this test would catch a regression that surfaces it.
+        assert_eq!(anthropic_response.model, upstream_dated);
+
+        let openai_response = build_openai_response(anthropic_response, sent, false);
+
+        assert_eq!(
+            openai_response.model, sent,
+            "non-streaming response must echo the SENT model name (transport consistency, #632)"
+        );
+        assert_ne!(
+            openai_response.model, upstream_dated,
+            "non-streaming response must NOT surface upstream's dated canonical name"
+        );
+    }
+
+    #[test]
+    fn test_non_streaming_response_model_matches_streaming_seed() {
+        // The streaming path seeds its per-chunk `model` from the same sent name
+        // via AnthropicParserState::new(model). Confirm the non-streaming helper
+        // and the streaming parser state agree on the model echoed for an
+        // identical request, regardless of what upstream returned (#632).
+        let sent = "claude-sonnet-4-5";
+        let upstream_dated = "claude-sonnet-4-5-20250929";
+
+        let non_streaming =
+            build_openai_response(make_anthropic_response(upstream_dated), sent, false);
+        let streaming_state = AnthropicParserState::new(sent.to_string());
+
+        assert_eq!(non_streaming.model, streaming_state.model);
+        assert_eq!(non_streaming.model, sent);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #632 (the internal transport-inconsistency part; "Plan A"). For the same chat-completions request to an Anthropic-backed external model, the response `model` field differed by transport:
- **non-streaming** echoed the upstream dated canonical name (e.g. `claude-haiku-4-5-20251001`)
- **streaming** echoed the name we sent (e.g. `claude-haiku-4-5`)

The streaming path seeds `AnthropicParserState.model` from the sent model arg and never deserializes the upstream name, so it already returns the sent name. This change makes the **non-streaming** path do the same: the response `model` now uses the requested/sent model name, and upstream's dated suffix is intentionally not surfaced. Both transports now echo the same value for an identical request.

## Implementation
- Extract the non-streaming response construction into a pure `build_openai_response(anthropic_response, sent_model, wants_json)` helper so the model-echo behavior is unit-testable without HTTP/infra. The only behavioral delta is `model`: `anthropic_response.model` → `sent_model.to_string()`.
- `AnthropicResponse.model` is now read only in tests; kept (with a comment) for wire-parity, marked `#[allow(dead_code)]` to keep clippy `-D warnings` clean.

## Scope / alias-transparency (#573)
This is the **minimal** consistency fix only. Broader global model-name normalization across all backends/transports (the issue's "Plan B") is intentionally **out of scope** and left for separate discussion.

The #573 alias-transparency contract is intact: the override e2e assertions in `model_alias_transparency.rs` (`body["model"] == upstream`) exercise the **openai_compatible mock** backend (not Anthropic), and for the override case the sent/effective model name equals the upstream override string — so those assertions are unaffected.

## Tests
```
cargo test  -p inference_providers   # 345 passed / 0 failed / 1 ignored  (+2 new #632 tests)
cargo clippy -p inference_providers --all-targets --all-features -- -D warnings   # clean
cargo build -p inference_providers && cargo build -p api   # ok
```
The `crates/api` e2e alias suite could not be executed locally due to a pre-existing shared-DB migration mismatch (the shared `platform_api_e2e` DB has recorded `V63__add_allow_free_to_models`, which isn't on `main`); this is environment state, unrelated to this change, which touches only the Anthropic backend.
