### PR TITLE
feat: revenue density $/min units + provider_type filter

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3630,6 +3630,8 @@ pub async fn get_performance_timeseries(
 pub struct RevenueDensityParams {
     pub start: Option<String>,
     pub end: Option<String>,
+    /// Optional provider type filter (e.g. "nearai", "external").
+    pub provider_type: Option<String>,
 }
 
 /// Get revenue density percentiles (Admin only)
@@ -3656,7 +3658,11 @@ pub async fn get_revenue_density(
 
     let result = app_state
         .analytics_service
-        .get_revenue_density(services::admin::RevenueDensityQuery { start, end })
+        .get_revenue_density(services::admin::RevenueDensityQuery {
+            start,
+            end,
+            provider_type: params.provider_type,
+        })
         .await
         .map_err(|e| {
             error!("Failed to get revenue density: {:?}", e);

--- a/crates/database/src/repositories/analytics.rs
+++ b/crates/database/src/repositories/analytics.rs
@@ -1076,40 +1076,46 @@ impl AnalyticsRepository for PgAnalyticsRepository {
             .await
             .map_err(|e| RepositoryError::PoolError(e.into()))?;
 
+        const NANO_TO_USD: f64 = 1.0 / 1_000_000_000.0;
+        // 1 minute × 60 min/h × 24 h/d × 365 d/yr
+        const YEAR_MINUTES: f64 = 60.0 * 24.0 * 365.0;
+
         // ── Platform-wide percentiles ─────────────────────────────────────────
-        // Inner CTE: one row per minute bucket with sum(cost)/60 = nano-USD/s.
+        // Inner CTE: one row per minute bucket with sum(cost) = nano-USD/min.
         // Outer query: PERCENTILE_CONT + MAX over active minutes only (cost > 0).
         let platform_row = client
             .query_one(
                 r#"
                 WITH per_minute AS (
                     SELECT
-                        DATE_TRUNC('minute', created_at)    AS bucket,
-                        SUM(total_cost)::float8 / 60.0      AS revenue_per_sec
-                    FROM organization_usage_log
-                    WHERE created_at >= $1
-                      AND created_at < $2
+                        DATE_TRUNC('minute', ul.created_at) AS bucket,
+                        SUM(ul.total_cost)::float8          AS revenue_per_min
+                    FROM organization_usage_log ul
+                    LEFT JOIN models m ON m.id = ul.model_id
+                    WHERE ul.created_at >= $1
+                      AND ul.created_at < $2
+                      AND ($3::text IS NULL OR m.provider_type = $3)
                     GROUP BY 1
                 )
                 SELECT
                     COALESCE(
-                        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY revenue_per_sec)
-                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY revenue_per_min)
+                            FILTER (WHERE revenue_per_min > 0), 0.0
                     )::float8 AS p50,
                     COALESCE(
-                        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY revenue_per_sec)
-                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY revenue_per_min)
+                            FILTER (WHERE revenue_per_min > 0), 0.0
                     )::float8 AS p95,
                     COALESCE(
-                        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY revenue_per_sec)
-                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY revenue_per_min)
+                            FILTER (WHERE revenue_per_min > 0), 0.0
                     )::float8 AS p99,
-                    COALESCE(MAX(revenue_per_sec), 0.0)::float8              AS peak,
-                    COUNT(*) FILTER (WHERE revenue_per_sec > 0)::bigint       AS active_minutes,
+                    COALESCE(MAX(revenue_per_min), 0.0)::float8              AS peak,
+                    COUNT(*) FILTER (WHERE revenue_per_min > 0)::bigint       AS active_minutes,
                     COUNT(*)::bigint                                           AS sampled_minutes
                 FROM per_minute
                 "#,
-                &[&query.start, &query.end],
+                &[&query.start, &query.end, &query.provider_type],
             )
             .await
             .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
@@ -1120,9 +1126,6 @@ impl AnalyticsRepository for PgAnalyticsRepository {
         let peak_nano: f64 = platform_row.get(3);
         let active_minutes: i64 = platform_row.get(4);
         let sampled_minutes: i64 = platform_row.get(5);
-
-        const NANO_TO_USD: f64 = 1.0 / 1_000_000_000.0;
-        const YEAR_SECONDS: f64 = 86400.0 * 365.0;
 
         let p50 = p50_nano * NANO_TO_USD;
         let p95 = p95_nano * NANO_TO_USD;
@@ -1135,36 +1138,38 @@ impl AnalyticsRepository for PgAnalyticsRepository {
                 r#"
                 WITH per_minute AS (
                     SELECT
-                        model_name,
-                        DATE_TRUNC('minute', created_at)    AS bucket,
-                        SUM(total_cost)::float8 / 60.0      AS revenue_per_sec
-                    FROM organization_usage_log
-                    WHERE created_at >= $1
-                      AND created_at < $2
+                        ul.model_name,
+                        DATE_TRUNC('minute', ul.created_at) AS bucket,
+                        SUM(ul.total_cost)::float8          AS revenue_per_min
+                    FROM organization_usage_log ul
+                    LEFT JOIN models m ON m.id = ul.model_id
+                    WHERE ul.created_at >= $1
+                      AND ul.created_at < $2
+                      AND ($3::text IS NULL OR m.provider_type = $3)
                     GROUP BY 1, 2
                 )
                 SELECT
                     model_name,
                     COALESCE(
-                        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY revenue_per_sec)
-                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                        PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY revenue_per_min)
+                            FILTER (WHERE revenue_per_min > 0), 0.0
                     )::float8 AS p50,
                     COALESCE(
-                        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY revenue_per_sec)
-                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY revenue_per_min)
+                            FILTER (WHERE revenue_per_min > 0), 0.0
                     )::float8 AS p95,
                     COALESCE(
-                        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY revenue_per_sec)
-                            FILTER (WHERE revenue_per_sec > 0), 0.0
+                        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY revenue_per_min)
+                            FILTER (WHERE revenue_per_min > 0), 0.0
                     )::float8 AS p99,
-                    COALESCE(MAX(revenue_per_sec), 0.0)::float8              AS peak,
-                    COUNT(*) FILTER (WHERE revenue_per_sec > 0)::bigint       AS active_minutes,
-                    SUM(revenue_per_sec * 60.0)::float8                       AS total_cost_nano
+                    COALESCE(MAX(revenue_per_min), 0.0)::float8              AS peak,
+                    COUNT(*) FILTER (WHERE revenue_per_min > 0)::bigint       AS active_minutes,
+                    SUM(revenue_per_min)::float8                              AS total_cost_nano
                 FROM per_minute
                 GROUP BY model_name
                 ORDER BY total_cost_nano DESC
                 "#,
-                &[&query.start, &query.end],
+                &[&query.start, &query.end, &query.provider_type],
             )
             .await
             .map_err(|e| RepositoryError::DatabaseError(e.into()))?;
@@ -1178,12 +1183,12 @@ impl AnalyticsRepository for PgAnalyticsRepository {
                 let model_peak = row.get::<_, f64>(4) * NANO_TO_USD;
                 RevenueDensityModelRow {
                     model_name: row.get(0),
-                    p50_usd_per_sec: model_p50,
-                    p95_usd_per_sec: model_p95,
-                    p99_usd_per_sec: model_p99,
-                    peak_usd_per_sec: model_peak,
-                    p99_annualized_usd: model_p99 * YEAR_SECONDS,
-                    peak_annualized_usd: model_peak * YEAR_SECONDS,
+                    p50_usd_per_min: model_p50,
+                    p95_usd_per_min: model_p95,
+                    p99_usd_per_min: model_p99,
+                    peak_usd_per_min: model_peak,
+                    p99_annualized_usd: model_p99 * YEAR_MINUTES,
+                    peak_annualized_usd: model_peak * YEAR_MINUTES,
                     active_minutes: row.get(5),
                 }
             })
@@ -1194,12 +1199,12 @@ impl AnalyticsRepository for PgAnalyticsRepository {
             period_end: query.end,
             sampled_minutes,
             active_minutes,
-            p50_usd_per_sec: p50,
-            p95_usd_per_sec: p95,
-            p99_usd_per_sec: p99,
-            peak_usd_per_sec: peak,
-            p99_annualized_usd: p99 * YEAR_SECONDS,
-            peak_annualized_usd: peak * YEAR_SECONDS,
+            p50_usd_per_min: p50,
+            p95_usd_per_min: p95,
+            p99_usd_per_min: p99,
+            peak_usd_per_min: peak,
+            p99_annualized_usd: p99 * YEAR_MINUTES,
+            peak_annualized_usd: peak * YEAR_MINUTES,
             by_model,
         })
     }

--- a/crates/services/src/admin/analytics.rs
+++ b/crates/services/src/admin/analytics.rs
@@ -422,23 +422,23 @@ pub struct PerformanceTimeseries {
 
 /// Per-model revenue density row.
 ///
-/// All rate fields are in USD/second, derived from 1-minute buckets.
+/// All rate fields are in USD/minute, derived from 1-minute buckets.
 /// Percentiles are computed over **active minutes only** (buckets with >0 revenue)
 /// to reflect the rate during actual serving windows, not idle time.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RevenueDensityModelRow {
     pub model_name: String,
-    /// P50 revenue rate during active minutes, USD/s
-    pub p50_usd_per_sec: f64,
-    /// P95 revenue rate during active minutes, USD/s
-    pub p95_usd_per_sec: f64,
-    /// P99 revenue rate during active minutes, USD/s
-    pub p99_usd_per_sec: f64,
-    /// Maximum observed revenue rate, USD/s
-    pub peak_usd_per_sec: f64,
-    /// Annualized revenue if p99 rate were constant: p99 × 86400 × 365, USD
+    /// P50 revenue rate during active minutes, USD/min
+    pub p50_usd_per_min: f64,
+    /// P95 revenue rate during active minutes, USD/min
+    pub p95_usd_per_min: f64,
+    /// P99 revenue rate during active minutes, USD/min
+    pub p99_usd_per_min: f64,
+    /// Maximum observed revenue rate, USD/min
+    pub peak_usd_per_min: f64,
+    /// Annualized revenue if p99 rate were constant: p99 × 60 × 24 × 365, USD
     pub p99_annualized_usd: f64,
-    /// Annualized revenue if peak rate were constant: peak × 86400 × 365, USD
+    /// Annualized revenue if peak rate were constant: peak × 60 × 24 × 365, USD
     pub peak_annualized_usd: f64,
     /// Number of 1-minute buckets with revenue > 0 in the period
     pub active_minutes: i64,
@@ -454,10 +454,10 @@ pub struct RevenueDensityReport {
     /// Buckets with any revenue > 0
     pub active_minutes: i64,
     // Platform-wide percentiles (over active minutes, all models combined)
-    pub p50_usd_per_sec: f64,
-    pub p95_usd_per_sec: f64,
-    pub p99_usd_per_sec: f64,
-    pub peak_usd_per_sec: f64,
+    pub p50_usd_per_min: f64,
+    pub p95_usd_per_min: f64,
+    pub p99_usd_per_min: f64,
+    pub peak_usd_per_min: f64,
     pub p99_annualized_usd: f64,
     pub peak_annualized_usd: f64,
     /// Per-model breakdown, sorted by total consumed cost DESC
@@ -469,6 +469,8 @@ pub struct RevenueDensityReport {
 pub struct RevenueDensityQuery {
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
+    /// Optional provider_type filter (e.g. "nearai", "external").
+    pub provider_type: Option<String>,
 }
 
 /// Query params for the performance timeseries endpoint.


### PR DESCRIPTION
## Summary
- Renames all `*_usd_per_sec` struct fields to `*_usd_per_min`: a 1-minute bucket sum is naturally USD/min with no division needed
- Adds `provider_type: Option<String>` to `RevenueDensityQuery`; both the platform-wide and per-model SQL queries `LEFT JOIN models m ON m.id = ul.model_id` and apply `$3::text IS NULL OR m.provider_type = $3`
- Annualization constant updated: `YEAR_MINUTES = 60 × 24 × 365 = 525 600`; result is numerically identical to the prior `p99_per_sec × 86400 × 365`
- `RevenueDensityParams` in the handler gains `provider_type: Option<String>` and passes it through

## Test plan
- [ ] `cargo check` / `cargo fmt --check` / `cargo clippy` clean
- [ ] `cargo test --lib --bins` passes
- [ ] `cargo test --test e2e_test` passes
- [ ] `GET /admin/platform/revenue-density?provider_type=nearai` returns only nearai models in `by_model`
- [ ] Without `provider_type`, all models returned as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)