### PR TITLE
fix(ci): make reproducible-build verification runnable on self-hosted runners

### DIFF
--- a/.github/workflows/verify-reproducible-build.yml
+++ b/.github/workflows/verify-reproducible-build.yml
@@ -7,13 +7,23 @@ on:
       - 'main'
 
 jobs:
-  # Build on multiple runners in parallel to test cross-machine reproducibility
+  # Build in parallel on the self-hosted infra fleet. With roughly one runner
+  # per host, the two instances usually land on different machines, giving
+  # best-effort cross-machine reproducibility coverage.
+  #
+  # The build is fully hermetic (pinned BuildKit image, base-image digests,
+  # Debian apt snapshot, SOURCE_DATE_EPOCH=0, rewrite-timestamp), so the host OS
+  # cannot affect the output digest. That is why this no longer uses the old
+  # ubuntu-latest / ubuntu-22.04 / ubuntu-24.04 cross-OS matrix — the pinning
+  # already guarantees host-independence, and GitHub-hosted runners are no
+  # longer available to this repo anyway (CI migrated to [self-hosted, infra]).
   build:
-    name: Build (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
+    name: Cross-machine build ${{ matrix.instance }}
+    runs-on: [self-hosted, infra]
     strategy:
+      fail-fast: false
       matrix:
-        runner: [ubuntu-latest, ubuntu-22.04, ubuntu-24.04]
+        instance: [1, 2]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -39,8 +49,10 @@ jobs:
           # Save digest to file for artifact upload
           echo "${DIGEST}" > digest.txt
 
-      - name: Guard: committed pins match resolved pins
-        if: matrix.runner == 'ubuntu-latest'
+      # Run once (only on instance 1) — the pins are snapshot-derived and
+      # host-independent, so a single satisfiability check covers all builds.
+      - name: Guard - committed pins match resolved pins
+        if: matrix.instance == 1
         run: |
           set -e
           diff -u pinned-packages-builder.txt pinned-packages-builder.resolved.txt
@@ -50,18 +62,19 @@ jobs:
       - name: Upload digest artifact
         uses: actions/upload-artifact@v7
         with:
-          name: digest-${{ matrix.runner }}
+          name: digest-${{ matrix.instance }}
           path: digest.txt
           retention-days: 1
 
-      # Clean up OCI tar to free disk space (not needed for verification)
+      # Free workspace disk on the shared host (oci.tar is large).
       - name: Clean up build artifacts
+        if: always()
         run: rm -f oci.tar
 
-  # Sequential builds on the same runner to test build-to-build reproducibility
+  # Sequential builds on the same runner to test build-to-build reproducibility.
   sequential-builds:
     name: Sequential Builds
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, infra]
     outputs:
       mismatch: ${{ steps.compare.outputs.mismatch }}
     steps:
@@ -89,28 +102,16 @@ jobs:
           # Save first build artifact
           mv oci.tar oci-first.tar
 
-      - name: Clean build environment
-        run: |
-          echo "=== Cleaning build environment ==="
-
-          # Extract builder name from build-image.sh to stay in sync
-          BUILDER_NAME=$(grep -oP '(?<=--name )\w+' build-image.sh | head -1) || true
-          if [ -n "$BUILDER_NAME" ]; then
-            echo "Removing builder: ${BUILDER_NAME}"
-            docker buildx rm "${BUILDER_NAME}" || true
-          fi
-
-          # Prune all docker resources
-          docker system prune -af --volumes || true
-
-          # Remove any cached layers
-          docker builder prune -af || true
-
-          echo "Build environment cleaned"
+      # IMPORTANT: do NOT run `docker system prune` / `docker builder prune`
+      # here. These jobs run on shared production hosts (the infra fleet lives
+      # on the GPU inference machines), and a global prune would delete images
+      # and volumes belonging to other services. build-image.sh already builds
+      # with `--no-cache`, so the second build reuses no layers from the first
+      # regardless — that is what makes this a valid build-to-build test.
 
       - name: Second build
         run: |
-          echo "=== Starting second build ==="
+          echo "=== Starting second build (no cache reused; --no-cache) ==="
           ./build-image.sh
 
           DIGEST=$(skopeo inspect oci-archive:./oci.tar | jq -r '.Digest')
@@ -155,13 +156,16 @@ jobs:
             oci-second.tar
           retention-days: 1
 
+      # Free workspace disk on the shared host (oci tars are large).
+      - name: Clean up build artifacts
+        if: always()
+        run: rm -f oci-first.tar oci-second.tar
+
   # Verify all builds produced identical digests
   verify:
     name: Verify Reproducibility
     needs: [build, sequential-builds]
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ steps.verify.outputs.result }}
+    runs-on: [self-hosted, infra]
     steps:
       - name: Download all digest artifacts
         uses: actions/download-artifact@v8
@@ -176,42 +180,38 @@ jobs:
           echo ""
 
           # Initialize default values for outputs (in case of early failure)
-          echo "digest_ubuntu_latest=(not available)" >> "$GITHUB_OUTPUT"
-          echo "digest_ubuntu_22=(not available)" >> "$GITHUB_OUTPUT"
-          echo "digest_ubuntu_24=(not available)" >> "$GITHUB_OUTPUT"
+          echo "digest_cm1=(not available)" >> "$GITHUB_OUTPUT"
+          echo "digest_cm2=(not available)" >> "$GITHUB_OUTPUT"
           echo "digest_seq_first=(not available)" >> "$GITHUB_OUTPUT"
           echo "digest_seq_second=(not available)" >> "$GITHUB_OUTPUT"
           echo "result=failed" >> "$GITHUB_OUTPUT"
 
           # Read digests from artifact files
-          DIGEST_UBUNTU_LATEST=$(cat digest-ubuntu-latest/digest.txt 2>/dev/null || echo "")
-          DIGEST_UBUNTU_22=$(cat digest-ubuntu-22.04/digest.txt 2>/dev/null || echo "")
-          DIGEST_UBUNTU_24=$(cat digest-ubuntu-24.04/digest.txt 2>/dev/null || echo "")
+          DIGEST_CM1=$(cat digest-1/digest.txt 2>/dev/null || echo "")
+          DIGEST_CM2=$(cat digest-2/digest.txt 2>/dev/null || echo "")
           DIGEST_SEQ_FIRST=$(cat digest-sequential/digest-first.txt 2>/dev/null || echo "")
           DIGEST_SEQ_SECOND=$(cat digest-sequential/digest-second.txt 2>/dev/null || echo "")
 
           # Export actual values for summary step (overwrite defaults)
           {
-            echo "digest_ubuntu_latest=${DIGEST_UBUNTU_LATEST:-"(not available)"}"
-            echo "digest_ubuntu_22=${DIGEST_UBUNTU_22:-"(not available)"}"
-            echo "digest_ubuntu_24=${DIGEST_UBUNTU_24:-"(not available)"}"
+            echo "digest_cm1=${DIGEST_CM1:-"(not available)"}"
+            echo "digest_cm2=${DIGEST_CM2:-"(not available)"}"
             echo "digest_seq_first=${DIGEST_SEQ_FIRST:-"(not available)"}"
             echo "digest_seq_second=${DIGEST_SEQ_SECOND:-"(not available)"}"
           } >> "$GITHUB_OUTPUT"
 
-          echo "Digests from parallel builds on different runners:"
-          echo "  ubuntu-latest:  ${DIGEST_UBUNTU_LATEST:-(not available)}"
-          echo "  ubuntu-22.04:   ${DIGEST_UBUNTU_22:-(not available)}"
-          echo "  ubuntu-24.04:   ${DIGEST_UBUNTU_24:-(not available)}"
+          echo "Digests from parallel cross-machine builds:"
+          echo "  instance 1:   ${DIGEST_CM1:-(not available)}"
+          echo "  instance 2:   ${DIGEST_CM2:-(not available)}"
           echo ""
           echo "Digests from sequential builds:"
-          echo "  First build:    ${DIGEST_SEQ_FIRST:-(not available)}"
-          echo "  Second build:   ${DIGEST_SEQ_SECOND:-(not available)}"
+          echo "  First build:  ${DIGEST_SEQ_FIRST:-(not available)}"
+          echo "  Second build: ${DIGEST_SEQ_SECOND:-(not available)}"
           echo ""
 
           # Verify all digests are non-empty
           FAILED=false
-          for digest in "$DIGEST_UBUNTU_LATEST" "$DIGEST_UBUNTU_22" "$DIGEST_UBUNTU_24" "$DIGEST_SEQ_FIRST" "$DIGEST_SEQ_SECOND"; do
+          for digest in "$DIGEST_CM1" "$DIGEST_CM2" "$DIGEST_SEQ_FIRST" "$DIGEST_SEQ_SECOND"; do
             if [ -z "$digest" ]; then
               echo "ERROR: One or more builds failed to produce a digest"
               FAILED=true
@@ -223,10 +223,10 @@ jobs:
           fi
 
           # Compare all digests - they should all match
-          REFERENCE_DIGEST="$DIGEST_UBUNTU_LATEST"
+          REFERENCE_DIGEST="$DIGEST_CM1"
           MISMATCH=false
 
-          echo "=== Comparing all digests against reference (ubuntu-latest) ==="
+          echo "=== Comparing all digests against reference (cross-machine instance 1) ==="
           echo ""
 
           compare_digest() {
@@ -242,8 +242,7 @@ jobs:
             fi
           }
 
-          compare_digest "ubuntu-22.04" "$DIGEST_UBUNTU_22"
-          compare_digest "ubuntu-24.04" "$DIGEST_UBUNTU_24"
+          compare_digest "Cross-machine instance 2" "$DIGEST_CM2"
           compare_digest "Sequential first" "$DIGEST_SEQ_FIRST"
           compare_digest "Sequential second" "$DIGEST_SEQ_SECOND"
 
@@ -263,9 +262,8 @@ jobs:
       - name: Generate summary
         if: always()
         run: |
-          DIGEST_LATEST="${{ steps.verify.outputs.digest_ubuntu_latest }}"
-          DIGEST_22="${{ steps.verify.outputs.digest_ubuntu_22 }}"
-          DIGEST_24="${{ steps.verify.outputs.digest_ubuntu_24 }}"
+          DIGEST_CM1="${{ steps.verify.outputs.digest_cm1 }}"
+          DIGEST_CM2="${{ steps.verify.outputs.digest_cm2 }}"
           DIGEST_FIRST="${{ steps.verify.outputs.digest_seq_first }}"
           DIGEST_SECOND="${{ steps.verify.outputs.digest_seq_second }}"
           RESULT="${{ steps.verify.outputs.result }}"
@@ -277,9 +275,8 @@ jobs:
             echo ""
             echo "| Environment | Digest |"
             echo "|-------------|--------|"
-            echo "| ubuntu-latest | \`${DIGEST_LATEST:-"(not available)"}\` |"
-            echo "| ubuntu-22.04 | \`${DIGEST_22:-"(not available)"}\` |"
-            echo "| ubuntu-24.04 | \`${DIGEST_24:-"(not available)"}\` |"
+            echo "| Cross-machine (instance 1) | \`${DIGEST_CM1:-"(not available)"}\` |"
+            echo "| Cross-machine (instance 2) | \`${DIGEST_CM2:-"(not available)"}\` |"
             echo "| Sequential (first) | \`${DIGEST_FIRST:-"(not available)"}\` |"
             echo "| Sequential (second) | \`${DIGEST_SECOND:-"(not available)"}\` |"
             echo ""

--- a/build-image.sh
+++ b/build-image.sh
@@ -22,9 +22,20 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-# Check if buildkit_20 already exists before creating it
-if ! docker buildx inspect buildkit_20 &>/dev/null; then
-    docker buildx create --use --driver-opt image=moby/buildkit:v0.20.2 --name buildkit_20
+# The buildx builder MUST run the pinned BuildKit version. OCI layer
+# serialization and compression differ between BuildKit versions, so a builder
+# created with a different image silently produces a different image digest and
+# breaks cross-machine reproducibility. The previous "create only if absent"
+# check honored the pin only on first creation, so any host whose buildkit_20
+# was created without it (or with a newer default) drifted -- e.g. gpu11 ran
+# BuildKit v0.27.1 while the rest of the fleet ran the pinned v0.20.2, producing
+# a different digest for identical inputs. Recreate the builder unless it
+# already uses the pinned image.
+BUILDKIT_IMAGE="moby/buildkit:v0.20.2"
+if ! docker buildx inspect buildkit_20 2>/dev/null | grep -qF "${BUILDKIT_IMAGE}"; then
+    echo "Creating buildx builder 'buildkit_20' pinned to ${BUILDKIT_IMAGE}"
+    docker buildx rm buildkit_20 2>/dev/null || true
+    docker buildx create --use --driver-opt image="${BUILDKIT_IMAGE}" --name buildkit_20
 fi
 touch pinned-packages-builder.txt pinned-packages-runtime.txt
 git rev-parse HEAD > .GIT_REV

--- a/build-image.sh
+++ b/build-image.sh
@@ -22,30 +22,35 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-# The buildx builder MUST run the pinned BuildKit version. OCI layer
-# serialization and compression differ between BuildKit versions, so a builder
-# created with a different image silently produces a different image digest and
-# breaks cross-machine reproducibility. The previous "create only if absent"
-# check honored the pin only on first creation, so any host whose buildkit_20
-# was created without it (or with a newer default) drifted -- e.g. gpu11 ran
-# BuildKit v0.27.1 while the rest of the fleet ran the pinned v0.20.2, producing
-# a different digest for identical inputs. Recreate the builder unless it
-# already uses the pinned image.
+# Use a unique, freshly-created BuildKit builder pinned to a specific version.
+# Two reasons:
+#   1. Reproducibility: OCI layer serialization and compression differ between
+#      BuildKit versions, so the builder image must be pinned. Creating it fresh
+#      each run guarantees the pinned version -- a long-lived, reused builder
+#      only honored the pin on first creation, so a host whose builder predated
+#      the pin silently drifted (e.g. gpu11 ran v0.27.1 while the rest of the
+#      fleet ran the pinned v0.20.2, producing a different digest for identical
+#      inputs).
+#   2. Parallelism: the CI fleet runs builds on shared Docker daemons. A unique
+#      per-invocation builder name means concurrent builds never reuse or tear
+#      down each other's builder.
+# The builder is removed on exit so buildkitd containers do not accumulate on
+# shared hosts.
 BUILDKIT_IMAGE="moby/buildkit:v0.20.2"
-if ! docker buildx inspect buildkit_20 2>/dev/null | grep -qF "${BUILDKIT_IMAGE}"; then
-    echo "Creating buildx builder 'buildkit_20' pinned to ${BUILDKIT_IMAGE}"
-    docker buildx rm buildkit_20 2>/dev/null || true
-    docker buildx create --use --driver-opt image="${BUILDKIT_IMAGE}" --name buildkit_20
-fi
+BUILDER_NAME="cloud-api-buildkit-$$-${RANDOM}"
+docker buildx create --driver-opt image="${BUILDKIT_IMAGE}" --name "${BUILDER_NAME}" >/dev/null
+trap 'docker buildx rm "${BUILDER_NAME}" >/dev/null 2>&1 || true' EXIT
 touch pinned-packages-builder.txt pinned-packages-runtime.txt
 git rev-parse HEAD > .GIT_REV
-TEMP_TAG="cloud-api-temp:$(date +%s)"
+# Unique tag so two builds co-located on one daemon cannot collide (and one's
+# `docker rmi` cannot yank an image the other is still reading).
+TEMP_TAG="cloud-api-temp:$(date +%s)-$$-${RANDOM}"
 # --ulimit nofile: raise the open-file limit for RUN steps. The default soft
 # limit on the self-hosted runners is low enough that the parallel `cargo build`
 # exhausts file descriptors ("Too many open files (os error 24)"). This only
 # affects build-time resource limits, never the output bytes, so it is safe for
 # reproducibility.
-docker buildx build --builder buildkit_20 --no-cache --platform linux/amd64 \
+docker buildx build --builder "${BUILDER_NAME}" --no-cache --platform linux/amd64 \
     --ulimit nofile=1048576:1048576 \
     --build-arg SOURCE_DATE_EPOCH="0" \
     --output type=oci,dest=./oci.tar,rewrite-timestamp=true \

--- a/build-image.sh
+++ b/build-image.sh
@@ -29,7 +29,13 @@ fi
 touch pinned-packages-builder.txt pinned-packages-runtime.txt
 git rev-parse HEAD > .GIT_REV
 TEMP_TAG="cloud-api-temp:$(date +%s)"
+# --ulimit nofile: raise the open-file limit for RUN steps. The default soft
+# limit on the self-hosted runners is low enough that the parallel `cargo build`
+# exhausts file descriptors ("Too many open files (os error 24)"). This only
+# affects build-time resource limits, never the output bytes, so it is safe for
+# reproducibility.
 docker buildx build --builder buildkit_20 --no-cache --platform linux/amd64 \
+    --ulimit nofile=1048576:1048576 \
     --build-arg SOURCE_DATE_EPOCH="0" \
     --output type=oci,dest=./oci.tar,rewrite-timestamp=true \
     --output type=docker,name="$TEMP_TAG",rewrite-timestamp=true .


### PR DESCRIPTION
## Problem

`verify-reproducible-build` has been red on **every** main push, but for reasons
#843 (the apt-pin fix) could not resolve. Three independent issues:

1. **The workflow couldn't run at all.** #818 migrated CI to `[self-hosted, infra]`
   but deliberately left this workflow on GitHub-hosted `ubuntu-latest` / `22.04`
   / `24.04` for cross-OS coverage — runners that are no longer available to the
   repo. Since the migration every run failed at **startup** ("workflow file
   issue") and scheduled **zero jobs**; the build never ran. #843's apt-pin fix
   was correct but could never turn the check green because nothing started.
2. **EMFILE on the build.** `cargo build` intermittently failed on the infra
   runners with `Too many open files (os error 24)` — the runners' default
   open-file limit is too low for the parallel compile. This has also been
   turning `build.yml` (the production build) red.
3. **The image isn't reproducible across hosts** — found once the workflow could
   finally run (see Validation). The published digest silently depended on which
   host built it.

## Fix

**`verify-reproducible-build.yml`**
- Migrate all three jobs to `[self-hosted, infra]` — makes the workflow runnable.
- Replace the `ubuntu-*` cross-OS matrix with a **2-instance cross-machine
  matrix**. The build is hermetic (pinned BuildKit + base-image digests + Debian
  apt snapshot + `SOURCE_DATE_EPOCH=0` + `rewrite-timestamp`), so host OS can't
  affect the digest — cross-OS was redundant. The instances run in parallel and
  land on different infra hosts for real cross-machine coverage.
- **Drop `docker system prune -af --volumes` / `docker builder prune -af`** from
  the sequential job. The infra fleet runs on the **shared GPU inference hosts**,
  where a global prune would delete other services' images and volumes.
  `build-image.sh` builds with `--no-cache`, so the second build reuses no layers
  regardless — that is what makes it a valid build-to-build test.

**`build-image.sh`**
- **Use a unique, freshly-created BuildKit builder per invocation**, pinned to
  `moby/buildkit:v0.20.2` and removed on exit. This is the **root-cause fix for
  cross-machine non-reproducibility**: the old script reused a long-lived
  `buildkit_20` builder and applied the version pin *only on first creation*, so
  a host whose builder predated the pin silently kept a different BuildKit
  version. gpu11 was running BuildKit **v0.27.1** while the rest of the fleet ran
  the pinned **v0.20.2**; since OCI layer serialization/compression differ
  between versions, identical source produced two different digests — and
  `build.yml`'s production digest has been non-deterministic across the fleet for
  the same reason. Creating the builder fresh each run makes the pin airtight and
  is digest-neutral (same version → same output). A unique per-invocation name
  also prevents collisions now that CI runs builds in parallel on shared daemons.
- **`--ulimit nofile=1048576:1048576`** on `docker buildx build` — fixes the
  recurring EMFILE. Build-time resource limit only; never affects output bytes.
- **Unique `TEMP_TAG`** (`…-$$-$RANDOM`) so co-located builds can't collide on
  the daemon image.

## Validation

The workflow only triggers on `push: main` + `workflow_dispatch` (not PRs), so
validated via `workflow_dispatch` on this branch:

- **First run** scheduled jobs on infra (no more startup failure), EMFILE gone,
  and the new cross-machine check immediately **caught the latent bug**:
  gpu04/crabshack0 → `512b8c54…`, **gpu11 → `44f1f030…`** (the BuildKit-version
  drift above). The sequential build-to-build digests matched perfectly.
- **After the builder-pin fix**
  ([run 28044671713](https://github.com/nearai/cloud-api/actions/runs/28044671713)):
  **green** — all four digests `512b8c54…` across gpu03 / gpu04 / gpu23.
- Final per-invocation-builder design re-validated by a fresh dispatch.

The merged change self-heals any drifted host (e.g. gpu11): the new script
ignores stale `buildkit_20` builders and always builds with a fresh pinned
v0.20.2 builder. (The orphaned legacy `buildkit_20` builders can be pruned from
hosts at leisure; nothing uses them after this lands.)

CI / build-infra only — nothing new is baked into the image.
