### PR TITLE
feat(attestation): short-TTL cache + single-flight for no-nonce reports (cut /report 503 herd)

### DIFF
--- a/crates/services/src/attestation/mod.rs
+++ b/crates/services/src/attestation/mod.rs
@@ -42,6 +42,12 @@ pub mod ports;
 const GATEWAY_KEY_PATH_ED25519: &str = "/signing-key/ed25519";
 const GATEWAY_KEY_PATH_ECDSA: &str = "/signing-key/ecdsa";
 
+/// Default TTL (seconds) for the no-nonce attestation-report cache. Reports for
+/// nonce-less requests are short-lived snapshots; ~10s collapses the bursty
+/// monitoring herd (bursts arrive within seconds) while keeping reports fresh.
+/// Override with `ATTESTATION_REPORT_CACHE_TTL_SECS`; `0` disables the cache.
+const DEFAULT_ATTESTATION_REPORT_CACHE_TTL_SECS: u64 = 10;
+
 pub struct AttestationService {
     pub repository: Arc<dyn AttestationRepository + Send + Sync>,
     pub inference_provider_pool: Arc<InferenceProviderPool>,
@@ -55,6 +61,15 @@ pub struct AttestationService {
     ed25519_verifying_key: Arc<VerifyingKey>,
     ecdsa_signing_key: Arc<EcdsaSigningKey>,
     ecdsa_verifying_key: Arc<EcdsaVerifyingKey>,
+    /// Short-TTL cache for attestation reports of **nonce-less** requests only.
+    /// Keyed on (model, algo, tls_fp, provider_filter, signing_address) — never
+    /// on a nonce. moka's `try_get_with` also single-flights concurrent misses,
+    /// so a burst of identical no-nonce probes triggers ONE backend build.
+    /// `None` when disabled (TTL=0). Nonce-bearing requests bypass it entirely
+    /// because the nonce is cryptographically bound into the TDX report_data and
+    /// the GPU evidence — serving a cached report for a different nonce would
+    /// defeat the freshness/replay guarantee.
+    report_cache: Option<moka::future::Cache<String, Arc<AttestationReport>>>,
 }
 
 impl AttestationService {
@@ -135,6 +150,29 @@ impl AttestationService {
                 }
             };
 
+        // Build the no-nonce attestation-report cache from env (TTL=0 disables it).
+        let cache_ttl_secs = std::env::var("ATTESTATION_REPORT_CACHE_TTL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_ATTESTATION_REPORT_CACHE_TTL_SECS);
+        let report_cache = if cache_ttl_secs == 0 {
+            tracing::info!("Attestation-report cache disabled (TTL=0)");
+            None
+        } else {
+            tracing::info!(
+                ttl_secs = cache_ttl_secs,
+                "Attestation-report cache enabled"
+            );
+            Some(
+                moka::future::Cache::builder()
+                    // One entry per (model, algo, tls_fp, provider, signing_addr)
+                    // combination; the live model catalog is well under this.
+                    .max_capacity(1024)
+                    .time_to_live(std::time::Duration::from_secs(cache_ttl_secs))
+                    .build(),
+            )
+        };
+
         Ok(Self {
             repository,
             inference_provider_pool,
@@ -148,6 +186,7 @@ impl AttestationService {
             ed25519_verifying_key: Arc::new(ed25519_verifying_key),
             ecdsa_signing_key: Arc::new(ecdsa_signing_key),
             ecdsa_verifying_key: Arc::new(ecdsa_verifying_key),
+            report_cache,
         })
     }
 
@@ -569,6 +608,32 @@ pub fn load_vpc_shared_secret() -> Option<String> {
     }
 }
 
+/// Build the cache key for the no-nonce attestation-report cache.
+///
+/// SAFETY-CRITICAL: the nonce is deliberately NOT an input — this cache is only
+/// ever consulted for nonce-less requests (the caller checks `nonce.is_none()`
+/// before using the returned key). Every other parameter that changes the report
+/// contents IS part of the key, so a request can never receive a report built
+/// for a different model / algo / tls-fingerprint / provider tier / signing
+/// address. `signing_algo` is lowercased and defaulted to match the service's
+/// own algo normalization.
+fn report_cache_key(
+    model: Option<&str>,
+    signing_algo: Option<&str>,
+    include_tls_fingerprint: bool,
+    provider_filter: Option<inference_providers::ProviderTier>,
+    signing_address: Option<&str>,
+) -> String {
+    format!(
+        "m={}|a={}|tls={}|pf={}|sa={}",
+        model.unwrap_or("*"),
+        signing_algo.unwrap_or("ed25519").to_ascii_lowercase(),
+        include_tls_fingerprint,
+        provider_filter.map(|t| t.as_str()).unwrap_or("-"),
+        signing_address.unwrap_or("-"),
+    )
+}
+
 #[async_trait]
 impl ports::AttestationServiceTrait for AttestationService {
     async fn get_chat_signature(
@@ -749,177 +814,242 @@ impl ports::AttestationServiceTrait for AttestationService {
         include_tls_fingerprint: bool,
         provider_filter: Option<inference_providers::ProviderTier>,
     ) -> Result<AttestationReport, AttestationError> {
-        // Track whether the caller supplied a nonce. Only caller-supplied nonces are
-        // forwarded to inference-proxy: when None, inference-proxy can serve its
-        // 5-minute cached report (skipping a fresh GPU-evidence NVIDIA NRAS round-trip
-        // that serializes behind a per-backend Mutex and costs ~700 ms per call).
-        let user_provided_nonce = nonce.clone();
+        let env_tag = format!("{TAG_ENVIRONMENT}:{}", get_environment());
 
-        // Produce (gateway_nonce: String, nonce_bytes: Vec<u8>) in one pass:
-        // – caller-supplied nonce: validate hex, decode once.
-        // – auto-generated nonce: fill random bytes, hex-encode once (no round-trip).
-        let (gateway_nonce, nonce_bytes) = match nonce {
-            Some(n) => {
-                let bytes = hex::decode(&n).map_err(|e| {
-                    tracing::error!("Failed to decode nonce hex string: {}", e);
-                    AttestationError::InvalidParameter(format!("Invalid nonce format: {e}"))
-                })?;
-                if bytes.len() != 32 {
-                    return Err(AttestationError::InvalidParameter(format!(
-                        "Nonce must be exactly 32 bytes, got {} bytes",
-                        bytes.len()
-                    )));
+        // Precompute the no-nonce cache key BEFORE the params are moved into the
+        // build closure below.
+        let cache_key = report_cache_key(
+            model.as_deref(),
+            signing_algo.as_deref(),
+            include_tls_fingerprint,
+            provider_filter,
+            signing_address.as_deref(),
+        );
+
+        // The full (expensive) report build. `nonce` is the closure parameter so
+        // the body below is unchanged. Called exactly once per request: the
+        // bypass arm diverges via `return`, the cache arm via `try_get_with`.
+        let build = |nonce: Option<String>| async move {
+            // Track whether the caller supplied a nonce. Only caller-supplied nonces are
+            // forwarded to inference-proxy: when None, inference-proxy can serve its
+            // 5-minute cached report (skipping a fresh GPU-evidence NVIDIA NRAS round-trip
+            // that serializes behind a per-backend Mutex and costs ~700 ms per call).
+            let user_provided_nonce = nonce.clone();
+
+            // Produce (gateway_nonce: String, nonce_bytes: Vec<u8>) in one pass:
+            // – caller-supplied nonce: validate hex, decode once.
+            // – auto-generated nonce: fill random bytes, hex-encode once (no round-trip).
+            let (gateway_nonce, nonce_bytes) = match nonce {
+                Some(n) => {
+                    let bytes = hex::decode(&n).map_err(|e| {
+                        tracing::error!("Failed to decode nonce hex string: {}", e);
+                        AttestationError::InvalidParameter(format!("Invalid nonce format: {e}"))
+                    })?;
+                    if bytes.len() != 32 {
+                        return Err(AttestationError::InvalidParameter(format!(
+                            "Nonce must be exactly 32 bytes, got {} bytes",
+                            bytes.len()
+                        )));
+                    }
+                    (n, bytes)
                 }
-                (n, bytes)
+                None => {
+                    let mut bytes = vec![0u8; 32];
+                    OsRng.fill_bytes(&mut bytes);
+                    let hex = hex::encode(&bytes);
+                    tracing::debug!(
+                        "No nonce provided for attestation report, generated nonce: {hex}"
+                    );
+                    (hex, bytes)
+                }
+            };
+
+            // Determine which signing algorithm to use for report_data (default to ed25519)
+            let algo = signing_algo
+                .as_ref()
+                .map(|s| s.to_lowercase())
+                .unwrap_or_else(|| "ed25519".to_string());
+
+            if algo != "ecdsa" && algo != "ed25519" {
+                return Err(AttestationError::InvalidParameter(format!(
+                    "Invalid signing algorithm: {algo}, must be 'ecdsa' or 'ed25519'"
+                )));
             }
-            None => {
-                let mut bytes = vec![0u8; 32];
-                OsRng.fill_bytes(&mut bytes);
-                let hex = hex::encode(&bytes);
-                tracing::debug!("No nonce provided for attestation report, generated nonce: {hex}");
-                (hex, bytes)
-            }
-        };
 
-        // Determine which signing algorithm to use for report_data (default to ed25519)
-        let algo = signing_algo
-            .as_ref()
-            .map(|s| s.to_lowercase())
-            .unwrap_or_else(|| "ed25519".to_string());
+            // Resolve model alias synchronously (fast DB lookup ~10 ms) before spawning
+            // the parallel futures below.
+            let resolved_canonical = if let Some(ref m) = model {
+                let resolved_model = self
+                    .models_repository
+                    .resolve_and_get_model(m)
+                    .await
+                    .map_err(|e| {
+                        AttestationError::ProviderError(format!("Failed to resolve model: {e}"))
+                    })?
+                    .ok_or_else(|| {
+                        AttestationError::ProviderError(format!(
+                            "Model '{m}' not found. It's not a valid model name or alias."
+                        ))
+                    })?;
+                let canonical = resolved_model.model_name.clone();
+                if &canonical != m {
+                    tracing::debug!(
+                        requested_model = %m,
+                        canonical_model = %canonical,
+                        "Resolved alias to canonical model name for attestation report"
+                    );
+                }
+                Some(canonical)
+            } else {
+                None
+            };
 
-        if algo != "ecdsa" && algo != "ed25519" {
-            return Err(AttestationError::InvalidParameter(format!(
-                "Invalid signing algorithm: {algo}, must be 'ecdsa' or 'ed25519'"
-            )));
-        }
+            // Prepare gateway-quote inputs synchronously (no await needed).
+            let vpc = self.vpc_info.clone();
+            let signing_address_to_use = self.get_signing_address_hex(&algo)?;
+            let signing_address_clean = signing_address_to_use
+                .strip_prefix("0x")
+                .unwrap_or(&signing_address_to_use);
+            let signing_address_bytes = hex::decode(signing_address_clean).map_err(|e| {
+                tracing::error!("Failed to decode signing address hex string: {}", e);
+                AttestationError::InvalidParameter(format!("Invalid signing address format: {e}"))
+            })?;
+            let signing_address_for_report = if signing_address_bytes.len() > 32 {
+                signing_address_bytes[..32].to_vec()
+            } else {
+                signing_address_bytes
+            };
 
-        // Resolve model alias synchronously (fast DB lookup ~10 ms) before spawning
-        // the parallel futures below.
-        let resolved_canonical = if let Some(ref m) = model {
-            let resolved_model = self
-                .models_repository
-                .resolve_and_get_model(m)
-                .await
-                .map_err(|e| {
-                    AttestationError::ProviderError(format!("Failed to resolve model: {e}"))
-                })?
-                .ok_or_else(|| {
-                    AttestationError::ProviderError(format!(
-                        "Model '{m}' not found. It's not a valid model name or alias."
-                    ))
-                })?;
-            let canonical = resolved_model.model_name.clone();
-            if &canonical != m {
-                tracing::debug!(
-                    requested_model = %m,
-                    canonical_model = %canonical,
-                    "Resolved alias to canonical model name for attestation report"
-                );
-            }
-            Some(canonical)
-        } else {
-            None
-        };
-
-        // Prepare gateway-quote inputs synchronously (no await needed).
-        let vpc = self.vpc_info.clone();
-        let signing_address_to_use = self.get_signing_address_hex(&algo)?;
-        let signing_address_clean = signing_address_to_use
-            .strip_prefix("0x")
-            .unwrap_or(&signing_address_to_use);
-        let signing_address_bytes = hex::decode(signing_address_clean).map_err(|e| {
-            tracing::error!("Failed to decode signing address hex string: {}", e);
-            AttestationError::InvalidParameter(format!("Invalid signing address format: {e}"))
-        })?;
-        let signing_address_for_report = if signing_address_bytes.len() > 32 {
-            signing_address_bytes[..32].to_vec()
-        } else {
-            signing_address_bytes
-        };
-
-        let tls_fingerprint = if include_tls_fingerprint {
-            Some(self.tls_cert_fingerprint.clone().ok_or_else(|| {
+            let tls_fingerprint = if include_tls_fingerprint {
+                Some(self.tls_cert_fingerprint.clone().ok_or_else(|| {
                 AttestationError::InternalError(
                     "include_tls_fingerprint=true but TLS_CERT_PATH is not set or fingerprint could not be computed".to_string(),
                 )
             })?)
-        } else {
-            None
-        };
-
-        // Build report_data: [first_32_bytes || nonce (32 bytes)]
-        // When include_tls_fingerprint=true: first_32 = SHA256(signing_address_bytes || cert_fingerprint_bytes)
-        // Otherwise: first_32 = signing_address (right-padded with zeros)
-        let mut report_data = vec![0u8; 64];
-        if let Some(ref fp_hex) = tls_fingerprint {
-            use sha2::Digest;
-            let fp_bytes = hex::decode(fp_hex).map_err(|e| {
-                AttestationError::InternalError(format!("bad cert fingerprint hex: {e}"))
-            })?;
-            let mut hasher = sha2::Sha256::new();
-            hasher.update(&signing_address_for_report);
-            hasher.update(&fp_bytes);
-            let hash = hasher.finalize();
-            report_data[..32].copy_from_slice(&hash);
-        } else {
-            report_data[..signing_address_for_report.len()]
-                .copy_from_slice(&signing_address_for_report);
-        }
-        report_data[32..64].copy_from_slice(&nonce_bytes);
-
-        // Read TLS certificate PEM if fingerprint is requested (for the response body).
-        let tls_certificate = if include_tls_fingerprint {
-            if let Ok(path) = std::env::var("TLS_CERT_PATH") {
-                tokio::fs::read_to_string(&path).await.ok()
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
 
-        // Run model-attestation fetch and gateway TDX-quote generation concurrently.
-        // These are independent: the model fetch is an outbound HTTP call to the
-        // inference backend; the gateway quote is a local dstack Unix-socket call.
-        let model_fut = {
-            let pool = &self.inference_provider_pool;
-            async move {
-                if let Some(canonical) = resolved_canonical {
-                    pool.get_attestation_report(
-                        canonical,
-                        signing_algo,
-                        // Key fix: only forward the nonce when the caller supplied one.
-                        // When None, inference-proxy serves its 5-min cached report
-                        // instead of forcing a fresh GPU-evidence collection (~700 ms).
-                        user_provided_nonce,
-                        signing_address,
-                        include_tls_fingerprint,
-                        provider_filter,
-                    )
-                    .await
-                    .map_err(|e| AttestationError::ProviderError(e.to_string()))
+            // Build report_data: [first_32_bytes || nonce (32 bytes)]
+            // When include_tls_fingerprint=true: first_32 = SHA256(signing_address_bytes || cert_fingerprint_bytes)
+            // Otherwise: first_32 = signing_address (right-padded with zeros)
+            let mut report_data = vec![0u8; 64];
+            if let Some(ref fp_hex) = tls_fingerprint {
+                use sha2::Digest;
+                let fp_bytes = hex::decode(fp_hex).map_err(|e| {
+                    AttestationError::InternalError(format!("bad cert fingerprint hex: {e}"))
+                })?;
+                let mut hasher = sha2::Sha256::new();
+                hasher.update(&signing_address_for_report);
+                hasher.update(&fp_bytes);
+                let hash = hasher.finalize();
+                report_data[..32].copy_from_slice(&hash);
+            } else {
+                report_data[..signing_address_for_report.len()]
+                    .copy_from_slice(&signing_address_for_report);
+            }
+            report_data[32..64].copy_from_slice(&nonce_bytes);
+
+            // Read TLS certificate PEM if fingerprint is requested (for the response body).
+            let tls_certificate = if include_tls_fingerprint {
+                if let Ok(path) = std::env::var("TLS_CERT_PATH") {
+                    tokio::fs::read_to_string(&path).await.ok()
                 } else {
-                    Ok(vec![])
+                    None
                 }
+            } else {
+                None
+            };
+
+            // Run model-attestation fetch and gateway TDX-quote generation concurrently.
+            // These are independent: the model fetch is an outbound HTTP call to the
+            // inference backend; the gateway quote is a local dstack Unix-socket call.
+            let model_fut = {
+                let pool = &self.inference_provider_pool;
+                async move {
+                    if let Some(canonical) = resolved_canonical {
+                        pool.get_attestation_report(
+                            canonical,
+                            signing_algo,
+                            // Key fix: only forward the nonce when the caller supplied one.
+                            // When None, inference-proxy serves its 5-min cached report
+                            // instead of forcing a fresh GPU-evidence collection (~700 ms).
+                            user_provided_nonce,
+                            signing_address,
+                            include_tls_fingerprint,
+                            provider_filter,
+                        )
+                        .await
+                        .map_err(|e| AttestationError::ProviderError(e.to_string()))
+                    } else {
+                        Ok(vec![])
+                    }
+                }
+            };
+
+            let gateway_fut = build_gateway_quote(
+                signing_address_to_use,
+                algo,
+                vpc,
+                report_data,
+                gateway_nonce,
+                tls_fingerprint,
+            );
+
+            let (model_attestations, gateway_attestation) =
+                tokio::try_join!(model_fut, gateway_fut)?;
+
+            Ok(AttestationReport {
+                gateway_attestation,
+                model_attestations,
+                tls_certificate,
+            })
+        }; // end `build` closure
+
+        // Nonce-bearing requests (and the disabled-cache case) bypass the cache:
+        // the nonce is cryptographically bound into the TDX report_data and the
+        // GPU evidence, so serving a cached report for a different nonce would
+        // defeat the freshness / replay guarantee. Only nonce-LESS requests —
+        // which already opt out of freshness (the gateway auto-generates a random
+        // nonce and inference-proxy serves its own cached report) — are cached.
+        let cache = match &self.report_cache {
+            Some(c) if nonce.is_none() => c.clone(),
+            _ => {
+                self.metrics_service.record_count(
+                    METRIC_ATTESTATION_REPORT_CACHE,
+                    1,
+                    &[&format!("{TAG_RESULT}:bypass"), &env_tag],
+                );
+                return build(nonce).await;
             }
         };
 
-        let gateway_fut = build_gateway_quote(
-            signing_address_to_use,
-            algo,
-            vpc,
-            report_data,
-            gateway_nonce,
-            tls_fingerprint,
+        // No-nonce path: short-TTL cache + single-flight. `try_get_with` coalesces
+        // concurrent misses on the same key, so a burst of identical no-nonce
+        // probes triggers ONE backend build instead of N (collapsing the
+        // monitoring thundering-herd that sheds 503s at the inference backend).
+        let computed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = computed.clone();
+        let res = cache
+            .try_get_with(cache_key, async move {
+                flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                build(None).await.map(Arc::new)
+            })
+            .await;
+        let result = if computed.load(std::sync::atomic::Ordering::Relaxed) {
+            "miss"
+        } else {
+            "hit"
+        };
+        self.metrics_service.record_count(
+            METRIC_ATTESTATION_REPORT_CACHE,
+            1,
+            &[&format!("{TAG_RESULT}:{result}"), &env_tag],
         );
-
-        let (model_attestations, gateway_attestation) = tokio::try_join!(model_fut, gateway_fut)?;
-
-        Ok(AttestationReport {
-            gateway_attestation,
-            model_attestations,
-            tls_certificate,
-        })
+        // Clone the report out of the shared `Arc`; map the coalesced
+        // `Arc<AttestationError>` back to an owned error so the route still maps
+        // it to the correct HTTP status.
+        res.map(|arc| (*arc).clone()).map_err(|e| (*e).clone())
     }
 
     async fn verify_vpc_signature(
@@ -1033,4 +1163,95 @@ async fn build_gateway_quote(
         nonce,
         tls_fingerprint,
     ))
+}
+
+#[cfg(test)]
+mod cache_key_tests {
+    use super::report_cache_key;
+    use inference_providers::ProviderTier;
+
+    #[test]
+    fn key_is_independent_of_nonce_by_construction() {
+        // The function has no nonce parameter — this test documents that the
+        // safety-critical invariant (a cached no-nonce report is never keyed on,
+        // nor served for, a specific nonce) holds at the type level: two requests
+        // with identical params map to one key regardless of any nonce the caller
+        // did or didn't send.
+        let a = report_cache_key(Some("gpt-oss-120b"), Some("ecdsa"), false, None, None);
+        let b = report_cache_key(Some("gpt-oss-120b"), Some("ecdsa"), false, None, None);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn algo_defaults_and_lowercases() {
+        // None defaults to ed25519; case is normalized so ECDSA and ecdsa collide.
+        assert_eq!(
+            report_cache_key(Some("m"), None, false, None, None),
+            report_cache_key(Some("m"), Some("ed25519"), false, None, None),
+        );
+        assert_eq!(
+            report_cache_key(Some("m"), Some("ECDSA"), false, None, None),
+            report_cache_key(Some("m"), Some("ecdsa"), false, None, None),
+        );
+    }
+
+    #[test]
+    fn distinct_params_produce_distinct_keys() {
+        let base = report_cache_key(Some("m"), Some("ecdsa"), false, None, None);
+        // Each differing dimension must yield a different key (no cross-serving).
+        assert_ne!(
+            base,
+            report_cache_key(Some("m2"), Some("ecdsa"), false, None, None)
+        );
+        assert_ne!(
+            base,
+            report_cache_key(Some("m"), Some("ed25519"), false, None, None)
+        );
+        assert_ne!(
+            base,
+            report_cache_key(Some("m"), Some("ecdsa"), true, None, None)
+        );
+        assert_ne!(
+            base,
+            report_cache_key(
+                Some("m"),
+                Some("ecdsa"),
+                false,
+                Some(ProviderTier::Near),
+                None
+            )
+        );
+        assert_ne!(
+            base,
+            report_cache_key(Some("m"), Some("ecdsa"), false, None, Some("0xabc"))
+        );
+        // Near vs Attested3p must not collide.
+        assert_ne!(
+            report_cache_key(
+                Some("m"),
+                Some("ecdsa"),
+                false,
+                Some(ProviderTier::Near),
+                None
+            ),
+            report_cache_key(
+                Some("m"),
+                Some("ecdsa"),
+                false,
+                Some(ProviderTier::Attested3p),
+                None
+            ),
+        );
+    }
+
+    #[test]
+    fn none_model_is_distinct_from_wildcard_literal() {
+        // A request for all models (None) keys on "*"; a model literally named
+        // "*" is not a realistic catalog entry, so this is acceptable and just
+        // documents the sentinel.
+        assert_eq!(
+            report_cache_key(None, Some("ecdsa"), false, None, None),
+            report_cache_key(Some("*"), Some("ecdsa"), false, None, None),
+        );
+    }
 }

--- a/crates/services/src/attestation/models.rs
+++ b/crates/services/src/attestation/models.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 /// Error types for attestation operations
-#[derive(Debug, thiserror::Error)]
+// `Clone` so a cached/coalesced attestation-report build (moka `try_get_with`,
+// which yields `Arc<AttestationError>`) can return an owned error that preserves
+// the variant for correct HTTP status mapping. All variants hold only `String`.
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum AttestationError {
     #[error("Signature not found: {0}")]
     SignatureNotFound(String),
@@ -104,6 +107,9 @@ impl DstackCpuQuote {
     }
 }
 
+// `Clone` so the no-nonce report cache can store an `Arc<AttestationReport>` and
+// hand owned copies back to the trait method (which returns by value).
+#[derive(Clone)]
 pub struct AttestationReport {
     pub gateway_attestation: DstackCpuQuote,
     pub model_attestations: Vec<serde_json::Map<String, serde_json::Value>>,

--- a/crates/services/src/metrics/consts.rs
+++ b/crates/services/src/metrics/consts.rs
@@ -15,6 +15,13 @@ pub const METRIC_VERIFICATION_DURATION: &str = "cloud_api.verification.duration"
 pub const METRIC_SIGNATURE_CREATION_SUCCESS: &str = "cloud_api.signature.creation.success";
 pub const METRIC_SIGNATURE_CREATION_DURATION: &str = "cloud_api.signature.creation.duration";
 
+// Attestation-report cache: one increment per /v1/attestation/report, tagged
+// `result` (hit|miss|bypass) + environment. Lets dashboards see the no-nonce
+// cache collapse the monitoring thundering-herd (bypass = nonce-bearing request
+// served fresh; hit = no-nonce request served from the short-TTL cache).
+pub const METRIC_ATTESTATION_REPORT_CACHE: &str = "cloud_api.attestation.report_cache";
+pub const TAG_RESULT: &str = "result";
+
 // Usage/engagement metrics
 pub const METRIC_REQUEST_COUNT: &str = "cloud_api.request.count";
 pub const METRIC_TOKENS_INPUT: &str = "cloud_api.tokens.input";

--- a/crates/services/src/metrics/mod.rs
+++ b/crates/services/src/metrics/mod.rs
@@ -108,6 +108,9 @@ impl MetricsServiceTrait for OtlpMetricsService {
                 consts::METRIC_SIGNATURE_CREATION_SUCCESS => {
                     "Successful gateway signature creation operations"
                 }
+                consts::METRIC_ATTESTATION_REPORT_CACHE => {
+                    "Attestation-report cache outcomes by result (hit|miss|bypass)"
+                }
                 consts::METRIC_HTTP_REQUESTS => {
                     "Total HTTP requests by endpoint, method, and status"
                 }


### PR DESCRIPTION
## Problem

`/v1/attestation/report` sheds ~10% **503s in regular ~6-min bursts** (213/1887 over a sampled hour in prod). Datadog logs show the cause: **many independent monitors** — `Datadog/Synthetics`, `Blackbox Exporter`, Go/python probes, cloud-ui — poll the **full 58-model catalog** on overlapping schedules. Each report does an expensive per-backend **GPU-evidence NRAS round-trip (~700ms, serialized behind a per-backend mutex)**; when the monitors' schedules overlap, concurrent requests thundering-herd the backend, which sheds 503. (Confirmed pre-existing — the burst pattern runs for hours before any recent deploy; not customer chat traffic, which stays clean.)

## Key constraint (why naive caching is unsafe)

From the logs: **65% of report requests send NO nonce; the 35% that do each use a UNIQUE nonce** (zero reuse). The nonce is cryptographically bound into the TDX `report_data` **and** the GPU evidence (NRAS freshness — that's *why* the existing code only skips GPU collection when the nonce is absent). So a cached report **cannot** be served for a different nonce without defeating replay/freshness. Nonce-bearing requests must stay fresh.

## Fix — cache only the no-nonce majority

- **No-nonce requests (the 65%)**: already freshness-opted-out (the codebase forwards `None` so inference-proxy serves *its* 5-min cache, but cloud-api still re-ran the full orchestration each time). Now served from a cloud-api short-TTL `moka` cache (**default 10s**, env `ATTESTATION_REPORT_CACHE_TTL_SECS`, `0` disables). `try_get_with` **also single-flights** concurrent misses, so a burst of identical no-nonce probes triggers **one** backend build instead of N.
- **Nonce-bearing requests (the 35%)**: **bypass the cache entirely**, always built fresh.

Collapsing the no-nonce majority frees backend capacity → cuts the 503 shed rate for the genuinely-fresh nonce requests.

## Safety (by construction + unit-tested)

- `report_cache_key()` **never includes the nonce** and the cache is consulted **only when `nonce.is_none()`** — a request can never receive a report built for a different model / algo / tls-fingerprint / provider tier / signing address. Unit tests assert distinct params → distinct keys (Near vs Attested3p don't collide; algo case-normalized).
- Mirrors existing accepted behavior: inference-proxy already replays a cached report (with a baked `request_nonce`) to no-nonce callers.
- `AttestationError` gains `Clone` so the coalesced `Arc<Error>` maps back to an owned error → route still maps it to the correct HTTP status.

## Observability
New `cloud_api.attestation.report_cache{result:hit|miss|bypass}` — watch `hit` rise and backend `/report` 503s fall.

## Diff note
Most of the `attestation/mod.rs` churn (+523/−152) is **rustfmt reindentation** from wrapping the existing report-build body in a `build` closure — the body itself is unchanged. The real logic is the ~60-line dispatch wrapper + `report_cache_key` + the cache field/init.

## Test plan
- [x] `cargo test -p services --lib` — 427 pass (incl. 4 new `cache_key_tests`). `cargo clippy`/`fmt` clean; `api` crate builds.
- [ ] Staging: set traffic, confirm `report_cache{result:hit}` climbs for no-nonce probes and `result:bypass` for nonce requests; verify a nonce-bearing `/report` still returns a fresh quote bound to the sent nonce.
- [ ] Prod (after soak): confirm `/v1/attestation/report` 503 burst rate drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)