### PR TITLE
ci: speed up test workflow with parallel jobs, sccache, and mold

### DIFF
--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -52,9 +52,11 @@ runs:
         TARBALL="mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux.tar.gz"
         URL="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${TARBALL}"
         curl -fsSL "$URL" -o "/tmp/${TARBALL}"
-        sudo tar -xzf "/tmp/${TARBALL}" -C /usr/local --strip-components=2 "mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux/bin/mold"
+        # Extract bin/mold from the tarball directly into /usr/local/bin.
+        sudo tar -xzf "/tmp/${TARBALL}" -C /usr/local/bin --strip-components=2 "mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux/bin/mold"
         rm -f "/tmp/${TARBALL}"
         echo "Installed: $(mold --version)"
+        command -v mold
 
     - name: Cache Rust dependencies
       uses: swatinem/rust-cache@v2

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -38,7 +38,13 @@ runs:
       run: |
         # Install mold via release binary to avoid dpkg lock contention when
         # multiple jobs run in parallel on the same self-hosted runner.
-        if command -v mold >/dev/null 2>&1; then
+        #
+        # We install both `mold` and `ld.mold`. Rustc invokes the cc driver
+        # with -fuse-ld=mold (set via RUSTFLAGS in test.yml), which makes cc
+        # look for `ld.mold` on PATH. Rustc also passes its own
+        # -fuse-ld=lld + a -B path to its bundled lld; the last -fuse-ld
+        # flag wins, so -fuse-ld=mold takes effect and cc finds ld.mold.
+        if command -v mold >/dev/null 2>&1 && [ -x /usr/local/bin/ld.mold ]; then
           echo "mold already installed: $(mold --version)"
           exit 0
         fi
@@ -52,11 +58,13 @@ runs:
         TARBALL="mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux.tar.gz"
         URL="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${TARBALL}"
         curl -fsSL "$URL" -o "/tmp/${TARBALL}"
-        # Extract bin/mold from the tarball directly into /usr/local/bin.
-        sudo tar -xzf "/tmp/${TARBALL}" -C /usr/local/bin --strip-components=2 "mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux/bin/mold"
+        # Extract both mold and ld.mold into /usr/local/bin.
+        sudo tar -xzf "/tmp/${TARBALL}" -C /usr/local/bin --strip-components=2 \
+          "mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux/bin/mold" \
+          "mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux/bin/ld.mold"
         rm -f "/tmp/${TARBALL}"
         echo "Installed: $(mold --version)"
-        command -v mold
+        echo "ld.mold at: $(command -v ld.mold)"
 
     - name: Cache Rust dependencies
       uses: swatinem/rust-cache@v2

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -1,0 +1,63 @@
+name: 'Setup Rust CI'
+description: |
+  Sets up the Rust toolchain, sccache, the mold linker, cargo-nextest, and the
+  swatinem/rust-cache. Used by every job in test.yml to share setup logic and
+  to avoid apt lock contention from parallel jobs installing mold on the same
+  self-hosted runner.
+
+  Mold is installed via GitHub release binary (not apt) so concurrent jobs do
+  not contend on dpkg locks. It is placed on PATH at /usr/local/bin/mold.
+
+inputs:
+  cache-key:
+    description: 'Suffix for the swatinem/rust-cache key (per-job isolation).'
+    required: true
+  components:
+    description: 'Extra Rust components (e.g. "rustfmt, clippy").'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: ${{ inputs.components }}
+
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@nextest
+
+    - name: Install sccache
+      uses: taiki-e/install-action@v2
+      with:
+        tool: sccache
+
+    - name: Install mold linker
+      shell: bash
+      run: |
+        # Install mold via release binary to avoid dpkg lock contention when
+        # multiple jobs run in parallel on the same self-hosted runner.
+        if command -v mold >/dev/null 2>&1; then
+          echo "mold already installed: $(mold --version)"
+          exit 0
+        fi
+        MOLD_VERSION=2.41.0
+        ARCH=$(uname -m)
+        case "$ARCH" in
+          x86_64) TARBALL_ARCH=x86_64 ;;
+          aarch64) TARBALL_ARCH=aarch64 ;;
+          *) echo "Unsupported arch for mold: $ARCH" >&2; exit 1 ;;
+        esac
+        TARBALL="mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux.tar.gz"
+        URL="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${TARBALL}"
+        curl -fsSL "$URL" -o "/tmp/${TARBALL}"
+        sudo tar -xzf "/tmp/${TARBALL}" -C /usr/local --strip-components=2 "mold-${MOLD_VERSION}-${TARBALL_ARCH}-linux/bin/mold"
+        rm -f "/tmp/${TARBALL}"
+        echo "Installed: $(mold --version)"
+
+    - name: Cache Rust dependencies
+      uses: swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true
+        key: ${{ inputs.cache-key }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,19 @@ env:
   # no actions/cache step is needed.
   RUSTC_WRAPPER: sccache
   # Use the mold linker on Linux for much faster linking of the large test
-  # binaries (5-crate workspace, ~400 deps). Set via env var rather than in
-  # .cargo/config.toml so the Docker reproducible build (which copies
-  # .cargo/config.toml into the image) is unaffected and keeps using ld.
-  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: mold
+  # binaries (5-crate workspace, ~400 deps). We pass -fuse-ld=mold through
+  # the default cc driver rather than setting mold as the linker directly,
+  # because mold is a linker, not a driver, and does not understand gcc
+  # driver flags like -m64.
+  #
+  # NOTE: Setting RUSTFLAGS here replaces the target.cfg.rustflags from
+  # .cargo/config.toml (cargo treats these as mutually exclusive sources).
+  # That is intentional for CI: the dropped flags (--remap-path-prefix,
+  # --build-id=none, --hash-style=gnu, --no-undefined) are reproducibility-
+  # only and irrelevant for tests. We keep -C debuginfo=0 for faster test
+  # compiles. The Docker reproducible build does not set RUSTFLAGS, so it
+  # keeps using the full .cargo/config.toml rustflags with ld.
+  RUSTFLAGS: "-C debuginfo=0 -C link-arg=-fuse-ld=mold"
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - '**/Cargo.lock'
       - 'crates/database/src/migrations/**'
       - '.github/workflows/test.yml'
+      - '.config/nextest.toml'
   pull_request:
     branches: [ main, develop ]
     paths:
@@ -17,11 +18,24 @@ on:
       - '**/Cargo.lock'
       - 'crates/database/src/migrations/**'
       - '.github/workflows/test.yml'
+      - '.config/nextest.toml'
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0  # Faster CI builds
+  # Use sccache to cache compiled artifacts across runs. Complements
+  # swatinem/rust-cache (which caches target/) by caching at the object-file
+  # granularity, so dependency recompiles after a Cargo.lock bump or a
+  # feature-flag change are served from cache. On a self-hosted runner the
+  # default cache dir (~/.cache/sccache) persists across runs on disk, so
+  # no actions/cache step is needed.
+  RUSTC_WRAPPER: sccache
+  # Use the mold linker on Linux for much faster linking of the large test
+  # binaries (5-crate workspace, ~400 deps). Set via env var rather than in
+  # .cargo/config.toml so the Docker reproducible build (which copies
+  # .cargo/config.toml into the image) is unaffected and keeps using ld.
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: mold
 
 jobs:
   lint:
@@ -31,24 +45,82 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Setup Rust CI
+      uses: ./.github/actions/setup-rust-ci
       with:
+        cache-key: lint
         components: rustfmt, clippy
-
-    - name: Cache Rust dependencies
-      uses: swatinem/rust-cache@v2
-      with:
-        cache-on-failure: true
 
     - name: Run cargo fmt
       run: cargo fmt --all -- --check
 
+    # Clippy reuses the same target/ dir as tests, so this also warms the
+    # sccache + rust-cache for the parallel test jobs.
     - name: Run cargo clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
 
-  test:
-    name: Test Suite
+  # Unit tests (library + binary tests) run without PostgreSQL: the in-crate
+  # #[test] functions use mocks and do not establish real DB connections.
+  unit-test:
+    name: Unit tests
+    runs-on: [self-hosted, infra]
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Rust CI
+      uses: ./.github/actions/setup-rust-ci
+      with:
+        cache-key: unit
+
+    - name: Run unit tests
+      run: cargo nextest run --lib --bins
+      env:
+        POSTGRES_PRIMARY_APP_ID: ${{ secrets.POSTGRES_PRIMARY_APP_ID }}
+        DATABASE_HOST: localhost
+        DATABASE_PORT: 5432
+        DATABASE_NAME: platform_api
+        DATABASE_USERNAME: postgres
+        DATABASE_PASSWORD: postgres
+        DATABASE_MAX_CONNECTIONS: 5
+        DATABASE_TLS_ENABLED: "false"
+        MODEL_DISCOVERY_SERVER_URL: ${{ secrets.MODEL_DISCOVERY_SERVER_URL }}
+        MODEL_DISCOVERY_API_KEY: ${{ secrets.MODEL_DISCOVERY_API_KEY }}
+        AUTH_ADMIN_DOMAINS: ${{ secrets.AUTH_ADMIN_DOMAINS }}
+        AUTH_ENCODING_KEY: ${{ secrets.AUTH_ENCODING_KEY }}
+        BRAVE_SEARCH_PRO_API_KEY: ${{ secrets.BRAVE_SEARCH_PRO_API_KEY }}
+        DEV: "true"
+
+  # vLLM provider integration tests. Uses MockProvider by default
+  # (USE_REAL_VLLM is not set), so these run without external dependencies
+  # and without PostgreSQL. Kept as a separate job so a flake here doesn't
+  # block the e2e suite.
+  integration-test:
+    name: Integration tests
+    runs-on: [self-hosted, infra]
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Rust CI
+      uses: ./.github/actions/setup-rust-ci
+      with:
+        cache-key: integration
+
+    - name: Run integration tests
+      run: cargo nextest run --test integration_tests
+      env:
+        VLLM_BASE_URL: ${{ secrets.VLLM_BASE_URL }}
+        VLLM_API_KEY: ${{ secrets.VLLM_API_KEY }}
+
+  # End-to-end tests. All e2e tests are compiled into a single binary
+  # (tests/e2e_all/) for faster linking. Isolation comes from UUID-scoped
+  # orgs/workspaces/keys on a shared database, not separate databases.
+  # nextest concurrency is capped by .config/nextest.toml (e2e-db group
+  # max-threads = 16; 16 * 4 pool conns = 64 < PG default max_connections
+  # = 100), so no ALTER SYSTEM / restart step is needed.
+  e2e-test:
+    name: E2E tests
     runs-on: [self-hosted, infra]
     environment: Cloud API test env
 
@@ -71,53 +143,12 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Increase PostgreSQL max connections
-      run: |
-        # 16 parallel tests * 4 pool connections = 64, but allow headroom for spikes.
-        docker exec ${{ job.services.postgres.id }} \
-          psql -U postgres -c "ALTER SYSTEM SET max_connections = 150;"
-        docker restart ${{ job.services.postgres.id }}
-        for i in $(seq 1 30); do
-          docker exec ${{ job.services.postgres.id }} pg_isready -U postgres && break
-          sleep 1
-        done
-        if ! docker exec ${{ job.services.postgres.id }} pg_isready -U postgres; then
-          echo "PostgreSQL did not become ready after restart within 30 seconds" >&2
-          exit 1
-        fi
-
-    - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-
-    - name: Cache Rust dependencies
-      uses: swatinem/rust-cache@v2
+    - name: Setup Rust CI
+      uses: ./.github/actions/setup-rust-ci
       with:
-        cache-on-failure: true
+        cache-key: e2e
 
-    - name: Install cargo-nextest
-      uses: taiki-e/install-action@nextest
-
-    - name: Run unit tests
-      run: cargo nextest run --lib --bins
-      env:
-        POSTGRES_PRIMARY_APP_ID: ${{ secrets.POSTGRES_PRIMARY_APP_ID }}
-        DATABASE_HOST: localhost
-        DATABASE_PORT: 5432
-        DATABASE_NAME: platform_api
-        DATABASE_USERNAME: postgres
-        DATABASE_PASSWORD: postgres
-        DATABASE_MAX_CONNECTIONS: 5
-        DATABASE_TLS_ENABLED: "false"
-        MODEL_DISCOVERY_SERVER_URL: ${{ secrets.MODEL_DISCOVERY_SERVER_URL }}
-        MODEL_DISCOVERY_API_KEY: ${{ secrets.MODEL_DISCOVERY_API_KEY }}
-        AUTH_ADMIN_DOMAINS: ${{ secrets.AUTH_ADMIN_DOMAINS }}
-        AUTH_ENCODING_KEY: ${{ secrets.AUTH_ENCODING_KEY }}
-        BRAVE_SEARCH_PRO_API_KEY: ${{ secrets.BRAVE_SEARCH_PRO_API_KEY }}
-        DEV: "true"
-
-    # All e2e tests are compiled into a single binary (tests/e2e_all/) for faster linking.
-    # Isolation comes from UUID-scoped orgs/workspaces/keys, not separate databases.
-    - name: Run integration tests
+    - name: Run e2e tests
       run: cargo nextest run --test e2e_all
       env:
         POSTGRES_PRIMARY_APP_ID: ${{ secrets.POSTGRES_PRIMARY_APP_ID }}
@@ -137,22 +168,21 @@ jobs:
         RUST_LOG: debug
         DEV: "true"
 
-    - name: Run vLLM integration tests
-      run: cargo test --test integration_tests -- --nocapture
-      env:
-        VLLM_BASE_URL: ${{ secrets.VLLM_BASE_URL }}
-        VLLM_API_KEY: ${{ secrets.VLLM_API_KEY }}
+  # Release build, only on main pushes. Split into its own job so it does
+  # not block the test jobs and does not pull in PostgreSQL or test env vars
+  # (there is no build.rs; cargo build --release needs none of them).
+  build-release:
+    name: Build release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, infra]
 
-    # Only build release on main branch, not on PRs
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Rust CI
+      uses: ./.github/actions/setup-rust-ci
+      with:
+        cache-key: release
+
     - name: Build release
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: cargo build --release
-      env:
-        POSTGRES_PRIMARY_APP_ID: ${{ secrets.POSTGRES_PRIMARY_APP_ID }}
-        DATABASE_HOST: localhost
-        DATABASE_PORT: 5432
-        DATABASE_NAME: platform_api
-        DATABASE_USERNAME: postgres
-        DATABASE_PASSWORD: postgres
-        MODEL_DISCOVERY_SERVER_URL: ${{ secrets.MODEL_DISCOVERY_SERVER_URL }}
-        AUTH_ENCODING_KEY: ${{ secrets.AUTH_ENCODING_KEY }}


### PR DESCRIPTION
## Summary

Splits the single sequential `test` job into **five parallel jobs** and adds **sccache** + the **mold linker** to cut CI wall-clock time. Targets the cloud-api test workflow, which already runs on our self-hosted runner (`gpu11`) but was slow because everything ran sequentially in one job.

## Does it already run on our runners?

**Yes** — both the old `lint` and `test` jobs already used `runs-on: [self-hosted, infra]`. This PR keeps that. The slowness comes from (a) sequential execution, (b) no object-level compile cache, (c) slow GNU `ld` linking of the large test binaries, and (d) a dead `ALTER SYSTEM + docker restart` step.

## Results

| Job | Time |
|-----|------|
| Lint | 3m59s |
| Unit tests | 2m50s |
| Integration tests | 2m58s |
| E2E tests | 5m58s |
| **Total wall-clock (parallel)** | **~6m** |

Baseline (old workflow on main, sequential): **~10-11m**. This is **~40% faster on a cold cache**; sccache will improve further on warm runs.

## Changes

### Job split (parallel execution)
Old: `lint` ‖ `test` (where `test` ran unit → e2e → vLLM → release sequentially)

New: `lint` ‖ `unit-test` ‖ `integration-test` ‖ `e2e-test` ‖ `build-release` (all parallel)

- **`unit-test`** (`cargo nextest run --lib --bins`): no PostgreSQL needed — in-crate `#[test]`s use mocks.
- **`integration-test`** (`cargo nextest run --test integration_tests`): no PostgreSQL needed — `MockProvider` is used by default (`USE_REAL_VLLM` is not set).
- **`e2e-test`** (`cargo nextest run --test e2e_all`): the only job with the PostgreSQL service container.
- **`build-release`** (`cargo build --release`): main-push only, split out so it doesn't block tests and doesn't pull in PostgreSQL (there is no `build.rs`).

### sccache (`RUSTC_WRAPPER=sccache`)
Caches compiled objects at the object-file granularity, complementing `swatinem/rust-cache` (which caches `target/`). Survives `Cargo.lock` bumps and feature-flag changes better. On a self-hosted runner the default cache dir (`~/.cache/sccache`) persists on disk across runs, so no `actions/cache` step is needed.

### mold linker (`RUSTFLAGS="-C link-arg=-fuse-ld=mold"`)
2-5× faster linking of the ~60MB test binary. Installed via GitHub release binary (both `mold` and `ld.mold`) — not apt — to avoid dpkg lock contention between parallel jobs. Configured via `RUSTFLAGS` env var rather than in `.cargo/config.toml` so:
- The **Docker reproducible build** (which copies `.cargo/config.toml` and does NOT set `RUSTFLAGS`) is unaffected and keeps using `ld`.
- `RUSTFLAGS` env replaces `target.cfg.rustflags` from config (cargo treats them as mutually exclusive), which is fine for CI — the dropped flags (`--remap-path-prefix`, `--build-id=none`, `--hash-style=gnu`, `--no-undefined`) are reproducibility-only and irrelevant for tests. `-C debuginfo=0` is kept for faster test compiles.

**Mold integration gotcha**: `gcc -fuse-ld=mold` looks for `ld.mold` on PATH (not `mold`). Rustc also passes its own `-fuse-ld=lld` + a `-B` path to its bundled lld; the last `-fuse-ld` flag wins, so `-fuse-ld=mold` takes effect. Installing `ld.mold` from the mold tarball resolves the `collect2: cannot find 'ld'` error.

### Cleanup
- **Removed the `ALTER SYSTEM SET max_connections=150 + docker restart` step** (was test.yml:74-87). `.config/nextest.toml` already caps the `e2e-db` test group at `max-threads = 16` (16 × 4 pool conns = 64 < PG default `max_connections = 100`), so the override was dead code adding ~15-30s and a failure point.
- **Switched vLLM integration tests** from `cargo test --test integration_tests -- --nocapture` to `cargo nextest run --test integration_tests` for consistent tooling.
- **Stripped vestigial env vars** from the release build (no `build.rs` → `cargo build --release` needs none of `DATABASE_*` / `MODEL_DISCOVERY_*` / `AUTH_*`).

### Composite action (`.github/actions/setup-rust-ci`)
New composite action centralizes: Rust toolchain, cargo-nextest, sccache, mold, and `swatinem/rust-cache` (with per-job `cache-key` for isolation). Avoids step duplication across 5 jobs.

## Verification
- [x] All 5 jobs pass on this PR (Lint 3m59s, Unit 2m50s, Integration 2m58s, E2E 5m58s)
- [x] YAML validated (5 jobs, correct `runs-on`, only `e2e-test` has `postgres` service, only `build-release` is main-gated)
- [x] Confirmed no `build.rs` anywhere in the workspace (`cargo build --release` needs no env vars)
- [x] Confirmed `integration_tests` target lives in `crates/inference_providers/tests/` and uses `MockProvider` by default
- [x] Confirmed `.config/nextest.toml` already caps e2e concurrency at 16 threads (justifies removing the PG restart step)
- [x] mold v2.41.0 release verified to exist and tarball structure confirmed (`bin/mold` + `bin/ld.mold`)

## Follow-up issues (not in this PR)
- **e2e sharding** with `nextest --partition hash i/N` (~3× e2e speedup) — needs a separate runner label or matrix to be effective.
- **Dedicated CI VM** to remove `gpu11` prod-host contention (the root cause of CI-duration variability).
- **Pre-built CI Docker image** with deps compiled (`cargo test --no-run`), refreshed on `Cargo.lock` changes.

## Follow-up issues
- nearai/cloud-api#832 — e2e sharding with nextest --partition hash (~3× e2e speedup)
- nearai/cloud-api#833 — pre-build CI Docker image with deps compiled
- nearai/infra#184 — dedicated CI VM to remove gpu11 prod-host contention
