### PR TITLE
fix(billing): make cache_read_cost_per_token nullable — 0 no longer means disabled

### DIFF
--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -1053,7 +1053,7 @@ pub struct ModelPricing {
     /// OpenRouter: USD per request, as a string ("0" when not applicable).
     pub request: String,
     /// OpenRouter: USD per cached input token, as a string. Omitted when cache-read
-    /// pricing is disabled or unknown.
+    /// pricing is disabled; `"0"` means cached input tokens are genuinely free.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_cache_read: Option<String>,
 }
@@ -3300,8 +3300,13 @@ pub struct AdminModelWithPricing {
     pub output_cost_per_token: DecimalPrice,
     #[serde(rename = "costPerImage")]
     pub cost_per_image: DecimalPrice,
-    #[serde(rename = "cacheReadCostPerToken")]
-    pub cache_read_cost_per_token: DecimalPrice,
+    /// Cost per cached input token. Omitted when cache pricing is disabled;
+    /// an amount of 0 means cached tokens are genuinely free.
+    #[serde(
+        rename = "cacheReadCostPerToken",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_read_cost_per_token: Option<DecimalPrice>,
     pub metadata: ModelMetadata,
     #[serde(rename = "isActive")]
     pub is_active: bool,
@@ -3322,8 +3327,13 @@ pub struct ModelWithPricing {
     pub output_cost_per_token: DecimalPrice,
     #[serde(rename = "costPerImage")]
     pub cost_per_image: DecimalPrice,
-    #[serde(rename = "cacheReadCostPerToken")]
-    pub cache_read_cost_per_token: DecimalPrice,
+    /// Cost per cached input token. Omitted when cache pricing is disabled;
+    /// an amount of 0 means cached tokens are genuinely free.
+    #[serde(
+        rename = "cacheReadCostPerToken",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_read_cost_per_token: Option<DecimalPrice>,
     pub metadata: ModelMetadata,
 }
 
@@ -3477,11 +3487,22 @@ pub struct UpdateModelApiRequest {
     pub output_cost_per_token: Option<DecimalPriceRequest>,
     #[serde(rename = "costPerImage")]
     pub cost_per_image: Option<DecimalPriceRequest>,
+    /// Cost per cached input token.
+    ///
+    /// Tri-state PATCH semantics:
+    /// - omitted → leave unchanged
+    /// - `null` → disable cache pricing (cached tokens billed at the full
+    ///   input rate; `cacheReadCostPerToken` / `input_cache_read` omitted from
+    ///   catalog responses)
+    /// - a price → set verbatim (an amount of 0 = genuinely free cache reads)
     #[serde(
         rename = "cacheReadCostPerToken",
+        default,
+        deserialize_with = "deserialize_nullable",
         skip_serializing_if = "Option::is_none"
     )]
-    pub cache_read_cost_per_token: Option<DecimalPriceRequest>,
+    #[schema(value_type = Option<DecimalPriceRequest>)]
+    pub cache_read_cost_per_token: Nullable<DecimalPriceRequest>,
     #[serde(rename = "modelDisplayName")]
     pub model_display_name: Option<String>,
     #[serde(rename = "modelDescription")]
@@ -3735,15 +3756,19 @@ pub struct PricingChangeBatchRequest {
     pub change_reason: Option<String>,
 }
 
-/// Full pricing snapshot (all four fields).
+/// Full pricing snapshot. `cacheReadCostPerToken` is omitted when cache
+/// pricing was disabled at snapshot time.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct PricingFields {
     #[serde(rename = "inputCostPerToken")]
     pub input_cost_per_token: DecimalPrice,
     #[serde(rename = "outputCostPerToken")]
     pub output_cost_per_token: DecimalPrice,
-    #[serde(rename = "cacheReadCostPerToken")]
-    pub cache_read_cost_per_token: DecimalPrice,
+    #[serde(
+        rename = "cacheReadCostPerToken",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_read_cost_per_token: Option<DecimalPrice>,
     #[serde(rename = "costPerImage")]
     pub cost_per_image: DecimalPrice,
 }
@@ -3858,8 +3883,12 @@ pub struct ModelHistoryEntry {
     pub output_cost_per_token: DecimalPrice,
     #[serde(rename = "costPerImage")]
     pub cost_per_image: DecimalPrice,
-    #[serde(rename = "cacheReadCostPerToken")]
-    pub cache_read_cost_per_token: DecimalPrice,
+    /// Omitted when cache pricing was disabled at this point in time.
+    #[serde(
+        rename = "cacheReadCostPerToken",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_read_cost_per_token: Option<DecimalPrice>,
     #[serde(rename = "contextLength")]
     pub context_length: i32,
     #[serde(rename = "modelName")]

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -239,7 +239,12 @@ pub async fn batch_upsert_models(
         validate_price(&request.input_cost_per_token, "inputCostPerToken")?;
         validate_price(&request.output_cost_per_token, "outputCostPerToken")?;
         validate_price(&request.cost_per_image, "costPerImage")?;
-        validate_price(&request.cache_read_cost_per_token, "cacheReadCostPerToken")?;
+        // Tri-state field: only a concrete price needs validation; an omitted
+        // field (unchanged) and an explicit null (disable) are both fine.
+        validate_price(
+            &request.cache_read_cost_per_token.clone().flatten(),
+            "cacheReadCostPerToken",
+        )?;
 
         // OpenRouter vocabulary checks. The provider spec at
         // https://openrouter.ai/docs/guides/community/for-providers enumerates
@@ -379,10 +384,12 @@ pub async fn batch_upsert_models(
                     input_cost_per_token: request.input_cost_per_token.as_ref().map(|p| p.amount),
                     output_cost_per_token: request.output_cost_per_token.as_ref().map(|p| p.amount),
                     cost_per_image: request.cost_per_image.as_ref().map(|p| p.amount),
+                    // Tri-state passes through: outer None = leave unchanged,
+                    // Some(None) = disable cache pricing, Some(Some(p)) = set.
                     cache_read_cost_per_token: request
                         .cache_read_cost_per_token
                         .as_ref()
-                        .map(|p| p.amount),
+                        .map(|inner| inner.as_ref().map(|p| p.amount)),
                     model_display_name: request.model_display_name.clone(),
                     model_description: request.model_description.clone(),
                     model_icon: request.model_icon.clone(),
@@ -636,11 +643,7 @@ pub async fn batch_upsert_models(
                 scale: 9,
                 currency: "USD".to_string(),
             },
-            cache_read_cost_per_token: DecimalPrice {
-                amount: updated_model.cache_read_cost_per_token,
-                scale: 9,
-                currency: "USD".to_string(),
-            },
+            cache_read_cost_per_token: updated_model.cache_read_cost_per_token.map(usd_price),
             metadata: ModelMetadata {
                 verifiable: updated_model.verifiable,
                 context_length: updated_model.context_length,
@@ -746,11 +749,7 @@ pub async fn list_models(
                 scale: 9,
                 currency: "USD".to_string(),
             },
-            cache_read_cost_per_token: DecimalPrice {
-                amount: model.cache_read_cost_per_token,
-                scale: 9,
-                currency: "USD".to_string(),
-            },
+            cache_read_cost_per_token: model.cache_read_cost_per_token.map(usd_price),
             metadata: ModelMetadata {
                 verifiable: model.verifiable,
                 context_length: model.context_length,
@@ -886,11 +885,7 @@ pub async fn get_model_history(
                 scale: 9,
                 currency: "USD".to_string(),
             },
-            cache_read_cost_per_token: DecimalPrice {
-                amount: h.cache_read_cost_per_token,
-                scale: 9,
-                currency: "USD".to_string(),
-            },
+            cache_read_cost_per_token: h.cache_read_cost_per_token.map(usd_price),
             context_length: h.context_length,
             model_name: h.model_name,
             model_display_name: h.model_display_name,
@@ -1444,11 +1439,7 @@ pub async fn deprecate_model(
             scale: 9,
             currency: "USD".to_string(),
         },
-        cache_read_cost_per_token: DecimalPrice {
-            amount: m.cache_read_cost_per_token,
-            scale: 9,
-            currency: "USD".to_string(),
-        },
+        cache_read_cost_per_token: m.cache_read_cost_per_token.map(usd_price),
         metadata: ModelMetadata {
             verifiable: m.verifiable,
             context_length: m.context_length,
@@ -1673,7 +1664,7 @@ fn scheduled_pricing_change_to_dto(
         old_pricing: PricingFields {
             input_cost_per_token: usd_price(change.old_input_cost_per_token),
             output_cost_per_token: usd_price(change.old_output_cost_per_token),
-            cache_read_cost_per_token: usd_price(change.old_cache_read_cost_per_token),
+            cache_read_cost_per_token: change.old_cache_read_cost_per_token.map(usd_price),
             cost_per_image: usd_price(change.old_cost_per_image),
         },
         new_pricing: PricingFieldUpdates {
@@ -1736,7 +1727,7 @@ pub async fn preview_model_pricing_changes(
                 old_pricing: PricingFields {
                     input_cost_per_token: usd_price(m.old_input_cost_per_token),
                     output_cost_per_token: usd_price(m.old_output_cost_per_token),
-                    cache_read_cost_per_token: usd_price(m.old_cache_read_cost_per_token),
+                    cache_read_cost_per_token: m.old_cache_read_cost_per_token.map(usd_price),
                     cost_per_image: usd_price(m.old_cost_per_image),
                 },
                 new_pricing: PricingFieldUpdates {

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -2724,8 +2724,11 @@ fn model_with_pricing_to_info(model: services::models::ModelWithPricing) -> Mode
         completion: nano_dollars_to_per_token_string(model.output_cost_per_token),
         image: nano_dollars_to_per_token_string(model.cost_per_image),
         request: "0".to_string(),
-        input_cache_read: (model.cache_read_cost_per_token > 0)
-            .then(|| nano_dollars_to_per_token_string(model.cache_read_cost_per_token)),
+        // None = cache pricing disabled -> omit the field entirely.
+        // Some(0) is a real (genuinely free) price and renders as "0".
+        input_cache_read: model
+            .cache_read_cost_per_token
+            .map(nano_dollars_to_per_token_string),
     };
 
     // OpenRouter's provider spec marks `input_modalities` / `output_modalities`
@@ -2859,7 +2862,7 @@ mod tests {
             input_cost_per_token: 0,
             output_cost_per_token: 0,
             cost_per_image: 0,
-            cache_read_cost_per_token: 0,
+            cache_read_cost_per_token: None,
             context_length: 4096,
             verifiable: false,
             aliases: vec![],
@@ -2930,19 +2933,32 @@ mod tests {
 
         assert!(
             json["pricing"].get("input_cache_read").is_none(),
-            "zero cache-read pricing is an internal unknown/disabled sentinel and must be omitted"
+            "None means cache pricing is disabled and input_cache_read must be omitted"
         );
     }
 
     #[test]
     fn model_with_cache_read_pricing_emits_positive_input_cache_read() {
         let mut model = make_model_with_pricing(None, None);
-        model.cache_read_cost_per_token = 50_000;
+        model.cache_read_cost_per_token = Some(50_000);
 
         let info = model_with_pricing_to_info(model);
         let json = serde_json::to_value(&info).unwrap();
 
         assert_eq!(json["pricing"]["input_cache_read"], "0.00005");
+    }
+
+    #[test]
+    fn model_with_free_cache_read_pricing_emits_zero_input_cache_read() {
+        // Some(0) is a genuinely free cache-read price — unlike None
+        // (disabled), it must render as the string "0", not be omitted.
+        let mut model = make_model_with_pricing(None, None);
+        model.cache_read_cost_per_token = Some(0);
+
+        let info = model_with_pricing_to_info(model);
+        let json = serde_json::to_value(&info).unwrap();
+
+        assert_eq!(json["pricing"]["input_cache_read"], "0");
     }
 
     #[test]

--- a/crates/api/src/routes/models.rs
+++ b/crates/api/src/routes/models.rs
@@ -126,11 +126,11 @@ pub async fn list_models(
                 scale: 9,
                 currency: "USD".to_string(),
             },
-            cache_read_cost_per_token: DecimalPrice {
-                amount: model.cache_read_cost_per_token,
+            cache_read_cost_per_token: model.cache_read_cost_per_token.map(|amount| DecimalPrice {
+                amount,
                 scale: 9,
                 currency: "USD".to_string(),
-            },
+            }),
             metadata: ModelMetadata {
                 verifiable: model.verifiable,
                 context_length: model.context_length,
@@ -245,11 +245,11 @@ pub async fn get_model_by_name(
             scale: 9,
             currency: "USD".to_string(),
         },
-        cache_read_cost_per_token: DecimalPrice {
-            amount: model.cache_read_cost_per_token,
+        cache_read_cost_per_token: model.cache_read_cost_per_token.map(|amount| DecimalPrice {
+            amount,
             scale: 9,
             currency: "USD".to_string(),
-        },
+        }),
         metadata: ModelMetadata {
             verifiable: model.verifiable,
             context_length: model.context_length,

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -40,8 +40,8 @@ pub const MOCK_USER_ID: &str = "11111111-1111-1111-1111-111111111111";
 pub const E2E_QWEN_MODEL_NAME: &str = "Qwen/Qwen3-30B-A3B-Instruct-2507";
 pub const E2E_QWEN_INPUT_COST_PER_TOKEN: i64 = 1_000_000;
 pub const E2E_QWEN_OUTPUT_COST_PER_TOKEN: i64 = 2_000_000;
-/// Cache-read cost when setup_qwen_model is used (no cache pricing in API).
-pub const E2E_QWEN_CACHE_READ_COST_NO_CACHE: i64 = 0;
+/// Cache-read cost when setup_qwen_model is used (cache pricing disabled).
+pub const E2E_QWEN_CACHE_READ_COST_NO_CACHE: Option<i64> = None;
 /// Cache-read cost when setup_qwen_model_with_cache_pricing is used.
 pub const E2E_QWEN_CACHE_READ_COST_WITH_CACHE: i64 = 500_000;
 
@@ -833,7 +833,12 @@ pub async fn setup_qwen_model_with_cache_pricing(server: &axum_test::TestServer)
         "Output cost per token should match E2E_QWEN_OUTPUT_COST_PER_TOKEN"
     );
     assert_eq!(
-        updated[0].cache_read_cost_per_token.amount, E2E_QWEN_CACHE_READ_COST_WITH_CACHE,
+        updated[0]
+            .cache_read_cost_per_token
+            .as_ref()
+            .expect("cache-read pricing must be present when configured")
+            .amount,
+        E2E_QWEN_CACHE_READ_COST_WITH_CACHE,
         "Cache-read cost per token should match E2E_QWEN_CACHE_READ_COST_WITH_CACHE"
     );
     // Ensure mock provider registers model before test proceeds
@@ -861,7 +866,7 @@ pub fn e2e_qwen_model_pricing_with_cache() -> ModelPricing {
         input_cost_per_token: E2E_QWEN_INPUT_COST_PER_TOKEN,
         output_cost_per_token: E2E_QWEN_OUTPUT_COST_PER_TOKEN,
         cost_per_image: 0,
-        cache_read_cost_per_token: E2E_QWEN_CACHE_READ_COST_WITH_CACHE,
+        cache_read_cost_per_token: Some(E2E_QWEN_CACHE_READ_COST_WITH_CACHE),
     }
 }
 

--- a/crates/database/src/migrations/sql/V0068__cache_read_cost_nullable.sql
+++ b/crates/database/src/migrations/sql/V0068__cache_read_cost_nullable.sql
@@ -1,0 +1,33 @@
+-- Make cache_read_cost_per_token nullable and stop overloading 0.
+--
+-- Before this migration the column was BIGINT NOT NULL DEFAULT 0, with 0
+-- meaning "cache pricing disabled -> bill cached tokens at the full input
+-- rate". That made a genuinely FREE cache-read price (0) inexpressible.
+--
+-- New semantics:
+--   NULL = cache pricing disabled (cached tokens billed at input_cost_per_token,
+--          input_cache_read omitted from the public model catalog)
+--   >= 0 = cached tokens billed at this rate (0 = genuinely free)
+--
+-- Existing 0 rows meant "disabled", so they are converted to NULL: billing
+-- for every existing model is unchanged.
+
+ALTER TABLE models ALTER COLUMN cache_read_cost_per_token DROP NOT NULL;
+ALTER TABLE models ALTER COLUMN cache_read_cost_per_token DROP DEFAULT;
+UPDATE models SET cache_read_cost_per_token = NULL WHERE cache_read_cost_per_token = 0;
+
+ALTER TABLE model_history ALTER COLUMN cache_read_cost_per_token DROP NOT NULL;
+ALTER TABLE model_history ALTER COLUMN cache_read_cost_per_token DROP DEFAULT;
+UPDATE model_history SET cache_read_cost_per_token = NULL WHERE cache_read_cost_per_token = 0;
+
+-- scheduled_model_pricing_changes:
+--   * old_cache_read_cost_per_token is the pricing snapshot at confirm time;
+--     it mirrors models.cache_read_cost_per_token, so NULL = cache pricing
+--     was disabled when the change was confirmed. Existing 0 snapshots meant
+--     "disabled" and are converted the same way.
+--   * new_cache_read_cost_per_token is deliberately left as-is: it is already
+--     nullable and NULL there means "field unchanged" (see V0058), NOT
+--     "disable cache pricing". A scheduled change therefore cannot disable
+--     cache pricing; use PATCH /v1/admin/models with an explicit null for that.
+ALTER TABLE scheduled_model_pricing_changes ALTER COLUMN old_cache_read_cost_per_token DROP NOT NULL;
+UPDATE scheduled_model_pricing_changes SET old_cache_read_cost_per_token = NULL WHERE old_cache_read_cost_per_token = 0;

--- a/crates/database/src/models.rs
+++ b/crates/database/src/models.rs
@@ -432,8 +432,10 @@ pub struct Model {
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
     pub cost_per_image: i64,
-    /// Cost per cached input token (0 = no cache pricing; when set, cached tokens billed at this rate)
-    pub cache_read_cost_per_token: i64,
+    /// Cost per cached input token. `None` = cache pricing disabled (cached
+    /// tokens billed at `input_cost_per_token`); `Some(x)` (x >= 0) = cached
+    /// tokens billed at `x` (`Some(0)` = genuinely free).
+    pub cache_read_cost_per_token: Option<i64>,
 
     // Model metadata
     pub context_length: i32,
@@ -500,7 +502,10 @@ pub struct UpdateModelPricingRequest {
     pub input_cost_per_token: Option<i64>,
     pub output_cost_per_token: Option<i64>,
     pub cost_per_image: Option<i64>,
-    pub cache_read_cost_per_token: Option<i64>,
+    /// Tri-state: `None` = leave unchanged, `Some(None)` = disable cache
+    /// pricing (set column to NULL), `Some(Some(v))` = set to `v`
+    /// (`Some(Some(0))` = genuinely free cache reads).
+    pub cache_read_cost_per_token: Option<Option<i64>>,
     pub model_display_name: Option<String>,
     pub model_description: Option<String>,
     pub model_icon: Option<String>,
@@ -555,7 +560,9 @@ pub struct ModelHistory {
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
     pub cost_per_image: i64,
-    pub cache_read_cost_per_token: i64,
+    /// `None` = cache pricing disabled at this point in time; `Some(x)` =
+    /// cached tokens billed at `x` (`Some(0)` = genuinely free).
+    pub cache_read_cost_per_token: Option<i64>,
 
     // Model metadata snapshot
     pub context_length: i32,

--- a/crates/database/src/repositories/admin_composite.rs
+++ b/crates/database/src/repositories/admin_composite.rs
@@ -196,7 +196,7 @@ impl AdminRepository for AdminCompositeRepository {
     async fn get_model_costs(
         &self,
         model_name: &str,
-    ) -> Result<Option<(i64, i64, i64, i64, bool)>> {
+    ) -> Result<Option<(i64, i64, i64, Option<i64>, bool)>> {
         let model = self.model_repo.get_by_internal_name(model_name).await?;
         Ok(model.map(|m| {
             (
@@ -430,7 +430,7 @@ impl AdminRepository for AdminCompositeRepository {
                 &deprecated_row_after.get::<_, i64>("input_cost_per_token"),
                 &deprecated_row_after.get::<_, i64>("output_cost_per_token"),
                 &deprecated_row_after.get::<_, i64>("cost_per_image"),
-                &deprecated_row_after.get::<_, i64>("cache_read_cost_per_token"),
+                &deprecated_row_after.get::<_, Option<i64>>("cache_read_cost_per_token"),
                 &deprecated_row_after.get::<_, i32>("context_length"),
                 &deprecated_row_after.get::<_, String>("model_name"),
                 &deprecated_row_after.get::<_, String>("model_display_name"),

--- a/crates/database/src/repositories/model.rs
+++ b/crates/database/src/repositories/model.rs
@@ -414,6 +414,9 @@ impl ModelRepository {
         let openrouter_slug_value: Option<String> =
             update_request.openrouter_slug.clone().flatten();
         let openrouter_slug_clear: bool = matches!(update_request.openrouter_slug, Some(None));
+        // Tri-state as well: explicit `null` disables cache pricing (NULL column).
+        let cache_read_value: Option<i64> = update_request.cache_read_cost_per_token.flatten();
+        let cache_read_clear: bool = matches!(update_request.cache_read_cost_per_token, Some(None));
 
         let row = retry_db!("upsert_model_pricing", {
             let client = self
@@ -432,7 +435,7 @@ impl ModelRepository {
                             input_cost_per_token = COALESCE($2, input_cost_per_token),
                             output_cost_per_token = COALESCE($3, output_cost_per_token),
                             cost_per_image = COALESCE($4, cost_per_image),
-                            cache_read_cost_per_token = COALESCE($5, cache_read_cost_per_token),
+                            cache_read_cost_per_token = CASE WHEN $32 THEN NULL ELSE COALESCE($5, cache_read_cost_per_token) END,
                             model_display_name = COALESCE($6, model_display_name),
                             model_description = COALESCE($7, model_description),
                             model_icon = COALESCE($8, model_icon),
@@ -469,7 +472,7 @@ impl ModelRepository {
                             &update_request.input_cost_per_token,
                             &update_request.output_cost_per_token,
                             &update_request.cost_per_image,
-                            &update_request.cache_read_cost_per_token,
+                            &cache_read_value,
                             &update_request.model_display_name,
                             &update_request.model_description,
                             &update_request.model_icon,
@@ -496,6 +499,7 @@ impl ModelRepository {
                             &openrouter_slug_value,
                             &openrouter_slug_clear,
                             &update_request.allow_free,
+                            &cache_read_clear,
                         ],
                     )
                     .await
@@ -589,7 +593,10 @@ impl ModelRepository {
                             &update_request.input_cost_per_token.unwrap_or(0),
                             &update_request.output_cost_per_token.unwrap_or(0),
                             &update_request.cost_per_image.unwrap_or(0),
-                            &update_request.cache_read_cost_per_token.unwrap_or(0),
+                            // Absent and explicit-null both insert NULL = cache
+                            // pricing disabled (the old code inserted the
+                            // equally-disabled 0 default here).
+                            &cache_read_value,
                             &display_name.as_ref().unwrap(),
                             &description.as_ref().unwrap(),
                             &update_request.model_icon,
@@ -680,6 +687,8 @@ impl ModelRepository {
         let is_ready_value: Option<bool> = req.is_ready.flatten();
         let deprecation_date_value: Option<DateTime<Utc>> = req.deprecation_date.flatten();
         let openrouter_slug_value: Option<String> = req.openrouter_slug.clone().flatten();
+        // Absent and explicit-null both insert NULL = cache pricing disabled.
+        let cache_read_value: Option<i64> = req.cache_read_cost_per_token.flatten();
 
         let row = retry_db!("seed_model_if_absent", {
             let client = self
@@ -727,7 +736,7 @@ impl ModelRepository {
                         &req.input_cost_per_token.unwrap_or(0),
                         &req.output_cost_per_token.unwrap_or(0),
                         &req.cost_per_image.unwrap_or(0),
-                        &req.cache_read_cost_per_token.unwrap_or(0),
+                        &cache_read_value,
                         &display_name,
                         &description,
                         &req.model_icon,
@@ -1149,7 +1158,7 @@ impl ModelRepository {
                     &model_row.get::<_, i64>("input_cost_per_token"),
                     &model_row.get::<_, i64>("output_cost_per_token"),
                     &model_row.get::<_, i64>("cost_per_image"),
-                    &model_row.get::<_, i64>("cache_read_cost_per_token"),
+                    &model_row.get::<_, Option<i64>>("cache_read_cost_per_token"),
                     &model_row.get::<_, i32>("context_length"),
                     &model_row.get::<_, String>("model_name"),
                     &model_row.get::<_, String>("model_display_name"),

--- a/crates/services/src/admin/mod.rs
+++ b/crates/services/src/admin/mod.rs
@@ -1298,7 +1298,7 @@ impl AdminServiceImpl {
             existing_image,
             existing_cache_read,
             existing_allow_free,
-        ) = existing.unwrap_or((0, 0, 0, 0, false));
+        ) = existing.unwrap_or((0, 0, 0, None, false));
 
         let effective_is_active = request.is_active.unwrap_or(is_new_model);
 
@@ -1306,6 +1306,10 @@ impl AdminServiceImpl {
             let effective_input = request.input_cost_per_token.unwrap_or(existing_input);
             let effective_output = request.output_cost_per_token.unwrap_or(existing_output);
             let effective_image = request.cost_per_image.unwrap_or(existing_image);
+            // Tri-state: absent = keep existing, explicit null = disabled (None),
+            // value = that value. Disabled (None) and an explicit free price
+            // (Some(0)) both contribute no revenue, so neither counts as
+            // "priced" for the activation gate.
             let effective_cache_read = request
                 .cache_read_cost_per_token
                 .unwrap_or(existing_cache_read);
@@ -1314,7 +1318,7 @@ impl AdminServiceImpl {
             if effective_input == 0
                 && effective_output == 0
                 && effective_image == 0
-                && effective_cache_read == 0
+                && effective_cache_read.unwrap_or(0) == 0
                 && !effective_allow_free
             {
                 return Err(AdminError::InvalidPricing(format!(

--- a/crates/services/src/admin/ports.rs
+++ b/crates/services/src/admin/ports.rs
@@ -8,7 +8,12 @@ pub struct UpdateModelAdminRequest {
     pub input_cost_per_token: Option<i64>,
     pub output_cost_per_token: Option<i64>,
     pub cost_per_image: Option<i64>,
-    pub cache_read_cost_per_token: Option<i64>,
+    /// Cost per cached input token.
+    ///
+    /// Tri-state: `None` = leave unchanged, `Some(None)` = disable cache
+    /// pricing (cached tokens billed at the full input rate), `Some(Some(v))`
+    /// = set to `v` (`Some(Some(0))` = genuinely free cache reads).
+    pub cache_read_cost_per_token: Option<Option<i64>>,
     pub model_display_name: Option<String>,
     pub model_description: Option<String>,
     pub model_icon: Option<String>,
@@ -74,7 +79,9 @@ pub struct ModelPricing {
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
     pub cost_per_image: i64,
-    pub cache_read_cost_per_token: i64,
+    /// `None` = cache pricing disabled; `Some(x)` = cached tokens billed at
+    /// `x` (`Some(0)` = genuinely free).
+    pub cache_read_cost_per_token: Option<i64>,
     pub context_length: i32,
     pub verifiable: bool,
     pub is_active: bool,
@@ -115,7 +122,8 @@ pub struct ModelHistoryEntry {
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
     pub cost_per_image: i64,
-    pub cache_read_cost_per_token: i64,
+    /// `None` = cache pricing disabled at this point in time.
+    pub cache_read_cost_per_token: Option<i64>,
     pub context_length: i32,
     pub model_name: String,
     pub model_display_name: String,
@@ -233,7 +241,9 @@ pub struct AdminModelInfo {
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
     pub cost_per_image: i64,
-    pub cache_read_cost_per_token: i64,
+    /// `None` = cache pricing disabled; `Some(x)` = cached tokens billed at
+    /// `x` (`Some(0)` = genuinely free).
+    pub cache_read_cost_per_token: Option<i64>,
     pub context_length: i32,
     pub verifiable: bool,
     pub is_active: bool,
@@ -393,7 +403,8 @@ pub struct ModelPricingSnapshot {
     pub model_display_name: String,
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
-    pub cache_read_cost_per_token: i64,
+    /// `None` = cache pricing disabled at confirm time.
+    pub cache_read_cost_per_token: Option<i64>,
     pub cost_per_image: i64,
 }
 
@@ -409,7 +420,8 @@ pub struct ScheduledPricingChangeInsert {
     pub new_cost_per_image: Option<i64>,
     pub old_input_cost_per_token: i64,
     pub old_output_cost_per_token: i64,
-    pub old_cache_read_cost_per_token: i64,
+    /// `None` = cache pricing was disabled at confirm time.
+    pub old_cache_read_cost_per_token: Option<i64>,
     pub old_cost_per_image: i64,
     pub effective_at: chrono::DateTime<chrono::Utc>,
 }
@@ -428,7 +440,8 @@ pub struct ScheduledPricingChange {
     pub new_cost_per_image: Option<i64>,
     pub old_input_cost_per_token: i64,
     pub old_output_cost_per_token: i64,
-    pub old_cache_read_cost_per_token: i64,
+    /// `None` = cache pricing was disabled at confirm time.
+    pub old_cache_read_cost_per_token: Option<i64>,
     pub old_cost_per_image: i64,
     pub effective_at: chrono::DateTime<chrono::Utc>,
     pub status: ScheduledPricingChangeStatus,
@@ -464,7 +477,8 @@ pub struct PricingChangeModelPreview {
     pub organization_count: i64,
     pub old_input_cost_per_token: i64,
     pub old_output_cost_per_token: i64,
-    pub old_cache_read_cost_per_token: i64,
+    /// `None` = cache pricing currently disabled.
+    pub old_cache_read_cost_per_token: Option<i64>,
     pub old_cost_per_image: i64,
     pub new_input_cost_per_token: Option<i64>,
     pub new_output_cost_per_token: Option<i64>,
@@ -599,11 +613,12 @@ pub trait AdminRepository: Send + Sync {
 
     /// Fetch the current pricing costs and allow_free flag for a model by name.
     /// Returns `None` if the model does not exist (new model).
-    /// Returns `Some((input_cost, output_cost, cost_per_image, cache_read_cost_per_token, allow_free))`.
+    /// Returns `Some((input_cost, output_cost, cost_per_image, cache_read_cost_per_token, allow_free))`,
+    /// where `cache_read_cost_per_token` is `None` when cache pricing is disabled.
     async fn get_model_costs(
         &self,
         model_name: &str,
-    ) -> Result<Option<(i64, i64, i64, i64, bool)>, anyhow::Error>;
+    ) -> Result<Option<(i64, i64, i64, Option<i64>, bool)>, anyhow::Error>;
 
     /// Get complete history for a model with pagination (includes pricing and other attributes)
     async fn get_model_history(

--- a/crates/services/src/admin/pricing_scheduler.rs
+++ b/crates/services/src/admin/pricing_scheduler.rs
@@ -144,7 +144,7 @@ impl ModelPricingScheduler {
                     .is_none_or(|v| v == current.output_cost_per_token)
                 && change
                     .new_cache_read_cost_per_token
-                    .is_none_or(|v| v == current.cache_read_cost_per_token)
+                    .is_none_or(|v| Some(v) == current.cache_read_cost_per_token)
                 && change
                     .new_cost_per_image
                     .is_none_or(|v| v == current.cost_per_image);
@@ -179,7 +179,11 @@ impl ModelPricingScheduler {
             input_cost_per_token: change.new_input_cost_per_token,
             output_cost_per_token: change.new_output_cost_per_token,
             cost_per_image: change.new_cost_per_image,
-            cache_read_cost_per_token: change.new_cache_read_cost_per_token,
+            // Scheduled changes carry `None` = "field unchanged" and can only
+            // SET a cache-read price, never disable it (that would need the
+            // update-request's explicit-null `Some(None)` state; disabling is
+            // done via PATCH /v1/admin/models instead).
+            cache_read_cost_per_token: change.new_cache_read_cost_per_token.map(Some),
             model_display_name: None,
             model_description: None,
             model_icon: None,

--- a/crates/services/src/completions/provider_attribution_tests.rs
+++ b/crates/services/src/completions/provider_attribution_tests.rs
@@ -55,7 +55,7 @@ fn test_model(model_name: &str) -> ModelWithPricing {
         input_cost_per_token: 1,
         output_cost_per_token: 1,
         cost_per_image: 0,
-        cache_read_cost_per_token: 0,
+        cache_read_cost_per_token: None,
         context_length: 4096,
         verifiable: true,
         aliases: Vec::new(),

--- a/crates/services/src/email.rs
+++ b/crates/services/src/email.rs
@@ -29,6 +29,8 @@ pub struct ModelDeprecationEmail {
 
 /// One model's entry in a consolidated pricing change email.
 /// Amounts are nano-dollars (scale 9); `new_*` is `None` when unchanged.
+/// `old_cache_read_cost_per_token` is `None` when cache pricing was disabled
+/// at confirm time.
 #[derive(Debug, Clone)]
 pub struct PricingChangeEmailModel {
     pub model_id: String,
@@ -38,7 +40,7 @@ pub struct PricingChangeEmailModel {
     pub new_input_cost_per_token: Option<i64>,
     pub old_output_cost_per_token: i64,
     pub new_output_cost_per_token: Option<i64>,
-    pub old_cache_read_cost_per_token: i64,
+    pub old_cache_read_cost_per_token: Option<i64>,
     pub new_cache_read_cost_per_token: Option<i64>,
     pub old_cost_per_image: i64,
     pub new_cost_per_image: Option<i64>,
@@ -466,11 +468,18 @@ fn pricing_change_lines(model: &PricingChangeEmailModel) -> Vec<String> {
         model.old_output_cost_per_token,
         model.new_output_cost_per_token,
     );
-    per_million(
-        "Cache reads",
-        model.old_cache_read_cost_per_token,
-        model.new_cache_read_cost_per_token,
-    );
+    // Cache-read pricing may have been disabled (None) before this change;
+    // render that as "not set" rather than a fabricated $0 price.
+    if let Some(new) = model.new_cache_read_cost_per_token {
+        lines.push(format!(
+            "Cache reads: {} → {} per 1M tokens",
+            model
+                .old_cache_read_cost_per_token
+                .map(format_usd_per_million_tokens)
+                .unwrap_or_else(|| "not set".to_string()),
+            format_usd_per_million_tokens(new),
+        ));
+    }
     if let Some(new) = model.new_cost_per_image {
         lines.push(format!(
             "Images: {} → {} per image",
@@ -697,7 +706,7 @@ mod tests {
                     new_input_cost_per_token: Some(280),
                     old_output_cost_per_token: 850,
                     new_output_cost_per_token: None,
-                    old_cache_read_cost_per_token: 25,
+                    old_cache_read_cost_per_token: Some(25),
                     new_cache_read_cost_per_token: None,
                     old_cost_per_image: 0,
                     new_cost_per_image: None,
@@ -710,7 +719,7 @@ mod tests {
                     new_input_cost_per_token: None,
                     old_output_cost_per_token: 15_000,
                     new_output_cost_per_token: Some(12_000),
-                    old_cache_read_cost_per_token: 0,
+                    old_cache_read_cost_per_token: None,
                     new_cache_read_cost_per_token: None,
                     old_cost_per_image: 2_000_000_000,
                     new_cost_per_image: Some(2_500_000_000),

--- a/crates/services/src/models/mod.rs
+++ b/crates/services/src/models/mod.rs
@@ -220,7 +220,7 @@ mod tests {
             input_cost_per_token: 1,
             output_cost_per_token: 1,
             cost_per_image: 0,
-            cache_read_cost_per_token: 0,
+            cache_read_cost_per_token: None,
             context_length: 4096,
             verifiable: true,
             aliases: Vec::new(),

--- a/crates/services/src/models/ports.rs
+++ b/crates/services/src/models/ports.rs
@@ -30,7 +30,11 @@ pub struct ModelWithPricing {
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
     pub cost_per_image: i64,
-    pub cache_read_cost_per_token: i64,
+    /// Cost per cached input token. `None` = cache pricing disabled (cached
+    /// tokens billed at `input_cost_per_token`, `input_cache_read` omitted
+    /// from the public catalog); `Some(x)` = cached tokens billed at `x`
+    /// (`Some(0)` = genuinely free, rendered as `"0"`).
+    pub cache_read_cost_per_token: Option<i64>,
 
     // Model metadata
     pub context_length: i32,

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -40,11 +40,13 @@ const EXTERNAL_USAGE_ID_NAMESPACE: Uuid = Uuid::from_u128(0x1966acaf_9f95_5dab_b
 /// - `total = input_cost + output_cost`
 ///
 /// **Important semantic**:
-/// - When `pricing.cache_read_cost_per_token == 0`, cache pricing is treated as **disabled** and
+/// - When `pricing.cache_read_cost_per_token` is `None`, cache pricing is **disabled** and
 ///   all input tokens (including cached ones) are billed at `input_cost_per_token`.
 ///   This preserves legacy behavior for existing models even if providers start reporting
-///   `cached_tokens > 0`. Admins must explicitly set a non-zero `cache_read_cost_per_token`
-///   on a model to enable discounted cache billing.
+///   `cached_tokens > 0`. Admins must explicitly set a `cache_read_cost_per_token`
+///   on a model to enable cache billing.
+/// - `Some(0)` means cached tokens are genuinely **free**; `Some(x)` bills them at the
+///   (typically discounted) rate `x`.
 ///
 /// All costs are in nano-dollars (scale 9). Uses checked arithmetic for overflow safety.
 pub fn compute_token_cost(
@@ -63,13 +65,11 @@ pub fn compute_token_cost(
 
     let cache_read = cache_read_tokens.min(input_tokens).max(0) as i64;
     let non_cached_input = (input_tokens as i64) - cache_read;
-    // If cache_read_cost_per_token is 0, treat cache pricing as disabled and bill cached tokens
-    // at the normal input rate. This avoids making cached tokens free for existing models.
-    let effective_cache_rate = if pricing.cache_read_cost_per_token == 0 {
-        pricing.input_cost_per_token
-    } else {
-        pricing.cache_read_cost_per_token
-    };
+    // If cache_read_cost_per_token is None, cache pricing is disabled: bill cached tokens
+    // at the normal input rate. Some(0) is a genuinely free cache-read price.
+    let effective_cache_rate = pricing
+        .cache_read_cost_per_token
+        .unwrap_or(pricing.input_cost_per_token);
     let input_cost = non_cached_input
         .checked_mul(pricing.input_cost_per_token)
         .and_then(|c| {
@@ -154,8 +154,9 @@ impl UsageServiceTrait for UsageServiceImpl {
     /// Uses the same semantics as `record_usage` / `compute_token_cost`:
     /// - For token-based chat-style models, applies cache-aware pricing:
     ///   `(input - cache_read) * input_rate + cache_read * cache_read_rate + output * output_rate`.
-    /// - When `cache_read_cost_per_token == 0`, cache pricing is treated as **disabled** and
-    ///   all input tokens (including cached ones) are billed at `input_cost_per_token` (no free cache).
+    /// - When `cache_read_cost_per_token` is `None`, cache pricing is **disabled** and
+    ///   all input tokens (including cached ones) are billed at `input_cost_per_token`.
+    ///   `Some(0)` means cached tokens are genuinely free; `Some(x)` bills them at `x`.
     /// - Non-token billing types (image, audio duration, rerank, etc.) have dedicated paths in
     ///   `record_usage` and do not use this helper.
     ///
@@ -779,7 +780,7 @@ mod tests {
     fn make_pricing(
         input_cost_per_token: i64,
         output_cost_per_token: i64,
-        cache_read_cost_per_token: i64,
+        cache_read_cost_per_token: Option<i64>,
     ) -> ModelPricing {
         ModelPricing {
             id: Uuid::nil(),
@@ -797,7 +798,7 @@ mod tests {
 
     #[test]
     fn test_compute_token_cost_no_cache() {
-        let pricing = make_pricing(10, 20, 5);
+        let pricing = make_pricing(10, 20, Some(5));
         let cost = unwrap_cost(compute_token_cost(100, 50, 0, &pricing));
 
         assert_eq!(cost.input_cost, 100 * 10);
@@ -807,7 +808,8 @@ mod tests {
 
     #[test]
     fn test_compute_token_cost_partial_cache() {
-        let pricing = make_pricing(10, 20, 5);
+        // Some(x): cached tokens are billed at the configured rate x.
+        let pricing = make_pricing(10, 20, Some(5));
         let cost = unwrap_cost(compute_token_cost(100, 50, 40, &pricing));
 
         // 60 non-cached * 10 + 40 cached * 5 = 600 + 200
@@ -818,7 +820,7 @@ mod tests {
 
     #[test]
     fn test_compute_token_cost_cache_capped_to_input() {
-        let pricing = make_pricing(10, 20, 5);
+        let pricing = make_pricing(10, 20, Some(5));
         // cache_read_tokens > input_tokens, should be capped to input_tokens (30)
         let cost = unwrap_cost(compute_token_cost(30, 0, 100, &pricing));
 
@@ -829,14 +831,28 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_token_cost_cache_disabled_when_zero() {
-        // cache_read_cost_per_token == 0 means "cache pricing disabled": all input tokens
-        // (including cached) are billed at input_cost_per_token. No free cached tokens.
-        let pricing = make_pricing(10, 20, 0);
+    fn test_compute_token_cost_cache_disabled_when_none() {
+        // cache_read_cost_per_token == None means "cache pricing disabled": all input
+        // tokens (including cached) are billed at input_cost_per_token. No free cached
+        // tokens.
+        let pricing = make_pricing(10, 20, None);
         let cost = unwrap_cost(compute_token_cost(100, 50, 40, &pricing));
 
         // All 100 input tokens at input rate (cached 40 are not discounted)
         assert_eq!(cost.input_cost, 100 * 10);
+        assert_eq!(cost.output_cost, 50 * 20);
+        assert_eq!(cost.total_cost, cost.input_cost + cost.output_cost);
+    }
+
+    #[test]
+    fn test_compute_token_cost_cache_genuinely_free_when_some_zero() {
+        // Some(0) is a real price: cached tokens cost exactly 0 (unlike None,
+        // which bills them at the full input rate).
+        let pricing = make_pricing(10, 20, Some(0));
+        let cost = unwrap_cost(compute_token_cost(100, 50, 40, &pricing));
+
+        // 60 non-cached * 10 + 40 cached * 0 = 600
+        assert_eq!(cost.input_cost, 60 * 10);
         assert_eq!(cost.output_cost, 50 * 20);
         assert_eq!(cost.total_cost, cost.input_cost + cost.output_cost);
     }

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -202,9 +202,9 @@ pub trait UsageServiceTrait: Send + Sync {
     ///   where `cache_read` is the effective cached token count (see below).
     /// - **Capping**: The provided `cached_tokens` (or `cache_read_tokens`) is treated as
     ///   `min(cached_tokens, input_tokens).max(0)`; i.e. cached count is never negative and never exceeds input.
-    /// - **Cache pricing disabled**: When the model’s `cache_read_cost_per_token == 0`, cache pricing is
+    /// - **Cache pricing disabled**: When the model’s `cache_read_cost_per_token` is `None`, cache pricing is
     ///   disabled and all input tokens (including cached) are billed at `input_cost_per_token` (cached tokens
-    ///   are not free).
+    ///   are not free). `Some(0)` means cached tokens are genuinely free; `Some(x)` bills them at `x`.
     async fn calculate_cost(
         &self,
         model_id: &str,
@@ -533,7 +533,10 @@ pub struct ModelPricing {
     pub input_cost_per_token: i64,
     pub output_cost_per_token: i64,
     pub cost_per_image: i64,
-    pub cache_read_cost_per_token: i64,
+    /// Cost per cached input token. `None` = cache pricing disabled (cached
+    /// tokens billed at `input_cost_per_token`); `Some(x)` (x >= 0) = cached
+    /// tokens billed at `x` (`Some(0)` = genuinely free).
+    pub cache_read_cost_per_token: Option<i64>,
 }
 
 /// Organization spending limit


### PR DESCRIPTION
## Problem (RFC infra#171 §2.5, asked by @PierreLeGuen)

`cache_read_cost_per_token` is `BIGINT NOT NULL DEFAULT 0` with `0` overloaded to mean "cache pricing disabled → bill cached tokens at the full input rate". Two consequences:

- a genuinely **free** cache-read price (0) is inexpressible;
- an admin setting a model's cache price to 0 (intending "free") silently bills customers the **full input rate** for cached tokens.

## Change

New semantics, threaded end-to-end (DB → repositories → services → admin API → public catalog):

| value | billing | public catalog `input_cache_read` |
|---|---|---|
| `NULL` / `None` | cached tokens at `input_cost_per_token` (= today's `0`) | omitted |
| `Some(0)` | genuinely free | `"0"` |
| `Some(x)` | rate `x` | rendered |

- **Migration `V0068`**: `DROP NOT NULL`/`DROP DEFAULT` + `0 → NULL` on `models`, `model_history`, and `scheduled_model_pricing_changes.old_cache_read_cost_per_token`. Billing for every existing model is **byte-identical** after migration.
- **Admin update API is tri-state** via the existing `Nullable<T>`/`deserialize_nullable` pattern (same as `isReady`/`deprecationDate`): field absent = unchanged, explicit `null` = disable, value = set. SQL uses the existing clear-flag `CASE WHEN` pattern.
- **Scheduled pricing changes**: `new_cache_read_cost_per_token` NULL already means "field unchanged" (V0058) — semantics preserved exactly; a scheduled change can set but not disable cache pricing (documented in the migration and scheduler). `old_` is a snapshot and follows the model column.
- **Activation gate**: `None` and `Some(0)` both count as "no revenue-bearing cache price" (unchanged revenue gating).

## Heads-up for API consumers

`cacheReadCostPerToken` / `input_cache_read` in `/v1/models`, `/v1/model/list`, `/v1/admin/models` and history/pricing-change snapshots is now **omitted** when cache pricing is disabled (previously rendered as amount 0). nearai-cloud-ui / nearai-cloud-admin-ui should tolerate the missing key.

## Testing

- `cargo test --workspace --lib --bins`: **1075 passed, 0 failed** (api 216, config 27, database 15, inference_providers 371, services 446), incl. new unit tests: `None` → full input rate; `Some(0)` → free; `Some(x)` → discounted; catalog renders `Some(0)` as `"0"` and omits `None`.
- `cargo check --workspace --all-targets` (e2e compilation) clean; `cargo fmt --check` clean; `cargo clippy --workspace --lib --bins` zero warnings.
- Migration is standard DDL matching existing patterns; e2e suite runs in CI (needs PostgreSQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)