### PR TITLE
ci: install gh CLI on self-hosted runner in promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -52,10 +52,10 @@ jobs:
           username: ${{ vars.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
-      - name: Install skopeo and jq
+      - name: Install skopeo, jq, and gh
         run: |
           sudo apt-get update
-          sudo apt-get install -y skopeo jq
+          sudo apt-get install -y skopeo jq gh
 
       # Resolve the source digest BEFORE copying to :prod. This avoids the
       # inspect-after-write race where reading back :prod could in theory hit a
@@ -66,6 +66,10 @@ jobs:
         run: |
           set -euo pipefail
           DIGEST_INPUT="${{ inputs.digest }}"
+          if [ -n "$DIGEST_INPUT" ] && ! echo "$DIGEST_INPUT" | grep -qE '^sha256:[a-f0-9]{64}$'; then
+            echo "::error::digest input must be 'sha256:<64 hex chars>', got: '${DIGEST_INPUT}'"
+            exit 1
+          fi
           if [ -n "$DIGEST_INPUT" ]; then
             echo "Promoting by digest: ${DIGEST_INPUT}"
             SOURCE="${{ env.IMAGE }}@${DIGEST_INPUT}"


### PR DESCRIPTION
## Summary

- The promote workflow was migrated to `[self-hosted, infra]` runners in #820, but self-hosted runners don't have `gh` CLI pre-installed (unlike GitHub-hosted `ubuntu-latest`). The `Create GitHub release` step was failing with `gh: command not found`.
- Add `gh` to the `apt-get install` step (same pattern as the rust toolchain fix in security-audit.yml in #820).
- Bonus: add fast-fail digest format validation — the previous two runs failed because `inputs.digest` received `"promote"` instead of a real `sha256:...` digest; the new guard catches that immediately.

## Test plan

- [ ] Merge and re-run promote workflow — `Create GitHub release` step should succeed
- [ ] Try triggering with a bad digest (e.g. `promote`) — should fail at `Resolve source digest and SHA` with a clear error before touching Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)