### PR TITLE
Pin Chutes v1.3.1 golden measurements (GLM-5.2-TEE attested fallback)

### DIFF
--- a/crates/services/src/attestation/chutes.rs
+++ b/crates/services/src/attestation/chutes.rs
@@ -206,17 +206,20 @@ impl ChutesInstanceVerifier for ChutesBackendVerifier {
 }
 
 /// A vetted snapshot of Chutes' published golden measurements (from the public
-/// `GET https://api.chutes.ai/servers/tee/measurements`) for the **v1.3.0**
-/// software release across all of Chutes' GPU hardware platforms.
+/// `GET https://api.chutes.ai/servers/tee/measurements`) across the software
+/// releases we accept (**v1.3.0** and the **v1.3.1** family) and all of Chutes'
+/// GPU hardware platforms.
 ///
-/// Within v1.3.0 the five rows below are byte-identical on MRTD (firmware),
-/// RTMR1 (kernel), RTMR2 (cmdline/initrd) **and the runtime RTMR3**
+/// Within a single software release the hardware rows are byte-identical on MRTD
+/// (firmware), RTMR1 (kernel), RTMR2 (cmdline/initrd) **and the runtime RTMR3**
 /// (`runtime_rtmrs.RTMR3`, the running app/IMA layer) — i.e. the full *software*
 /// identity is one and the same. They differ **only in RTMR0**, the TD-HOB/ACPI/
-/// VM-config layer that varies with the GPU SKU and VM sizing (8×H200,
-/// 8×RTX PRO 6000, 8×B200, 8×B200-eth, 8×B300). Pinning each published RTMR0
-/// lets a request land on any of Chutes' vetted hardware platforms while still
-/// authenticating the full software stack against a single, fixed identity.
+/// VM-config layer that varies with the GPU SKU and VM sizing. Pinning each
+/// published RTMR0 lets a request land on any of Chutes' vetted hardware
+/// platforms while still authenticating the full software stack against a fixed,
+/// per-release identity. A *different* software release (v1.3.0 vs v1.3.1 vs
+/// v1.3.1-rc1) is a distinct identity (different MRTD and/or RTMR1/2/3) and is
+/// listed as its own family below.
 ///
 /// Live cross-checks against genuine, DCAP-signature-verified, report-data-bound
 /// quotes (the measurement check runs only *after* the Intel signature chain and
@@ -226,41 +229,99 @@ impl ChutesInstanceVerifier for ChutesBackendVerifier {
 ///   deepseek-v3.2 / minimax-m2.5 served live over E2EE (2026-06-11).
 /// - `8xRTX_PRO_6000 v1.3.0` — Qwen3-32B-TEE, observed register set matched the
 ///   published row byte-for-byte (2026-06-11).
+/// - `8xb200 / 8xb200-xeon6 / 8xb300 v1.3.1-rc1` — **GLM-5.2-TEE**, 3 distinct
+///   Blackwell register sets matched the published `1.3.1-rc1` rows byte-for-byte
+///   (MRTD + RTMR0 + RTMR1 + RTMR2 + runtime RTMR3), 2026-06-24. GLM-5.2's live
+///   fleet runs the `-rc1` firmware; the final `v1.3.1` rows are pinned too so the
+///   model keeps attesting once Chutes promotes the chute off the release
+///   candidate (the `-rc1` and final identities differ on RTMR1/2/3).
 ///
-/// The remaining Blackwell rows (b200 / b200-eth / b300) are taken from the same
-/// published v1.3.0 release and carry the identical software identity; they are
-/// accepted so a model scheduled onto Blackwell hardware serves without a
-/// per-SKU re-vet. The cryptographic root of trust is the Intel DCAP signature,
-/// not the transparency endpoint — these rows merely enumerate which genuine
-/// software identities we accept.
+/// The remaining rows in each family are taken from the same published release
+/// and carry the identical software identity; they are accepted so a model
+/// scheduled onto another vetted hardware SKU serves without a per-SKU re-vet.
+/// The cryptographic root of trust is the Intel DCAP signature, not the
+/// transparency endpoint — these rows merely enumerate which genuine software
+/// identities we accept.
 ///
 /// NOT included (fail-closed): the v1.0.0–v1.2.0 rows publish RTMR3 = all-zeros
-/// (a boot template, never matchable against a live extended RTMR3), and v1.3.1
-/// is a distinct firmware/kernel (different MRTD/RTMR1) with no live instance yet
-/// — add it once Chutes upgrades and a live quote cross-checks. Anything not
-/// listed here is rejected.
+/// (a boot template, never matchable against a live extended RTMR3 — the running
+/// app is unmeasured). Both v1.3.1 and v1.3.1-rc1 publish a non-zero runtime
+/// RTMR3, so the app/IMA layer is genuinely measured. Anything not listed here is
+/// rejected.
 pub fn vetted_golden_measurements() -> ChutesMeasurementPolicy {
-    // v1.3.0 software identity — shared across every hardware row below.
-    const MRTD: &str = "ddc6efcdd2309e10837f8a7f64b71272b7ef003b129460410fe715bdfffec38c7c0c1686dddb2a23d4fd623d145e8455";
-    const RTMR1: &str = "f858ed2aecba4ecd29084352c6b5c6e403c0bec89b8c852f90fa5a8cee796ffa095518c5cd8b92c25c1856e932a95877";
-    const RTMR2: &str = "7719f4fde518994a5dd6767a8b8b87a38168cc0f3480e7498d4ace99e49319be6a7fed26c21ad43310d2d488fc68ab1c";
-    // runtime RTMR3 (runtime_rtmrs.RTMR3) — the running app/IMA layer.
-    const RTMR3: &str = "bfac8bbe97148d00c0bc5dea273ccd926e2415511f08f5dedaa96d3c19e824d2bf01fae86e8987ff509fd3ad31374a60";
+    // Each family shares one software identity (MRTD/RTMR1/RTMR2/runtime-RTMR3);
+    // only RTMR0 (the per-hardware boot/VM-config register) varies across rows.
+    struct Family {
+        version: &'static str,
+        mrtd: &'static str,
+        rtmr1: &'static str,
+        rtmr2: &'static str,
+        /// runtime RTMR3 (runtime_rtmrs.RTMR3) — the running app/IMA layer.
+        rtmr3: &'static str,
+        /// (config name, per-hardware RTMR0).
+        hardware_rows: &'static [(&'static str, &'static str)],
+    }
 
-    // (config name, RTMR0) — the per-hardware boot/VM-config register.
-    let hardware_rows = [
-        ("8xh200", "2864b11878e8129095d62a5dd7c3e3aae178d3a077606a825617324768f189ad05aed08376947df92d6c75865d915cbf"),
-        ("8xRTX_PRO_6000", "5064826bfd530ca9f823ceecb74899d7dbd014b60897a77317a14200c8706f2368ecbbc0a04cec8ceef90474b8c955e1"),
-        ("8xb200", "734628b9a715ec492c2b14b409907f32d91847f439ba8bac2fa985b41c01245536348fefb2e021ed574c290c8c50347a"),
-        ("8xb200-eth", "724c1d0d20c11a479d2874fa543b0f1b920be32f2a5b9707fa5bcf6176fff31aeac9436e541e1125f78a0b61f7c2e165"),
-        ("8xb300", "31f6446add906b7d56132c600549270a8ea780193e0c89586f784b20b25136de441ca715d5ecf86ae72f0b40f7a47f39"),
+    const FAMILIES: &[Family] = &[
+        // v1.3.0 software identity.
+        Family {
+            version: "1.3.0",
+            mrtd: "ddc6efcdd2309e10837f8a7f64b71272b7ef003b129460410fe715bdfffec38c7c0c1686dddb2a23d4fd623d145e8455",
+            rtmr1: "f858ed2aecba4ecd29084352c6b5c6e403c0bec89b8c852f90fa5a8cee796ffa095518c5cd8b92c25c1856e932a95877",
+            rtmr2: "7719f4fde518994a5dd6767a8b8b87a38168cc0f3480e7498d4ace99e49319be6a7fed26c21ad43310d2d488fc68ab1c",
+            rtmr3: "bfac8bbe97148d00c0bc5dea273ccd926e2415511f08f5dedaa96d3c19e824d2bf01fae86e8987ff509fd3ad31374a60",
+            hardware_rows: &[
+                ("8xh200", "2864b11878e8129095d62a5dd7c3e3aae178d3a077606a825617324768f189ad05aed08376947df92d6c75865d915cbf"),
+                ("8xRTX_PRO_6000", "5064826bfd530ca9f823ceecb74899d7dbd014b60897a77317a14200c8706f2368ecbbc0a04cec8ceef90474b8c955e1"),
+                ("8xb200", "734628b9a715ec492c2b14b409907f32d91847f439ba8bac2fa985b41c01245536348fefb2e021ed574c290c8c50347a"),
+                ("8xb200-eth", "724c1d0d20c11a479d2874fa543b0f1b920be32f2a5b9707fa5bcf6176fff31aeac9436e541e1125f78a0b61f7c2e165"),
+                ("8xb300", "31f6446add906b7d56132c600549270a8ea780193e0c89586f784b20b25136de441ca715d5ecf86ae72f0b40f7a47f39"),
+            ],
+        },
+        // v1.3.1-rc1 software identity — GLM-5.2-TEE's live fleet (Blackwell only,
+        // live-verified 2026-06-24).
+        Family {
+            version: "1.3.1-rc1",
+            mrtd: "261ce538b435e2d0e85fc97e254bc99154c507b7a8e13d59b69f8532384f1d0bfaadfddf3fccc6e0a411203840bbee8d",
+            rtmr1: "8cfb5e5a387eef8b5fb7be77ab4405d4b68990d20990e6eec0551c5b682ee7d9fcf7fad7bd6e07b373b2e23321c98a5f",
+            rtmr2: "2de048a63a3f1ae6bf0f9631bbfa5ffc703392211e2e71dd5fcf645187ee6c4b404883fbbadfcdce294274d9f4ae70ce",
+            rtmr3: "5b6a2b127a80e4aa71dae6dfa2f1f813e1c1606fdf4ee0947010d29f582813a0860e919860e25febfeb60125988cb9bb",
+            hardware_rows: &[
+                ("8xb200", "7c028a01902475caaa81c245151184d08fcb847cfcbac4ced3c6812d2abe101680d5c015e7cfdb1c98ae54ae7ff0d524"),
+                ("8xb200-xeon6", "2b22fa53ace208d4f046ae90b7ad28d71a7f4ef0573897d40f6c82b4036217e3170c856f91e54bc19c20c9958c5d1e36"),
+                ("8xb300", "43204fcb166114bee9ea562d88fef18d618f591499f8b73ac87be07962f2b228569b680d2ede4ed719d4a3514f90feda"),
+            ],
+        },
+        // Final v1.3.1 software identity — pinned so GLM-5.2 keeps attesting once
+        // Chutes promotes the chute off the release candidate. Same MRTD as -rc1,
+        // distinct RTMR1/2/3. Published + app-measured; not yet live cross-checked
+        // (no instance observed on the final release yet).
+        Family {
+            version: "1.3.1",
+            mrtd: "261ce538b435e2d0e85fc97e254bc99154c507b7a8e13d59b69f8532384f1d0bfaadfddf3fccc6e0a411203840bbee8d",
+            rtmr1: "9b8b2915351a3166f742024edafb6cce244c1df4056eb1f9eb608c3616b9d63729ae00c98d1dc108009c0978b19dc207",
+            rtmr2: "8471360414fe80b4343fb17dd59e442bdc55b5955df0adf610b1de15ad7b454e98fb8e9d38cc188b82369f4f620b6968",
+            rtmr3: "51204be641a2af357f5f4e6a121d348d6cb1cbe53c4c35d9dcc3364196b4d41a6e1de75025bb2e76f3b00cc7192f9433",
+            hardware_rows: &[
+                ("8xh200 [10.2.1]", "212d8284fe29a52a033cd662763e452915d2002bcc3c3e73aa660b100087bd3cce8aef414c3d7012f6a857f392c1919b"),
+                ("8xh200 [10.1.0]", "7e76988fae31dda82f0043b331d908f0716e9da24fed80b6ea6cec9b6615ff84f24321056a8befbea3fff67bd1e59205"),
+                ("8xRTX_PRO_6000", "0917443cc41e9a5afebc8e87e69a63f32208c47d4b4b4fd410fbc1a705e1880c1383a4ad51903a5ed20cb4090420185a"),
+                ("8xb200", "7c028a01902475caaa81c245151184d08fcb847cfcbac4ced3c6812d2abe101680d5c015e7cfdb1c98ae54ae7ff0d524"),
+                ("8xb200-xeon6", "2b22fa53ace208d4f046ae90b7ad28d71a7f4ef0573897d40f6c82b4036217e3170c856f91e54bc19c20c9958c5d1e36"),
+                ("8xb300", "43204fcb166114bee9ea562d88fef18d618f591499f8b73ac87be07962f2b228569b680d2ede4ed719d4a3514f90feda"),
+            ],
+        },
     ];
 
     ChutesMeasurementPolicy::new(
-        hardware_rows
-            .into_iter()
-            .map(|(name, rtmr0)| {
-                ExpectedMeasurement::new(name, "1.3.0", MRTD, rtmr0, RTMR1, RTMR2, RTMR3)
+        FAMILIES
+            .iter()
+            .flat_map(|f| {
+                f.hardware_rows.iter().map(move |(name, rtmr0)| {
+                    ExpectedMeasurement::new(
+                        *name, f.version, f.mrtd, rtmr0, f.rtmr1, f.rtmr2, f.rtmr3,
+                    )
+                })
             })
             .collect(),
     )
@@ -388,12 +449,120 @@ mod tests {
         fn covers_the_full_v130_hardware_family() {
             // All five published v1.3.0 hardware platforms are accepted — by name,
             // so swapping a row for a different config (count unchanged) still fails.
-            assert_eq!(vetted_golden_measurements().len(), 5);
+            // Total = 5 (v1.3.0) + 3 (v1.3.1-rc1 Blackwell) + 6 (v1.3.1 final).
+            assert_eq!(vetted_golden_measurements().len(), 14);
             accepts(RTMR0_H200, "8xh200");
             accepts(RTMR0_RTX_PRO_6000, "8xRTX_PRO_6000");
             accepts(RTMR0_B200, "8xb200");
             accepts(RTMR0_B200_ETH, "8xb200-eth");
             accepts(RTMR0_B300, "8xb300");
+        }
+
+        // ── v1.3.1 family (GLM-5.2-TEE) ──────────────────────────────────────
+        // v1.3.1-rc1 software identity — GLM-5.2's live fleet (Blackwell only),
+        // cross-checked byte-for-byte against signature-verified quotes 2026-06-24.
+        const MRTD_V131: &str = "261ce538b435e2d0e85fc97e254bc99154c507b7a8e13d59b69f8532384f1d0bfaadfddf3fccc6e0a411203840bbee8d";
+        const RC1_RTMR1: &str = "8cfb5e5a387eef8b5fb7be77ab4405d4b68990d20990e6eec0551c5b682ee7d9fcf7fad7bd6e07b373b2e23321c98a5f";
+        const RC1_RTMR2: &str = "2de048a63a3f1ae6bf0f9631bbfa5ffc703392211e2e71dd5fcf645187ee6c4b404883fbbadfcdce294274d9f4ae70ce";
+        const RC1_RTMR3: &str = "5b6a2b127a80e4aa71dae6dfa2f1f813e1c1606fdf4ee0947010d29f582813a0860e919860e25febfeb60125988cb9bb";
+        const RC1_RTMR0_B200: &str = "7c028a01902475caaa81c245151184d08fcb847cfcbac4ced3c6812d2abe101680d5c015e7cfdb1c98ae54ae7ff0d524";
+        const RC1_RTMR0_B200_XEON6: &str = "2b22fa53ace208d4f046ae90b7ad28d71a7f4ef0573897d40f6c82b4036217e3170c856f91e54bc19c20c9958c5d1e36";
+        const RC1_RTMR0_B300: &str = "43204fcb166114bee9ea562d88fef18d618f591499f8b73ac87be07962f2b228569b680d2ede4ed719d4a3514f90feda";
+        // Final v1.3.1 software identity — same MRTD as -rc1, distinct RTMR1/2/3.
+        const FINAL_RTMR1: &str = "9b8b2915351a3166f742024edafb6cce244c1df4056eb1f9eb608c3616b9d63729ae00c98d1dc108009c0978b19dc207";
+        const FINAL_RTMR2: &str = "8471360414fe80b4343fb17dd59e442bdc55b5955df0adf610b1de15ad7b454e98fb8e9d38cc188b82369f4f620b6968";
+        const FINAL_RTMR3: &str = "51204be641a2af357f5f4e6a121d348d6cb1cbe53c4c35d9dcc3364196b4d41a6e1de75025bb2e76f3b00cc7192f9433";
+        const FINAL_RTMR0_H200_1021: &str = "212d8284fe29a52a033cd662763e452915d2002bcc3c3e73aa660b100087bd3cce8aef414c3d7012f6a857f392c1919b";
+
+        fn accepts_family(
+            rtmr0: &str,
+            mrtd: &str,
+            rtmr1: &str,
+            rtmr2: &str,
+            rtmr3: &str,
+            name: &str,
+            version: &str,
+        ) {
+            let policy = vetted_golden_measurements();
+            let matched = policy
+                .verify(
+                    &reg(mrtd),
+                    &reg(rtmr0),
+                    &reg(rtmr1),
+                    &reg(rtmr2),
+                    &reg(rtmr3),
+                )
+                .unwrap_or_else(|e| panic!("{name} v{version} must be accepted: {e}"));
+            assert_eq!(matched.name, name);
+            assert_eq!(matched.version, version);
+        }
+
+        #[test]
+        fn accepts_glm52_live_rc1_blackwell_rows() {
+            // The three Blackwell register sets observed live on GLM-5.2-TEE's
+            // fleet (2026-06-24) — genuine, signature-verified, nonce-bound quotes.
+            // Each must verify against the pinned v1.3.1-rc1 family.
+            accepts_family(
+                RC1_RTMR0_B200,
+                MRTD_V131,
+                RC1_RTMR1,
+                RC1_RTMR2,
+                RC1_RTMR3,
+                "8xb200",
+                "1.3.1-rc1",
+            );
+            accepts_family(
+                RC1_RTMR0_B200_XEON6,
+                MRTD_V131,
+                RC1_RTMR1,
+                RC1_RTMR2,
+                RC1_RTMR3,
+                "8xb200-xeon6",
+                "1.3.1-rc1",
+            );
+            accepts_family(
+                RC1_RTMR0_B300,
+                MRTD_V131,
+                RC1_RTMR1,
+                RC1_RTMR2,
+                RC1_RTMR3,
+                "8xb300",
+                "1.3.1-rc1",
+            );
+        }
+
+        #[test]
+        fn accepts_final_v131_for_rc1_promotion() {
+            // Forward-insurance: once Chutes promotes the GLM-5.2 chute off the
+            // release candidate, the final v1.3.1 identity (distinct RTMR1/2/3)
+            // must already verify so the model does not fail closed again.
+            accepts_family(
+                FINAL_RTMR0_H200_1021,
+                MRTD_V131,
+                FINAL_RTMR1,
+                FINAL_RTMR2,
+                FINAL_RTMR3,
+                "8xh200 [10.2.1]",
+                "1.3.1",
+            );
+        }
+
+        #[test]
+        fn rejects_rc1_software_with_final_v131_rtmr3() {
+            // The -rc1 and final v1.3.1 identities must not cross-match: an -rc1
+            // boot/kernel (RTMR1/2) stapled to the final runtime RTMR3 matches no
+            // single published row — partial matches are rejected (fail-closed).
+            let policy = vetted_golden_measurements();
+            let err = policy
+                .verify(
+                    &reg(MRTD_V131),
+                    &reg(RC1_RTMR0_B200),
+                    &reg(RC1_RTMR1),
+                    &reg(RC1_RTMR2),
+                    &reg(FINAL_RTMR3),
+                )
+                .unwrap_err();
+            assert!(matches!(err, MeasurementError::NoMatch { .. }));
         }
 
         #[test]

--- a/crates/services/src/attestation/chutes.rs
+++ b/crates/services/src/attestation/chutes.rs
@@ -317,9 +317,9 @@ pub fn vetted_golden_measurements() -> ChutesMeasurementPolicy {
         FAMILIES
             .iter()
             .flat_map(|f| {
-                f.hardware_rows.iter().map(move |(name, rtmr0)| {
+                f.hardware_rows.iter().map(move |&(name, rtmr0)| {
                     ExpectedMeasurement::new(
-                        *name, f.version, f.mrtd, rtmr0, f.rtmr1, f.rtmr2, f.rtmr3,
+                        name, f.version, f.mrtd, rtmr0, f.rtmr1, f.rtmr2, f.rtmr3,
                     )
                 })
             })


### PR DESCRIPTION
## Why

Companion to **[cvm-ansible #338](https://github.com/nearai/cvm-ansible-playbooks/pull/338)**, which adds `z-ai/glm-5.2=zai-org/GLM-5.2-TEE` to `CHUTES_MODELS` so Chutes serves as an attested fallback under the existing active `z-ai/glm-5.2` NEAR row.

The config change alone is **not sufficient**: GLM-5.2-TEE's live fleet runs Chutes firmware **v1.3.1-rc1** on Blackwell hardware, but `vetted_golden_measurements()` pinned **only v1.3.0**. The measurement register-pin would therefore match no accepted config and **fail closed** (masked 502/503) — exactly like `mistralai/mistral-nemo` on v1.2.0 (infra#776), but for a different reason (unvetted *version*, not unmeasured app layer).

## What

Restructures the vetted snapshot into per-release `Family` blocks (each shares one software identity — MRTD/RTMR1/RTMR2/runtime-RTMR3 — and varies only RTMR0 per hardware SKU) and adds the full **v1.3.1 family**:

- **v1.3.1-rc1** — 3 Blackwell rows (`8xb200`, `8xb200-xeon6`, `8xb300`). **Live cross-checked 2026-06-24**: 3 distinct register sets observed on GLM-5.2-TEE's fleet matched the published rows byte-for-byte (MRTD + RTMR0 + RTMR1 + RTMR2 + **runtime** RTMR3). These are genuine, DCAP-signature-verified, report-data-bound quotes (the measurement check runs only after the Intel signature chain + nonce/e2e-key/SPKI bindings pass).
- **v1.3.1 final** — 6 rows (2× h200, RTX_PRO_6000, 3× Blackwell). Same MRTD as `-rc1`, **distinct** RTMR1/2/3. Pinned as **forward-insurance** so GLM-5.2 keeps attesting once Chutes promotes the chute off the release candidate. Published + app-measured, but not yet live cross-checked (no instance observed on the final release yet).

Both v1.3.1 and v1.3.1-rc1 publish a **non-zero runtime RTMR3** (the app/IMA layer is genuinely measured) — unlike v1.0.0–v1.2.0 (RTMR3 = all-zeros, app unmeasured), which remain excluded fail-closed.

The cryptographic root of trust is unchanged: the Intel DCAP signature, not the (unsigned) transparency endpoint. These rows merely enumerate which genuine software identities we accept.

## Tests

`crates/services/src/attestation/chutes.rs` `golden` module:
- `accepts_glm52_live_rc1_blackwell_rows` — the 3 live-observed rc1 Blackwell register sets verify.
- `accepts_final_v131_for_rc1_promotion` — a final-v1.3.1 row verifies (promotion path).
- `rejects_rc1_software_with_final_v131_rtmr3` — an rc1 boot/kernel spliced to the final runtime RTMR3 matches no single row → fail-closed (`NoMatch`).
- `covers_the_full_v130_hardware_family` — row count updated 5 → 14; v1.3.0 rows still verify by name.
- `every_vetted_row_is_well_formed_48_byte_hex` — now guards all 14 pinned rows.

All 12 chutes attestation tests pass; clippy clean; NEAR path untouched.

## Deploy order

Merge **this** PR (and let it reach prod/staging) **before** merging cvm-ansible #338 — otherwise the GLM-5.2 fallback routes but fails closed on attestation. NEAR-primary serving of `z-ai/glm-5.2` is unaffected either way.