### PR TITLE
[codex] Add customer-facing request correlation

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1325,6 +1325,7 @@ pub fn build_app_with_config(
         // endpoints) sign the *request* body hash, not the HTTP response body,
         // so compression is safe for them as well.
         .layer(CompressionLayer::new())
+        .layer(from_fn(middleware::request_correlation_middleware))
 }
 
 /// Build VPC authentication routes

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -30,7 +30,7 @@ async fn get_admin_user_by_id(
         .await
     {
         Ok(user) => {
-            debug!("Found admin user: {}", user.email);
+            debug!(admin_user_id = %user.id, "Found admin user");
             Ok(convert_user_to_db_user(user))
         }
         Err(_) => {
@@ -58,10 +58,13 @@ pub async fn auth_middleware_with_api_key(
         .get("authorization")
         .and_then(|h| h.to_str().ok());
 
-    tracing::debug!("Auth API KEY middleware: {:?}", auth_header);
+    tracing::debug!(
+        authorization_present = auth_header.is_some(),
+        "Auth API KEY middleware"
+    );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
             authenticate_api_key(&state, token).await
         } else {
@@ -87,7 +90,7 @@ pub async fn auth_middleware_with_api_key(
     match auth_result {
         Ok(api_key) => {
             // Clone request to add extension
-            debug!("Adding API key to request: {:?}", api_key);
+            debug!(api_key_id = %api_key.id.0, "Adding API key to request");
             let mut request = request;
             request.extensions_mut().insert(api_key);
             Ok(next.run(request).await)
@@ -107,10 +110,13 @@ pub async fn auth_middleware_with_workspace_context(
         .get("authorization")
         .and_then(|h| h.to_str().ok());
 
-    tracing::debug!("Auth API KEY with workspace middleware: {:?}", auth_header);
+    tracing::debug!(
+        authorization_present = auth_header.is_some(),
+        "Auth API KEY with workspace middleware"
+    );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
             authenticate_api_key_with_context(&state, token).await
         } else {
@@ -157,14 +163,14 @@ pub async fn auth_middleware(
         .and_then(|h| h.to_str().ok());
 
     tracing::debug!(
-        "Auth middleware (session access token only): {:?}",
-        auth_header
+        authorization_present = auth_header.is_some(),
+        "Auth middleware (session access token only)"
     );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
-            debug!("Extracted Bearer token: {}", token);
+            debug!("Extracted Bearer token");
             authenticate_session_access(&state, token.to_string()).await
         } else {
             debug!("Authorization header does not start with 'Bearer '");
@@ -216,19 +222,26 @@ pub async fn admin_middleware(
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
 
-    tracing::debug!("Admin auth middleware: {:?}", auth_header);
+    tracing::debug!(
+        authorization_present = auth_header.is_some(),
+        "Admin auth middleware"
+    );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
-            debug!("Extracted Bearer token for admin auth: {}", token);
+            debug!("Extracted Bearer token for admin auth");
 
             // Check if this looks like an admin access token (starts with "adm_")
             // Admin access tokens should ONLY be validated as admin tokens, no fallback
             if token.starts_with("adm_") {
                 match authenticate_admin_access_token(&state, token, user_agent.as_deref()).await {
                     Ok(admin_token) => {
-                        debug!("Authenticated via admin access token: {}", admin_token.name);
+                        debug!(
+                            admin_access_token_id = %admin_token.id,
+                            authenticated = true,
+                            "Authenticated via admin access token"
+                        );
 
                         // Check if this is an admin access token management endpoint
                         let path = request.uri().path();
@@ -249,8 +262,10 @@ pub async fn admin_middleware(
                         match get_admin_user_by_id(&state, admin_token.created_by_user_id).await {
                             Ok(admin_user) => {
                                 debug!(
-                                    "Retrieved admin user: {} for access token: {}",
-                                    admin_user.email, admin_token.name
+                                    admin_user_id = %admin_user.id,
+                                    admin_access_token_id = %admin_token.id,
+                                    authenticated = true,
+                                    "Retrieved admin user for access token"
                                 );
                                 Ok(admin_user)
                             }
@@ -314,10 +329,7 @@ pub async fn admin_middleware(
                 ));
             }
 
-            debug!(
-                "Admin access granted for user: {} ({})",
-                user.id, user.email
-            );
+            debug!(admin_user_id = %user.id, authenticated = true, "Admin access granted");
 
             // Add both AuthenticatedUser and AdminUser extensions
             let mut request = request;
@@ -357,7 +369,7 @@ async fn authenticate_admin_access_token(
     database::models::AdminAccessToken,
     (StatusCode, axum::Json<crate::models::ErrorResponse>),
 > {
-    debug!("Authenticating admin access token: {}", token);
+    debug!("Authenticating admin access token");
 
     match state
         .admin_access_token_repository
@@ -366,8 +378,9 @@ async fn authenticate_admin_access_token(
     {
         Ok(Some(admin_token)) => {
             debug!(
-                "Admin access token validated successfully: {}",
-                admin_token.name
+                admin_access_token_id = %admin_token.id,
+                validated = true,
+                "Admin access token validated successfully"
             );
             Ok(admin_token)
         }
@@ -398,7 +411,7 @@ async fn authenticate_session_access(
     state: &AuthState,
     token: String, // jwt
 ) -> Result<DbUser, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
-    debug!("Authenticating session access token: {}", token);
+    debug!("Authenticating session access token");
     // Use auth service
 
     let auth_service = &state.auth_service;
@@ -409,7 +422,7 @@ async fn authenticate_session_access(
             .await
         {
             Ok(user) => {
-                debug!("Authenticated user {} via session", user.email);
+                debug!(user_id = %user.id.0, authenticated = true, "Authenticated user via session");
                 return Ok(convert_user_to_db_user(user));
             }
             Err(AuthError::SessionNotFound) | Err(AuthError::UserNotFound) => {
@@ -458,15 +471,15 @@ pub async fn refresh_middleware(
         .and_then(|h| h.to_str().ok());
 
     tracing::debug!(
-        "Auth middleware (refresh token): refresh token: {:?}, user agent: {:?}",
-        auth_header,
-        user_agent
+        authorization_present = auth_header.is_some(),
+        user_agent_present = user_agent.is_some(),
+        "Auth middleware (refresh token)"
     );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
-            debug!("Extracted Bearer token: {}", token);
+            debug!("Extracted Bearer token");
             if let Some(user_agent_value) = user_agent {
                 authenticate_session_refresh(
                     &state,
@@ -505,7 +518,7 @@ async fn authenticate_session_refresh(
     token: SessionToken,
     user_agent: &str,
 ) -> Result<(services::auth::Session, DbUser), StatusCode> {
-    debug!("Authenticating session refresh token: {}", token);
+    debug!("Authenticating session refresh token");
     // Use auth service to validate session with refresh token and user agent
     {
         let auth_service = &state.auth_service;
@@ -515,7 +528,7 @@ async fn authenticate_session_refresh(
             .await
         {
             Ok((session, user)) => {
-                debug!("Authenticated user {} via session", user.email);
+                debug!(user_id = %user.id.0, authenticated = true, "Authenticated user via session");
                 return Ok((session, convert_user_to_db_user(user)));
             }
             Err(AuthError::SessionNotFound) | Err(AuthError::UserNotFound) => {
@@ -540,11 +553,11 @@ async fn authenticate_api_key(
     api_key: &str,
 ) -> Result<services::workspace::ApiKey, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
     let auth_service = &state.auth_service;
-    debug!("Calling auth service to validate API key: {}", api_key);
+    debug!("Calling auth service to validate API key");
 
     match auth_service.validate_api_key(api_key.to_string()).await {
         Ok(api_key) => {
-            debug!("Authenticated via API key: {:?}", api_key);
+            debug!(api_key_id = %api_key.id.0, "Authenticated via API key");
             Ok(api_key)
         }
         Err(AuthError::Unauthorized) => {
@@ -604,8 +617,8 @@ async fn authenticate_api_key_with_context(
     {
         Ok(Some((workspace, organization))) => {
             debug!(
-                "Resolved workspace: {} and organization: {} for API key",
-                workspace.name, organization.name
+                "Resolved workspace_id={} organization_id={} workspace_active={} organization_active={} for API key",
+                workspace.id, organization.id, workspace.is_active, organization.is_active
             );
             Ok(AuthenticatedApiKey {
                 api_key: validated_api_key,

--- a/crates/api/src/middleware/mod.rs
+++ b/crates/api/src/middleware/mod.rs
@@ -7,6 +7,7 @@ pub mod auth;
 pub mod body_hash;
 pub mod metrics;
 pub mod rate_limit;
+pub mod request_correlation;
 pub mod usage;
 
 // Re-export commonly used items
@@ -14,4 +15,5 @@ pub use auth::{admin_middleware, auth_middleware, AdminUser, AuthState, Authenti
 pub use body_hash::{body_hash_middleware, RequestBodyHash};
 pub use metrics::{http_metrics_middleware, MetricsState};
 pub use rate_limit::{api_key_rate_limit_middleware, RateLimitState};
+pub use request_correlation::{request_correlation_middleware, RequestCorrelation};
 pub use usage::{usage_check_middleware, UsageState};

--- a/crates/api/src/middleware/request_correlation.rs
+++ b/crates/api/src/middleware/request_correlation.rs
@@ -1,0 +1,155 @@
+use axum::{
+    body::Body,
+    http::{HeaderValue, Request},
+    middleware::Next,
+    response::Response,
+};
+use tracing::Instrument;
+use uuid::Uuid;
+
+#[cfg(test)]
+mod privacy_log_scanner;
+
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+
+#[derive(Debug, Clone, Copy)]
+pub struct RequestCorrelation {
+    pub request_id: Uuid,
+}
+
+pub async fn request_correlation_middleware(mut request: Request<Body>, next: Next) -> Response {
+    let request_id = request
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| Uuid::parse_str(value).ok())
+        .unwrap_or_else(Uuid::new_v4);
+
+    request
+        .extensions_mut()
+        .insert(RequestCorrelation { request_id });
+
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    let span = tracing::info_span!(
+        "http_request",
+        request_id = %request_id,
+        method = %method,
+        path = %path,
+    );
+
+    let mut response = async move { next.run(request).await }
+        .instrument(span)
+        .await;
+    if let Ok(value) = HeaderValue::from_str(&request_id.to_string()) {
+        response.headers_mut().insert(REQUEST_ID_HEADER, value);
+    }
+    tracing::debug!(
+        request_id = %request_id,
+        method = %method,
+        path = %path,
+        status = response.status().as_u16(),
+        "request completed"
+    );
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::privacy_log_scanner::assert_production_logs_exclude_forbidden_expressions;
+    use super::*;
+    use axum::{middleware::from_fn, routing::post, Router};
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tower::ServiceExt;
+    use tracing::Level;
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    struct CapturedLogsWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CapturedLogsWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut logs = self
+                .0
+                .lock()
+                .expect("captured logs mutex should not poison");
+            logs.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl CapturedLogs {
+        fn writer(&self) -> CapturedLogsWriter {
+            CapturedLogsWriter(Arc::clone(&self.0))
+        }
+
+        fn contents(&self) -> String {
+            let logs = self
+                .0
+                .lock()
+                .expect("captured logs mutex should not poison");
+            String::from_utf8_lossy(&logs).into_owned()
+        }
+    }
+
+    #[tokio::test]
+    async fn tracing_logs_exclude_customer_content() {
+        assert_production_logs_exclude_forbidden_expressions();
+
+        let logs = CapturedLogs::default();
+        let writer_logs = logs.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(Level::DEBUG)
+            .with_ansi(false)
+            .with_writer(move || writer_logs.writer())
+            .finish();
+        let request_id = Uuid::new_v4();
+        let body = Body::from(
+            r#"{"prompt":"CUSTOMER_PROMPT_SENTINEL","tool_arguments":{"secret":"TOOL_ARG_SENTINEL"},"api_key":"sk-log-sentinel"}"#,
+        );
+        let app = Router::new()
+            .route("/privacy-log-check", post(|| async { "ok" }))
+            .layer(from_fn(request_correlation_middleware));
+
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/privacy-log-check")
+                    .header(REQUEST_ID_HEADER, request_id.to_string())
+                    .header("x-org-id", "spoofed-org-sentinel")
+                    .header("authorization", "Bearer sk-log-sentinel")
+                    .header("User-Agent", "USER_AGENT_LOG_SENTINEL")
+                    .body(body)
+                    .expect("test request should build"),
+            )
+            .await
+            .expect("test request should complete");
+
+        assert_eq!(response.status().as_u16(), 200);
+        let captured = logs.contents();
+        assert!(captured.contains(&request_id.to_string()));
+        assert!(captured.contains("method=POST"));
+        assert!(captured.contains("path=/privacy-log-check"));
+        assert!(captured.contains("status=200"));
+        for forbidden in [
+            "CUSTOMER_PROMPT_SENTINEL",
+            "TOOL_ARG_SENTINEL",
+            "sk-log-sentinel",
+            "spoofed-org-sentinel",
+            "USER_AGENT_LOG_SENTINEL",
+        ] {
+            assert!(
+                !captured.contains(forbidden),
+                "captured logs must not contain {forbidden}; logs: {captured}"
+            );
+        }
+    }
+}

--- a/crates/api/src/middleware/request_correlation.rs
+++ b/crates/api/src/middleware/request_correlation.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Body,
-    http::{HeaderValue, Request},
+    http::{header::CACHE_CONTROL, HeaderMap, HeaderValue, Request},
     middleware::Next,
     response::Response,
 };
@@ -30,7 +30,7 @@ pub async fn request_correlation_middleware(mut request: Request<Body>, next: Ne
         .insert(RequestCorrelation { request_id });
 
     let method = request.method().clone();
-    let path = request.uri().path().to_string();
+    let path = log_safe_path(request.uri().path());
     let span = tracing::info_span!(
         "http_request",
         request_id = %request_id,
@@ -43,6 +43,7 @@ pub async fn request_correlation_middleware(mut request: Request<Body>, next: Ne
         .await;
     if let Ok(value) = HeaderValue::from_str(&request_id.to_string()) {
         response.headers_mut().insert(REQUEST_ID_HEADER, value);
+        prevent_request_id_caching(response.headers_mut());
     }
     tracing::debug!(
         request_id = %request_id,
@@ -52,6 +53,38 @@ pub async fn request_correlation_middleware(mut request: Request<Body>, next: Ne
         "request completed"
     );
     response
+}
+
+fn prevent_request_id_caching(headers: &mut HeaderMap) {
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+}
+
+fn log_safe_path(path: &str) -> String {
+    path.split('/')
+        .map(|segment| {
+            if should_redact_path_segment(segment) {
+                "[redacted]"
+            } else {
+                segment
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn should_redact_path_segment(segment: &str) -> bool {
+    if segment.is_empty() {
+        return false;
+    }
+
+    Uuid::parse_str(segment).is_ok() || is_long_token_segment(segment)
+}
+
+fn is_long_token_segment(segment: &str) -> bool {
+    segment.len() >= 32
+        && segment
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
 }
 
 #[cfg(test)]
@@ -113,8 +146,9 @@ mod tests {
         let body = Body::from(
             r#"{"prompt":"CUSTOMER_PROMPT_SENTINEL","tool_arguments":{"secret":"TOOL_ARG_SENTINEL"},"api_key":"sk-log-sentinel"}"#,
         );
+        let token_path = "tok_live_customer_invitation_secret_1234567890";
         let app = Router::new()
-            .route("/privacy-log-check", post(|| async { "ok" }))
+            .route("/v1/invitations/{token}", post(|| async { "ok" }))
             .layer(from_fn(request_correlation_middleware));
 
         let _subscriber_guard = tracing::subscriber::set_default(subscriber);
@@ -122,7 +156,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/privacy-log-check")
+                    .uri(format!("/v1/invitations/{token_path}"))
                     .header(REQUEST_ID_HEADER, request_id.to_string())
                     .header("x-org-id", "spoofed-org-sentinel")
                     .header("authorization", "Bearer sk-log-sentinel")
@@ -134,10 +168,17 @@ mod tests {
             .expect("test request should complete");
 
         assert_eq!(response.status().as_u16(), 200);
+        assert_eq!(
+            response
+                .headers()
+                .get(CACHE_CONTROL)
+                .expect("request-specific responses should disable shared caching"),
+            "no-store"
+        );
         let captured = logs.contents();
         assert!(captured.contains(&request_id.to_string()));
         assert!(captured.contains("method=POST"));
-        assert!(captured.contains("path=/privacy-log-check"));
+        assert!(captured.contains("path=/v1/invitations/[redacted]"));
         assert!(captured.contains("status=200"));
         for forbidden in [
             "CUSTOMER_PROMPT_SENTINEL",
@@ -145,6 +186,7 @@ mod tests {
             "sk-log-sentinel",
             "spoofed-org-sentinel",
             "USER_AGENT_LOG_SENTINEL",
+            token_path,
         ] {
             assert!(
                 !captured.contains(forbidden),

--- a/crates/api/src/middleware/request_correlation/privacy_log_scanner.rs
+++ b/crates/api/src/middleware/request_correlation/privacy_log_scanner.rs
@@ -1,0 +1,271 @@
+pub(super) fn assert_production_logs_exclude_forbidden_expressions() {
+    let sources = [
+        (
+            "crates/api/src/routes/completions.rs",
+            include_str!("../../routes/completions.rs"),
+        ),
+        (
+            "crates/api/src/routes/responses.rs",
+            include_str!("../../routes/responses.rs"),
+        ),
+        (
+            "crates/api/src/routes/admin.rs",
+            include_str!("../../routes/admin.rs"),
+        ),
+        (
+            "crates/api/src/routes/auth.rs",
+            include_str!("../../routes/auth.rs"),
+        ),
+        (
+            "crates/api/src/routes/conversations.rs",
+            include_str!("../../routes/conversations.rs"),
+        ),
+        (
+            "crates/api/src/routes/users.rs",
+            include_str!("../../routes/users.rs"),
+        ),
+        (
+            "crates/api/src/middleware/auth.rs",
+            include_str!("../auth.rs"),
+        ),
+        (
+            "crates/database/src/repositories/oauth_state.rs",
+            include_str!("../../../../database/src/repositories/oauth_state.rs"),
+        ),
+    ];
+    let forbidden = [
+        "json_data",
+        "event.delta",
+        "admin_token.name",
+        "workspace.name",
+        "organization.name",
+        "response_body",
+        "request_body",
+        "content_preview",
+        "tool_arguments",
+    ];
+
+    for (path, source) in sources {
+        for (line, body) in logging_macro_bodies(source) {
+            let code = string_literals_removed(&body);
+            for expression in forbidden {
+                assert!(
+                    !body.contains(expression),
+                    "{path}:{line} production logging macro must not contain {expression}: {body}"
+                );
+            }
+            for identifier in [
+                "auth_value",
+                "bearer_token",
+                "session_token",
+                "raw_signature",
+                "signature_body",
+            ] {
+                assert!(
+                    !contains_standalone_identifier(&code, identifier),
+                    "{path}:{line} production logging macro must not contain raw auth identifier {identifier}: {body}"
+                );
+            }
+            for identifier in ["user_agent", "user_agent_header"] {
+                assert!(
+                    !logs_raw_identifier(&code, identifier),
+                    "{path}:{line} production logging macro must not log raw User-Agent identifier {identifier}: {body}"
+                );
+            }
+            assert!(
+                !logs_raw_oauth_state(&code),
+                "{path}:{line} production logging macro must not log raw OAuth state: {body}"
+            );
+            assert!(
+                !logs_api_key_debug_dump(&body, &code),
+                "{path}:{line} production logging macro must not dump full ApiKey with Debug: {body}"
+            );
+            assert!(
+                !logs_raw_email_field(&code),
+                "{path}:{line} production logging macro must not log raw email fields: {body}"
+            );
+        }
+    }
+}
+
+fn logging_macro_bodies(source: &str) -> Vec<(usize, String)> {
+    let prefixes = [
+        "tracing::debug!(",
+        "tracing::info!(",
+        "tracing::warn!(",
+        "tracing::error!(",
+        "tracing::trace!(",
+        "debug!(",
+        "info!(",
+        "warn!(",
+        "error!(",
+        "trace!(",
+    ];
+    let mut bodies = Vec::new();
+    let mut search_start = 0;
+
+    while let Some((start, prefix_len)) = next_logging_macro(source, search_start, &prefixes) {
+        let line = source[..start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count()
+            + 1;
+        if let Some((body, end)) = read_parenthesized_body(source, start + prefix_len) {
+            bodies.push((line, body));
+            search_start = end;
+        } else {
+            search_start = start + prefix_len;
+        }
+    }
+
+    bodies
+}
+
+fn next_logging_macro(
+    source: &str,
+    search_start: usize,
+    prefixes: &[&str],
+) -> Option<(usize, usize)> {
+    prefixes
+        .iter()
+        .filter_map(|prefix| {
+            source[search_start..]
+                .find(prefix)
+                .map(|offset| (search_start + offset, prefix.len()))
+        })
+        .min_by_key(|(start, _)| *start)
+}
+
+fn read_parenthesized_body(source: &str, body_start: usize) -> Option<(String, usize)> {
+    let mut depth = 1usize;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (offset, ch) in source[body_start..].char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    let end = body_start + offset;
+                    return Some((source[body_start..end].to_string(), end + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn string_literals_removed(body: &str) -> String {
+    let mut result = String::with_capacity(body.len());
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in body.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            result.push(' ');
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            result.push(' ');
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+fn logs_raw_oauth_state(code: &str) -> bool {
+    code.contains("params.state")
+        || code.contains("state.state")
+        || has_positional_argument_named(code, "state")
+}
+
+fn logs_api_key_debug_dump(body: &str, code: &str) -> bool {
+    body.contains("{:?}") && has_positional_argument_named(code, "api_key")
+}
+
+fn logs_raw_email_field(code: &str) -> bool {
+    code.match_indices(".email").any(|(start, _)| {
+        let after = &code[start + ".email".len()..];
+        if after
+            .as_bytes()
+            .first()
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+        {
+            return false;
+        }
+
+        let after = after.trim_start();
+        !(after.starts_with(".len(") || after.starts_with(".is_empty("))
+    })
+}
+
+fn logs_raw_identifier(code: &str, identifier: &str) -> bool {
+    has_positional_argument_named(code, identifier) || has_raw_prefixed_identifier(code, identifier)
+}
+
+fn has_raw_prefixed_identifier(code: &str, identifier: &str) -> bool {
+    code.match_indices(identifier).any(|(start, _)| {
+        let before = code[..start]
+            .bytes()
+            .rev()
+            .find(|byte| !byte.is_ascii_whitespace());
+        let after = code[start + identifier.len()..]
+            .bytes()
+            .find(|byte| !byte.is_ascii_whitespace());
+
+        before.is_some_and(|byte| matches!(byte, b'=' | b'?' | b'%'))
+            && !matches!(after, Some(byte) if is_identifier_byte(Some(byte)) || byte == b'.')
+    })
+}
+
+fn has_positional_argument_named(code: &str, identifier: &str) -> bool {
+    code.split(',').skip(1).any(|argument| {
+        let trimmed = argument.trim();
+        trimmed == identifier
+            || trimmed
+                .strip_prefix(identifier)
+                .is_some_and(|tail| tail.trim_start().starts_with(')'))
+    })
+}
+
+fn contains_standalone_identifier(body: &str, identifier: &str) -> bool {
+    body.match_indices(identifier).any(|(start, _)| {
+        let before = start
+            .checked_sub(1)
+            .and_then(|index| body.as_bytes().get(index))
+            .copied();
+        let after = body.as_bytes().get(start + identifier.len()).copied();
+
+        !is_identifier_byte(before) && !is_identifier_byte(after)
+    })
+}
+
+fn is_identifier_byte(byte: Option<u8>) -> bool {
+    byte.is_some_and(|value| value.is_ascii_alphanumeric() || value == b'_')
+}

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -2663,9 +2663,13 @@ pub async fn create_admin_access_token(
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
 
+    let expires_in_hours = request_body.expires_in_hours;
+    let user_agent_present = user_agent.is_some();
     debug!(
-        "Creating admin access token for user: {} with {} hours expiration; (User-Agent: {:?})",
-        admin_user.0.email, request_body.expires_in_hours, user_agent
+        admin_user_id = %admin_user.0.id,
+        expires_in_hours,
+        user_agent_present,
+        "Creating admin access token"
     );
 
     // Validate expiration time (must be positive)
@@ -2695,8 +2699,9 @@ pub async fn create_admin_access_token(
     {
         Ok((admin_token, access_token)) => {
             debug!(
-                "Admin access token created successfully for user: {}",
-                admin_user.0.email
+                admin_user_id = %admin_user.0.id,
+                token_id = %admin_token.id,
+                "Admin access token created successfully"
             );
 
             let response = AdminAccessTokenResponse {
@@ -2753,8 +2758,10 @@ pub async fn list_admin_access_tokens(
     crate::routes::common::validate_limit_offset(params.limit, params.offset)?;
 
     debug!(
-        "List admin access tokens request with limit={}, offset={} by admin: {}",
-        params.limit, params.offset, admin_user.0.email
+        admin_user_id = %admin_user.0.id,
+        limit = params.limit,
+        offset = params.offset,
+        "List admin access tokens request"
     );
 
     match app_state
@@ -2820,8 +2827,9 @@ pub async fn delete_admin_access_token(
     Json(request): Json<DeleteAdminAccessTokenRequest>,
 ) -> Result<ResponseJson<serde_json::Value>, (StatusCode, ResponseJson<ErrorResponse>)> {
     debug!(
-        "Delete admin access token request for token_id: {} by admin: {}",
-        token_id, admin_user.0.email
+        admin_user_id = %admin_user.0.id,
+        token_id = %token_id,
+        "Delete admin access token request"
     );
 
     // Parse token ID
@@ -2843,8 +2851,9 @@ pub async fn delete_admin_access_token(
     {
         Ok(true) => {
             debug!(
-                "Admin access token {} revoked successfully by admin: {}",
-                token_id, admin_user.0.email
+                admin_user_id = %admin_user.0.id,
+                token_id = %token_id,
+                "Admin access token revoked successfully"
             );
 
             let response = serde_json::json!({

--- a/crates/api/src/routes/auth.rs
+++ b/crates/api/src/routes/auth.rs
@@ -273,7 +273,12 @@ pub async fn github_login(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    debug!("Redirecting to GitHub with state: {}", state);
+    let state_present = !state.is_empty();
+    let state_len = state.len();
+    debug!(
+        state_present,
+        state_len, "Redirecting to GitHub OAuth provider"
+    );
     Ok(Redirect::to(&auth_url))
 }
 
@@ -316,7 +321,12 @@ pub async fn google_login(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    debug!("Redirecting to Google with state: {}", state);
+    let state_present = !state.is_empty();
+    let state_len = state.len();
+    debug!(
+        state_present,
+        state_len, "Redirecting to Google OAuth provider"
+    );
     Ok(Redirect::to(&auth_url))
 }
 
@@ -331,7 +341,9 @@ pub async fn oauth_callback(
     State((oauth, state_store, auth_service, config)): State<AuthState>,
     request: Request,
 ) -> Response {
-    debug!("OAuth callback received with state: {}", params.state);
+    let state_present = !params.state.is_empty();
+    let state_len = params.state.len();
+    debug!(state_present, state_len, "OAuth callback received");
 
     let user_agent_header = match request
         .headers()
@@ -356,7 +368,7 @@ pub async fn oauth_callback(
     let oauth_state_row = match state_store.get_and_delete(&params.state).await {
         Ok(Some(row)) => row,
         Ok(None) => {
-            tracing::warn!("Invalid or expired OAuth state: {}", params.state);
+            tracing::warn!(state_present, state_len, "Invalid or expired OAuth state");
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({
@@ -452,9 +464,10 @@ pub async fn oauth_callback(
     };
 
     // Create session for the user (24 hours)
+    let user_id = user.id.clone();
     let session_result = auth_service
         .create_session(
-            user.id,
+            user_id.clone(),
             None,
             user_agent_header.to_string(),
             config.auth.encoding_key.to_string(),
@@ -465,7 +478,7 @@ pub async fn oauth_callback(
 
     match session_result {
         Ok((access_token, refresh_session, refresh_token)) => {
-            debug!("Session created successfully for user: {}", user.email);
+            debug!(user_id = %user_id.0, "Session created successfully for user");
 
             if let Some(frontend_url) = oauth_state_row.frontend_callback {
                 let validated_url = match validate_frontend_callback(&frontend_url, &config.cors) {
@@ -535,7 +548,7 @@ pub async fn current_user(Extension(user): Extension<AuthenticatedUser>) -> Json
 
 /// Logout endpoint
 pub async fn logout(Extension(user): Extension<AuthenticatedUser>) -> Response {
-    debug!("Logging out user: {}", user.0.email);
+    debug!("Logging out user_id={}", user.0.id);
 
     // This would need the session_id from cookie in real implementation
     // For now, just clear the cookie

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -81,6 +81,16 @@ fn insert_encryption_headers(
     }
 }
 
+fn insert_request_id_header(
+    correlation: RequestCorrelation,
+    extra: &mut std::collections::HashMap<String, serde_json::Value>,
+) {
+    extra.insert(
+        "x_request_id".to_string(),
+        serde_json::Value::String(correlation.request_id.to_string()),
+    );
+}
+
 // Custom header for exposing the inference ID as a UUID
 const HEADER_INFERENCE_ID: &str = "Inference-Id";
 
@@ -4108,6 +4118,7 @@ pub async fn image_generations(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     OpenAiJson(request): OpenAiJson<crate::models::ImageGenerationRequest>,
 ) -> axum::response::Response {
@@ -4197,6 +4208,7 @@ pub async fn image_generations(
     // Convert API request to provider params
     let mut extra = std::collections::HashMap::new();
     insert_encryption_headers(&encryption_headers, &mut extra);
+    insert_request_id_header(correlation, &mut extra);
 
     let params = inference_providers::ImageGenerationParams {
         model: request.model.clone(),
@@ -4362,6 +4374,7 @@ pub async fn audio_transcriptions(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     mut multipart: Multipart,
 ) -> axum::response::Response {
@@ -4523,6 +4536,7 @@ pub async fn audio_transcriptions(
     // Convert API request to provider params
     let mut extra = std::collections::HashMap::new();
     insert_encryption_headers(&encryption_headers, &mut extra);
+    insert_request_id_header(correlation, &mut extra);
 
     let requested_response_format = request.response_format.clone();
     let provider_response_format = match requested_response_format.as_deref() {
@@ -5260,6 +5274,7 @@ pub async fn rerank(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(_body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     OpenAiJson(request): OpenAiJson<crate::models::RerankRequest>,
 ) -> axum::response::Response {
@@ -5322,6 +5337,7 @@ pub async fn rerank(
     // Convert API request to provider params
     let mut extra = std::collections::HashMap::new();
     insert_encryption_headers(&encryption_headers, &mut extra);
+    insert_request_id_header(correlation, &mut extra);
 
     let params = inference_providers::RerankParams {
         model: request.model.clone(),
@@ -5605,6 +5621,7 @@ pub async fn embeddings(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(_body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     body: Bytes,
 ) -> axum::response::Response {
@@ -5672,6 +5689,7 @@ pub async fn embeddings(
     };
     let mut extra = std::collections::HashMap::new();
     insert_encryption_headers(&encryption_headers, &mut extra);
+    insert_request_id_header(correlation, &mut extra);
 
     match app_state
         .completion_service
@@ -5909,6 +5927,7 @@ pub async fn privacy_classify(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(_body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     body: Bytes,
 ) -> axum::response::Response {
@@ -5974,6 +5993,7 @@ pub async fn privacy_classify(
     };
     let mut extra = std::collections::HashMap::new();
     insert_encryption_headers(&encryption_headers, &mut extra);
+    insert_request_id_header(correlation, &mut extra);
 
     match app_state
         .completion_service
@@ -6235,6 +6255,7 @@ pub async fn privacy_redact(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(_body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     body: Bytes,
 ) -> axum::response::Response {
@@ -6373,6 +6394,7 @@ pub async fn privacy_redact(
     };
     let mut extra = std::collections::HashMap::new();
     insert_encryption_headers(&encryption_headers, &mut extra);
+    insert_request_id_header(correlation, &mut extra);
 
     // Forward a normalized classify request to the upstream model. We
     // deliberately rebuild the body rather than passing the client body
@@ -6696,6 +6718,7 @@ pub async fn score(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     OpenAiJson(request): OpenAiJson<crate::models::ScoreRequest>,
 ) -> axum::response::Response {
@@ -6768,6 +6791,7 @@ pub async fn score(
                     };
                 let mut extra = std::collections::HashMap::new();
                 insert_encryption_headers(&encryption_headers, &mut extra);
+                insert_request_id_header(correlation, &mut extra);
 
                 inference_providers::ScoreParams {
                     model: request.model.clone(),

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1,5 +1,5 @@
 use crate::{
-    middleware::{auth::AuthenticatedApiKey, RequestBodyHash},
+    middleware::{auth::AuthenticatedApiKey, RequestBodyHash, RequestCorrelation},
     models::*,
     routes::{
         api::AppState,
@@ -1296,6 +1296,7 @@ pub async fn chat_completions(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     OpenAiJson(request): OpenAiJson<ChatCompletionRequest>,
 ) -> axum::response::Response {
@@ -1312,14 +1313,7 @@ pub async fn chat_completions(
         return (StatusCode::BAD_REQUEST, ResponseJson(error)).into_response();
     }
 
-    // Generate a per-request correlation ID. Reuse the client's X-Request-Id if
-    // present and parseable as a UUID; otherwise generate a fresh one. This ID
-    // propagates downstream as X-Request-Id on every outbound inference call.
-    let request_id = headers
-        .get("x-request-id")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| Uuid::parse_str(s).ok())
-        .unwrap_or_else(Uuid::new_v4);
+    let request_id = correlation.request_id;
 
     // Create a span carrying correlation IDs so every log line within this
     // request carries request_id/org_id/workspace_id in Datadog.
@@ -1739,12 +1733,48 @@ async fn chat_completions_inner(
                                         );
                                         "{}".to_string()
                                     });
-                                    // Do not log json_data: it contains AI response content
-                                    // (text deltas) which must never appear in logs even at
-                                    // debug level (CLAUDE.md logging policy). The
-                                    // re-serialization path is reached by non-attested models
-                                    // when strip_intermediate_usage is active, so user message
-                                    // context can be reflected back in these chunks.
+                                    let (
+                                        serialized_chunk_len,
+                                        choices_count,
+                                        finish_reason_count,
+                                        usage_present,
+                                    ) = match &chunk {
+                                        inference_providers::StreamChunk::Chat(chat) => (
+                                            json_data.len(),
+                                            chat.choices.len(),
+                                            chat.choices
+                                                .iter()
+                                                .filter(|choice| choice.finish_reason.is_some())
+                                                .count(),
+                                            chat.usage.is_some(),
+                                        ),
+                                        inference_providers::StreamChunk::Text(text) => (
+                                            json_data.len(),
+                                            text.choices.len(),
+                                            text.choices
+                                                .iter()
+                                                .filter(|choice| choice.finish_reason.is_some())
+                                                .count(),
+                                            text.usage.is_some(),
+                                        ),
+                                    };
+                                    // Suppress per-chunk debug logging when
+                                    // auto_redact is enabled: the chunk now
+                                    // holds the user's original PII (we just
+                                    // un-redacted it). Logging it would
+                                    // defeat the privacy guarantee at debug.
+                                    if !auto_redact_enabled {
+                                        tracing::debug!(
+                                            %request_id,
+                                            serialized_chunk_len,
+                                            choices_count,
+                                            has_choices = choices_count > 0,
+                                            finish_reason_count,
+                                            has_finish_reason = finish_reason_count > 0,
+                                            usage_present,
+                                            "Completion stream event serialized"
+                                        );
+                                    }
                                     // Format as SSE event with proper newlines
                                     let sse_bytes = Bytes::from(format!("data: {json_data}\n\n"));
                                     if gateway_signature_enabled {
@@ -2126,6 +2156,7 @@ pub async fn completions(
     State(app_state): State<AppState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: header::HeaderMap,
     OpenAiJson(request): OpenAiJson<CompletionRequest>,
 ) -> axum::response::Response {
@@ -2143,13 +2174,7 @@ pub async fn completions(
         return (StatusCode::BAD_REQUEST, ResponseJson(error)).into_response();
     }
 
-    // Per-request correlation ID: reuse the client's X-Request-Id if present and
-    // parseable as a UUID, otherwise generate one. Matches chat_completions.
-    let request_id = headers
-        .get("x-request-id")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| Uuid::parse_str(s).ok())
-        .unwrap_or_else(Uuid::new_v4);
+    let request_id = correlation.request_id;
 
     // See chat_completions: do NOT span.enter() in async code; .instrument() the
     // inner future so the span wraps every await without leaking across tasks.

--- a/crates/api/src/routes/conversations.rs
+++ b/crates/api/src/routes/conversations.rs
@@ -59,7 +59,11 @@ pub async fn create_conversation(
     Json(request): Json<CreateConversationRequest>,
 ) -> Result<(StatusCode, ResponseJson<ConversationObject>), (StatusCode, ResponseJson<ErrorResponse>)>
 {
-    debug!("Create conversation request from key: {:?}", api_key);
+    debug!(
+        workspace_id = %api_key.workspace_id.0,
+        api_key_present = true,
+        "Create conversation request from API key"
+    );
 
     // Validate the request
     if let Err(error) = request.validate() {

--- a/crates/api/src/routes/responses.rs
+++ b/crates/api/src/routes/responses.rs
@@ -1,5 +1,5 @@
 use crate::{
-    middleware::{auth::AuthenticatedApiKey, RequestBodyHash},
+    middleware::{auth::AuthenticatedApiKey, RequestBodyHash, RequestCorrelation},
     models::{ErrorResponse, ResponseInputItemList},
     routes::common::{HEADER_SHOULD_RETRY, SHOULD_RETRY_FALSE},
     routes::extractors::OpenAiJson,
@@ -242,6 +242,7 @@ pub async fn create_response(
     State(state): State<ResponseRouteState>,
     Extension(api_key): Extension<AuthenticatedApiKey>,
     Extension(body_hash): Extension<RequestBodyHash>,
+    Extension(correlation): Extension<RequestCorrelation>,
     headers: HeaderMap,
     OpenAiJson(mut request): OpenAiJson<CreateResponseRequest>,
 ) -> axum::response::Response {
@@ -313,6 +314,7 @@ pub async fn create_response(
                 request,
                 services::UserId(api_key.api_key.created_by_user_id.0),
                 api_key.api_key.id.0.clone(),
+                correlation.request_id,
                 api_key.organization.id.0,
                 api_key.workspace.id.0,
                 body_hash.hash.clone(),
@@ -436,6 +438,7 @@ pub async fn create_response(
                 request.clone(),
                 services::UserId(api_key.api_key.created_by_user_id.0),
                 api_key.api_key.id.0.clone(),
+                correlation.request_id,
                 api_key.organization.id.0,
                 api_key.workspace.id.0,
                 body_hash.hash.clone(),
@@ -466,13 +469,17 @@ pub async fn create_response(
                 let mut delta_count = 0;
                 while let Some(event) = stream.next().await {
                     event_count += 1;
+                    let event_type = event.event_type.as_str();
+                    let delta_len = event.delta.as_ref().map_or(0, String::len);
+                    let has_delta = event.delta.is_some();
                     tracing::debug!(
-                        "Non-streaming collection: received event #{} type={} delta={:?}",
                         event_count,
-                        event.event_type,
-                        event.delta
+                        event_type,
+                        has_delta,
+                        delta_len,
+                        "Non-streaming collection received event"
                     );
-                    match event.event_type.as_str() {
+                    match event_type {
                         "response.created" => {
                             // Extract response ID from response object
                             if let Some(response) = &event.response {
@@ -488,10 +495,9 @@ pub async fn create_response(
                             if let Some(delta) = &event.delta {
                                 delta_count += 1;
                                 tracing::debug!(
-                                    "Non-streaming: delta #{} len={} content='{}'",
+                                    "Non-streaming: delta #{} len={}",
                                     delta_count,
-                                    delta.len(),
-                                    delta
+                                    delta.len()
                                 );
                                 content.push_str(delta);
                             }
@@ -531,8 +537,8 @@ pub async fn create_response(
                                                 } = content_part
                                                 {
                                                     tracing::debug!(
-                                                        "Non-streaming: final_response output[{}].content[{}] text_len={} text='{}'",
-                                                        idx, cidx, text.len(), text
+                                                        "Non-streaming: final_response output[{}].content[{}] text_len={}",
+                                                        idx, cidx, text.len()
                                                     );
                                                 }
                                             }

--- a/crates/api/src/routes/users.rs
+++ b/crates/api/src/routes/users.rs
@@ -479,7 +479,7 @@ pub async fn list_user_invitations(
     Json<Vec<crate::models::OrganizationInvitationWithOrgResponse>>,
     (StatusCode, Json<ErrorResponse>),
 > {
-    debug!("Listing invitations for user: {}", user.0.email);
+    debug!("Listing invitations for user_id={}", user.0.id);
 
     match app_state
         .organization_service
@@ -534,12 +534,13 @@ pub async fn accept_invitation(
     Extension(user): Extension<AuthenticatedUser>,
     Path(invitation_id): Path<Uuid>,
 ) -> Result<Json<crate::models::AcceptInvitationResponse>, (StatusCode, Json<ErrorResponse>)> {
-    debug!(
-        "User {} accepting invitation {}",
-        user.0.email, invitation_id
-    );
-
     let user_id = authenticated_user_to_user_id(user.clone());
+    debug!(
+        user_id = %user_id.0,
+        invitation_id = %invitation_id,
+        action = "accept",
+        "User invitation action requested"
+    );
 
     match app_state
         .organization_service
@@ -615,9 +616,12 @@ pub async fn decline_invitation(
     Extension(user): Extension<AuthenticatedUser>,
     Path(invitation_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let user_id = authenticated_user_to_user_id(user.clone());
     debug!(
-        "User {} declining invitation {}",
-        user.0.email, invitation_id
+        user_id = %user_id.0,
+        invitation_id = %invitation_id,
+        action = "decline",
+        "User invitation action requested"
     );
 
     match app_state
@@ -741,7 +745,7 @@ pub async fn accept_invitation_by_token(
     Extension(user): Extension<AuthenticatedUser>,
     Path(token): Path<String>,
 ) -> Result<Json<crate::models::AcceptInvitationResponse>, (StatusCode, Json<ErrorResponse>)> {
-    debug!("User {} accepting invitation by token", user.0.email);
+    debug!("User_id={} accepting invitation by token", user.0.id);
 
     let user_id = authenticated_user_to_user_id(user.clone());
 

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -54,6 +54,7 @@ mod privacy_redact;
 mod provider_errors;
 mod reasoning;
 mod repositories;
+mod request_id_contract;
 mod rerank;
 mod response_signature_verification;
 mod score;

--- a/crates/api/tests/e2e_all/request_id_contract.rs
+++ b/crates/api/tests/e2e_all/request_id_contract.rs
@@ -1,0 +1,244 @@
+use crate::common::{
+    get_api_key_for_org, list_workspaces, setup_org_with_credits, setup_qwen_model,
+    setup_test_server_with_search_providers, MockWebSearchProvider,
+};
+use axum::http::Method;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use uuid::Uuid;
+
+const REQUEST_ID_HEADER: &str = "x-request-id";
+const ORG_ID_HEADER: &str = "x-org-id";
+const WORKSPACE_ID_HEADER: &str = "x-workspace-id";
+static DEV_ENV: OnceLock<()> = OnceLock::new();
+
+fn allow_debug_attestation_keys() {
+    DEV_ENV.get_or_init(|| {
+        std::env::set_var("DEV", "1");
+        std::env::set_var("BRAVE_SEARCH_PRO_API_KEY", "request-id-contract-test");
+    });
+}
+
+async fn setup_request_id_server() -> (
+    axum_test::TestServer,
+    Arc<inference_providers::mock::MockProvider>,
+) {
+    allow_debug_attestation_keys();
+    let (server, _, mock_provider) = setup_test_server_with_search_providers(
+        Arc::new(MockWebSearchProvider::default_results()),
+        None,
+    )
+    .await;
+    (server, mock_provider)
+}
+
+fn request_id(response: &axum_test::TestResponse) -> Uuid {
+    let value = response
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|header| header.to_str().ok())
+        .expect("response should include x-request-id");
+    Uuid::parse_str(value).expect("x-request-id should be a UUID")
+}
+
+fn assert_uuid_response_id(label: &str, response: &axum_test::TestResponse) -> Uuid {
+    let id = request_id(response);
+    println!(
+        "request_id_contract {label}: status={} x-request-id={id}",
+        response.status_code()
+    );
+    id
+}
+
+fn header_value(response: &axum_test::TestResponse, name: &str) -> String {
+    response
+        .headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .expect("response should include expected header")
+        .to_string()
+}
+
+fn assert_header_csv_contains(response: &axum_test::TestResponse, name: &str, expected: &str) {
+    let header = header_value(response, name);
+    assert!(
+        header
+            .split(',')
+            .map(str::trim)
+            .any(|part| part == "*" || part.eq_ignore_ascii_case(expected)),
+        "{name} should include {expected}; actual value: {header}"
+    );
+}
+
+#[tokio::test]
+async fn test_request_id_contract_for_public_and_error_surfaces() {
+    // Given
+    let (server, _) = setup_request_id_server().await;
+    let valid_id = Uuid::new_v4();
+    let org = setup_org_with_credits(&server, 10_000_000_000).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+    let model = setup_qwen_model(&server).await;
+
+    // When
+    let health = server
+        .get("/v1/health")
+        .add_header(REQUEST_ID_HEADER, valid_id.to_string())
+        .await;
+    let invalid = server
+        .get("/v1/health")
+        .add_header(REQUEST_ID_HEADER, "not-a-uuid")
+        .await;
+    let absent = server.get("/v1/health").await;
+    let unknown = server.get("/v1/unknown-route-for-request-id").await;
+    let auth = server
+        .post("/v1/chat/completions")
+        .json(&serde_json::json!({
+            "model": "request-id-contract",
+            "messages": [{"role": "user", "content": "sentinel-auth"}]
+        }))
+        .await;
+    let validation = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&serde_json::json!({
+            "model": model,
+            "messages": []
+        }))
+        .await;
+
+    // Then
+    assert_eq!(
+        assert_uuid_response_id("success valid reuse", &health),
+        valid_id
+    );
+
+    let invalid_id = assert_uuid_response_id("invalid replacement", &invalid);
+    assert_ne!(invalid_id.to_string(), "not-a-uuid");
+
+    let absent_id = assert_uuid_response_id("generated absent", &absent);
+    assert_ne!(absent_id, invalid_id);
+
+    assert_uuid_response_id("unknown route error", &unknown);
+    assert_uuid_response_id("auth error", &auth);
+    assert_eq!(validation.status_code(), 400);
+    assert_uuid_response_id("validation error", &validation);
+}
+
+#[tokio::test]
+async fn test_request_id_contract_for_cors_and_streaming_surfaces() {
+    // Given
+    let (server, mock_provider) = setup_request_id_server().await;
+    let org = setup_org_with_credits(&server, 10_000_000_000).await;
+    let workspaces = list_workspaces(&server, org.id.clone()).await;
+    let workspace_id = workspaces
+        .first()
+        .expect("test org should have a default workspace")
+        .id
+        .clone();
+    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+    let model = setup_qwen_model(&server).await;
+    let spoofed_org_id = Uuid::new_v4().to_string();
+    let spoofed_workspace_id = Uuid::new_v4().to_string();
+    let inbound_request_id = Uuid::new_v4();
+
+    // When
+    let cors = server
+        .method(Method::OPTIONS, "/v1/health")
+        .add_header("Origin", "http://localhost:3000")
+        .add_header("Access-Control-Request-Method", "GET")
+        .add_header("Access-Control-Request-Headers", REQUEST_ID_HEADER)
+        .await;
+    let cors_actual = server
+        .get("/v1/health")
+        .add_header("Origin", "http://localhost:3000")
+        .await;
+    let streaming = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .add_header(REQUEST_ID_HEADER, inbound_request_id.to_string())
+        .add_header(ORG_ID_HEADER, spoofed_org_id.clone())
+        .add_header(WORKSPACE_ID_HEADER, spoofed_workspace_id.clone())
+        .json(&serde_json::json!({
+            "model": model,
+            "stream": true,
+            "messages": [{"role": "user", "content": "sentinel-stream"}]
+        }))
+        .await;
+
+    // Then
+    assert_uuid_response_id("CORS preflight", &cors);
+    assert_header_csv_contains(&cors, "access-control-allow-headers", REQUEST_ID_HEADER);
+    println!(
+        "request_id_contract CORS allow status={} x-request-id_allowed=true access-control-allow-headers={}",
+        cors.status_code(),
+        header_value(&cors, "access-control-allow-headers")
+    );
+    assert_uuid_response_id("CORS actual", &cors_actual);
+    assert_header_csv_contains(
+        &cors_actual,
+        "access-control-expose-headers",
+        REQUEST_ID_HEADER,
+    );
+    println!(
+        "request_id_contract CORS expose status={} x-request-id_exposed=true access-control-expose-headers={}",
+        cors_actual.status_code(),
+        header_value(&cors_actual, "access-control-expose-headers")
+    );
+    let selected_id = assert_uuid_response_id("streaming success", &streaming);
+    assert_eq!(streaming.status_code(), 200);
+    assert_eq!(selected_id, inbound_request_id);
+    println!(
+        "request_id_contract streaming headers observed before body chunks status={} x-request-id={selected_id}",
+        streaming.status_code()
+    );
+    let streaming_body = streaming.text();
+    assert!(
+        streaming_body.contains("[DONE]"),
+        "streaming test must drain the finite SSE response"
+    );
+    let params = mock_provider
+        .last_chat_params()
+        .await
+        .expect("streaming request should reach mock provider");
+    assert_eq!(
+        params
+            .extra
+            .get("x_request_id")
+            .and_then(serde_json::Value::as_str),
+        Some(selected_id.to_string().as_str()),
+        "provider propagation should use selected middleware request ID"
+    );
+    assert_eq!(
+        params
+            .extra
+            .get("x_org_id")
+            .and_then(serde_json::Value::as_str),
+        Some(org.id.as_str()),
+        "provider propagation should use the authenticated organization"
+    );
+    assert_eq!(
+        params
+            .extra
+            .get("x_workspace_id")
+            .and_then(serde_json::Value::as_str),
+        Some(workspace_id.as_str()),
+        "provider propagation should use the authenticated workspace"
+    );
+    assert_ne!(
+        params
+            .extra
+            .get("x_org_id")
+            .and_then(serde_json::Value::as_str),
+        Some(spoofed_org_id.as_str()),
+        "public tenant spoofing headers must not propagate"
+    );
+    assert_ne!(
+        params
+            .extra
+            .get("x_workspace_id")
+            .and_then(serde_json::Value::as_str),
+        Some(spoofed_workspace_id.as_str()),
+        "public workspace spoofing headers must not propagate"
+    );
+    println!("request_id_contract tenant spoof rejection: public tenant headers ignored");
+}

--- a/crates/api/tests/e2e_all/usage_chat_completions.rs
+++ b/crates/api/tests/e2e_all/usage_chat_completions.rs
@@ -6,11 +6,22 @@ use crate::common::*;
 use inference_providers::StreamChunk;
 use serde_json::json;
 use services::usage::compute_token_cost;
+use std::sync::OnceLock;
+
+static DEV_ENV: OnceLock<()> = OnceLock::new();
+
+fn ensure_usage_chat_completions_env() {
+    DEV_ENV.get_or_init(|| {
+        std::env::set_var("DEV", "1");
+        std::env::set_var("BRAVE_SEARCH_PRO_API_KEY", "request-id-contract-test");
+    });
+}
 
 /// Call chat/completions (non-streaming), assert usage in response, then verify org usage
 /// history contains a matching entry (including cache_read_tokens).
 #[tokio::test]
 async fn test_chat_completions_records_usage_and_history() {
+    ensure_usage_chat_completions_env();
     let server = setup_test_server().await;
 
     setup_qwen_model(&server).await;
@@ -124,6 +135,7 @@ async fn test_chat_completions_records_usage_and_history() {
 /// for attested models to preserve provider signatures; billing capture must remain independent.
 #[tokio::test]
 async fn test_chat_completions_stream_records_usage_in_history() {
+    ensure_usage_chat_completions_env();
     let server = setup_test_server().await;
 
     setup_qwen_model(&server).await;
@@ -342,6 +354,7 @@ async fn test_chat_completions_stream_include_usage_false_emits_usage_null_in_al
 
 #[tokio::test]
 async fn test_chat_completions_stream_include_usage_true_emits_final_usage_only() {
+    ensure_usage_chat_completions_env();
     let server = setup_test_server().await;
 
     setup_qwen_model(&server).await;
@@ -409,6 +422,7 @@ async fn test_chat_completions_stream_include_usage_true_emits_final_usage_only(
 
 #[tokio::test]
 async fn test_chat_completions_stream_error_does_not_emit_final_usage() {
+    ensure_usage_chat_completions_env();
     let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
 
     mock_provider
@@ -485,6 +499,7 @@ async fn test_chat_completions_stream_error_does_not_emit_final_usage() {
 /// we assert equality without clamping in the test.
 #[tokio::test]
 async fn test_chat_completions_with_cache_records_cache_in_history() {
+    ensure_usage_chat_completions_env();
     let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
 
     let message = "hello world";
@@ -552,6 +567,7 @@ async fn test_chat_completions_with_cache_records_cache_in_history() {
 /// Stream version: cache based on provider token estimate; assert equality without clamping.
 #[tokio::test]
 async fn test_chat_completions_stream_with_cache_records_cache_in_history() {
+    ensure_usage_chat_completions_env();
     let (server, _pool, mock_provider, _db) = setup_test_server_with_pool().await;
 
     let message = "hello world";

--- a/crates/database/src/repositories/oauth_state.rs
+++ b/crates/database/src/repositories/oauth_state.rs
@@ -92,7 +92,9 @@ impl OAuthStateRepository {
                 Ok(Some(oauth_state))
             }
             None => {
-                debug!("OAuth state not found or expired: {}", state);
+                let state_present = !state.is_empty();
+                let state_len = state.len();
+                debug!(state_present, state_len, "OAuth state not found or expired");
                 Ok(None)
             }
         }

--- a/crates/database/src/repositories/organization_invitation.rs
+++ b/crates/database/src/repositories/organization_invitation.rs
@@ -184,8 +184,8 @@ impl OrganizationInvitationRepository for PgOrganizationInvitationRepository {
         let expires_at = Utc::now() + Duration::hours(request.expires_in_hours);
 
         debug!(
-            "Creating invitation for {} to organization {} with role {}",
-            request.email, org_id, role
+            "Creating invitation for organization {} with role {}",
+            org_id, role
         );
 
         let row = retry_db!("create_organization_invitation", {

--- a/crates/database/src/repositories/user.rs
+++ b/crates/database/src/repositories/user.rs
@@ -65,7 +65,7 @@ impl UserRepository {
                 .map_err(map_db_error)
         })?;
 
-        debug!("Created/updated user: {} ({})", email, id);
+        debug!("Created/updated user: {}", id);
         self.row_to_user(row)
     }
 

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -289,8 +289,8 @@ impl AuthServiceTrait for AuthService {
 
         // Create default organization and workspace for new user
         debug!(
-            "Creating default organization and workspace for new user: {}",
-            new_user.email
+            user_id = %new_user.id.0,
+            "Creating default organization and workspace for new user"
         );
 
         // Generate organization name from user email with random suffix
@@ -316,8 +316,9 @@ impl AuthServiceTrait for AuthService {
         {
             Ok(organization) => {
                 debug!(
-                    "Created default organization: {} for user: {}",
-                    organization.id.0, new_user.email
+                    organization_id = %organization.id.0,
+                    user_id = %new_user.id.0,
+                    "Created default organization for user"
                 );
 
                 // Create default workspace
@@ -334,8 +335,9 @@ impl AuthServiceTrait for AuthService {
                 match workspace_result {
                     Ok(workspace) => {
                         debug!(
-                            "Created default workspace: {} for user: {}",
-                            workspace.id.0, new_user.email
+                            workspace_id = %workspace.id.0,
+                            user_id = %new_user.id.0,
+                            "Created default workspace for user"
                         );
                     }
                     Err(_) => {

--- a/crates/services/src/auth/oauth.rs
+++ b/crates/services/src/auth/oauth.rs
@@ -158,7 +158,11 @@ impl OAuthManager {
             avatar_url: user_info.avatar_url,
         };
 
-        debug!("GitHub user authenticated: {}", oauth_info.email);
+        debug!(
+            provider = "github",
+            provider_user_id = %oauth_info.provider_user_id,
+            "OAuth user authenticated"
+        );
         Ok((oauth_info, access_token.to_string()))
     }
 
@@ -206,7 +210,11 @@ impl OAuthManager {
             avatar_url: user_info.picture,
         };
 
-        debug!("Google user authenticated: {}", oauth_info.email);
+        debug!(
+            provider = "google",
+            provider_user_id = %oauth_info.provider_user_id,
+            "OAuth user authenticated"
+        );
         Ok((oauth_info, access_token.to_string()))
     }
 

--- a/crates/services/src/auth/ports.rs
+++ b/crates/services/src/auth/ports.rs
@@ -530,14 +530,14 @@ impl AuthServiceTrait for MockAuthService {
         match self.validate_session_access_token(access_token.clone(), encoding_key) {
             Ok(Some(claims)) => {
                 let user = Self::create_mock_user_with_id(claims.sub);
-                tracing::debug!("MockAuthService returning mock user: {}", user.email);
+                tracing::debug!(user_id = %user.id.0, "MockAuthService returning mock user");
                 Ok(user)
             }
             Ok(None) => {
                 // JWT decoding failed - try to extract user ID from rt_ token format
                 let user_id = Self::extract_user_id_from_token(&access_token);
                 let user = Self::create_mock_user_with_id(user_id);
-                tracing::debug!("MockAuthService returning mock user: {}", user.email);
+                tracing::debug!(user_id = %user.id.0, "MockAuthService returning mock user");
                 Ok(user)
             }
             Err(_) => Err(AuthError::SessionNotFound),
@@ -566,17 +566,19 @@ impl AuthServiceTrait for MockAuthService {
         session_token: SessionToken,
         user_agent: &str,
     ) -> Result<(Session, User), AuthError> {
+        let session_token_present = !session_token.0.is_empty();
+        let user_agent_present = !user_agent.is_empty();
         tracing::debug!(
-            "MockAuthService::validate_session called with token: {}, user_agent: {}",
-            session_token,
-            user_agent
+            session_token_present,
+            user_agent_present,
+            "MockAuthService::validate_session called"
         );
         // Accept any token that starts with "rt_"
         if session_token.0.starts_with("rt_") && user_agent == MOCK_USER_AGENT {
             let user_id = Self::extract_user_id_from_token(&session_token.0);
             let user = Self::create_mock_user_with_id(user_id);
             let (_, session, _) = self.create_mock_session(user.id.clone());
-            tracing::debug!("MockAuthService returning mock user: {}", user.email);
+            tracing::debug!(user_id = %user.id.0, "MockAuthService returning mock user");
             Ok((session, user))
         } else {
             Err(AuthError::SessionNotFound)

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -17,6 +17,7 @@ use futures_util::{Future, Stream};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
+use tracing::Instrument;
 
 const FINALIZE_TIMEOUT_SECS: u64 = 5;
 const DEEPSEEK_V4_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
@@ -265,89 +266,92 @@ where
         // Spawn critical billing operations on blocking thread pool with timeout.
         // The tokio runtime waits for blocking tasks during graceful shutdown,
         // which helps prevent data loss compared to regular spawn.
+        let handle_clone = handle.clone();
         handle.spawn_blocking(move || {
-            let _span_guard = span.enter();
+            handle_clone.block_on(
+                async move {
+                    let result = tokio::time::timeout(Duration::from_secs(2), async move {
+                        let stop_reason = if let Some(ref err) = last_error {
+                            Some(crate::usage::StopReason::from_completion_error(err))
+                        } else if !stream_completed {
+                            Some(crate::usage::StopReason::ClientDisconnect)
+                        } else if let Some(ref finish_reason) = last_finish_reason {
+                            Some(crate::usage::StopReason::from_provider_finish_reason(
+                                finish_reason,
+                            ))
+                        } else {
+                            Some(crate::usage::StopReason::Completed)
+                        };
 
-            let runtime = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(runtime) => runtime,
-                Err(error) => {
-                    tracing::error!(%error, "Failed to create usage recording runtime");
-                    return;
-                }
-            };
+                        if usage_service
+                            .record_usage(RecordUsageServiceRequest {
+                                organization_id,
+                                workspace_id,
+                                api_key_id,
+                                model_id,
+                                input_tokens,
+                                output_tokens,
+                                cache_read_tokens,
+                                inference_type,
+                                ttft_ms,
+                                avg_itl_ms,
+                                inference_id: Some(inference_id),
+                                provider_request_id: Some(chat_id),
+                                stop_reason,
+                                response_id,
+                                image_count: None,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            tracing::error!("Failed to record usage");
+                        }
 
-            runtime.block_on(async move {
-                let result = tokio::time::timeout(Duration::from_secs(2), async move {
-                    let stop_reason = if let Some(ref err) = last_error {
-                        Some(crate::usage::StopReason::from_completion_error(err))
-                    } else if !stream_completed {
-                        Some(crate::usage::StopReason::ClientDisconnect)
-                    } else if let Some(ref finish_reason) = last_finish_reason {
-                        Some(crate::usage::StopReason::from_provider_finish_reason(
-                            finish_reason,
-                        ))
-                    } else {
-                        Some(crate::usage::StopReason::Completed)
-                    };
+                        // Record metrics
+                        let tags: Vec<&str> = metric_tags.iter().map(|s| s.as_str()).collect();
+                        metrics_service.record_latency(METRIC_LATENCY_TOTAL, e2e_duration, &tags);
 
-                    if usage_service
-                        .record_usage(RecordUsageServiceRequest {
-                            organization_id,
-                            workspace_id,
-                            api_key_id,
-                            model_id,
-                            input_tokens,
-                            output_tokens,
-                            cache_read_tokens,
-                            inference_type,
-                            ttft_ms,
-                            avg_itl_ms,
-                            inference_id: Some(inference_id),
-                            provider_request_id: Some(chat_id),
-                            stop_reason,
-                            response_id,
-                            image_count: None,
-                        })
-                        .await
-                        .is_err()
-                    {
-                        tracing::error!("Failed to record usage");
-                    }
+                        if let Some(first_token_instant) = first_token_time {
+                            let decoding_duration = first_token_instant.elapsed();
+                            metrics_service.record_latency(
+                                METRIC_LATENCY_DECODING_TIME,
+                                decoding_duration,
+                                &tags,
+                            );
 
-                    // Record metrics
-                    let tags: Vec<&str> = metric_tags.iter().map(|s| s.as_str()).collect();
-                    metrics_service.record_latency(METRIC_LATENCY_TOTAL, e2e_duration, &tags);
+                            let decode_secs = decoding_duration.as_secs_f64();
+                            if decode_secs > 0.0 {
+                                let tps = output_tokens as f64 / decode_secs;
+                                metrics_service.record_histogram(
+                                    METRIC_TOKENS_PER_SECOND,
+                                    tps,
+                                    &tags,
+                                );
+                            }
+                        }
 
-                    if let Some(first_token_instant) = first_token_time {
-                        let decoding_duration = first_token_instant.elapsed();
-                        metrics_service.record_latency(
-                            METRIC_LATENCY_DECODING_TIME,
-                            decoding_duration,
+                        metrics_service.record_count(
+                            METRIC_TOKENS_INPUT,
+                            input_tokens as i64,
                             &tags,
                         );
+                        metrics_service.record_count(
+                            METRIC_TOKENS_OUTPUT,
+                            output_tokens as i64,
+                            &tags,
+                        );
+                    })
+                    .await;
 
-                        let decode_secs = decoding_duration.as_secs_f64();
-                        if decode_secs > 0.0 {
-                            let tps = output_tokens as f64 / decode_secs;
-                            metrics_service.record_histogram(METRIC_TOKENS_PER_SECOND, tps, &tags);
-                        }
+                    if result.is_err() {
+                        tracing::error!(
+                            "Timeout recording usage and metrics (2s exceeded), inference_id={}",
+                            inference_id
+                        );
                     }
-
-                    metrics_service.record_count(METRIC_TOKENS_INPUT, input_tokens as i64, &tags);
-                    metrics_service.record_count(METRIC_TOKENS_OUTPUT, output_tokens as i64, &tags);
-                })
-                .await;
-
-                if result.is_err() {
-                    tracing::error!(
-                        "Timeout recording usage and metrics (2s exceeded), inference_id={}",
-                        inference_id
-                    );
                 }
-            })
+                .instrument(span),
+            )
         });
     }
 }

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -262,13 +262,24 @@ where
         let mut metric_tags = self.metric_tags.clone();
         metric_tags.push(format!("{TAG_INPUT_BUCKET}:{input_bucket}"));
 
-        // Spawn critical billing operations on blocking thread pool with timeout
+        // Spawn critical billing operations on blocking thread pool with timeout.
         // The tokio runtime waits for blocking tasks during graceful shutdown,
-        // which helps prevent data loss compared to regular spawn
-        let handle_clone = handle.clone();
+        // which helps prevent data loss compared to regular spawn.
         handle.spawn_blocking(move || {
             let _span_guard = span.enter();
-            handle_clone.block_on(async move {
+
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    tracing::error!(%error, "Failed to create usage recording runtime");
+                    return;
+                }
+            };
+
+            runtime.block_on(async move {
                 let result = tokio::time::timeout(Duration::from_secs(2), async move {
                     let stop_reason = if let Some(ref err) = last_error {
                         Some(crate::usage::StopReason::from_completion_error(err))
@@ -1172,6 +1183,7 @@ impl CompletionServiceImpl {
         }
     }
 
+    // CLIPPY-ALLOW: InterceptStream construction needs the full tracing, billing, timing, and concurrency context at one ownership boundary.
     #[allow(clippy::too_many_arguments)]
     async fn handle_stream_with_context(
         &self,

--- a/crates/services/src/responses/citation_tracker.rs
+++ b/crates/services/src/responses/citation_tracker.rs
@@ -324,7 +324,13 @@ impl CitationTracker {
                         // Citation is closing - finalize it immediately with correct indices
                         if let Some(active) = self.active_citation.take() {
                             if active.source_id == source_id {
-                                tracing::debug!("CitationTracker: Citation tag closed [/s:{}] - indices=[{}, {}], text='{}'", source_id, active.start_index, self.clean_position, active.accumulated_content);
+                                tracing::debug!(
+                                    "CitationTracker: Citation tag closed [/s:{}] - indices=[{}, {}], cited_text_len={}",
+                                    source_id,
+                                    active.start_index,
+                                    self.clean_position,
+                                    active.accumulated_content.len()
+                                );
                                 let citation = Citation {
                                     start_index: active.start_index,
                                     end_index: self.clean_position,
@@ -395,8 +401,8 @@ impl CitationTracker {
         // If there's pending token_buffer (incomplete tag at end), treat as literal
         if !self.token_buffer.is_empty() {
             tracing::debug!(
-                "CitationTracker: Flushing incomplete token_buffer at finalize: '{}'",
-                self.token_buffer
+                "CitationTracker: Flushing incomplete token_buffer at finalize: token_buffer_len={}",
+                self.token_buffer.len()
             );
             let buffer_content = self.token_buffer.clone();
             let _ = self.do_flush_to_clean_text(&buffer_content);

--- a/crates/services/src/responses/ports.rs
+++ b/crates/services/src/responses/ports.rs
@@ -126,6 +126,7 @@ pub trait ResponseServiceTrait: Send + Sync {
         request: models::CreateResponseRequest,
         user_id: UserId,
         api_key_id: String,
+        request_id: uuid::Uuid,
         organization_id: uuid::Uuid,
         workspace_id: uuid::Uuid,
         body_hash: String,

--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -31,6 +31,7 @@ struct ProcessStreamContext {
     request: models::CreateResponseRequest,
     user_id: crate::UserId,
     api_key_id: String,
+    request_id: uuid::Uuid,
     organization_id: uuid::Uuid,
     workspace_id: uuid::Uuid,
     body_hash: String,
@@ -141,6 +142,7 @@ impl ports::ResponseServiceTrait for ResponseServiceImpl {
         request: models::CreateResponseRequest,
         user_id: crate::UserId,
         api_key_id: String,
+        request_id: uuid::Uuid,
         organization_id: uuid::Uuid,
         workspace_id: uuid::Uuid,
         body_hash: String,
@@ -210,6 +212,7 @@ impl ports::ResponseServiceTrait for ResponseServiceImpl {
                 request,
                 user_id,
                 api_key_id,
+                request_id,
                 organization_id,
                 workspace_id,
                 body_hash,
@@ -1011,6 +1014,7 @@ impl ResponseServiceImpl {
             &context.request,
             context.user_id.clone(),
             context.api_key_id.clone(),
+            context.request_id,
             context.organization_id,
             context.workspace_id,
             context.conversation_service.clone(),
@@ -1396,7 +1400,7 @@ impl ResponseServiceImpl {
 
             // Create completion request (names not included - tracked via database analytics)
             let completion_request = CompletionRequest {
-                request_id: uuid::Uuid::new_v4(),
+                request_id: process_context.request_id,
                 model: process_context.request.model.clone(),
                 messages: messages.clone(),
                 max_tokens: process_context.request.max_output_tokens,
@@ -2820,6 +2824,7 @@ impl ResponseServiceImpl {
         request: &models::CreateResponseRequest,
         user_id: crate::UserId,
         api_key_id: String,
+        request_id: uuid::Uuid,
         organization_id: uuid::Uuid,
         workspace_id: uuid::Uuid,
         conversation_service: Arc<dyn ConversationServiceTrait>,
@@ -2890,6 +2895,7 @@ impl ResponseServiceImpl {
                 user_id,
                 user_message,
                 api_key_id,
+                request_id,
                 organization_id,
                 workspace_id,
                 conversation_service,
@@ -2909,6 +2915,7 @@ impl ResponseServiceImpl {
         user_id: crate::UserId,
         user_message: String,
         api_key_id: String,
+        request_id: uuid::Uuid,
         organization_id: uuid::Uuid,
         workspace_id: uuid::Uuid,
         conversation_service: Arc<dyn ConversationServiceTrait>,
@@ -2960,7 +2967,7 @@ impl ResponseServiceImpl {
         let title_model = std::env::var("TITLE_GENERATION_MODEL")
             .unwrap_or_else(|_| "Qwen/Qwen3-30B-A3B-Instruct-2507".to_string());
         let completion_request = crate::completions::ports::CompletionRequest {
-            request_id: uuid::Uuid::new_v4(),
+            request_id,
             model: title_model,
             messages: vec![crate::completions::ports::CompletionMessage {
                 role: "user".to_string(),

--- a/crates/services/src/responses/tools/tool_config.rs
+++ b/crates/services/src/responses/tools/tool_config.rs
@@ -557,12 +557,11 @@ pub fn convert_tool_calls(
                         available_tools = ?available_tool_names,
                         "Tool call has no name and multiple tools available, cannot infer"
                     );
-                    // Log args at debug level for staging troubleshooting (not in prod)
                     tracing::debug!(
                         model = model,
                         index = idx,
-                        args = args_str,
-                        "Tool call missing name - arguments for debugging"
+                        arguments_len = args_str.len(),
+                        "Tool call missing name"
                     );
                     let id = resolve_tool_call_id(id_opt, ERROR_TOOL_TYPE);
                     tool_calls_detected.push(ToolCallInfo {
@@ -604,13 +603,12 @@ pub fn convert_tool_calls(
                     index = idx,
                     "Failed to parse tool call arguments"
                 );
-                // Log args at debug level for staging troubleshooting (not in prod)
                 tracing::debug!(
                     model = model,
                     tool_name = name,
                     index = idx,
-                    args = args_str,
-                    "Failed to parse tool call - arguments for debugging"
+                    arguments_len = args_str.len(),
+                    "Failed to parse tool call"
                 );
                 tool_calls_detected.push(create_invalid_json_error(
                     &name,


### PR DESCRIPTION
## Summary
- Adds customer-facing x-request-id selection and response propagation across Cloud API public/error/streaming surfaces.
- Threads the selected request ID through logs and downstream completions/responses calls without logging customer payloads.
- Adds contract and privacy-oriented tests for request ID behavior.

## Validation
- cargo fmt --all -- --check
- TEST_DATABASE_NAME=platform_api_e2e_request_id_codex_<timestamp> cargo test -p api --test e2e_all request_id_contract -- --nocapture
- git diff --cached --check
- High-confidence staged secret pattern scan: clean

## Related PRs
- Related PR links will be added after all PRs are created.
