### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
The `security_audit` workflow started failing on every branch this morning: **RUSTSEC-2026-0204** (published 2026-07-06) flags `crossbeam-epoch 0.9.18` — invalid pointer dereference in the `fmt::Pointer`/`fmt::Display` impls for `Atomic`/`Shared` when the underlying pointer is null. First seen on the `main` run after #865 merged (the PR run predated the advisory landing in the DB; the failure is unrelated to that change).

Lock-only, semver-compatible bump to the patched `0.9.20` (`cargo update -p crossbeam-epoch`). No source changes; workspace builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)