### PR TITLE
docs: fix provider_type example values in revenue density comments

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3630,7 +3630,7 @@ pub async fn get_performance_timeseries(
 pub struct RevenueDensityParams {
     pub start: Option<String>,
     pub end: Option<String>,
-    /// Optional provider type filter (e.g. "nearai", "external").
+    /// Optional provider type filter (e.g. "vllm", "external", "chutes").
     pub provider_type: Option<String>,
 }
 

--- a/crates/services/src/admin/analytics.rs
+++ b/crates/services/src/admin/analytics.rs
@@ -469,7 +469,7 @@ pub struct RevenueDensityReport {
 pub struct RevenueDensityQuery {
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
-    /// Optional provider_type filter (e.g. "nearai", "external").
+    /// Optional provider_type filter (e.g. "vllm", "external", "chutes").
     pub provider_type: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
Two docstrings cited `"nearai"` as an example `provider_type` value, but the column stores `'vllm'` (NEAR AI TEE-hosted), `'external'`, and `'chutes'` (per V0042/V0056/V0060). No logic change — comments only.

Caught by Pierre's review of #819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)