### PR TITLE
feat: adaptive load balancing (TTFT EMA + prefix-hash cache routing + context-length routing)

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -496,7 +496,7 @@ pub async fn batch_upsert_models(
 
     // Register inference_url models (our own vLLM/SGLang backends)
     // Only for active, non-external models with an inference_url set
-    let inference_url_models: Vec<(String, String)> = batch_request
+    let inference_url_models: Vec<(String, String, Option<u32>)> = batch_request
         .iter()
         .filter_map(|(model_name, request)| {
             let is_active = request.is_active != Some(false);
@@ -505,7 +505,7 @@ pub async fn batch_upsert_models(
                 request
                     .inference_url
                     .clone()
-                    .map(|url| (model_name.clone(), url))
+                    .map(|url| (model_name.clone(), url, request.context_length.map(|c| c as u32)))
             } else {
                 None
             }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -502,10 +502,13 @@ pub async fn batch_upsert_models(
             let is_active = request.is_active != Some(false);
             let is_external = request.provider_type.as_deref() == Some("external");
             if is_active && !is_external {
-                request
-                    .inference_url
-                    .clone()
-                    .map(|url| (model_name.clone(), url, request.context_length.map(|c| c as u32)))
+                request.inference_url.clone().map(|url| {
+                    (
+                        model_name.clone(),
+                        url,
+                        request.context_length.map(|c| c as u32),
+                    )
+                })
             } else {
                 None
             }

--- a/crates/database/src/repositories/model.rs
+++ b/crates/database/src/repositories/model.rs
@@ -1444,8 +1444,8 @@ impl ModelRepository {
     }
 
     /// Get all active models with inference_url set.
-    /// Returns (model_name, inference_url) pairs for direct routing.
-    pub async fn get_inference_url_models(&self) -> Result<Vec<(String, String)>> {
+    /// Returns (model_name, inference_url, context_length) triples for direct routing.
+    pub async fn get_inference_url_models(&self) -> Result<Vec<(String, String, Option<u32>)>> {
         let rows = retry_db!("get_inference_url_models", {
             let client = self
                 .pool
@@ -1457,7 +1457,7 @@ impl ModelRepository {
             client
                 .query(
                     r#"
-                    SELECT model_name, inference_url
+                    SELECT model_name, inference_url, context_length
                     FROM models
                     WHERE is_active = true
                       AND inference_url IS NOT NULL
@@ -1474,7 +1474,8 @@ impl ModelRepository {
             .map(|row| {
                 let model_name: String = row.get("model_name");
                 let inference_url: String = row.get("inference_url");
-                (model_name, inference_url)
+                let context_length: i32 = row.get("context_length");
+                (model_name, inference_url, Some(context_length as u32))
             })
             .collect();
         Ok(models)
@@ -1542,7 +1543,7 @@ impl services::inference_provider_pool::ExternalModelsSource for ModelRepository
             .collect())
     }
 
-    async fn fetch_inference_url_models(&self) -> Result<Vec<(String, String)>, String> {
+    async fn fetch_inference_url_models(&self) -> Result<Vec<(String, String, Option<u32>)>, String> {
         self.get_inference_url_models()
             .await
             .map_err(|e| format!("Failed to fetch inference_url models: {e}"))

--- a/crates/database/src/repositories/model.rs
+++ b/crates/database/src/repositories/model.rs
@@ -1543,7 +1543,9 @@ impl services::inference_provider_pool::ExternalModelsSource for ModelRepository
             .collect())
     }
 
-    async fn fetch_inference_url_models(&self) -> Result<Vec<(String, String, Option<u32>)>, String> {
+    async fn fetch_inference_url_models(
+        &self,
+    ) -> Result<Vec<(String, String, Option<u32>)>, String> {
         self.get_inference_url_models()
             .await
             .map_err(|e| format!("Failed to fetch inference_url models: {e}"))

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -102,6 +102,9 @@ where
     /// Whether to fetch/store provider chat signatures before ending the stream.
     store_provider_chat_signature: bool,
     provider_attribution: crate::usage::ProviderAttribution,
+    /// Callback to report observed TTFT back to the provider pool for latency-aware
+    /// routing. Called once with the backend TTFT (ms) from record_usage_and_metrics.
+    latency_reporter: Option<super::inference_provider_pool::ProviderLatencyReporter>,
 }
 
 impl<S> InterceptStream<S>
@@ -250,6 +253,12 @@ where
         let usage_service = self.usage_service.clone();
         let metrics_service = self.metrics_service.clone();
         let ttft_ms = self.ttft_ms;
+
+        // Feed TTFT back to the provider pool for latency-aware routing.
+        if let (Some(ttft), Some(reporter)) = (self.ttft_ms, &self.latency_reporter) {
+            reporter(ttft);
+        }
+
         let e2e_duration = self.service_start_time.elapsed();
         let first_token_time = self.first_token_time;
         let stream_completed = self.stream_completed;
@@ -523,6 +532,51 @@ const ORG_LIMIT_CACHE_TTL_SECS: u64 = 300;
 /// Trade-off: if legitimate long-running requests are still in-flight when the TTL fires,
 /// the limit can be temporarily exceeded until those old requests complete.
 const CONCURRENT_COUNT_TTL_SECS: u64 = 600;
+
+/// Compute a prefix hash from the first PREFIX_HASH_MESSAGES messages for cache-hit routing.
+/// We only hash text content (not image URLs) since only text lands in the KV cache.
+fn compute_prefix_hash(messages: &[inference_providers::ChatMessage]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for msg in messages
+        .iter()
+        .take(super::inference_provider_pool::PREFIX_HASH_MESSAGES)
+    {
+        // Hash role as its debug string since MessageRole doesn't implement Hash.
+        format!("{:?}", msg.role).hash(&mut hasher);
+        match &msg.content {
+            Some(serde_json::Value::String(s)) => s.hash(&mut hasher),
+            Some(serde_json::Value::Array(parts)) => {
+                for part in parts {
+                    if let Some("text") = part.get("type").and_then(|t| t.as_str()) {
+                        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                            text.hash(&mut hasher);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    hasher.finish()
+}
+
+/// Rough token count estimate for context-length routing (4 chars ≈ 1 token).
+fn estimate_input_tokens(messages: &[inference_providers::ChatMessage]) -> u32 {
+    let chars: usize = messages
+        .iter()
+        .map(|m| match &m.content {
+            Some(serde_json::Value::String(s)) => s.len(),
+            Some(serde_json::Value::Array(parts)) => parts
+                .iter()
+                .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                .map(|s| s.len())
+                .sum(),
+            _ => 0,
+        })
+        .sum();
+    (chars / 4).max(1) as u32
+}
 
 impl CompletionServiceImpl {
     /// Inject tracing correlation IDs into the `extra` map that is forwarded
@@ -1209,6 +1263,7 @@ impl CompletionServiceImpl {
         attestation_supported: bool,
         store_provider_chat_signature: bool,
         provider_attribution: crate::usage::ProviderAttribution,
+        latency_reporter: Option<super::inference_provider_pool::ProviderLatencyReporter>,
     ) -> StreamingResult {
         // Create low-cardinality metric tags (no org/workspace/key - those go to database)
         let metric_tags = Self::create_metric_tags(&model_name);
@@ -1253,6 +1308,7 @@ impl CompletionServiceImpl {
             attestation_supported,
             store_provider_chat_signature,
             provider_attribution,
+            latency_reporter,
         };
         Box::pin(intercepted_stream)
     }
@@ -1380,13 +1436,19 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
 
         let provider_start_time = Instant::now();
 
+        // Compute routing hints from the request messages for adaptive load balancing.
+        let routing_hints = super::inference_provider_pool::ChatRoutingHints {
+            prefix_hash: Some(compute_prefix_hash(&chat_params.messages)),
+            estimated_tokens: Some(estimate_input_tokens(&chat_params.messages)),
+        };
+
         // Get the LLM stream
         let attributed_stream = match self
             .inference_provider_pool
-            .chat_completion_stream_with_attribution(chat_params, request.body_hash.clone())
+            .chat_completion_stream_with_attribution(chat_params, request.body_hash.clone(), routing_hints)
             .await
         {
-            Ok(stream) => stream,
+            Ok(pair) => pair,
             Err(e) => {
                 // Guard will decrement counter on drop
                 let err = Self::map_provider_error(
@@ -1401,6 +1463,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         };
         let llm_stream = attributed_stream.stream;
         let provider_attribution = attributed_stream.provider_attribution;
+        let latency_reporter = attributed_stream.latency_reporter;
 
         // Transfer counter ownership to InterceptStream (which decrements on drop)
         let counter = guard.disarm();
@@ -1430,6 +1493,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
                 model.attestation_supported,
                 !request.skip_provider_chat_signature,
                 provider_attribution,
+                Some(latency_reporter),
             )
             .await;
 
@@ -2077,6 +2141,7 @@ mod tests {
             attestation_supported: true,
             store_provider_chat_signature: true,
             provider_attribution: crate::usage::ProviderAttribution::default(),
+            latency_reporter: None,
         };
 
         // Consume the stream
@@ -2242,6 +2307,7 @@ mod tests {
             attestation_supported: true,
             store_provider_chat_signature: true,
             provider_attribution: crate::usage::ProviderAttribution::default(),
+            latency_reporter: None,
         };
 
         // Consume the stream
@@ -2364,6 +2430,7 @@ mod tests {
             attestation_supported: true,
             store_provider_chat_signature: true,
             provider_attribution: crate::usage::ProviderAttribution::default(),
+            latency_reporter: None,
         };
 
         let _ = intercept_stream.collect::<Vec<_>>().await;
@@ -2570,6 +2637,7 @@ mod tests {
                 attestation_supported: true,
                 store_provider_chat_signature: true,
                 provider_attribution: crate::usage::ProviderAttribution::default(),
+                latency_reporter: None,
             };
             // InterceptStream goes out of scope here and Drop is called
         }

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -1445,7 +1445,11 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         // Get the LLM stream
         let attributed_stream = match self
             .inference_provider_pool
-            .chat_completion_stream_with_attribution(chat_params, request.body_hash.clone(), routing_hints)
+            .chat_completion_stream_with_attribution(
+                chat_params,
+                request.body_hash.clone(),
+                routing_hints,
+            )
             .await
         {
             Ok(pair) => pair,

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -172,7 +172,9 @@ pub trait ExternalModelsSource: Send + Sync {
     /// Fetch models that have a direct inference URL configured.
     /// Returns (model_name, inference_url, context_length) triples for active models with inference_url set.
     /// These models are routed directly to the URL, bypassing the discovery server.
-    async fn fetch_inference_url_models(&self) -> Result<Vec<(String, String, Option<u32>)>, String>;
+    async fn fetch_inference_url_models(
+        &self,
+    ) -> Result<Vec<(String, String, Option<u32>)>, String>;
 }
 
 /// Result of an attestation-discovery pass against a model URL.
@@ -1741,7 +1743,9 @@ impl InferenceProviderPool {
                 .iter()
                 .filter_map(|p| {
                     let ptr = Arc::as_ptr(p) as *const () as usize;
-                    states.get(&ptr).filter(|s| s.ttft_samples >= TTFT_WARMUP_SAMPLES && s.ttft_ewma_ms > 0.0)
+                    states
+                        .get(&ptr)
+                        .filter(|s| s.ttft_samples >= TTFT_WARMUP_SAMPLES && s.ttft_ewma_ms > 0.0)
                 })
                 .map(|s| s.ttft_ewma_ms)
                 .fold(f64::MAX, f64::min);
@@ -1776,10 +1780,7 @@ impl InferenceProviderPool {
             let mut ordered = providers;
             ordered.sort_by_key(&key_of); // stable sort
             let head_key = key_of(&ordered[0]);
-            let group_len = ordered
-                .iter()
-                .take_while(|p| key_of(p) == head_key)
-                .count();
+            let group_len = ordered.iter().take_while(|p| key_of(p) == head_key).count();
             (ordered, group_len)
         };
 
@@ -3314,7 +3315,10 @@ impl InferenceProviderPool {
             "Starting rerank request"
         );
 
-        let providers = match self.get_providers_with_fallback(&model_id, None, &ChatRoutingHints::default()).await {
+        let providers = match self
+            .get_providers_with_fallback(&model_id, None, &ChatRoutingHints::default())
+            .await
+        {
             Some(p) => p,
             None => {
                 return Err(RerankError::GenerationError(format!(
@@ -3363,7 +3367,10 @@ impl InferenceProviderPool {
     ) -> Result<bytes::Bytes, inference_providers::EmbeddingError> {
         tracing::debug!(model = %model, "Starting embeddings request");
 
-        let providers = match self.get_providers_with_fallback(model, None, &ChatRoutingHints::default()).await {
+        let providers = match self
+            .get_providers_with_fallback(model, None, &ChatRoutingHints::default())
+            .await
+        {
             Some(p) => p,
             None => {
                 return Err(inference_providers::EmbeddingError::RequestFailed(format!(
@@ -3419,7 +3426,10 @@ impl InferenceProviderPool {
     ) -> Result<bytes::Bytes, inference_providers::PrivacyClassifyError> {
         tracing::debug!(model = %model, "Starting privacy classify request");
 
-        let providers = match self.get_providers_with_fallback(model, None, &ChatRoutingHints::default()).await {
+        let providers = match self
+            .get_providers_with_fallback(model, None, &ChatRoutingHints::default())
+            .await
+        {
             Some(p) => p,
             None => {
                 return Err(inference_providers::PrivacyClassifyError::RequestFailed(
@@ -3483,7 +3493,10 @@ impl InferenceProviderPool {
 
         tracing::debug!(model = %model_id, "Starting score request");
 
-        let providers = match self.get_providers_with_fallback(&model_id, None, &ChatRoutingHints::default()).await {
+        let providers = match self
+            .get_providers_with_fallback(&model_id, None, &ChatRoutingHints::default())
+            .await
+        {
             Some(p) => p,
             None => {
                 return Err(inference_providers::ScoreError::GenerationError(format!(
@@ -3615,7 +3628,11 @@ impl InferenceProviderPool {
     /// provided models without evicting untouched entries.  Pass
     /// `partial = false` from the periodic sync / startup paths to replace
     /// the URL-provider cache wholesale and prune stale entries.
-    pub async fn load_inference_url_models(&self, models: Vec<(String, String, Option<u32>)>, partial: bool) {
+    pub async fn load_inference_url_models(
+        &self,
+        models: Vec<(String, String, Option<u32>)>,
+        partial: bool,
+    ) {
         if models.is_empty() {
             return;
         }
@@ -5383,7 +5400,11 @@ mod tests {
         };
 
         let mut stream = pool
-            .chat_completion_stream(params, "test-request-hash".to_string(), ChatRoutingHints::default())
+            .chat_completion_stream(
+                params,
+                "test-request-hash".to_string(),
+                ChatRoutingHints::default(),
+            )
             .await
             .expect("Should create stream");
 
@@ -8351,8 +8372,11 @@ mod tests {
         }
 
         // Partial load — only the patched model is included.
-        pool.load_inference_url_models(vec![(patched_model.clone(), patched_url.clone(), None)], true)
-            .await;
+        pool.load_inference_url_models(
+            vec![(patched_model.clone(), patched_url.clone(), None)],
+            true,
+        )
+        .await;
 
         // The untouched model's URL must still be present in the URL cache.
         {

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -118,6 +118,51 @@ fn record_provider_attempt(
 /// stream return or growing the stash unbounded (issue #701).
 const MAX_LEADING_CONTROL_EVENTS: usize = 32;
 
+/// EMA α for TTFT during warmup (first TTFT_WARMUP_SAMPLES observations).
+const TTFT_EWMA_ALPHA_WARMUP: f64 = 0.5;
+/// EMA α for TTFT after warmup (stable tracking).
+const TTFT_EWMA_ALPHA_STABLE: f64 = 0.1;
+/// Observations before switching from warmup to stable α.
+const TTFT_WARMUP_SAMPLES: u32 = 8;
+/// A provider is "latency-demoted" when its TTFT EMA exceeds this multiple
+/// of the fastest peer's EMA (AND the absolute floor below).
+const TTFT_SLOW_RATIO: f64 = 2.0;
+/// Absolute TTFT floor (ms): no provider is latency-demoted unless its EMA
+/// exceeds this, avoiding penalty for minor variance among fast backends.
+const TTFT_SLOW_FLOOR_MS: f64 = 500.0;
+/// Number of messages hashed from the front of the request for prefix-based
+/// cache-hit routing (system prompt + first user turn covers most prefix cache).
+pub const PREFIX_HASH_MESSAGES: usize = 2;
+
+/// Per-provider latency and capacity state for adaptive routing.
+#[derive(Default, Clone)]
+struct ProviderLatencyState {
+    /// Exponential moving average of TTFT in milliseconds.
+    ttft_ewma_ms: f64,
+    /// Number of TTFT samples used in the EMA (for warmup α adjustment).
+    ttft_samples: u32,
+    /// Maximum context length (tokens) this provider is configured to handle.
+    /// None = no limit configured; treat as unlimited.
+    max_context_tokens: Option<u32>,
+}
+
+/// Routing hints derived from the request content to guide provider selection.
+#[derive(Default)]
+pub struct ChatRoutingHints {
+    /// Consistent hash of the first PREFIX_HASH_MESSAGES messages for KV-cache routing.
+    /// When set, provider selection within the leading tier uses this hash instead of
+    /// pure round-robin, so requests with the same prefix tend to land on the same backend.
+    pub prefix_hash: Option<u64>,
+    /// Rough token count estimate (total chars / 4). Providers whose
+    /// max_context_tokens < this value are sorted after capable providers.
+    pub estimated_tokens: Option<u32>,
+}
+
+/// Callback for reporting observed TTFT (ms) back to the pool for future routing.
+/// The pool creates this when returning a stream from chat_completion_stream and
+/// passes it to InterceptStream, which calls it once on Drop.
+pub type ProviderLatencyReporter = Arc<dyn Fn(i32) + Send + Sync>;
+
 /// Trait for fetching external model configurations from a data source (e.g., database).
 /// This decouples the InferenceProviderPool from the database crate (hexagonal architecture).
 #[async_trait::async_trait]
@@ -125,9 +170,9 @@ pub trait ExternalModelsSource: Send + Sync {
     async fn fetch_external_models(&self) -> Result<Vec<(String, serde_json::Value)>, String>;
 
     /// Fetch models that have a direct inference URL configured.
-    /// Returns (model_name, inference_url) pairs for active models with inference_url set.
+    /// Returns (model_name, inference_url, context_length) triples for active models with inference_url set.
     /// These models are routed directly to the URL, bypassing the discovery server.
-    async fn fetch_inference_url_models(&self) -> Result<Vec<(String, String)>, String>;
+    async fn fetch_inference_url_models(&self) -> Result<Vec<(String, String, Option<u32>)>, String>;
 }
 
 /// Result of an attestation-discovery pass against a model URL.
@@ -299,6 +344,9 @@ pub struct InferenceProviderPool {
     /// Uses std::sync::RwLock (not tokio) because all operations are non-blocking
     /// HashMap lookups/inserts — no .await while holding the lock.
     provider_failure_counts: Arc<std::sync::RwLock<HashMap<usize, u32>>>,
+    /// Per-provider latency and capacity state for adaptive routing.
+    /// Keyed by Arc pointer address (same convention as provider_failure_counts).
+    provider_load_state: Arc<std::sync::RwLock<HashMap<usize, ProviderLatencyState>>>,
     /// Cache of inference_url → serving provider. When a model's URL hasn't changed
     /// across refreshes, the existing provider (and its warm reqwest::Client with
     /// pooled TLS connections) is reused instead of creating a new one.
@@ -603,6 +651,7 @@ impl InferenceProviderPool {
             chat_id_mapping: Arc::new(RwLock::new(HashMap::new())),
             refresh_task_handle: Arc::new(Mutex::new(None)),
             provider_failure_counts: Arc::new(std::sync::RwLock::new(HashMap::new())),
+            provider_load_state: Arc::new(std::sync::RwLock::new(HashMap::new())),
             inference_url_providers: Arc::new(RwLock::new(HashMap::new())),
             inference_url_fingerprint_states: Arc::new(RwLock::new(HashMap::new())),
             tls_roots: SharedTlsRoots::load(),
@@ -1602,6 +1651,7 @@ impl InferenceProviderPool {
         &self,
         model_id: &str,
         model_pub_key: Option<&str>,
+        hints: &ChatRoutingHints,
     ) -> Option<Vec<Arc<InferenceProviderTrait>>> {
         let mappings = self.provider_mappings.read().await;
 
@@ -1675,42 +1725,87 @@ impl InferenceProviderPool {
                 inference_providers::ProviderTier::NonAttested => 2,
             }
         }
-        // (demoted, tier_rank): healthy-before-demoted, NEAR-before-Chutes-before-plaintext.
+        // (context_overflow, demoted, latency_demoted, tier_rank): prefer capable, healthy, fast, NEAR.
         let (mut ordered, group_len) = {
             let counts = self
                 .provider_failure_counts
                 .read()
                 .unwrap_or_else(|e| e.into_inner());
-            let key_of = |p: &Arc<InferenceProviderTrait>| -> (u8, u8) {
-                let failures = counts
-                    .get(&(Arc::as_ptr(p) as *const () as usize))
-                    .copied()
-                    .unwrap_or(0);
+            let states = self
+                .provider_load_state
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+
+            // Find the minimum warmed-up TTFT EMA across all providers for relative comparison.
+            let min_ttft_ms = providers
+                .iter()
+                .filter_map(|p| {
+                    let ptr = Arc::as_ptr(p) as *const () as usize;
+                    states.get(&ptr).filter(|s| s.ttft_samples >= TTFT_WARMUP_SAMPLES && s.ttft_ewma_ms > 0.0)
+                })
+                .map(|s| s.ttft_ewma_ms)
+                .fold(f64::MAX, f64::min);
+
+            // Sort key: (context_overflow, hard_demoted, latency_demoted, tier_rank)
+            // Lower = preferred.
+            let key_of = |p: &Arc<InferenceProviderTrait>| -> (u8, u8, u8, u8) {
+                let ptr = Arc::as_ptr(p) as *const () as usize;
+                let failures = counts.get(&ptr).copied().unwrap_or(0);
+                let (ttft_ewma_ms, ttft_samples, max_context_tokens) = states
+                    .get(&ptr)
+                    .map(|s| (s.ttft_ewma_ms, s.ttft_samples, s.max_context_tokens))
+                    .unwrap_or((0.0, 0, None));
+
                 let demoted = u8::from(failures >= MAX_CONSECUTIVE_FAILURES);
-                (demoted, tier_rank(p))
+                // Provider can't handle the estimated request size.
+                let context_overflow = u8::from(
+                    hints
+                        .estimated_tokens
+                        .zip(max_context_tokens)
+                        .is_some_and(|(req, cap)| req > cap),
+                );
+                // Provider's TTFT EMA is significantly worse than the fastest peer.
+                let latency_demoted = u8::from(
+                    ttft_samples >= TTFT_WARMUP_SAMPLES
+                        && ttft_ewma_ms > TTFT_SLOW_FLOOR_MS
+                        && min_ttft_ms.is_finite()
+                        && ttft_ewma_ms > TTFT_SLOW_RATIO * min_ttft_ms,
+                );
+                (context_overflow, demoted, latency_demoted, tier_rank(p))
             };
             let mut ordered = providers;
-            ordered.sort_by_key(&key_of); // stable
+            ordered.sort_by_key(&key_of); // stable sort
             let head_key = key_of(&ordered[0]);
-            let group_len = ordered.iter().take_while(|p| key_of(p) == head_key).count();
+            let group_len = ordered
+                .iter()
+                .take_while(|p| key_of(p) == head_key)
+                .count();
             (ordered, group_len)
         };
 
-        // Round-robin rotate the leading group so its members share load evenly.
+        // Select within the leading group. When the request carries a prefix hash
+        // (computed from the first message(s)), use it for consistent placement so
+        // same-prefix requests land on the same backend — maximising KV-cache hits.
+        // Fall back to round-robin for requests without a meaningful prefix.
         if group_len > 1 {
             let index_key = if let Some(pub_key) = model_pub_key {
                 format!("pubkey:{}", pub_key)
             } else {
                 format!("id:{}", model_id)
             };
-            let mut indices = self
-                .load_balancer_index
-                .write()
-                .unwrap_or_else(|e| e.into_inner());
-            let index = indices.entry(index_key).or_insert(0);
-            let rot = *index % group_len;
-            *index = (*index + 1) % group_len;
-            drop(indices);
+            let rot = if let Some(hash) = hints.prefix_hash {
+                // Consistent prefix-based placement: don't advance the round-robin counter.
+                (hash as usize) % group_len
+            } else {
+                let mut indices = self
+                    .load_balancer_index
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner());
+                let index = indices.entry(index_key).or_insert(0);
+                let r = *index % group_len;
+                *index = (*index + 1) % group_len;
+                r
+            };
             ordered[..group_len].rotate_left(rot);
         }
 
@@ -2198,8 +2293,15 @@ impl InferenceProviderPool {
         F: Fn(Arc<InferenceProviderTrait>) -> Fut,
         Fut: std::future::Future<Output = Result<T, CompletionError>>,
     {
-        self.retry_with_fallback_caps(model_id, operation_name, model_pub_key, false, provider_fn)
-            .await
+        self.retry_with_fallback_caps(
+            model_id,
+            operation_name,
+            model_pub_key,
+            false,
+            &ChatRoutingHints::default(),
+            provider_fn,
+        )
+        .await
     }
 
     /// As [`Self::retry_with_fallback`], but filters the provider list to those that
@@ -2214,6 +2316,7 @@ impl InferenceProviderPool {
         operation_name: &str,
         model_pub_key: Option<&str>,
         needs_client_e2ee: bool,
+        hints: &ChatRoutingHints,
         provider_fn: F,
     ) -> Result<ServedProviderResult<T>, CompletionError>
     where
@@ -2221,7 +2324,7 @@ impl InferenceProviderPool {
         Fut: std::future::Future<Output = Result<T, CompletionError>>,
     {
         let providers = match self
-            .get_providers_with_fallback(model_id, model_pub_key)
+            .get_providers_with_fallback(model_id, model_pub_key, hints)
             .await
         {
             Some(p) => p,
@@ -2766,9 +2869,10 @@ impl InferenceProviderPool {
         &self,
         params: ChatCompletionParams,
         request_hash: String,
+        hints: ChatRoutingHints,
     ) -> Result<StreamingResult, CompletionError> {
         Ok(self
-            .chat_completion_stream_with_attribution(params, request_hash)
+            .chat_completion_stream_with_attribution(params, request_hash, hints)
             .await?
             .stream)
     }
@@ -2777,6 +2881,7 @@ impl InferenceProviderPool {
         &self,
         mut params: ChatCompletionParams,
         request_hash: String,
+        hints: ChatRoutingHints,
     ) -> Result<AttributedChatCompletionStream, CompletionError> {
         let model_id = params.model.clone();
 
@@ -2806,6 +2911,7 @@ impl InferenceProviderPool {
                 "chat_completion_stream",
                 model_pub_key,
                 needs_client_e2ee,
+                &hints,
                 |provider| {
                     let params = params_for_provider.clone();
                     let request_hash = request_hash.clone();
@@ -2816,6 +2922,30 @@ impl InferenceProviderPool {
         let stream = served.value;
         let provider = served.provider.clone();
         let provider_attribution = served.provider_attribution;
+
+        // Create TTFT reporter: called by InterceptStream on Drop to feed back
+        // the observed TTFT for this provider, enabling latency-aware routing on
+        // future requests for the same model.
+        let load_state = self.provider_load_state.clone();
+        let provider_ptr = Arc::as_ptr(&provider) as *const () as usize;
+        let latency_reporter: ProviderLatencyReporter = Arc::new(move |ttft_ms: i32| {
+            if ttft_ms <= 0 {
+                return;
+            }
+            let mut states = load_state.write().unwrap_or_else(|e| e.into_inner());
+            let state = states.entry(provider_ptr).or_default();
+            let alpha = if state.ttft_samples < TTFT_WARMUP_SAMPLES {
+                TTFT_EWMA_ALPHA_WARMUP
+            } else {
+                TTFT_EWMA_ALPHA_STABLE
+            };
+            state.ttft_ewma_ms = if state.ttft_ewma_ms == 0.0 {
+                ttft_ms as f64
+            } else {
+                alpha * ttft_ms as f64 + (1.0 - alpha) * state.ttft_ewma_ms
+            };
+            state.ttft_samples = state.ttft_samples.saturating_add(1);
+        });
 
         // Store chat_id mapping for sticky routing by peeking at the first event
         // Must be synchronous to ensure attestation service can find the provider
@@ -2870,6 +3000,7 @@ impl InferenceProviderPool {
         Ok(AttributedChatCompletionStream {
             stream,
             provider_attribution,
+            latency_reporter,
         })
     }
 
@@ -2920,6 +3051,7 @@ impl InferenceProviderPool {
                 "chat_completion",
                 model_pub_key,
                 needs_client_e2ee,
+                &ChatRoutingHints::default(),
                 |provider| {
                     let params = params_for_provider.clone();
                     let request_hash = request_hash.clone();
@@ -3182,7 +3314,7 @@ impl InferenceProviderPool {
             "Starting rerank request"
         );
 
-        let providers = match self.get_providers_with_fallback(&model_id, None).await {
+        let providers = match self.get_providers_with_fallback(&model_id, None, &ChatRoutingHints::default()).await {
             Some(p) => p,
             None => {
                 return Err(RerankError::GenerationError(format!(
@@ -3231,7 +3363,7 @@ impl InferenceProviderPool {
     ) -> Result<bytes::Bytes, inference_providers::EmbeddingError> {
         tracing::debug!(model = %model, "Starting embeddings request");
 
-        let providers = match self.get_providers_with_fallback(model, None).await {
+        let providers = match self.get_providers_with_fallback(model, None, &ChatRoutingHints::default()).await {
             Some(p) => p,
             None => {
                 return Err(inference_providers::EmbeddingError::RequestFailed(format!(
@@ -3287,7 +3419,7 @@ impl InferenceProviderPool {
     ) -> Result<bytes::Bytes, inference_providers::PrivacyClassifyError> {
         tracing::debug!(model = %model, "Starting privacy classify request");
 
-        let providers = match self.get_providers_with_fallback(model, None).await {
+        let providers = match self.get_providers_with_fallback(model, None, &ChatRoutingHints::default()).await {
             Some(p) => p,
             None => {
                 return Err(inference_providers::PrivacyClassifyError::RequestFailed(
@@ -3351,7 +3483,7 @@ impl InferenceProviderPool {
 
         tracing::debug!(model = %model_id, "Starting score request");
 
-        let providers = match self.get_providers_with_fallback(&model_id, None).await {
+        let providers = match self.get_providers_with_fallback(&model_id, None, &ChatRoutingHints::default()).await {
             Some(p) => p,
             None => {
                 return Err(inference_providers::ScoreError::GenerationError(format!(
@@ -3483,23 +3615,24 @@ impl InferenceProviderPool {
     /// provided models without evicting untouched entries.  Pass
     /// `partial = false` from the periodic sync / startup paths to replace
     /// the URL-provider cache wholesale and prune stale entries.
-    pub async fn load_inference_url_models(&self, models: Vec<(String, String)>, partial: bool) {
+    pub async fn load_inference_url_models(&self, models: Vec<(String, String, Option<u32>)>, partial: bool) {
         if models.is_empty() {
             return;
         }
 
         let api_key = self.api_key.clone();
+        let pool_load_state = self.provider_load_state.clone();
 
         // Check which models can reuse their existing provider (URL unchanged)
         let existing_cache = self.inference_url_providers.read().await;
         let mut reused: Vec<(String, String, Arc<InferenceProviderTrait>)> = Vec::new();
-        let mut needs_creation: Vec<(String, String)> = Vec::new();
+        let mut needs_creation: Vec<(String, String, Option<u32>)> = Vec::new();
 
-        for (model_name, url) in &models {
+        for (model_name, url, context_length) in &models {
             if let Some(existing) = existing_cache.get(url) {
                 reused.push((model_name.clone(), url.clone(), existing.clone()));
             } else {
-                needs_creation.push((model_name.clone(), url.clone()));
+                needs_creation.push((model_name.clone(), url.clone(), *context_length));
             }
         }
         drop(existing_cache);
@@ -3521,12 +3654,14 @@ impl InferenceProviderPool {
         let tls_roots = self.tls_roots.clone();
         let endpoint_futures: Vec<_> = needs_creation
             .iter()
-            .map(|(model_name, url)| {
+            .map(|(model_name, url, context_length)| {
                 let model_name = model_name.clone();
                 let url = url.clone();
+                let context_length = *context_length;
                 let api_key = api_key.clone();
                 let verifier = verifier.clone();
                 let tls_roots = tls_roots.clone();
+                let pool_load_state = pool_load_state.clone();
                 async move {
                     let state =
                         Arc::new(std::sync::RwLock::new(FingerprintState::Bootstrap));
@@ -3564,6 +3699,17 @@ impl InferenceProviderPool {
                     // on the first 5xx — without this, the very first 5xx
                     // before any refresh cycle would skip rotation entirely.
                     serving_provider.set_backend_count(outcome.backend_count);
+
+                    // Store the configured context length so latency routing can
+                    // filter out providers that can't serve oversized requests.
+                    if let Some(ctx_tokens) = context_length {
+                        let ptr = Arc::as_ptr(&serving_provider) as *const () as usize;
+                        let mut states = pool_load_state
+                            .write()
+                            .unwrap_or_else(|e| e.into_inner());
+                        states.entry(ptr).or_default().max_context_tokens =
+                            Some(ctx_tokens);
+                    }
 
                     if outcome.total_pinned == 0 {
                         // Fail closed: reject all TLS until a future refresh's
@@ -4281,7 +4427,7 @@ impl InferenceProviderPool {
 
     /// Refresh inference_url models from the database.
     /// Existing entries in provider_mappings are overwritten with new providers.
-    async fn sync_inference_url_models(&self, models: Vec<(String, String)>) {
+    async fn sync_inference_url_models(&self, models: Vec<(String, String, Option<u32>)>) {
         // Complete-set discovery path (periodic refresh): re-append pinned providers
         // for the discovered models (inside load_inference_url_models's merge), then
         // prune any pinned id that has LEFT discovery to pinned-only. The complete
@@ -4291,7 +4437,7 @@ impl InferenceProviderPool {
         // rebuilds those. Only the refresh calls this; the admin PATCH path calls
         // load_inference_url_models directly (partial batch, no prune).
         let complete_names: std::collections::HashSet<String> =
-            models.iter().map(|(name, _)| name.clone()).collect();
+            models.iter().map(|(name, _, _)| name.clone()).collect();
         self.load_inference_url_models(models, false).await;
         self.prune_stale_pinned(&complete_names).await;
     }
@@ -4359,6 +4505,10 @@ impl InferenceProviderPool {
             .write()
             .unwrap_or_else(|e| e.into_inner())
             .retain(|key, _| !removed_ptrs.contains(key));
+        self.provider_load_state
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .retain(|key, _| !removed_ptrs.contains(key));
 
         info!(
             removed = stale_models.len(),
@@ -4401,7 +4551,7 @@ impl InferenceProviderPool {
                     // Refresh inference_url models
                     match source.fetch_inference_url_models().await {
                         Ok(models) => {
-                            for (name, _) in &models {
+                            for (name, _, _) in &models {
                                 valid_model_names.insert(name.clone());
                             }
                             pool.sync_inference_url_models(models).await;
@@ -5233,7 +5383,7 @@ mod tests {
         };
 
         let mut stream = pool
-            .chat_completion_stream(params, "test-request-hash".to_string())
+            .chat_completion_stream(params, "test-request-hash".to_string(), ChatRoutingHints::default())
             .await
             .expect("Should create stream");
 
@@ -5584,7 +5734,7 @@ mod tests {
         .await;
 
         let providers = pool
-            .get_providers_with_fallback(&model, None)
+            .get_providers_with_fallback(&model, None, &ChatRoutingHints::default())
             .await
             .expect("model has providers");
         let tiers: Vec<ProviderTier> = providers.iter().map(|p| p.tier()).collect();
@@ -5611,7 +5761,7 @@ mod tests {
         .await;
 
         let providers = pool
-            .get_providers_with_fallback(&model, None)
+            .get_providers_with_fallback(&model, None, &ChatRoutingHints::default())
             .await
             .expect("model has providers");
         assert_eq!(providers.len(), 1);
@@ -5634,7 +5784,7 @@ mod tests {
         .await;
 
         let providers = pool
-            .get_providers_with_fallback(&model, None)
+            .get_providers_with_fallback(&model, None, &ChatRoutingHints::default())
             .await
             .expect("model has providers");
         assert_eq!(providers.len(), 1);
@@ -5667,7 +5817,7 @@ mod tests {
 
         assert!(pool.is_pinned(&model));
         let providers = pool
-            .get_providers_with_fallback(&model, None)
+            .get_providers_with_fallback(&model, None, &ChatRoutingHints::default())
             .await
             .expect("model has providers");
         let tiers: Vec<ProviderTier> = providers.iter().map(|p| p.tier()).collect();
@@ -5832,7 +5982,7 @@ mod tests {
         complete.insert(model.clone());
         pool.prune_stale_pinned(&complete).await;
         let tiers: Vec<ProviderTier> = pool
-            .get_providers_with_fallback(&model, None)
+            .get_providers_with_fallback(&model, None, &ChatRoutingHints::default())
             .await
             .expect("providers")
             .iter()
@@ -5843,7 +5993,7 @@ mod tests {
         // NEAR dropped it (absent from the complete set) → rebuilt pinned-only.
         pool.prune_stale_pinned(&HashSet::new()).await;
         let tiers: Vec<ProviderTier> = pool
-            .get_providers_with_fallback(&model, None)
+            .get_providers_with_fallback(&model, None, &ChatRoutingHints::default())
             .await
             .expect("providers")
             .iter()
@@ -6114,7 +6264,7 @@ mod tests {
 
         // Call load_inference_url_models — the provider should be reused and
         // the self-healing path should detect missing pubkeys and re-fetch them.
-        pool.load_inference_url_models(vec![(model_id.clone(), url)], false)
+        pool.load_inference_url_models(vec![(model_id.clone(), url, None)], false)
             .await;
 
         // Verify pubkeys were recovered
@@ -6679,7 +6829,7 @@ mod tests {
         mock_provider.set_fail_attestation(true);
 
         // Load — the provider is reused, pubkeys are missing, re-fetch fails
-        pool.load_inference_url_models(vec![(model_id.clone(), url.clone())], false)
+        pool.load_inference_url_models(vec![(model_id.clone(), url.clone(), None)], false)
             .await;
 
         // The URL should have been evicted from the cache
@@ -6754,7 +6904,7 @@ mod tests {
                 .insert("pretend-pubkey".to_string(), vec![mock.clone()]);
         }
 
-        pool.load_inference_url_models(vec![(model_id.clone(), url.clone())], false)
+        pool.load_inference_url_models(vec![(model_id.clone(), url.clone(), None)], false)
             .await;
 
         // Blocked URL evicted from URL cache
@@ -8201,7 +8351,7 @@ mod tests {
         }
 
         // Partial load — only the patched model is included.
-        pool.load_inference_url_models(vec![(patched_model.clone(), patched_url.clone())], true)
+        pool.load_inference_url_models(vec![(patched_model.clone(), patched_url.clone(), None)], true)
             .await;
 
         // The untouched model's URL must still be present in the URL cache.
@@ -8265,7 +8415,7 @@ mod tests {
         pool.unregister_provider(&model_name).await;
 
         // Partial load with the new URL — as if the admin PATCH changed inference_url.
-        pool.load_inference_url_models(vec![(model_name.clone(), new_url.clone())], true)
+        pool.load_inference_url_models(vec![(model_name.clone(), new_url.clone(), None)], true)
             .await;
 
         // The new URL must be present in the URL cache.

--- a/crates/services/src/inference_provider_pool/provider_attribution.rs
+++ b/crates/services/src/inference_provider_pool/provider_attribution.rs
@@ -9,6 +9,10 @@ pub struct AttributedChatCompletion {
 pub struct AttributedChatCompletionStream {
     pub stream: StreamingResult,
     pub provider_attribution: crate::usage::ProviderAttribution,
+    /// Callback to report observed TTFT back to the pool for latency-aware
+    /// routing (see [`super::ProviderLatencyReporter`]). Invoked once by the
+    /// caller's `InterceptStream` on drop with the backend TTFT.
+    pub latency_reporter: super::ProviderLatencyReporter,
 }
 
 pub struct AttributedImageGeneration {


### PR DESCRIPTION
## Summary

Adds three complementary routing signals to `InferenceProviderPool` that work together as a composite sort key `(context_overflow, hard_demoted, latency_demoted, tier_rank)`:

- **TTFT-based soft demotion**: track per-provider TTFT via exponential moving average (α=0.5 warmup / α=0.1 stable after 8 samples). Providers 2× slower than the fastest peer AND above the 500ms absolute floor get `latency_demoted=1`, placing them after fast peers while keeping them as fallbacks. Feedback flows via a `ProviderLatencyReporter` closure created in `chat_completion_stream` and called from `InterceptStream::Drop`.

- **Prefix-hash cache routing**: when a chat request carries messages, the first 2 messages are hashed. The hash selects deterministically within the leading provider group instead of advancing the round-robin counter — same-prefix conversations always route to the same backend, maximising KV-cache hits. Falls back to round-robin when no messages are present (image, audio, embed paths).

- **Context-length routing**: `context_length` is now returned from `fetch_inference_url_models` and stored in `ProviderLatencyState.max_context_tokens` per provider. Providers whose configured max < estimated request tokens (`chars/4`) are sorted last (`context_overflow=1`). Prepares for a future where `glm-5-2-i0` and `glm-5-2-i1` have different context windows.

## Key files

| File | Change |
|------|--------|
| `crates/services/src/inference_provider_pool/mod.rs` | New `ProviderLatencyState`, `ChatRoutingHints`, `ProviderLatencyReporter`; updated sort key; TTFT reporter creation; `load_inference_url_models` context_length plumbing |
| `crates/services/src/completions/mod.rs` | `latency_reporter` field on `InterceptStream`; `compute_prefix_hash` + `estimate_input_tokens` helpers; routing hints computed and threaded to pool |
| `crates/database/src/repositories/model.rs` | `get_inference_url_models` now includes `context_length` |
| `crates/api/src/routes/admin.rs` | Admin PATCH passes `context_length` through to pool |

## Test plan

- [ ] `cargo check --workspace` passes (verified locally — zero errors, zero new warnings)
- [ ] `cargo test --lib --bins` — unit tests pass
- [ ] Staging deploy: check Datadog `inference.latency.ttft` metric tagged by model to verify TTFT is still being recorded correctly
- [ ] With two backends for the same model (e.g. `glm-5-2-i0`, `glm-5-2-i1`): send the same system-prompt across multiple conversations and verify via Datadog `inference.provider` tag that they consistently land on the same backend
- [ ] After simulating a slow backend (manually delay one instance), verify it gets `latency_demoted` in routing logs after ~8 requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)