### PR TITLE
fix(ci): set use_anthropic=false and correct LLM URL for OCR

### DIFF
--- a/.github/workflows/open-code-review.yml
+++ b/.github/workflows/open-code-review.yml
@@ -59,6 +59,10 @@ jobs:
           ocr config set llm.url "${{ secrets.OCR_LLM_URL }}"
           ocr config set llm.auth_token "${{ secrets.OCR_LLM_AUTH_TOKEN }}"
           ocr config set llm.model "${{ secrets.OCR_LLM_MODEL }}"
+          ocr config set llm.use_anthropic false
+
+      - name: Test LLM connectivity
+        run: ocr llm test
 
       - name: Run OpenCodeReview
         id: review
@@ -78,6 +82,9 @@ jobs:
             --to "${HEAD_SHA}" \
             --format json \
             > /tmp/ocr-result.json 2>/tmp/ocr-stderr.log || true
+
+          echo "=== OCR stderr ==="
+          cat /tmp/ocr-stderr.log || true
 
       - name: Post review comments to PR
         uses: actions/github-script@v7


### PR DESCRIPTION
Root cause: OCR defaults to the Anthropic protocol, hitting `/v1/messages`. cloud-api is OpenAI-compatible, so:

1. Set `llm.use_anthropic false` — switches OCR to OpenAI protocol (`/chat/completions`)
2. Fix `OCR_LLM_URL` secret to `https://cloud-api.near.ai/v1` (base URL — OCR appends the endpoint path itself, not the full `/v1/chat/completions`)
3. Add `ocr llm test` step for connectivity verification

Verified locally:
```
$ ocr llm test
URL:    https://cloud-api.near.ai/v1
Model:  z-ai/glm-5.2
✓ Connection test successful
```