### PR TITLE
fix(models): tag privacy-filter as a non-completion (classification) model instead of hiding it

### DIFF
--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -2680,6 +2680,12 @@ pub async fn models(
 
     let response = ModelsResponse {
         object: "list".to_string(),
+        // Every active model is listed, including non-generative ones such as
+        // the `openai/privacy-filter` token-classification model. Clients tell
+        // model kinds apart from the per-model `output_modalities` /
+        // `architecture.outputModalities` fields — a classification model
+        // reports `["classification"]`, an image model `["image"]` — rather
+        // than by absence from the catalog (issue #615).
         data: models.into_iter().map(model_with_pricing_to_info).collect(),
     };
     Ok(ResponseJson(response))

--- a/crates/api/tests/e2e_all/general.rs
+++ b/crates/api/tests/e2e_all/general.rs
@@ -9,14 +9,21 @@ use inference_providers::{models::ChatCompletionChunk, StreamChunk};
 #[tokio::test]
 async fn test_models_api() {
     let server = setup_test_server().await;
-    setup_qwen_model(&server).await;
+    let chat_id = setup_qwen_model(&server).await;
     let (api_key, _) = create_org_and_api_key(&server).await;
     let response = list_models(&server, api_key).await;
 
     assert!(!response.data.is_empty());
 
-    // Verify pricing and context_length are present (HuggingFace integration)
-    let model = response.data.first().unwrap();
+    // Assert pricing/context_length on the model we configured, located by id.
+    // The e2e suite shares one model catalog, which can also contain other
+    // models (e.g. a zero-priced classification model), so keying off whichever
+    // entry happens to sort first would be order- and collation-dependent.
+    let model = response
+        .data
+        .iter()
+        .find(|m| m.id == chat_id)
+        .expect("configured chat model must be listed");
     assert!(model.pricing.is_some(), "Model should have pricing");
     let pricing = model.pricing.as_ref().unwrap();
     assert!(pricing.input > 0.0, "Input price should be positive");
@@ -28,6 +35,83 @@ async fn test_models_api() {
     assert!(
         model.context_length.unwrap() > 0,
         "Context length should be positive"
+    );
+}
+
+/// A token-classification model (like `openai/privacy-filter`) does not serve
+/// `/v1/chat/completions` — it exposes bespoke `/v1/privacy/*` routes — but it
+/// must still be LISTED in `GET /v1/models`, tagged with its true modality, so a
+/// client can tell it is not a completion model. This mirrors how image models
+/// are listed and tagged (`outputModalities = ["image"]`) rather than hidden: it
+/// is distinguished by its `output_modalities` / `architecture.outputModalities`
+/// reporting `["classification"]`, alongside an ordinary chat model that still
+/// reports `["text"]` (issue #615).
+#[tokio::test]
+async fn test_classification_model_listed_and_tagged() {
+    let server = setup_test_server().await;
+    let chat_id = setup_qwen_model(&server).await;
+
+    let classifier = "openai/privacy-filter".to_string();
+    let mut batch = BatchUpdateModelApiRequest::new();
+    batch.insert(
+        classifier.clone(),
+        serde_json::from_value(serde_json::json!({
+            "inputCostPerToken": { "amount": 1_000_000, "currency": "USD" },
+            "outputCostPerToken": { "amount": 0, "currency": "USD" },
+            "modelDisplayName": "Privacy Filter",
+            "modelDescription": "PII span detection (token classification)",
+            "contextLength": 512,
+            "maxOutputLength": 1024,
+            "verifiable": false,
+            "isActive": true,
+            "inputModalities": ["text"],
+            "outputModalities": ["classification"]
+        }))
+        .unwrap(),
+    );
+    admin_batch_upsert_models(&server, batch, get_session_id()).await;
+
+    let (api_key, _) = create_org_and_api_key(&server).await;
+    let response = list_models(&server, api_key).await;
+
+    // Both models are LISTED — the classifier is tagged, not hidden.
+    let chat = response
+        .data
+        .iter()
+        .find(|m| m.id == chat_id)
+        .expect("generative chat model must be listed");
+    let filter = response
+        .data
+        .iter()
+        .find(|m| m.id == classifier)
+        .unwrap_or_else(|| {
+            let ids: Vec<&str> = response.data.iter().map(|m| m.id.as_str()).collect();
+            panic!("classification model must be listed (tagged, not hidden); got {ids:?}")
+        });
+
+    // The classification model carries its true modality so a client can tell it
+    // is not a completion model — exactly how an image model reports ["image"].
+    // Both the OpenRouter-flat field and the nested architecture surface it.
+    assert_eq!(
+        filter.output_modalities,
+        Some(vec!["classification".to_string()]),
+        "privacy-filter must report output_modalities = [\"classification\"]"
+    );
+    assert_eq!(
+        filter
+            .architecture
+            .as_ref()
+            .map(|a| a.output_modalities.clone()),
+        Some(vec!["classification".to_string()]),
+        "privacy-filter architecture.outputModalities must be [\"classification\"]"
+    );
+
+    // The ordinary chat model still reports text output — the contrast a client
+    // uses to distinguish a completion model from the classifier.
+    assert_eq!(
+        chat.output_modalities,
+        Some(vec!["text".to_string()]),
+        "chat model must report output_modalities = [\"text\"]"
     );
 }
 

--- a/crates/database/src/migrations/sql/V0069__mark_privacy_filter_non_generative.sql
+++ b/crates/database/src/migrations/sql/V0069__mark_privacy_filter_non_generative.sql
@@ -1,0 +1,44 @@
+-- `openai/privacy-filter` is a token-classification (PII detection) model, not a
+-- generative chat model. Its only real endpoints are /v1/privacy/classify and
+-- /v1/privacy/redact; a /v1/chat/completions request against it returns an
+-- upstream 404. It was nonetheless seeded with output_modalities = {'text'}, so
+-- in GET /v1/models (and GET /v1/model/list) it was indistinguishable from an
+-- ordinary chat model — clients had no way to tell it is not a completion model
+-- (issue #615).
+--
+-- This migration TAGS the model with its true modality; it does NOT hide it. The
+-- catalog already encodes model kind in output_modalities, and both listing
+-- endpoints surface that field to clients (embedding models report
+-- {'embedding'}, image models report {'image'}). The privacy filter keeps
+-- appearing in the catalog exactly like an image or embedding model; correcting
+-- its OUTPUT modality to 'classification' lets a client distinguish it from a
+-- chat model instead of it masquerading as {'text'}. The input modality stays
+-- {'text'} — it still consumes text. Every path (privacy classify/redact, direct
+-- model lookup, admin) is unaffected.
+--
+-- Idempotent and operator-respecting: it only rewrites the row while it is still
+-- on the wrong {'text'} label, mirroring how V0061 repaired a mislabeled catalog
+-- row in place. It is a no-op on databases where the row does not exist (e.g.
+-- fresh/test databases that seed the model after migrations run). The correction
+-- is mirrored into the currently-open model_history snapshot so the audit trail
+-- stays faithful, exactly as the app write path does.
+-- Step 1: relabel the model row. output_modalities is a JSONB array of strings
+-- (V0043), stored as e.g. '["text"]'; set it to the JSON array
+-- '["classification"]'. Idempotent — skips the row once it is already fixed.
+UPDATE models
+SET
+    output_modalities = '["classification"]'::jsonb,
+    updated_at = NOW()
+WHERE model_name = 'openai/privacy-filter'
+  AND output_modalities IS DISTINCT FROM '["classification"]'::jsonb;
+
+-- Step 2: correct the currently-open history snapshot in place (a metadata fix,
+-- not a new state transition). Kept independent of step 1 — joined to `models`
+-- by name — so a prior manual patch to `models` still repairs the open snapshot.
+UPDATE model_history mh
+SET output_modalities = '["classification"]'::jsonb
+FROM models m
+WHERE m.model_name = 'openai/privacy-filter'
+  AND mh.model_id = m.id
+  AND mh.effective_until IS NULL
+  AND mh.output_modalities IS DISTINCT FROM '["classification"]'::jsonb;


### PR DESCRIPTION
## Problem

`GET /v1/models` (and `GET /v1/model/list`) advertised `openai/privacy-filter` as if it were an ordinary chat model. It is a **token-classification** (PII detection) model: its only real endpoints are `/v1/privacy/classify` and `/v1/privacy/redact`, and a `/v1/chat/completions` request against it hits a non-existent upstream path and 404s. Because the catalog exposed no notion of its kind, a client had no way to tell it apart from a completion model.

Fixes #615.

## Approach (revised per maintainer feedback)

> Maintainer feedback on the earlier version of this PR: *"Model should be there but tagged as not a completion model. Same as image models. Hiding it is not good."*

This PR **supersedes** its earlier hide-based version. Instead of filtering the model out of the catalog, it keeps the model **listed** and **tags it with its true modality** — exactly the way image and embedding models are represented ("list + tag, same as image models").

### Why tagging alone is sufficient

The catalog already encodes model kind in `output_modalities`, and **both listing endpoints already surface that field to clients**:

- `GET /v1/models` → each `ModelInfo` carries both the OpenRouter-flat `output_modalities` **and** the nested `architecture.outputModalities`.
- `GET /v1/model/list` → each model's `architecture.outputModalities` (built by `ModelArchitecture::from_options`).

An image model is listed with `outputModalities = ["image"]`; an embedding model with `["embedding"]`. The privacy filter was simply mislabeled `["text"]`, so it masqueraded as a chat model. Relabeling its output modality to `["classification"]` makes it self-describe as a classifier — a client distinguishes it by reading `output_modalities`, exactly as it would for an image model. No new field or scheme is introduced; this reuses the existing modality mechanism.

## Changes

- **Migration `V0069`** relabels the `openai/privacy-filter` row's `output_modalities` from the mislabeled `["text"]` to `["classification"]` (and mirrors the fix into the currently-open `model_history` snapshot). This is the whole fix. It is idempotent, a no-op on databases without the row (fresh/test DBs), and mirrors the in-place catalog-metadata repair pattern used by `V0061`. Input modality stays `["text"]` — it still consumes text. The migration comment block states its purpose is to correctly **tag** the model's modality, not to feed an api-layer hide filter.
  - *Renumbered `V0068` → `V0069`*: since this branch first opened, `main` landed its own `V0068` (`V0068__cache_read_cost_nullable.sql`). Two migrations sharing version `0068` would make refinery reject startup, so this one moves to the next free version. The branch has also been **rebased onto current `main`** so it carries main's `V0068` and this `V0069` side by side.
- **Removed** the catalog-hiding code from the earlier revision: the `.filter(...)` in `routes::completions::models` (`/v1/models`) and `routes::models::list_models` (`/v1/model/list`), plus the now-unused `is_listed_in_model_catalog` helper, the `NON_GENERATIVE_OUTPUT_MODALITIES` const, and its unit test in `routes::common`. (Net effect: `common.rs` and `models.rs` are unchanged from `main`; `completions.rs` gains only an explanatory comment.)

The privacy endpoints and direct `GET /v1/model/{name}` lookups were never affected either way.

> Note: the branch name (`fix/models-exclude-non-generative`) is now a slight misnomer — the fix tags rather than excludes/hides. Kept to preserve PR #872's URL and history.

> Note: the issue also raised (2) error categorization (upstream 404 → `400`). That is a separate systemic wrapping concern shared with #605–#609 and is intentionally out of scope here.

## Tests

- Replaced `test_non_generative_models_excluded_from_models_list` (asserted exclusion) with **`test_classification_model_listed_and_tagged`**: asserts `openai/privacy-filter` **is listed** in `/v1/models` and reports `output_modalities` / `architecture.outputModalities` = `["classification"]`, alongside a chat model still reporting `["text"]`.
- Adjusted `test_models_api` to locate the configured chat model **by id** rather than `data.first()`. With the classifier no longer hidden, the shared e2e catalog can now contain a zero-priced classification model that may sort first under some collations; keying off the first entry was order-dependent. Every other listing test already scopes by id.

## Validation (rebased state: `main` + this change)

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --tests` — clean
- `cargo clippy --workspace --tests` — clean
- **e2e against real Postgres**: full migration set (including main's `V0068` and this `V0069`) applies cleanly on a fresh bootstrap. `test_classification_model_listed_and_tagged` and `test_models_api` both pass, including against a catalog already containing the zero-priced classifier.
