### PR TITLE
ci: notify #cvm-alerts on reproducible-build failure

### DIFF
--- a/.github/workflows/verify-reproducible-build.yml
+++ b/.github/workflows/verify-reproducible-build.yml
@@ -291,3 +291,34 @@ jobs:
               echo "Build digests do not match across environments or verification failed."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Post a Slack alert to #cvm-alerts when any build/verify job fails.
+  # No-ops gracefully if SLACK_BOT_TOKEN is not configured on the repo.
+  notify-slack:
+    name: Notify Slack on failure
+    needs: [build, sequential-builds, verify]
+    if: always() && contains(needs.*.result, 'failure')
+    runs-on: [self-hosted, infra]
+    steps:
+      - name: Send Slack notification
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          if [ -z "${SLACK_BOT_TOKEN}" ]; then
+            echo "SLACK_BOT_TOKEN not set; skipping Slack notification"
+            exit 0
+          fi
+
+          command -v jq >/dev/null 2>&1 || { sudo apt-get update || true; sudo apt-get install -y jq; }
+
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG=":red_circle: *Reproducible build verification failed* on \`${{ github.repository }}\`
+          Branch: \`${{ github.ref_name }}\` · Commit: \`${GITHUB_SHA:0:7}\`
+          Jobs — build: \`${{ needs.build.result }}\` · sequential-builds: \`${{ needs.sequential-builds.result }}\` · verify: \`${{ needs.verify.result }}\`
+
+          <${RUN_URL}|GitHub Actions run>"
+
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg channel "C09EQ848HHC" --arg text "$MSG" '{channel: $channel, text: $text, unfurl_links: false}')"


### PR DESCRIPTION
## What

Adds a `notify-slack` job to `.github/workflows/verify-reproducible-build.yml` that posts a Slack alert to **#cvm-alerts** (`C09EQ848HHC`) whenever any of the `build`, `sequential-builds`, or `verify` jobs fail.

## Why

The reproducible-build verification runs on every push to `main` (and on demand). A failure means the build is no longer bit-for-bit reproducible — a supply-chain signal we want to know about immediately rather than discovering by manually checking the Actions tab.

## How

- New job `notify-slack` with `needs: [build, sequential-builds, verify]` and `if: always() && contains(needs.*.result, 'failure')`.
- Posts via Slack `chat.postMessage` using `secrets.SLACK_BOT_TOKEN`, mirroring the existing pattern in `infra-tests`.
- **No-ops gracefully** (`exit 0`) if `SLACK_BOT_TOKEN` is unset, so the workflow never breaks on forks or before the secret is configured.
- Message includes repo, branch, short commit, per-job results, and a link to the run.

## Follow-up required

`SLACK_BOT_TOKEN` is **not yet configured** on this repo (it's currently a repo-level secret only in `infra-tests`). The notify step will skip until the secret is added:

```
gh secret set SLACK_BOT_TOKEN --repo nearai/cloud-api
```

The bot must be a member of #cvm-alerts.

## Testing

- YAML validated with PyYAML.
- Notification logic mirrors the production `infra-tests` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)