### PR TITLE
ci: skip tests on PRs without Rust changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,20 @@ name: Tests
 on:
   push:
     branches: [ main, develop ]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'crates/database/src/migrations/**'
+      - '.github/workflows/test.yml'
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'crates/database/src/migrations/**'
+      - '.github/workflows/test.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Adds a `paths` filter to `test.yml` so the lint + test suite only runs when Rust-relevant files change:

- `**/*.rs` — Rust source
- `**/Cargo.toml` / `**/Cargo.lock` — dependency manifests
- `crates/database/src/migrations/**` — SQL migrations
- `.github/workflows/test.yml` — the workflow itself

PRs that only touch docs, `.github/`, `config/`, `Dockerfile`, etc. will skip CI entirely.