### PR TITLE
feat(metrics): cloud-api prefix-cache-hit metrics (tokens.cached + cache.hit_rate)

### DIFF
--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -38,6 +38,17 @@ pub fn hash_inference_id_to_uuid(full_id: &str) -> Uuid {
 
 /// Get input bucket tag based on token count for metrics breakdown
 /// Buckets: 0-1k, 1-4k, 4-16k, 16-32k, 32-64k, 64-128k, 128k+
+/// Per-request prefix-cache hit rate as a percentage (cache-read / prompt
+/// tokens). `None` when there are no prompt tokens (avoids div-by-zero and keeps
+/// empty-prompt requests out of the distribution). `cached` is already clamped to
+/// `[0, prompt]` by `TokenUsage::cached_tokens()`, so the result is in `[0, 100]`.
+fn cache_hit_rate_percent(cached_tokens: i32, prompt_tokens: i32) -> Option<f64> {
+    if prompt_tokens <= 0 {
+        return None;
+    }
+    Some((cached_tokens.max(0) as f64 / prompt_tokens as f64) * 100.0)
+}
+
 fn get_input_bucket(token_count: i32) -> &'static str {
     match token_count {
         0..=1000 => "0-1k",
@@ -352,6 +363,18 @@ where
                             output_tokens as i64,
                             &tags,
                         );
+                        // Prefix-cache-hit observability: cache-read token count
+                        // (token-weighted hit rate = cached/input) + per-request
+                        // hit-rate distribution.
+                        metrics_service.record_count(
+                            METRIC_TOKENS_CACHED,
+                            cache_read_tokens as i64,
+                            &tags,
+                        );
+                        if let Some(rate) = cache_hit_rate_percent(cache_read_tokens, input_tokens)
+                        {
+                            metrics_service.record_histogram(METRIC_CACHE_HIT_RATE, rate, &tags);
+                        }
                     })
                     .await;
 
@@ -1666,6 +1689,7 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
         let metrics_service = self.metrics_service.clone();
         let input_tokens = response_with_bytes.response.usage.prompt_tokens;
         let output_tokens = response_with_bytes.response.usage.completion_tokens;
+        let cache_read_tokens = response_with_bytes.response.usage.cached_tokens();
         let model_name = model.model_name.clone();
 
         tokio::spawn(async move {
@@ -1687,6 +1711,11 @@ impl ports::CompletionServiceTrait for CompletionServiceImpl {
 
             metrics_service.record_count(METRIC_TOKENS_INPUT, input_tokens as i64, &tags_str);
             metrics_service.record_count(METRIC_TOKENS_OUTPUT, output_tokens as i64, &tags_str);
+            // Prefix-cache-hit observability (mirrors the streaming path).
+            metrics_service.record_count(METRIC_TOKENS_CACHED, cache_read_tokens as i64, &tags_str);
+            if let Some(rate) = cache_hit_rate_percent(cache_read_tokens, input_tokens) {
+                metrics_service.record_histogram(METRIC_CACHE_HIT_RATE, rate, &tags_str);
+            }
         });
 
         // Record usage with model UUID
@@ -2191,6 +2220,107 @@ mod tests {
             assert!(val > 0.0);
         } else {
             panic!("TPS should be a histogram");
+        }
+    }
+
+    #[test]
+    fn cache_hit_rate_percent_computes_and_guards_zero_prompt() {
+        // No prompt tokens -> excluded from the distribution (no div-by-zero).
+        assert_eq!(cache_hit_rate_percent(0, 0), None);
+        assert_eq!(cache_hit_rate_percent(5, 0), None);
+        // cached/prompt as a percentage.
+        assert_eq!(cache_hit_rate_percent(0, 100), Some(0.0));
+        assert_eq!(cache_hit_rate_percent(50, 100), Some(50.0));
+        assert_eq!(cache_hit_rate_percent(100, 100), Some(100.0));
+        // Defensive: a negative cached count clamps to 0 (cached_tokens() never
+        // returns negative, but the helper must not emit a negative rate).
+        assert_eq!(cache_hit_rate_percent(-5, 100), Some(0.0));
+    }
+
+    #[tokio::test]
+    async fn test_intercept_stream_emits_cache_hit_metrics() {
+        let metrics_service = Arc::new(CapturingMetricsService::new());
+        let now = Instant::now();
+        // prompt=10, of which 7 were prefix-cache hits -> 70% hit rate.
+        let usage_chunk = SSEEvent {
+            raw_bytes: Bytes::from("data: ..."),
+            raw_passthrough: true,
+            chunk: Some(StreamChunk::Chat(ChatCompletionChunk {
+                id: "chat-1".to_string(),
+                object: "chat.completion.chunk".to_string(),
+                created: 1234567890,
+                model: "test-model".to_string(),
+                choices: vec![ChatChoice {
+                    index: 0,
+                    delta: None,
+                    logprobs: None,
+                    finish_reason: Some(FinishReason::Stop),
+                    token_ids: None,
+                }],
+                usage: Some(TokenUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 20,
+                    total_tokens: 30,
+                    prompt_tokens_details: Some(serde_json::json!({"cached_tokens": 7})),
+                }),
+                prompt_token_ids: None,
+                system_fingerprint: None,
+                modality: None,
+                extra: Default::default(),
+            })),
+        };
+        let stream = stream::iter(vec![Ok(usage_chunk)]);
+        let intercept_stream = InterceptStream {
+            inner: stream,
+            attestation_service: Arc::new(MockAttestationService),
+            usage_service: Arc::new(MockUsageService),
+            metrics_service: metrics_service.clone(),
+            request_id: Uuid::new_v4(),
+            organization_id: Uuid::new_v4(),
+            workspace_id: Uuid::new_v4(),
+            api_key_id: Uuid::new_v4(),
+            model_id: Uuid::new_v4(),
+            model_name: "test-model".to_string(),
+            inference_type: crate::usage::ports::InferenceType::ChatCompletionStream,
+            service_start_time: now,
+            provider_start_time: now,
+            first_token_received: false,
+            first_token_time: None,
+            ttft_ms: None,
+            token_count: 0,
+            last_token_time: None,
+            total_itl_ms: 0.0,
+            metric_tags: CompletionServiceImpl::create_metric_tags("test-model"),
+            concurrent_counter: None,
+            last_usage_stats: None,
+            last_chat_id: None,
+            stream_completed: false,
+            response_id: None,
+            last_finish_reason: None,
+            last_error: None,
+            state: StreamState::Streaming,
+            attestation_supported: true,
+            store_provider_chat_signature: true,
+            provider_attribution: crate::usage::ProviderAttribution::default(),
+            latency_reporter: None,
+        };
+        let _ = intercept_stream.collect::<Vec<_>>().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let metrics = metrics_service.get_metrics();
+
+        let cached = metrics
+            .iter()
+            .find(|m| m.name == METRIC_TOKENS_CACHED)
+            .expect("tokens.cached metric missing");
+        assert!(matches!(cached.value, MetricValue::Count(7)));
+
+        let rate = metrics
+            .iter()
+            .find(|m| m.name == METRIC_CACHE_HIT_RATE)
+            .expect("cache.hit_rate metric missing");
+        match rate.value {
+            MetricValue::Histogram(v) => assert!((v - 70.0).abs() < 1e-9, "hit rate = {v}"),
+            _ => panic!("cache.hit_rate should be a histogram"),
         }
     }
 

--- a/crates/services/src/completions/mod.rs
+++ b/crates/services/src/completions/mod.rs
@@ -46,7 +46,11 @@ fn cache_hit_rate_percent(cached_tokens: i32, prompt_tokens: i32) -> Option<f64>
     if prompt_tokens <= 0 {
         return None;
     }
-    Some((cached_tokens.max(0) as f64 / prompt_tokens as f64) * 100.0)
+    // Clamp to [0, prompt] so the result is provably within [0, 100], even if a
+    // provider ever reports cached > prompt. `TokenUsage::cached_tokens()` already
+    // clamps to this range, so this is belt-and-suspenders.
+    let cached = cached_tokens.clamp(0, prompt_tokens);
+    Some((cached as f64 / prompt_tokens as f64) * 100.0)
 }
 
 fn get_input_bucket(token_count: i32) -> &'static str {
@@ -2235,6 +2239,8 @@ mod tests {
         // Defensive: a negative cached count clamps to 0 (cached_tokens() never
         // returns negative, but the helper must not emit a negative rate).
         assert_eq!(cache_hit_rate_percent(-5, 100), Some(0.0));
+        // Defensive: cached > prompt clamps to prompt -> capped at 100%.
+        assert_eq!(cache_hit_rate_percent(150, 100), Some(100.0));
     }
 
     #[tokio::test]
@@ -2305,6 +2311,7 @@ mod tests {
             latency_reporter: None,
         };
         let _ = intercept_stream.collect::<Vec<_>>().await;
+        // Wait for the fire-and-forget usage/metrics task spawned in Drop to finish.
         tokio::time::sleep(Duration::from_millis(100)).await;
         let metrics = metrics_service.get_metrics();
 

--- a/crates/services/src/metrics/consts.rs
+++ b/crates/services/src/metrics/consts.rs
@@ -19,6 +19,16 @@ pub const METRIC_SIGNATURE_CREATION_DURATION: &str = "cloud_api.signature.creati
 pub const METRIC_REQUEST_COUNT: &str = "cloud_api.request.count";
 pub const METRIC_TOKENS_INPUT: &str = "cloud_api.tokens.input";
 pub const METRIC_TOKENS_OUTPUT: &str = "cloud_api.tokens.output";
+// Prefix-cache-hit observability (chat-completions path, request-granular, same
+// tags as tokens.input/output). `tokens.cached` is the cache-read token COUNT —
+// the token-weighted fleet hit rate is `sum(tokens.cached)/sum(tokens.input)`.
+// `cache.hit_rate` is the PER-REQUEST hit-rate distribution (percent), which the
+// token counters can't express (averaging vs token-weighting). Together they let
+// dashboards track the cache-affinity routing introduced in the Fleet
+// index-addressed change. (Distinct from billed.cache_read_tokens, which is
+// billing-namespaced and only emitted on a newly-inserted usage row.)
+pub const METRIC_TOKENS_CACHED: &str = "cloud_api.tokens.cached";
+pub const METRIC_CACHE_HIT_RATE: &str = "cloud_api.cache.hit_rate";
 
 // Tiered-routing visibility: one increment per served request, tagged with
 // `model`, `provider_tier` (near|attested_3p|non_attested), `fallback`

--- a/crates/services/src/metrics/mod.rs
+++ b/crates/services/src/metrics/mod.rs
@@ -100,6 +100,9 @@ impl MetricsServiceTrait for OtlpMetricsService {
                 }
                 consts::METRIC_TOKENS_INPUT => "Input tokens consumed",
                 consts::METRIC_TOKENS_OUTPUT => "Output tokens generated",
+                consts::METRIC_TOKENS_CACHED => {
+                    "Cache-read (prefix-cache hit) input tokens; hit rate = tokens.cached / tokens.input"
+                }
                 consts::METRIC_VERIFICATION_SUCCESS => "Successful verification operations",
                 consts::METRIC_VERIFICATION_FAILURE => "Failed verification operations",
                 consts::METRIC_SIGNATURE_CREATION_SUCCESS => {
@@ -152,6 +155,10 @@ impl MetricsServiceTrait for OtlpMetricsService {
         let histogram = histograms.entry(name.to_string()).or_insert_with(|| {
             let (description, unit) = match name {
                 consts::METRIC_TOKENS_PER_SECOND => ("Token generation throughput", "tokens/sec"),
+                consts::METRIC_CACHE_HIT_RATE => (
+                    "Per-request prefix-cache hit rate (cache-read / prompt tokens)",
+                    "percent",
+                ),
                 _ => ("Value distribution", ""),
             };
 


### PR DESCRIPTION
## Summary

cloud-api had **no cache-hit-rate metric**. The only cache signal was `cloud_api.billed.cache_read_tokens` — a billing-namespaced token *count* emitted once per newly-inserted usage row. The per-request hit-rate **distribution** was not observable anywhere, and the backend `sglang:cache_hit_rate` / `vllm:gpu_prefix_cache_hit_rate` gauges (already scraped to Datadog) carry no cloud-api request context (model alias, inference_type) and reflect the backend's internal radix cache, not what the client actually received.

This adds two metrics in the chat-completions path (both the streaming-drop path and the non-streaming path), **co-tagged with the existing `tokens.input`/`tokens.output`** (`model`, `inference_type`, `environment`, `input_bucket`):

| Metric | Type | Meaning |
|--------|------|---------|
| `cloud_api.tokens.cached` | counter | Cache-read (prefix-cache hit) input tokens. **Token-weighted fleet hit rate = `sum(tokens.cached) / sum(tokens.input)`** |
| `cloud_api.cache.hit_rate` | histogram (percent) | **Per-request** cached/prompt — the distribution the token counters can't express (p50/p90, regression detection) |

Two metrics because they answer different questions: the counter gives the canonical token-weighted aggregate KPI; the histogram gives the per-request spread (a 1-token request hitting 100% shouldn't count equal to a 10k-token request hitting 5%).

## Why now
The Fleet index-addressed routing change (#844) makes same-prefix requests stick to the same backend to maximize KV-cache hits. **This is the metric to confirm that's working** — chart `cache.hit_rate` / `tokens.cached÷tokens.input` by model before/after and watch it rise. (I verified the effect manually on staging via `cached_tokens` in responses; this makes it a first-class, continuously-tracked signal.)

## Implementation notes
- Hit rate via a guarded helper `cache_hit_rate_percent(cached, prompt)` → `None` when `prompt == 0` (keeps empty-prompt requests out of the distribution, no div-by-zero), clamps negative cached to 0. `cached_tokens()` is already clamped to `[0, prompt]`, so the rate ∈ [0, 100].
- No new tags (cardinality unchanged). No public API change.
- Distinct from the `billed.*` namespace, which is billing-oriented and insert-gated.

## Test plan
- [x] `cargo test -p services --lib` — 419 pass. New: `cache_hit_rate_percent_computes_and_guards_zero_prompt` (helper) + `test_intercept_stream_emits_cache_hit_metrics` (streaming: 7/10 cached → `tokens.cached=7`, `cache.hit_rate=70%`).
- [x] `cargo clippy` / `cargo fmt` clean.
- [ ] Staging: after deploy, confirm `cloud_api.tokens.cached` + `cloud_api.cache.hit_rate` appear in Datadog (us3) tagged by model, and that `tokens.cached/tokens.input` tracks sensibly vs the backend `sglang:cache_hit_rate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)