### PR TITLE
fix(chutes): retry transient fallback failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/inference_providers/src/attested/chutes/availability.rs
+++ b/crates/inference_providers/src/attested/chutes/availability.rs
@@ -1,0 +1,65 @@
+use crate::CompletionError;
+
+pub(super) fn retryable_provider_unavailable(ctx: &str, reason: &str) -> CompletionError {
+    CompletionError::HttpError {
+        status_code: 503,
+        message: format!("{ctx}: Chutes temporarily unavailable ({reason})"),
+        is_external: true,
+    }
+}
+
+pub(super) fn stale_invoke_target(ctx: &str, body: &str) -> bool {
+    if !ctx.contains("/e2e/invoke") {
+        return false;
+    }
+    let lower = body.to_ascii_lowercase();
+    let mentions_target = lower.contains("nonce") || lower.contains("instance");
+    let stale = lower.contains("expired")
+        || lower.contains("stale")
+        || lower.contains("already used")
+        || lower.contains("consumed")
+        || lower.contains("not found")
+        || lower.contains("invalid");
+    mentions_target && stale
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_invoke_target_requires_invoke_stage_and_stale_target_body() {
+        assert!(stale_invoke_target(
+            "Chutes /e2e/invoke",
+            "nonce token expired for selected instance",
+        ));
+        assert!(!stale_invoke_target(
+            "fetch evidence",
+            "nonce token expired for selected instance",
+        ));
+        assert!(!stale_invoke_target(
+            "Chutes /e2e/invoke",
+            "malformed encrypted payload",
+        ));
+    }
+
+    #[test]
+    fn retryable_provider_unavailable_is_http_503() {
+        match retryable_provider_unavailable(
+            "verify Chutes instance",
+            "instance i1 not present in /evidence",
+        ) {
+            CompletionError::HttpError {
+                status_code,
+                message,
+                is_external,
+            } => {
+                assert_eq!(status_code, 503);
+                assert!(is_external);
+                assert!(message.contains("verify Chutes instance"));
+                assert!(message.contains("/evidence"));
+            }
+            other => panic!("retryable Chutes outage must map to HttpError, got {other:?}"),
+        }
+    }
+}

--- a/crates/inference_providers/src/attested/chutes/mod.rs
+++ b/crates/inference_providers/src/attested/chutes/mod.rs
@@ -25,6 +25,7 @@
 //! unattested path. Turning Chutes on is gated behind an enable flag in the pool.
 
 pub mod attestation;
+mod availability;
 pub mod client;
 pub mod e2ee;
 pub mod e2ee_stream;
@@ -380,6 +381,11 @@ impl Provider {
     fn map_client_error(ctx: &str, e: client::ChutesClientError) -> CompletionError {
         let msg = format!("{ctx}: {e}");
         match e {
+            client::ChutesClientError::Status { status: 400, body }
+                if availability::stale_invoke_target(ctx, &body) =>
+            {
+                availability::retryable_provider_unavailable(ctx, "stale Chutes E2E target")
+            }
             // Retryable / correctly-masked upstream statuses: preserve so the
             // pool classifier can act on them. The message is the STAGE + STATUS
             // only — NOT the raw upstream body (#778 follow-up): a 5xx body could
@@ -396,13 +402,15 @@ impl Provider {
                 message: format!("{ctx}: Chutes returned HTTP {status}"),
                 is_external: true,
             },
+            client::ChutesClientError::Http(_) => {
+                availability::retryable_provider_unavailable(ctx, "Chutes HTTP transport error")
+            }
             // Any other upstream status (400/413/422/…) on an internally-built
             // request, plus all non-status client errors (transport / oversized
             // body / model-not-found / missing-chute-id / decode), mask as the
             // prior generic 502. Listed explicitly (no `_`) so a new
             // `ChutesClientError` variant forces this mapping to be revisited.
             client::ChutesClientError::Status { .. }
-            | client::ChutesClientError::Http(_)
             | client::ChutesClientError::BodyTooLarge { .. }
             | client::ChutesClientError::ModelNotFound(_)
             | client::ChutesClientError::MissingChuteId(_)
@@ -438,8 +446,9 @@ impl Provider {
             .filter(|i| !i.e2e_pubkey.is_empty() && !i.nonces.is_empty())
             .collect();
         if candidates.is_empty() {
-            return Err(CompletionError::CompletionError(
-                "no E2E-capable Chutes instance with an available nonce token".to_string(),
+            return Err(availability::retryable_provider_unavailable(
+                "discover instances",
+                "no E2E-capable instance with an available nonce token",
             ));
         }
 
@@ -468,12 +477,14 @@ impl Provider {
             INSTANCE_RR.fetch_add(1, Ordering::Relaxed) % n
         };
         let mut last_err = String::from("no candidate instances");
+        let mut last_err_retryable = false;
         for off in 0..n {
             let inst = candidates[(start + off) % n];
             let evidence = match evidence_resp.instance(&inst.instance_id) {
                 Some(e) => e,
                 None => {
                     last_err = format!("instance {} not present in /evidence", inst.instance_id);
+                    last_err_retryable = true;
                     continue;
                 }
             };
@@ -489,6 +500,7 @@ impl Provider {
                 Ok(info) => info,
                 Err(e) => {
                     last_err = format!("instance {} attestation failed: {e}", inst.instance_id);
+                    last_err_retryable = false;
                     continue;
                 }
             };
@@ -496,6 +508,7 @@ impl Provider {
                 Ok(pk) => pk,
                 Err(e) => {
                     last_err = format!("instance {} e2e_pubkey base64: {e}", inst.instance_id);
+                    last_err_retryable = false;
                     continue;
                 }
             };
@@ -503,6 +516,7 @@ impl Provider {
                 Ok(p) => p,
                 Err(e) => {
                     last_err = format!("instance {} E2EE build: {e}", inst.instance_id);
+                    last_err_retryable = false;
                     continue;
                 }
             };
@@ -517,6 +531,7 @@ impl Provider {
                 Some(n) => n,
                 None => {
                     last_err = format!("instance {} nonce pool drained", inst.instance_id);
+                    last_err_retryable = true;
                     continue;
                 }
             };
@@ -535,6 +550,12 @@ impl Provider {
                 blob,
                 session,
             });
+        }
+        if last_err_retryable {
+            return Err(availability::retryable_provider_unavailable(
+                "verify Chutes instance",
+                &last_err,
+            ));
         }
         Err(CompletionError::CompletionError(format!(
             "all candidate Chutes instances failed (refusing to send inference); last: {last_err}"
@@ -1801,14 +1822,42 @@ mod tests {
                 "Chutes /e2e/invoke",
                 ChutesClientError::Status {
                     status,
-                    // A nonce/token error body that must never reach the client.
-                    body: "consumed nonce token: secret-internal-detail".into(),
+                    body: "malformed encrypted request payload: secret-internal-detail".into(),
                 },
             );
             match mapped {
                 CompletionError::CompletionError(_) => {}
                 other => panic!("internal {status} must mask to CompletionError, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn map_client_error_retries_stale_invoke_400() {
+        use client::ChutesClientError;
+
+        let mapped = Provider::map_client_error(
+            "Chutes /e2e/invoke",
+            ChutesClientError::Status {
+                status: 400,
+                body: "nonce token expired for selected instance".into(),
+            },
+        );
+
+        match mapped {
+            CompletionError::HttpError {
+                status_code,
+                message,
+                is_external,
+            } => {
+                assert_eq!(status_code, 503);
+                assert!(is_external, "Chutes is an external upstream");
+                assert!(
+                    message.contains("Chutes /e2e/invoke") && message.contains("stale"),
+                    "message should identify the retryable stale-target case: {message}"
+                );
+            }
+            other => panic!("stale invoke 400 must map to retryable HttpError, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Problem

Chutes fallback still failed for Gemma/Qwen classes that were not measurement-pin rejects:

- stale `/e2e/invoke` 400s from expired/consumed nonce or instance targeting were collapsed to generic non-retryable `CompletionError`s
- missing `/evidence` for a selected Chutes instance and drained/no-nonce discovery snapshots were also non-retryable
- raw Chutes HTTP transport errors were flattened before the provider pool could classify them as transient

That meant a NEAR primary outage could fall through to Chutes once, hit one of these transient Chutes-side readiness/targeting failures, and stop instead of using the existing bounded retry path.

## Changes

- Adds a small Chutes availability classifier for retryable provider-unavailable cases.
- Maps stale Chutes `/e2e/invoke` 400s to external HTTP 503 so the existing pool retry/backoff path can mint fresh nonce/instance state.
- Maps Chutes transport errors to external HTTP 503 instead of generic completion errors.
- Treats empty E2E-capable instance snapshots, missing `/evidence` entries, and drained nonce pools as retryable Chutes unavailability.
- Keeps attestation, bad E2E pubkey, E2EE request-build, decode, oversized body, missing model/chute id, and truly malformed internal 4xx failures fail-closed/non-retryable.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p inference_providers attested::chutes::`
- `cargo test -p services test_classify_retry_decision`

LSP diagnostics could not run locally because the configured Rust toolchain is missing `rust-analyzer` (`Unknown binary 'rust-analyzer' in official toolchain '1.92.0-aarch64-apple-darwin'`).

## Rollout Notes

This is a Cloud API-only behavior change. It does not replace the infra-tests coverage and does not change Chutes golden measurements; it complements the measurement-pin PR by making transient Chutes availability/targeting failures retryable once Chutes is selected as fallback.
