### PR TITLE
feat: add programmatic usage reporting

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -10,7 +10,10 @@ use crate::ohttp_gateway::{OhttpAttestation, OhttpGateway};
 use crate::routes::mcp_server::{handle_mcp_request, McpRouteState};
 use crate::routes::ohttp::{ohttp_config, ohttp_relay};
 use crate::{
-    middleware::{auth::auth_middleware_with_api_key, auth_middleware, AuthState},
+    middleware::{
+        auth::{auth_middleware_with_api_key, auth_middleware_with_reporting_token},
+        auth_middleware, AuthState,
+    },
     openapi::ApiDoc,
     routes::{
         api::{build_management_router, AppState},
@@ -221,6 +224,11 @@ pub fn init_auth_services(database: Arc<Database>, config: &ApiConfig) -> AuthCo
         oauth_manager_arc.clone(),
         auth_service.clone(),
         workspace_repository.clone(),
+        Arc::new(
+            database::repositories::OrganizationReportingTokenRepository::new(
+                database.pool().clone(),
+            ),
+        ) as Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
         admin_access_token_repository,
         config.auth.admin_domains.clone(),
         config.auth.encoding_key.clone(),
@@ -1116,6 +1124,12 @@ pub fn build_app_with_config(
         attestation_service: domain_services.attestation_service.clone(),
         usage_service: domain_services.usage_service.clone(),
         service_usage_service: domain_services.service_usage_service.clone(),
+        reporting_token_repository: Arc::new(
+            database::repositories::OrganizationReportingTokenRepository::new(
+                database.pool().clone(),
+            ),
+        )
+            as Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
         user_service: domain_services.user_service.clone(),
         files_service: domain_services.files_service.clone(),
         inference_provider_pool: domain_services.inference_provider_pool.clone(),
@@ -1237,6 +1251,19 @@ pub fn build_app_with_config(
         domain_services.usage_service.clone(),
         &auth_components.auth_state_middleware,
     );
+    let reporting_usage_routes = build_reporting_usage_routes(
+        domain_services.usage_service.clone(),
+        domain_services.service_usage_service.clone(),
+        Arc::new(database::repositories::OrganizationUsageRepository::new(
+            database.pool().clone(),
+        )),
+        Arc::new(
+            database::repositories::OrganizationServiceUsageRepository::new(
+                database.pool().clone(),
+            ),
+        ),
+        &auth_components.auth_state_middleware,
+    );
 
     // Build OpenAPI and documentation routes
     let openapi_routes = build_openapi_routes();
@@ -1300,6 +1327,7 @@ pub fn build_app_with_config(
                 .merge(files_routes)
                 .merge(feature_request_routes)
                 .merge(billing_routes)
+                .merge(reporting_usage_routes)
                 .merge(gateway_routes)
                 .merge(internal_routes)
                 .merge(health_routes)
@@ -1756,6 +1784,57 @@ pub fn build_billing_routes(
             auth_state_middleware.clone(),
             middleware::auth::auth_middleware_with_workspace_context,
         ))
+}
+
+pub fn build_reporting_usage_routes(
+    usage_service: Arc<dyn services::usage::UsageServiceTrait + Send + Sync>,
+    service_usage_service: Arc<dyn services::service_usage::ServiceUsageServiceTrait + Send + Sync>,
+    inference_summary_repo: Arc<dyn services::reporting_usage::InferenceUsageSummaryRepository>,
+    service_summary_repo: Arc<dyn services::reporting_usage::ServiceUsageSummaryRepository>,
+    auth_state_middleware: &AuthState,
+) -> Router {
+    let export_state = crate::routes::reporting_usage::ReportingUsageExportState::new(
+        usage_service,
+        service_usage_service,
+    );
+    let summary_state = crate::routes::reporting_usage::ReportingUsageSummaryState::new(
+        inference_summary_repo,
+        service_summary_repo,
+    );
+    let export_router = Router::new()
+        .route(
+            "/organizations/{org_id}/usage/export",
+            get(crate::routes::reporting_usage::export_usage),
+        )
+        .with_state(export_state);
+    let summary_router = Router::new()
+        .route(
+            "/organizations/{org_id}/usage/summary",
+            get(crate::routes::reporting_usage::summary_usage),
+        )
+        .with_state(summary_state);
+    let router = Router::new().merge(export_router).merge(summary_router);
+
+    #[cfg(debug_assertions)]
+    {
+        router
+            .route(
+                "/organizations/{org_id}/usage/reporting-token-auth-probe",
+                get(crate::routes::reporting_usage::reporting_token_auth_probe),
+            )
+            .layer(from_fn_with_state(
+                auth_state_middleware.clone(),
+                auth_middleware_with_reporting_token,
+            ))
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        router.layer(from_fn_with_state(
+            auth_state_middleware.clone(),
+            auth_middleware_with_reporting_token,
+        ))
+    }
 }
 
 /// Build gateway routes for external model gateways to validate API keys.
@@ -2238,9 +2317,71 @@ mod tests {
         assert!(components.security_schemes.contains_key("session_token"));
         assert!(components.security_schemes.contains_key("refresh_token"));
         assert!(components.security_schemes.contains_key("api_key"));
+        assert!(components.security_schemes.contains_key("reporting_token"));
+
+        let spec_json = serde_json::to_value(&spec).unwrap();
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/reporting-tokens",
+            "post",
+            "session_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/reporting-tokens",
+            "get",
+            "session_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/reporting-tokens/{token_id}",
+            "delete",
+            "session_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/usage/export",
+            "get",
+            "reporting_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/usage/summary",
+            "get",
+            "reporting_token",
+        );
+        println!(
+            "OPENAPI_REPORTING_CONTRACT={}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "reporting_tokens": spec_json["paths"]["/v1/organizations/{org_id}/reporting-tokens"],
+                "reporting_token_revoke": spec_json["paths"]["/v1/organizations/{org_id}/reporting-tokens/{token_id}"],
+                "usage_export": spec_json["paths"]["/v1/organizations/{org_id}/usage/export"],
+                "usage_summary": spec_json["paths"]["/v1/organizations/{org_id}/usage/summary"],
+                "reporting_token_scheme": spec_json["components"]["securitySchemes"]["reporting_token"],
+            }))
+            .unwrap()
+        );
 
         // Verify servers are not hardcoded (will be set dynamically on client)
         assert!(spec.servers.is_none() || spec.servers.as_ref().unwrap().is_empty());
+    }
+
+    fn assert_reporting_path_security(
+        spec: &serde_json::Value,
+        path: &str,
+        method: &str,
+        scheme: &str,
+    ) {
+        let operation = &spec["paths"][path][method];
+        assert!(
+            operation.is_object(),
+            "missing OpenAPI operation: {method} {path}"
+        );
+        assert_eq!(
+            operation["security"],
+            serde_json::json!([{ scheme: [] }]),
+            "{method} {path} must use only {scheme} security"
+        );
     }
 
     #[test]

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -6,6 +6,8 @@ use axum::{
 };
 use database::User as DbUser;
 use services::auth::{AuthError, AuthServiceTrait, OAuthManager, SessionToken};
+use services::common::REPORTING_TOKEN_PREFIX;
+use services::reporting_tokens::{ReportingTokenScope, ValidatedOrganizationReportingToken};
 use std::sync::Arc;
 use tracing::{debug, error};
 
@@ -48,6 +50,14 @@ pub struct AuthenticatedApiKey {
     pub organization: services::organization::Organization,
 }
 
+#[derive(Clone, Debug)]
+pub struct AuthenticatedReportingToken {
+    pub id: uuid::Uuid,
+    pub organization_id: uuid::Uuid,
+    pub token_prefix: String,
+    pub scope: ReportingTokenScope,
+}
+
 pub async fn auth_middleware_with_api_key(
     State(state): State<AuthState>,
     request: Request,
@@ -58,14 +68,17 @@ pub async fn auth_middleware_with_api_key(
         .get("authorization")
         .and_then(|h| h.to_str().ok());
 
-    tracing::debug!("Auth API KEY middleware: {:?}", auth_header);
+    tracing::debug!(
+        has_authorization = auth_header.is_some(),
+        "Auth API KEY middleware"
+    );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
             authenticate_api_key(&state, token).await
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
@@ -107,14 +120,17 @@ pub async fn auth_middleware_with_workspace_context(
         .get("authorization")
         .and_then(|h| h.to_str().ok());
 
-    tracing::debug!("Auth API KEY with workspace middleware: {:?}", auth_header);
+    tracing::debug!(
+        has_authorization = auth_header.is_some(),
+        "Auth API KEY with workspace middleware"
+    );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
             authenticate_api_key_with_context(&state, token).await
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
@@ -157,21 +173,20 @@ pub async fn auth_middleware(
         .and_then(|h| h.to_str().ok());
 
     tracing::debug!(
-        "Auth middleware (session access token only): {:?}",
-        auth_header
+        has_authorization = auth_header.is_some(),
+        "Auth middleware (session access token only)"
     );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
-            debug!("Extracted Bearer token: {}", token);
             authenticate_session_access(&state, token.to_string()).await
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
-                    "Authorization header does not start with 'Bearer '".to_string(),
+                    "Invalid authorization header format".to_string(),
                     "unauthorized".to_string(),
                 )),
             ))
@@ -197,6 +212,55 @@ pub async fn auth_middleware(
     }
 }
 
+pub async fn auth_middleware_with_reporting_token(
+    State(state): State<AuthState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|h| h.to_str().ok());
+
+    tracing::debug!(
+        has_authorization = auth_header.is_some(),
+        "Auth reporting token middleware"
+    );
+
+    let auth_result = if let Some(auth_value) = auth_header {
+        debug!("Found Authorization header");
+        if let Some(token) = auth_value.strip_prefix("Bearer ") {
+            authenticate_reporting_token(&state, token).await
+        } else {
+            debug!("Authorization header uses unsupported scheme");
+            Err((
+                StatusCode::UNAUTHORIZED,
+                axum::Json(crate::models::ErrorResponse::new(
+                    "Invalid authorization header format".to_string(),
+                    "invalid_auth_header".to_string(),
+                )),
+            ))
+        }
+    } else {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            axum::Json(crate::models::ErrorResponse::new(
+                "Missing authorization header".to_string(),
+                "missing_auth_header".to_string(),
+            )),
+        ))
+    };
+
+    match auth_result {
+        Ok(reporting_token) => {
+            let mut request = request;
+            request.extensions_mut().insert(reporting_token);
+            Ok(next.run(request).await)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 /// Admin authentication middleware - verifies user is authenticated AND has admin access
 /// Supports both access tokens (with admin domain check) and admin access tokens
 pub async fn admin_middleware(
@@ -216,13 +280,14 @@ pub async fn admin_middleware(
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
 
-    tracing::debug!("Admin auth middleware: {:?}", auth_header);
+    tracing::debug!(
+        has_authorization = auth_header.is_some(),
+        "Admin auth middleware"
+    );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
-            debug!("Extracted Bearer token for admin auth: {}", token);
-
             // Check if this looks like an admin access token (starts with "adm_")
             // Admin access tokens should ONLY be validated as admin tokens, no fallback
             if token.starts_with("adm_") {
@@ -279,11 +344,11 @@ pub async fn admin_middleware(
                 authenticate_session_access(&state, token.to_string()).await
             }
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
-                    "Authorization header does not start with 'Bearer '".to_string(),
+                    "Invalid authorization header format".to_string(),
                     "unauthorized".to_string(),
                 )),
             ))
@@ -357,7 +422,7 @@ async fn authenticate_admin_access_token(
     database::models::AdminAccessToken,
     (StatusCode, axum::Json<crate::models::ErrorResponse>),
 > {
-    debug!("Authenticating admin access token: {}", token);
+    debug!("Authenticating admin access token");
 
     match state
         .admin_access_token_repository
@@ -398,7 +463,18 @@ async fn authenticate_session_access(
     state: &AuthState,
     token: String, // jwt
 ) -> Result<DbUser, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
-    debug!("Authenticating session access token: {}", token);
+    if token.starts_with(REPORTING_TOKEN_PREFIX) {
+        debug!("Reporting token rejected by session middleware");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            axum::Json(crate::models::ErrorResponse::new(
+                "Invalid or expired access token".to_string(),
+                "unauthorized".to_string(),
+            )),
+        ));
+    }
+
+    debug!("Authenticating session access token");
     // Use auth service
 
     let auth_service = &state.auth_service;
@@ -458,15 +534,18 @@ pub async fn refresh_middleware(
         .and_then(|h| h.to_str().ok());
 
     tracing::debug!(
-        "Auth middleware (refresh token): refresh token: {:?}, user agent: {:?}",
-        auth_header,
-        user_agent
+        has_authorization = auth_header.is_some(),
+        has_user_agent = user_agent.is_some(),
+        "Auth middleware (refresh token)"
     );
 
     let auth_result = if let Some(auth_value) = auth_header {
-        debug!("Found Authorization header: {}", auth_value);
+        debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
-            debug!("Extracted Bearer token: {}", token);
+            if token.starts_with(REPORTING_TOKEN_PREFIX) {
+                debug!("Reporting token rejected by refresh middleware");
+                return Err(StatusCode::UNAUTHORIZED);
+            }
             if let Some(user_agent_value) = user_agent {
                 authenticate_session_refresh(
                     &state,
@@ -479,7 +558,7 @@ pub async fn refresh_middleware(
                 Err(StatusCode::UNAUTHORIZED)
             }
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err(StatusCode::UNAUTHORIZED)
         }
     } else {
@@ -505,7 +584,7 @@ async fn authenticate_session_refresh(
     token: SessionToken,
     user_agent: &str,
 ) -> Result<(services::auth::Session, DbUser), StatusCode> {
-    debug!("Authenticating session refresh token: {}", token);
+    debug!("Authenticating session refresh token");
     // Use auth service to validate session with refresh token and user agent
     {
         let auth_service = &state.auth_service;
@@ -540,7 +619,7 @@ async fn authenticate_api_key(
     api_key: &str,
 ) -> Result<services::workspace::ApiKey, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
     let auth_service = &state.auth_service;
-    debug!("Calling auth service to validate API key: {}", api_key);
+    debug!("Calling auth service to validate API key");
 
     match auth_service.validate_api_key(api_key.to_string()).await {
         Ok(api_key) => {
@@ -577,6 +656,48 @@ async fn authenticate_api_key(
                 )),
             ))
         }
+    }
+}
+
+async fn authenticate_reporting_token(
+    state: &AuthState,
+    token: &str,
+) -> Result<AuthenticatedReportingToken, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
+    debug!("Calling reporting token repository to validate token");
+
+    match state.reporting_token_repository.validate(token).await {
+        Ok(Some(validated)) => Ok(reporting_token_extension(validated)),
+        Ok(None) => {
+            debug!("Invalid or expired reporting token");
+            Err((
+                StatusCode::UNAUTHORIZED,
+                axum::Json(crate::models::ErrorResponse::new(
+                    "Invalid or expired reporting token".to_string(),
+                    "invalid_reporting_token".to_string(),
+                )),
+            ))
+        }
+        Err(_) => {
+            error!("Failed to validate reporting token");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(crate::models::ErrorResponse::new(
+                    "Failed to validate reporting token".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            ))
+        }
+    }
+}
+
+fn reporting_token_extension(
+    validated: ValidatedOrganizationReportingToken,
+) -> AuthenticatedReportingToken {
+    AuthenticatedReportingToken {
+        id: validated.id,
+        organization_id: validated.organization_id,
+        token_prefix: validated.token_prefix,
+        scope: validated.scope,
     }
 }
 
@@ -642,6 +763,8 @@ pub struct AuthState {
     pub oauth_manager: Arc<OAuthManager>,
     pub auth_service: Arc<dyn AuthServiceTrait>,
     pub workspace_repository: Arc<dyn services::workspace::WorkspaceRepository>,
+    pub reporting_token_repository:
+        Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
     pub admin_access_token_repository: Arc<database::repositories::AdminAccessTokenRepository>,
     pub admin_domains: Vec<String>,
     pub encoding_key: String,
@@ -652,6 +775,9 @@ impl AuthState {
         oauth_manager: Arc<OAuthManager>,
         auth_service: Arc<dyn AuthServiceTrait>,
         workspace_repository: Arc<dyn services::workspace::WorkspaceRepository>,
+        reporting_token_repository: Arc<
+            dyn services::reporting_tokens::OrganizationReportingTokenRepository,
+        >,
         admin_access_token_repository: Arc<database::repositories::AdminAccessTokenRepository>,
         admin_domains: Vec<String>,
         encoding_key: String,
@@ -660,6 +786,7 @@ impl AuthState {
             oauth_manager,
             auth_service,
             workspace_repository,
+            reporting_token_repository,
             admin_access_token_repository,
             admin_domains,
             encoding_key,

--- a/crates/api/src/middleware/mod.rs
+++ b/crates/api/src/middleware/mod.rs
@@ -10,7 +10,10 @@ pub mod rate_limit;
 pub mod usage;
 
 // Re-export commonly used items
-pub use auth::{admin_middleware, auth_middleware, AdminUser, AuthState, AuthenticatedUser};
+pub use auth::{
+    admin_middleware, auth_middleware, AdminUser, AuthState, AuthenticatedReportingToken,
+    AuthenticatedUser,
+};
 pub use body_hash::{body_hash_middleware, RequestBodyHash};
 pub use metrics::{http_metrics_middleware, MetricsState};
 pub use rate_limit::{api_key_rate_limit_middleware, RateLimitState};

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -7,7 +7,7 @@ use utoipa::{Modify, OpenApi};
 #[openapi(
     info(
         title = "NEAR AI Cloud API",
-        description = "A comprehensive cloud API for AI model inference, conversation management, and organization administration.\n\n## Authentication\n\nThis API supports three authentication methods:\n\n1. **Access Token (JWT)**: Use `Authorization: Bearer <jwt_token>` with a short-lived JWT access token for most API endpoints. Obtain this by calling POST /users/me/access_tokens with a refresh token.\n2. **Refresh Token**: Use `Authorization: Bearer <refresh_token>` (prefix: `rt_`) only with POST /users/me/access_tokens to create new JWT access tokens. Obtained from OAuth login.\n3. **API Key (Programmatic Access)**: Use `Authorization: Bearer sk-<api_key>` with an API key (prefix: `sk-`)\n\nClick the **Authorize** button above to configure authentication.",
+        description = "A comprehensive cloud API for AI model inference, conversation management, and organization administration.\n\n## Authentication\n\nThis API supports four authentication methods:\n\n1. **Access Token (JWT)**: Use `Authorization: Bearer <jwt_token>` with a short-lived JWT access token for most API endpoints. Obtain this by calling POST /users/me/access_tokens with a refresh token.\n2. **Refresh Token**: Use `Authorization: Bearer <refresh_token>` (prefix: `rt_`) only with POST /users/me/access_tokens to create new JWT access tokens. Obtained from OAuth login.\n3. **API Key (Programmatic Access)**: Use `Authorization: Bearer sk-<api_key>` with an API key (prefix: `sk-`).\n4. **Reporting Token (Read-only Usage Reporting)**: Use `Authorization: Bearer rpt-<reporting_token>` only with usage reporting endpoints.\n\nClick the **Authorize** button above to configure authentication.",
         version = "1.0.0",
         contact(
             name = "NEAR AI Team",
@@ -34,6 +34,7 @@ use utoipa::{Modify, OpenApi};
         (name = "Users", description = "User profile and token management"),
         (name = "Invitations", description = "Token-based invitation handling"),
         (name = "Usage", description = "Usage tracking and billing information"),
+        (name = "Reporting", description = "Read-only customer usage reporting"),
         (name = "Billing", description = "Billing costs endpoint (HuggingFace integration)"),
         (name = "Health", description = "Health check endpoints"),
         (name = "Attestation", description = "Attestation and verification endpoints"),
@@ -125,6 +126,12 @@ use utoipa::{Modify, OpenApi};
         crate::routes::usage::get_api_key_usage_history,
         crate::routes::usage::get_user_organization_metrics,
         crate::routes::usage::get_user_organization_timeseries,
+        // Customer reporting endpoints
+        crate::routes::reporting_tokens::create_reporting_token,
+        crate::routes::reporting_tokens::list_reporting_tokens,
+        crate::routes::reporting_tokens::revoke_reporting_token,
+        crate::routes::reporting_usage::export::export_usage,
+        crate::routes::reporting_usage::summary::summary_usage,
         // Feature request endpoints
         crate::routes::feature_requests::submit_feature_request,
         crate::routes::feature_requests::list_admin_feature_requests,
@@ -278,6 +285,25 @@ use utoipa::{Modify, OpenApi};
             crate::routes::usage::UserWorkspaceMetrics,
             crate::routes::usage::UserTimeSeriesMetrics,
             crate::routes::usage::UserTimeSeriesPoint,
+            // Customer reporting models
+            services::reporting_tokens::ReportingTokenScope,
+            crate::routes::reporting_tokens::CreateReportingTokenRequest,
+            crate::routes::reporting_tokens::CreateReportingTokenResponse,
+            crate::routes::reporting_tokens::ReportingTokenResponse,
+            crate::routes::reporting_tokens::ListReportingTokensResponse,
+            crate::routes::reporting_usage::ReportingUsageSource,
+            crate::routes::reporting_usage::ReportingUsageRowSource,
+            crate::routes::reporting_usage::ReportingUsageExportResponse,
+            crate::routes::reporting_usage::ReportingUsageExportRow,
+            crate::routes::reporting_usage::ReportingInferenceUsage,
+            crate::routes::reporting_usage::ReportingServiceUsage,
+            crate::routes::reporting_usage::ReportingUsageSummaryResponse,
+            crate::routes::reporting_usage::ReportingUsageTotals,
+            crate::routes::reporting_usage::ReportingWorkspaceSummary,
+            crate::routes::reporting_usage::ReportingApiKeySummary,
+            crate::routes::reporting_usage::ReportingModelSummary,
+            crate::routes::reporting_usage::ReportingServiceSummary,
+            crate::routes::reporting_usage::ReportingDaySummary,
             // Feature request models
             crate::routes::feature_requests::FeatureRequestKind,
             crate::routes::feature_requests::SubmitFeatureRequest,
@@ -352,6 +378,16 @@ impl Modify for SecurityAddon {
                         .description(Some(
                             "API key for programmatic access (Authorization: Bearer sk-<api_key>)",
                         ))
+                        .build(),
+                ),
+            );
+            components.add_security_scheme(
+                "reporting_token",
+                SecurityScheme::Http(
+                    HttpBuilder::new()
+                        .scheme(HttpAuthScheme::Bearer)
+                        .bearer_format("reporting_token")
+                        .description(Some("Read-only reporting token for usage reporting endpoints (Authorization: Bearer rpt-<reporting_token>)"))
                         .build(),
                 ),
             );

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -26,6 +26,8 @@ pub struct AppState {
     pub usage_service: Arc<dyn services::usage::UsageServiceTrait + Send + Sync>,
     pub service_usage_service:
         Arc<dyn services::service_usage::ServiceUsageServiceTrait + Send + Sync>,
+    pub reporting_token_repository:
+        Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
     pub user_service: Arc<dyn services::user::UserServiceTrait + Send + Sync>,
     pub files_service: Arc<dyn FileServiceTrait + Send + Sync>,
     pub inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
@@ -139,6 +141,15 @@ pub fn build_management_router(app_state: AppState, auth_state: AuthState) -> Ro
         .route(
             "/{id}/usage/timeseries",
             get(crate::routes::usage::get_user_organization_timeseries),
+        )
+        .route(
+            "/{id}/reporting-tokens",
+            get(crate::routes::reporting_tokens::list_reporting_tokens)
+                .post(crate::routes::reporting_tokens::create_reporting_token),
+        )
+        .route(
+            "/{id}/reporting-tokens/{token_id}",
+            delete(crate::routes::reporting_tokens::revoke_reporting_token),
         );
 
     // User routes (require access token authentication)

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -17,6 +17,8 @@ pub mod models;
 pub mod ohttp;
 pub mod organization_members;
 pub mod organizations;
+pub mod reporting_tokens;
+pub mod reporting_usage;
 pub mod responses;
 pub mod services;
 pub mod unsupported;

--- a/crates/api/src/routes/reporting_tokens.rs
+++ b/crates/api/src/routes/reporting_tokens.rs
@@ -1,0 +1,269 @@
+use crate::{
+    conversions::authenticated_user_to_user_id, middleware::AuthenticatedUser,
+    models::ErrorResponse, routes::api::AppState,
+};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use services::{
+    common::RepositoryError,
+    organization::{MemberRole, OrganizationError, OrganizationId},
+    reporting_tokens::{CreateOrganizationReportingTokenRequest, OrganizationReportingToken},
+};
+use uuid::Uuid;
+
+mod schemas;
+
+pub use schemas::{
+    CreateReportingTokenRequest, CreateReportingTokenResponse, ListReportingTokensResponse,
+    ReportingTokenResponse,
+};
+
+type RouteError = (StatusCode, Json<ErrorResponse>);
+
+/// Create a read-only reporting token.
+///
+/// Organization owners and admins can create reporting tokens for usage
+/// export and summary endpoints. The raw `rpt-` token is returned once.
+#[utoipa::path(
+    post,
+    path = "/v1/organizations/{org_id}/reporting-tokens",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID")
+    ),
+    request_body = CreateReportingTokenRequest,
+    responses(
+        (status = 201, description = "Reporting token created", body = CreateReportingTokenResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn create_reporting_token(
+    State(app_state): State<AppState>,
+    axum::Extension(user): axum::Extension<AuthenticatedUser>,
+    Path(org_id): Path<Uuid>,
+    Json(request): Json<CreateReportingTokenRequest>,
+) -> Result<(StatusCode, Json<CreateReportingTokenResponse>), RouteError> {
+    request.validate().map_err(bad_request)?;
+    require_reporting_token_manager(&app_state, user.clone(), org_id).await?;
+
+    let user_id = authenticated_user_to_user_id(user).0;
+    let created = app_state
+        .reporting_token_repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id: org_id,
+            name: request.name.trim().to_string(),
+            created_by_user_id: user_id,
+            expires_at: request.expires_at,
+        })
+        .await
+        .map_err(map_repository_error)?;
+
+    let token = created.token;
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateReportingTokenResponse {
+            id: token.id,
+            organization_id: token.organization_id,
+            name: token.name,
+            token: created.raw_token,
+            token_prefix: token.token_prefix,
+            created_by_user_id: token.created_by_user_id,
+            created_at: token.created_at,
+            expires_at: token.expires_at,
+            last_used_at: token.last_used_at,
+            scope: token.scope,
+        }),
+    ))
+}
+
+/// List active reporting tokens for an organization.
+///
+/// The response includes non-secret prefixes and audit timestamps. It never
+/// includes raw reporting tokens or stored hashes.
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/reporting-tokens",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID")
+    ),
+    responses(
+        (status = 200, description = "Active reporting tokens", body = ListReportingTokensResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn list_reporting_tokens(
+    State(app_state): State<AppState>,
+    axum::Extension(user): axum::Extension<AuthenticatedUser>,
+    Path(org_id): Path<Uuid>,
+) -> Result<Json<ListReportingTokensResponse>, RouteError> {
+    require_reporting_token_manager(&app_state, user, org_id).await?;
+
+    let tokens = app_state
+        .reporting_token_repository
+        .list_active_by_organization(org_id)
+        .await
+        .map_err(map_repository_error)?;
+    let reporting_tokens: Vec<ReportingTokenResponse> =
+        tokens.into_iter().map(token_response).collect();
+    let total = i64::try_from(reporting_tokens.len()).map_err(|_| internal_error())?;
+
+    Ok(Json(ListReportingTokensResponse {
+        reporting_tokens,
+        total,
+    }))
+}
+
+/// Revoke a reporting token.
+///
+/// Revoked reporting tokens can no longer authenticate usage reporting
+/// requests.
+#[utoipa::path(
+    delete,
+    path = "/v1/organizations/{org_id}/reporting-tokens/{token_id}",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID"),
+        ("token_id" = Uuid, Path, description = "Reporting token ID")
+    ),
+    responses(
+        (status = 204, description = "Reporting token revoked"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Reporting token not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn revoke_reporting_token(
+    State(app_state): State<AppState>,
+    axum::Extension(user): axum::Extension<AuthenticatedUser>,
+    Path((org_id, token_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RouteError> {
+    require_reporting_token_manager(&app_state, user.clone(), org_id).await?;
+
+    let token = app_state
+        .reporting_token_repository
+        .get_by_id(token_id)
+        .await
+        .map_err(map_repository_error)?
+        .filter(|token| token.organization_id == org_id)
+        .ok_or_else(not_found)?;
+
+    if token.revoked_at.is_some() {
+        return Err(not_found());
+    }
+
+    let user_id = authenticated_user_to_user_id(user).0;
+    match app_state
+        .reporting_token_repository
+        .revoke(token_id, user_id)
+        .await
+        .map_err(map_repository_error)?
+    {
+        true => Ok(StatusCode::NO_CONTENT),
+        false => Err(not_found()),
+    }
+}
+
+async fn require_reporting_token_manager(
+    app_state: &AppState,
+    user: AuthenticatedUser,
+    org_id: Uuid,
+) -> Result<(), RouteError> {
+    let user_id = authenticated_user_to_user_id(user);
+    let role = app_state
+        .organization_service
+        .get_user_role(OrganizationId(org_id), user_id)
+        .await
+        .map_err(map_organization_error)?;
+
+    match role {
+        Some(MemberRole::Owner | MemberRole::Admin) => Ok(()),
+        Some(MemberRole::Member) | None => Err(forbidden()),
+    }
+}
+
+fn token_response(token: OrganizationReportingToken) -> ReportingTokenResponse {
+    ReportingTokenResponse {
+        id: token.id,
+        organization_id: token.organization_id,
+        name: token.name,
+        token_prefix: token.token_prefix,
+        created_by_user_id: token.created_by_user_id,
+        created_at: token.created_at,
+        expires_at: token.expires_at,
+        last_used_at: token.last_used_at,
+        scope: token.scope,
+    }
+}
+
+fn map_organization_error(error: OrganizationError) -> RouteError {
+    match error {
+        OrganizationError::NotFound => not_found(),
+        OrganizationError::Unauthorized(_) => forbidden(),
+        _ => internal_error(),
+    }
+}
+
+fn map_repository_error(error: RepositoryError) -> RouteError {
+    match error {
+        RepositoryError::NotFound(_) => not_found(),
+        RepositoryError::RequiredFieldMissing(message)
+        | RepositoryError::ValidationFailed(message) => bad_request(message),
+        _ => internal_error(),
+    }
+}
+
+fn bad_request(message: String) -> RouteError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(message, "bad_request".to_string())),
+    )
+}
+
+fn forbidden() -> RouteError {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new(
+            "You are not authorized to manage reporting tokens for this organization.".to_string(),
+            "forbidden".to_string(),
+        )),
+    )
+}
+
+fn not_found() -> RouteError {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new(
+            "Reporting token not found".to_string(),
+            "not_found".to_string(),
+        )),
+    )
+}
+
+fn internal_error() -> RouteError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            "Failed to manage reporting tokens".to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
+}

--- a/crates/api/src/routes/reporting_tokens/schemas.rs
+++ b/crates/api/src/routes/reporting_tokens/schemas.rs
@@ -1,0 +1,68 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use services::reporting_tokens::ReportingTokenScope;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateReportingTokenRequest {
+    /// Human-readable name for the reporting token.
+    pub name: String,
+    /// Optional expiration time. Must be in the future.
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ReportingTokenResponse {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub name: String,
+    /// Non-secret token prefix for display and audit correlation.
+    pub token_prefix: String,
+    pub created_by_user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct CreateReportingTokenResponse {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub name: String,
+    /// Raw reporting token. Returned only once when the token is created.
+    pub token: String,
+    /// Non-secret token prefix for display and audit correlation.
+    pub token_prefix: String,
+    pub created_by_user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListReportingTokensResponse {
+    pub reporting_tokens: Vec<ReportingTokenResponse>,
+    pub total: i64,
+}
+
+impl CreateReportingTokenRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        let name = self.name.trim();
+        if name.is_empty() {
+            return Err("name is required".to_string());
+        }
+        if name.len() > 255 {
+            return Err("name must be at most 255 characters".to_string());
+        }
+        if let Some(expires_at) = self.expires_at {
+            if expires_at <= Utc::now() {
+                return Err("expires_at must be in the future".to_string());
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/api/src/routes/reporting_usage/export.rs
+++ b/crates/api/src/routes/reporting_usage/export.rs
@@ -1,0 +1,251 @@
+use super::{
+    export_rows::{source_rank, ExportRow},
+    ReportingUsageCursor, ReportingUsageExportResponse, ReportingUsageExportRow,
+    ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams,
+    ReportingUsageRowSource, ReportingUsageSource, RouteError,
+};
+use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Extension, Json,
+};
+use services::{
+    service_usage::{
+        ports::{ServiceUsageReportCursor, ServiceUsageReportFilters},
+        ServiceUsageServiceTrait,
+    },
+    usage::{InferenceUsageReportCursor, InferenceUsageReportQuery, UsageServiceTrait},
+};
+use std::cmp::Reverse;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ReportingUsageExportState {
+    usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
+    service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
+}
+
+impl ReportingUsageExportState {
+    pub fn new(
+        usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
+        service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
+    ) -> Self {
+        Self {
+            usage_service,
+            service_usage_service,
+        }
+    }
+}
+
+/// Export organization usage and cost rows.
+///
+/// Requires a reporting token scoped to the organization in the path. Results
+/// are returned in descending `(created_at, source, id)` order with opaque
+/// cursor pagination.
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/usage/export",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID"),
+        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. The range between start_time and end_time must not exceed 366 days."),
+        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Must be greater than or equal to start_time when both are provided."),
+        ("source" = Option<ReportingUsageSource>, Query, description = "Usage source to export. Defaults to all."),
+        ("workspace_id" = Option<Uuid>, Query, description = "Filter by workspace ID."),
+        ("api_key_id" = Option<Uuid>, Query, description = "Filter by API key ID."),
+        ("model" = Option<String>, Query, description = "Filter inference rows by model name."),
+        ("inference_type" = Option<String>, Query, description = "Filter inference rows by inference type."),
+        ("service_name" = Option<String>, Query, description = "Filter service rows by platform service name."),
+        ("limit" = Option<u16>, Query, description = "Maximum rows to return. Defaults to 100 and must not exceed 1000."),
+        ("cursor" = Option<String>, Query, description = "Opaque cursor returned by the previous export page.")
+    ),
+    responses(
+        (status = 200, description = "Usage export page", body = ReportingUsageExportResponse),
+        (status = 400, description = "Invalid filters or cursor", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Reporting token is not scoped to this organization", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("reporting_token" = [])
+    )
+)]
+pub async fn export_usage(
+    State(state): State<ReportingUsageExportState>,
+    Extension(reporting_token): Extension<AuthenticatedReportingToken>,
+    Path(org_id): Path<Uuid>,
+    Query(params): Query<ReportingUsageQueryParams>,
+) -> Result<Json<ReportingUsageExportResponse>, RouteError> {
+    ensure_token_matches_org(&reporting_token, org_id)?;
+    let query = ReportingUsageQuery::try_from(params).map_err(query_error)?;
+    validate_cursor_source(&query)?;
+
+    let limit = usize::from(query.limit.value());
+    let fetch_limit = query.limit.value() + 1;
+    let rows = match query.source {
+        ReportingUsageSource::All => list_all_rows(&state, org_id, &query, fetch_limit).await?,
+        ReportingUsageSource::Inference => {
+            list_inference_rows(&state, org_id, &query, fetch_limit, query.cursor.clone()).await?
+        }
+        ReportingUsageSource::Service => {
+            list_service_rows(&state, org_id, &query, fetch_limit, query.cursor.clone()).await?
+        }
+    };
+
+    Ok(Json(page_response(rows, limit)?))
+}
+
+async fn list_all_rows(
+    state: &ReportingUsageExportState,
+    org_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let inference_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Inference);
+    let service_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Service);
+    let mut rows = list_inference_rows(state, org_id, query, fetch_limit, inference_cursor).await?;
+    rows.extend(list_service_rows(state, org_id, query, fetch_limit, service_cursor).await?);
+    rows.sort_by_key(|row| Reverse(row.sort_key()));
+    rows.truncate(usize::from(fetch_limit));
+    Ok(rows)
+}
+
+async fn list_inference_rows(
+    state: &ReportingUsageExportState,
+    org_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    cursor: Option<ReportingUsageCursor>,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let rows = state
+        .usage_service
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            organization_id: org_id,
+            start_time: query.start_time,
+            end_time: query.end_time,
+            workspace_id: query.workspace_id,
+            api_key_id: query.api_key_id,
+            model: query.model.clone(),
+            inference_type: query.inference_type.map(|value| value.as_str().to_string()),
+            limit: fetch_limit,
+            cursor: cursor.map(|value| InferenceUsageReportCursor {
+                created_at: value.created_at,
+                id: value.id,
+            }),
+        })
+        .await
+        .map_err(|_| internal_error("Failed to list inference usage export"))?;
+
+    Ok(rows.into_iter().map(ExportRow::Inference).collect())
+}
+
+async fn list_service_rows(
+    state: &ReportingUsageExportState,
+    org_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    cursor: Option<ReportingUsageCursor>,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let rows = state
+        .service_usage_service
+        .get_usage_report(&ServiceUsageReportFilters {
+            organization_id: org_id,
+            service_name: query.service_name.clone(),
+            workspace_id: query.workspace_id,
+            api_key_id: query.api_key_id,
+            start_time: query.start_time,
+            end_time: query.end_time,
+            cursor: cursor.map(|value| ServiceUsageReportCursor {
+                created_at: value.created_at,
+                id: value.id,
+            }),
+            limit: i64::from(fetch_limit),
+        })
+        .await
+        .map_err(|_| internal_error("Failed to list service usage export"))?;
+
+    Ok(rows.into_iter().map(ExportRow::Service).collect())
+}
+
+fn page_response(
+    rows: Vec<ExportRow>,
+    limit: usize,
+) -> Result<ReportingUsageExportResponse, RouteError> {
+    let has_more = rows.len() > limit;
+    let data: Vec<ReportingUsageExportRow> = rows.into_iter().take(limit).map(Into::into).collect();
+    let next_cursor = if has_more {
+        data.last()
+            .map(|row| ReportingUsageCursor::new(row.created_at, row.source, row.id).encode())
+            .transpose()
+            .map_err(query_error)?
+    } else {
+        None
+    };
+    Ok(ReportingUsageExportResponse { data, next_cursor })
+}
+
+fn ensure_token_matches_org(
+    reporting_token: &AuthenticatedReportingToken,
+    org_id: Uuid,
+) -> Result<(), RouteError> {
+    if reporting_token.organization_id == org_id {
+        return Ok(());
+    }
+    Err((
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new(
+            "Reporting token is not authorized for this organization.".to_string(),
+            "forbidden".to_string(),
+        )),
+    ))
+}
+
+fn validate_cursor_source(query: &ReportingUsageQuery) -> Result<(), RouteError> {
+    match (
+        query.source,
+        query.cursor.as_ref().map(|cursor| cursor.source),
+    ) {
+        (ReportingUsageSource::Inference, Some(ReportingUsageRowSource::Service))
+        | (ReportingUsageSource::Service, Some(ReportingUsageRowSource::Inference)) => {
+            Err(query_error(ReportingUsageQueryError::InvalidCursor))
+        }
+        _ => Ok(()),
+    }
+}
+
+fn source_cursor(
+    cursor: Option<&ReportingUsageCursor>,
+    row_source: ReportingUsageRowSource,
+) -> Option<ReportingUsageCursor> {
+    let cursor = cursor?;
+    let row_rank = source_rank(row_source);
+    let cursor_rank = source_rank(cursor.source);
+    let id = match row_rank.cmp(&cursor_rank) {
+        std::cmp::Ordering::Greater => Uuid::nil(),
+        std::cmp::Ordering::Equal => cursor.id,
+        std::cmp::Ordering::Less => Uuid::from_u128(u128::MAX),
+    };
+    Some(ReportingUsageCursor::new(cursor.created_at, row_source, id))
+}
+
+fn query_error(error: ReportingUsageQueryError) -> RouteError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(
+            error.to_string(),
+            "invalid_reporting_usage_query".to_string(),
+        )),
+    )
+}
+
+fn internal_error(message: &str) -> RouteError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            message.to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
+}

--- a/crates/api/src/routes/reporting_usage/export_rows.rs
+++ b/crates/api/src/routes/reporting_usage/export_rows.rs
@@ -1,0 +1,101 @@
+use super::{
+    ReportingInferenceUsage, ReportingServiceUsage, ReportingUsageExportRow,
+    ReportingUsageRowSource,
+};
+use services::{service_usage::ports::ServiceUsageReportEntry, usage::InferenceUsageReportRow};
+use uuid::Uuid;
+
+pub(super) enum ExportRow {
+    Inference(InferenceUsageReportRow),
+    Service(ServiceUsageReportEntry),
+}
+
+impl ExportRow {
+    pub(super) fn sort_key(&self) -> (chrono::DateTime<chrono::Utc>, u8, Uuid) {
+        (self.created_at(), source_rank(self.source()), self.id())
+    }
+
+    fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
+        match self {
+            Self::Inference(row) => row.created_at,
+            Self::Service(row) => row.created_at,
+        }
+    }
+
+    fn source(&self) -> ReportingUsageRowSource {
+        match self {
+            Self::Inference(_) => ReportingUsageRowSource::Inference,
+            Self::Service(_) => ReportingUsageRowSource::Service,
+        }
+    }
+
+    fn id(&self) -> Uuid {
+        match self {
+            Self::Inference(row) => row.id,
+            Self::Service(row) => row.id,
+        }
+    }
+}
+
+impl From<ExportRow> for ReportingUsageExportRow {
+    fn from(row: ExportRow) -> Self {
+        match row {
+            ExportRow::Inference(row) => inference_export_row(row),
+            ExportRow::Service(row) => service_export_row(row),
+        }
+    }
+}
+
+fn inference_export_row(row: InferenceUsageReportRow) -> ReportingUsageExportRow {
+    ReportingUsageExportRow {
+        source: ReportingUsageRowSource::Inference,
+        id: row.id,
+        created_at: row.created_at,
+        workspace_id: row.workspace_id,
+        api_key_id: row.api_key_id,
+        total_cost_nano_usd: row.total_cost_nano_usd,
+        total_cost_usd: None,
+        inference: Some(ReportingInferenceUsage {
+            model: row.model,
+            inference_type: row.inference_type,
+            input_tokens: row.input_tokens,
+            output_tokens: row.output_tokens,
+            cache_read_tokens: row.cache_read_tokens,
+            total_tokens: row.total_tokens,
+            input_cost_nano_usd: row.input_cost_nano_usd,
+            output_cost_nano_usd: row.output_cost_nano_usd,
+            cache_read_cost_nano_usd: row.cache_read_cost_nano_usd,
+            total_cost_nano_usd: row.total_cost_nano_usd,
+            response_id: row.response_id,
+            inference_id: row.inference_id,
+            image_count: row.image_count,
+        }),
+        service: None,
+    }
+}
+
+fn service_export_row(row: ServiceUsageReportEntry) -> ReportingUsageExportRow {
+    ReportingUsageExportRow {
+        source: ReportingUsageRowSource::Service,
+        id: row.id,
+        created_at: row.created_at,
+        workspace_id: row.workspace_id,
+        api_key_id: row.api_key_id,
+        total_cost_nano_usd: row.total_cost,
+        total_cost_usd: None,
+        inference: None,
+        service: Some(ReportingServiceUsage {
+            service_name: row.service_name,
+            quantity: i64::from(row.quantity),
+            total_cost_nano_usd: row.total_cost,
+            inference_id: row.inference_id,
+        }),
+    }
+}
+
+pub(super) const fn source_rank(source: ReportingUsageRowSource) -> u8 {
+    match source {
+        ReportingUsageRowSource::Inference => 0,
+        ReportingUsageRowSource::Service => 1,
+    }
+}

--- a/crates/api/src/routes/reporting_usage/mod.rs
+++ b/crates/api/src/routes/reporting_usage/mod.rs
@@ -1,0 +1,59 @@
+pub mod export;
+mod export_rows;
+mod query;
+mod schemas;
+pub mod summary;
+mod summary_merge;
+
+use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use axum::{extract::Path, http::StatusCode, Json};
+use serde::Serialize;
+use uuid::Uuid;
+
+pub use export::{export_usage, ReportingUsageExportState};
+pub use query::{
+    ReportingUsageCursor, ReportingUsageLimit, ReportingUsageQuery, ReportingUsageQueryError,
+    ReportingUsageQueryParams, ReportingUsageRowSource, ReportingUsageSource,
+};
+pub use schemas::{
+    ReportingApiKeySummary, ReportingDaySummary, ReportingInferenceUsage, ReportingModelSummary,
+    ReportingServiceSummary, ReportingServiceUsage, ReportingUsageExportResponse,
+    ReportingUsageExportRow, ReportingUsageSummaryResponse, ReportingUsageTotals,
+    ReportingWorkspaceSummary,
+};
+pub use summary::{summary_usage, ReportingUsageSummaryState};
+
+type RouteError = (StatusCode, Json<ErrorResponse>);
+
+#[derive(Debug, Serialize)]
+pub struct ReportingTokenAuthProbeResponse {
+    pub token_id: Uuid,
+    pub organization_id: Uuid,
+    pub token_prefix: String,
+    pub scope: services::reporting_tokens::ReportingTokenScope,
+}
+
+pub async fn reporting_token_auth_probe(
+    axum::Extension(reporting_token): axum::Extension<AuthenticatedReportingToken>,
+    Path(org_id): Path<Uuid>,
+) -> Result<Json<ReportingTokenAuthProbeResponse>, RouteError> {
+    if reporting_token.organization_id != org_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "Reporting token is not authorized for this organization.".to_string(),
+                "forbidden".to_string(),
+            )),
+        ));
+    }
+
+    Ok(Json(ReportingTokenAuthProbeResponse {
+        token_id: reporting_token.id,
+        organization_id: reporting_token.organization_id,
+        token_prefix: reporting_token.token_prefix,
+        scope: reporting_token.scope,
+    }))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/api/src/routes/reporting_usage/query.rs
+++ b/crates/api/src/routes/reporting_usage/query.rs
@@ -1,0 +1,269 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use services::usage::InferenceType;
+use std::str::FromStr;
+use thiserror::Error;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+const DEFAULT_REPORTING_USAGE_LIMIT: u16 = 100;
+const MAX_REPORTING_USAGE_LIMIT: u16 = 1000;
+const MAX_REPORTING_USAGE_RANGE_DAYS: i64 = 366;
+const REPORTING_USAGE_CURSOR_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportingUsageSource {
+    #[default]
+    All,
+    Inference,
+    Service,
+}
+
+impl FromStr for ReportingUsageSource {
+    type Err = ReportingUsageQueryError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "all" => Ok(Self::All),
+            "inference" => Ok(Self::Inference),
+            "service" => Ok(Self::Service),
+            other => Err(ReportingUsageQueryError::InvalidSource(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportingUsageRowSource {
+    Inference,
+    Service,
+}
+
+impl ReportingUsageRowSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Inference => "inference",
+            Self::Service => "service",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToSchema)]
+pub struct ReportingUsageLimit(u16);
+
+impl ReportingUsageLimit {
+    pub const fn value(self) -> u16 {
+        self.0
+    }
+
+    fn new(value: u16) -> Result<Self, ReportingUsageQueryError> {
+        if value == 0 {
+            return Err(ReportingUsageQueryError::LimitNotPositive);
+        }
+        if value > MAX_REPORTING_USAGE_LIMIT {
+            return Err(ReportingUsageQueryError::LimitTooLarge {
+                max: MAX_REPORTING_USAGE_LIMIT,
+            });
+        }
+        Ok(Self(value))
+    }
+}
+
+impl Default for ReportingUsageLimit {
+    fn default() -> Self {
+        Self(DEFAULT_REPORTING_USAGE_LIMIT)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportingUsageQuery {
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub source: ReportingUsageSource,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<InferenceType>,
+    pub service_name: Option<String>,
+    pub limit: ReportingUsageLimit,
+    pub cursor: Option<ReportingUsageCursor>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ReportingUsageQueryParams {
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub source: Option<String>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<String>,
+    pub service_name: Option<String>,
+    pub limit: Option<u16>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ReportingUsageQueryError {
+    #[error("start_time and end_time must be RFC3339 timestamps")]
+    InvalidTimestamp,
+    #[error("end_time must be greater than or equal to start_time")]
+    InvalidTimeRange,
+    #[error("time range must not exceed {max_days} days")]
+    TimeRangeTooLarge { max_days: i64 },
+    #[error("invalid source: {0}")]
+    InvalidSource(String),
+    #[error("invalid inference_type: {0}")]
+    InvalidInferenceType(String),
+    #[error("limit must be positive")]
+    LimitNotPositive,
+    #[error("limit must not exceed {max}")]
+    LimitTooLarge { max: u16 },
+    #[error("invalid cursor")]
+    InvalidCursor,
+}
+
+impl TryFrom<ReportingUsageQueryParams> for ReportingUsageQuery {
+    type Error = ReportingUsageQueryError;
+
+    fn try_from(params: ReportingUsageQueryParams) -> Result<Self, Self::Error> {
+        let (start_time, end_time) = normalize_time_range(
+            parse_optional_time(params.start_time.as_deref())?,
+            parse_optional_time(params.end_time.as_deref())?,
+        )?;
+
+        Ok(Self {
+            start_time: Some(start_time),
+            end_time: Some(end_time),
+            source: params
+                .source
+                .as_deref()
+                .map(ReportingUsageSource::from_str)
+                .transpose()?
+                .unwrap_or_default(),
+            workspace_id: params.workspace_id,
+            api_key_id: params.api_key_id,
+            model: params.model,
+            inference_type: params
+                .inference_type
+                .as_deref()
+                .map(InferenceType::from_str)
+                .transpose()
+                .map_err(ReportingUsageQueryError::InvalidInferenceType)?,
+            service_name: params.service_name,
+            limit: params
+                .limit
+                .map(ReportingUsageLimit::new)
+                .transpose()?
+                .unwrap_or_default(),
+            cursor: params
+                .cursor
+                .as_deref()
+                .map(ReportingUsageCursor::decode)
+                .transpose()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReportingUsageCursor {
+    pub created_at: DateTime<Utc>,
+    pub source: ReportingUsageRowSource,
+    pub id: Uuid,
+}
+
+impl ReportingUsageCursor {
+    pub const fn new(created_at: DateTime<Utc>, source: ReportingUsageRowSource, id: Uuid) -> Self {
+        Self {
+            created_at,
+            source,
+            id,
+        }
+    }
+
+    pub fn encode(&self) -> Result<String, ReportingUsageQueryError> {
+        let payload = ReportingUsageCursorPayload {
+            version: REPORTING_USAGE_CURSOR_VERSION,
+            created_at: self.created_at,
+            source: self.source,
+            id: self.id,
+        };
+        let bytes =
+            serde_json::to_vec(&payload).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+
+    pub fn decode(value: &str) -> Result<Self, ReportingUsageQueryError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        let payload: ReportingUsageCursorPayload =
+            serde_json::from_slice(&bytes).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        if payload.version != REPORTING_USAGE_CURSOR_VERSION {
+            return Err(ReportingUsageQueryError::InvalidCursor);
+        }
+        Ok(Self {
+            created_at: payload.created_at,
+            source: payload.source,
+            id: payload.id,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn encode_raw_for_tests(
+        value: &serde_json::Value,
+    ) -> Result<String, ReportingUsageQueryError> {
+        let bytes =
+            serde_json::to_vec(value).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReportingUsageCursorPayload {
+    #[serde(rename = "v")]
+    version: u8,
+    created_at: DateTime<Utc>,
+    source: ReportingUsageRowSource,
+    id: Uuid,
+}
+
+fn parse_optional_time(
+    value: Option<&str>,
+) -> Result<Option<DateTime<Utc>>, ReportingUsageQueryError> {
+    value
+        .map(|timestamp| {
+            DateTime::parse_from_rfc3339(timestamp)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|_| ReportingUsageQueryError::InvalidTimestamp)
+        })
+        .transpose()
+}
+
+fn validate_time_range(
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+) -> Result<(), ReportingUsageQueryError> {
+    if end_time < start_time {
+        return Err(ReportingUsageQueryError::InvalidTimeRange);
+    }
+    if end_time - start_time > Duration::days(MAX_REPORTING_USAGE_RANGE_DAYS) {
+        return Err(ReportingUsageQueryError::TimeRangeTooLarge {
+            max_days: MAX_REPORTING_USAGE_RANGE_DAYS,
+        });
+    }
+    Ok(())
+}
+
+fn normalize_time_range(
+    start_time: Option<DateTime<Utc>>,
+    end_time: Option<DateTime<Utc>>,
+) -> Result<(DateTime<Utc>, DateTime<Utc>), ReportingUsageQueryError> {
+    let end_time = end_time.unwrap_or_else(Utc::now);
+    let start_time =
+        start_time.unwrap_or_else(|| end_time - Duration::days(MAX_REPORTING_USAGE_RANGE_DAYS));
+    validate_time_range(start_time, end_time)?;
+    Ok((start_time, end_time))
+}

--- a/crates/api/src/routes/reporting_usage/schemas.rs
+++ b/crates/api/src/routes/reporting_usage/schemas.rs
@@ -1,0 +1,140 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::{ReportingUsageRowSource, ReportingUsageSource};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageExportResponse {
+    pub data: Vec<ReportingUsageExportRow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageExportRow {
+    pub source: ReportingUsageRowSource,
+    pub id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference: Option<ReportingInferenceUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<ReportingServiceUsage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingInferenceUsage {
+    pub model: String,
+    pub inference_type: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub input_cost_nano_usd: i64,
+    pub output_cost_nano_usd: i64,
+    /// Omitted when Cloud API has not persisted a separate cache-read cost split.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_cost_nano_usd: Option<i64>,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<Uuid>,
+    /// Customer-facing request correlation id for v1 reporting.
+    ///
+    /// Reporting intentionally excludes upstream provider request ids and provider-attribution fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_count: Option<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingServiceUsage {
+    pub service_name: String,
+    pub quantity: i64,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageSummaryResponse {
+    pub source: ReportingUsageSource,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub totals: ReportingUsageTotals,
+    pub by_workspace: Vec<ReportingWorkspaceSummary>,
+    pub by_api_key: Vec<ReportingApiKeySummary>,
+    pub by_model: Vec<ReportingModelSummary>,
+    pub by_service: Vec<ReportingServiceSummary>,
+    pub by_day: Vec<ReportingDaySummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageTotals {
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub inference_cost_nano_usd: i64,
+    pub service_cost_nano_usd: i64,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingWorkspaceSummary {
+    pub workspace_id: Uuid,
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingApiKeySummary {
+    pub api_key_id: Uuid,
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingModelSummary {
+    pub model: String,
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingServiceSummary {
+    pub service_name: String,
+    pub usage_count: i64,
+    pub quantity: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingDaySummary {
+    pub day: String,
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub inference_cost_nano_usd: i64,
+    pub service_cost_nano_usd: i64,
+    pub total_cost_nano_usd: i64,
+}

--- a/crates/api/src/routes/reporting_usage/summary.rs
+++ b/crates/api/src/routes/reporting_usage/summary.rs
@@ -1,0 +1,148 @@
+use super::{
+    ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams, ReportingUsageSource,
+    ReportingUsageSummaryResponse, RouteError,
+};
+use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Extension, Json,
+};
+use services::reporting_usage::{
+    InferenceUsageSummary, InferenceUsageSummaryRepository, ReportingUsageSummaryFilters,
+    ServiceUsageSummary, ServiceUsageSummaryRepository,
+};
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ReportingUsageSummaryState {
+    inference_repo: Arc<dyn InferenceUsageSummaryRepository>,
+    service_repo: Arc<dyn ServiceUsageSummaryRepository>,
+}
+
+impl ReportingUsageSummaryState {
+    pub fn new(
+        inference_repo: Arc<dyn InferenceUsageSummaryRepository>,
+        service_repo: Arc<dyn ServiceUsageSummaryRepository>,
+    ) -> Self {
+        Self {
+            inference_repo,
+            service_repo,
+        }
+    }
+}
+
+/// Summarize organization usage and costs.
+///
+/// Requires a reporting token scoped to the organization in the path. Totals
+/// include inference and platform service usage by default.
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/usage/summary",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID"),
+        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. The range between start_time and end_time must not exceed 366 days."),
+        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Must be greater than or equal to start_time when both are provided."),
+        ("source" = Option<ReportingUsageSource>, Query, description = "Usage source to summarize. Defaults to all."),
+        ("workspace_id" = Option<Uuid>, Query, description = "Filter by workspace ID."),
+        ("api_key_id" = Option<Uuid>, Query, description = "Filter by API key ID."),
+        ("model" = Option<String>, Query, description = "Filter inference usage by model name."),
+        ("inference_type" = Option<String>, Query, description = "Filter inference usage by inference type."),
+        ("service_name" = Option<String>, Query, description = "Filter service usage by platform service name.")
+    ),
+    responses(
+        (status = 200, description = "Usage summary", body = ReportingUsageSummaryResponse),
+        (status = 400, description = "Invalid filters", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Reporting token is not scoped to this organization", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("reporting_token" = [])
+    )
+)]
+pub async fn summary_usage(
+    State(state): State<ReportingUsageSummaryState>,
+    Extension(reporting_token): Extension<AuthenticatedReportingToken>,
+    Path(org_id): Path<Uuid>,
+    Query(params): Query<ReportingUsageQueryParams>,
+) -> Result<Json<ReportingUsageSummaryResponse>, RouteError> {
+    ensure_token_matches_org(&reporting_token, org_id)?;
+    let query = ReportingUsageQuery::try_from(params).map_err(query_error)?;
+    let filters = summary_filters(org_id, &query);
+
+    let inference = match query.source {
+        ReportingUsageSource::All | ReportingUsageSource::Inference => state
+            .inference_repo
+            .summarize_inference_usage(&filters)
+            .await
+            .map_err(|_| internal_error("Failed to summarize inference usage"))?,
+        ReportingUsageSource::Service => InferenceUsageSummary::default(),
+    };
+    let service = match query.source {
+        ReportingUsageSource::All | ReportingUsageSource::Service => state
+            .service_repo
+            .summarize_service_usage(&filters)
+            .await
+            .map_err(|_| internal_error("Failed to summarize service usage"))?,
+        ReportingUsageSource::Inference => ServiceUsageSummary::default(),
+    };
+
+    Ok(Json(super::summary_merge::summary_response(
+        query, inference, service,
+    )))
+}
+
+fn summary_filters(
+    organization_id: Uuid,
+    query: &ReportingUsageQuery,
+) -> ReportingUsageSummaryFilters {
+    ReportingUsageSummaryFilters {
+        organization_id,
+        start_time: query.start_time,
+        end_time: query.end_time,
+        workspace_id: query.workspace_id,
+        api_key_id: query.api_key_id,
+        model: query.model.clone(),
+        inference_type: query.inference_type.map(|value| value.as_str().to_string()),
+        service_name: query.service_name.clone(),
+    }
+}
+
+fn ensure_token_matches_org(
+    reporting_token: &AuthenticatedReportingToken,
+    org_id: Uuid,
+) -> Result<(), RouteError> {
+    if reporting_token.organization_id == org_id {
+        return Ok(());
+    }
+    Err((
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new(
+            "Reporting token is not authorized for this organization.".to_string(),
+            "forbidden".to_string(),
+        )),
+    ))
+}
+
+fn query_error(error: ReportingUsageQueryError) -> RouteError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(
+            error.to_string(),
+            "invalid_reporting_usage_query".to_string(),
+        )),
+    )
+}
+
+fn internal_error(message: &str) -> RouteError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            message.to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
+}

--- a/crates/api/src/routes/reporting_usage/summary_merge.rs
+++ b/crates/api/src/routes/reporting_usage/summary_merge.rs
@@ -1,0 +1,204 @@
+use super::{
+    ReportingApiKeySummary, ReportingDaySummary, ReportingModelSummary, ReportingServiceSummary,
+    ReportingUsageQuery, ReportingUsageSummaryResponse, ReportingUsageTotals,
+    ReportingWorkspaceSummary,
+};
+use chrono::{DateTime, Utc};
+use services::reporting_usage::{InferenceUsageSummary, ServiceUsageSummary};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+pub(super) fn summary_response(
+    query: ReportingUsageQuery,
+    inference: InferenceUsageSummary,
+    service: ServiceUsageSummary,
+) -> ReportingUsageSummaryResponse {
+    ReportingUsageSummaryResponse {
+        source: query.source,
+        start_time: query.start_time.unwrap_or(DateTime::<Utc>::UNIX_EPOCH),
+        end_time: query.end_time.unwrap_or_else(Utc::now),
+        totals: totals(&inference, &service),
+        by_workspace: by_workspace(&inference, &service),
+        by_api_key: by_api_key(&inference, &service),
+        by_model: by_model(&inference),
+        by_service: by_service(&service),
+        by_day: by_day(&service, &inference),
+    }
+}
+
+fn totals(
+    inference: &InferenceUsageSummary,
+    service: &ServiceUsageSummary,
+) -> ReportingUsageTotals {
+    let inference_cost = inference.totals.total_cost_nano_usd;
+    let service_cost = service.totals.total_cost_nano_usd;
+    ReportingUsageTotals {
+        request_count: inference.totals.request_count,
+        service_usage_count: service.totals.usage_count,
+        input_tokens: inference.totals.input_tokens,
+        output_tokens: inference.totals.output_tokens,
+        cache_read_tokens: inference.totals.cache_read_tokens,
+        total_tokens: inference.totals.total_tokens,
+        inference_cost_nano_usd: inference_cost,
+        service_cost_nano_usd: service_cost,
+        total_cost_nano_usd: inference_cost + service_cost,
+        total_cost_usd: None,
+    }
+}
+
+fn by_workspace(
+    inference: &InferenceUsageSummary,
+    service: &ServiceUsageSummary,
+) -> Vec<ReportingWorkspaceSummary> {
+    let mut rows: BTreeMap<Uuid, ReportingWorkspaceSummary> = BTreeMap::new();
+    for item in &inference.by_workspace {
+        rows.insert(
+            item.workspace_id,
+            ReportingWorkspaceSummary {
+                workspace_id: item.workspace_id,
+                request_count: item.request_count,
+                service_usage_count: 0,
+                total_cost_nano_usd: item.total_cost_nano_usd,
+            },
+        );
+    }
+    for item in &service.by_workspace {
+        let row = rows
+            .entry(item.workspace_id)
+            .or_insert(ReportingWorkspaceSummary {
+                workspace_id: item.workspace_id,
+                request_count: 0,
+                service_usage_count: 0,
+                total_cost_nano_usd: 0,
+            });
+        row.service_usage_count += item.usage_count;
+        row.total_cost_nano_usd += item.total_cost_nano_usd;
+    }
+    sorted_workspace(rows)
+}
+
+fn by_api_key(
+    inference: &InferenceUsageSummary,
+    service: &ServiceUsageSummary,
+) -> Vec<ReportingApiKeySummary> {
+    let mut rows: BTreeMap<Uuid, ReportingApiKeySummary> = BTreeMap::new();
+    for item in &inference.by_api_key {
+        rows.insert(
+            item.api_key_id,
+            ReportingApiKeySummary {
+                api_key_id: item.api_key_id,
+                request_count: item.request_count,
+                service_usage_count: 0,
+                total_cost_nano_usd: item.total_cost_nano_usd,
+            },
+        );
+    }
+    for item in &service.by_api_key {
+        let row = rows
+            .entry(item.api_key_id)
+            .or_insert(ReportingApiKeySummary {
+                api_key_id: item.api_key_id,
+                request_count: 0,
+                service_usage_count: 0,
+                total_cost_nano_usd: 0,
+            });
+        row.service_usage_count += item.usage_count;
+        row.total_cost_nano_usd += item.total_cost_nano_usd;
+    }
+    sorted_api_key(rows)
+}
+
+fn by_model(inference: &InferenceUsageSummary) -> Vec<ReportingModelSummary> {
+    inference
+        .by_model
+        .iter()
+        .map(|item| ReportingModelSummary {
+            model: item.model.clone(),
+            request_count: item.request_count,
+            input_tokens: item.input_tokens,
+            output_tokens: item.output_tokens,
+            cache_read_tokens: item.cache_read_tokens,
+            total_tokens: item.total_tokens,
+            total_cost_nano_usd: item.total_cost_nano_usd,
+        })
+        .collect()
+}
+
+fn by_service(service: &ServiceUsageSummary) -> Vec<ReportingServiceSummary> {
+    service
+        .by_service
+        .iter()
+        .map(|item| ReportingServiceSummary {
+            service_name: item.service_name.clone(),
+            usage_count: item.usage_count,
+            quantity: item.quantity,
+            total_cost_nano_usd: item.total_cost_nano_usd,
+        })
+        .collect()
+}
+
+fn by_day(
+    service: &ServiceUsageSummary,
+    inference: &InferenceUsageSummary,
+) -> Vec<ReportingDaySummary> {
+    let mut rows: BTreeMap<String, ReportingDaySummary> = BTreeMap::new();
+    for item in &inference.by_day {
+        rows.insert(
+            item.day.clone(),
+            ReportingDaySummary {
+                day: item.day.clone(),
+                request_count: item.request_count,
+                service_usage_count: 0,
+                input_tokens: item.input_tokens,
+                output_tokens: item.output_tokens,
+                cache_read_tokens: item.cache_read_tokens,
+                total_tokens: item.total_tokens,
+                inference_cost_nano_usd: item.total_cost_nano_usd,
+                service_cost_nano_usd: 0,
+                total_cost_nano_usd: item.total_cost_nano_usd,
+            },
+        );
+    }
+    for item in &service.by_day {
+        let row = rows.entry(item.day.clone()).or_insert(ReportingDaySummary {
+            day: item.day.clone(),
+            request_count: 0,
+            service_usage_count: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            total_tokens: 0,
+            inference_cost_nano_usd: 0,
+            service_cost_nano_usd: 0,
+            total_cost_nano_usd: 0,
+        });
+        row.service_usage_count += item.usage_count;
+        row.service_cost_nano_usd += item.total_cost_nano_usd;
+        row.total_cost_nano_usd += item.total_cost_nano_usd;
+    }
+    rows.into_values().collect()
+}
+
+fn sorted_workspace(
+    rows: BTreeMap<Uuid, ReportingWorkspaceSummary>,
+) -> Vec<ReportingWorkspaceSummary> {
+    let mut values: Vec<_> = rows.into_values().collect();
+    values.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+    });
+    values
+}
+
+fn sorted_api_key(rows: BTreeMap<Uuid, ReportingApiKeySummary>) -> Vec<ReportingApiKeySummary> {
+    let mut values: Vec<_> = rows.into_values().collect();
+    values.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.api_key_id.cmp(&right.api_key_id))
+    });
+    values
+}

--- a/crates/api/src/routes/reporting_usage/tests.rs
+++ b/crates/api/src/routes/reporting_usage/tests.rs
@@ -1,0 +1,241 @@
+use super::{
+    ReportingInferenceUsage, ReportingUsageCursor, ReportingUsageExportResponse,
+    ReportingUsageExportRow, ReportingUsageQuery, ReportingUsageQueryError,
+    ReportingUsageQueryParams, ReportingUsageRowSource, ReportingUsageSource,
+    ReportingUsageSummaryResponse, ReportingUsageTotals,
+};
+use chrono::{DateTime, Duration, Utc};
+use serde_json::json;
+use uuid::Uuid;
+
+fn ts(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+#[test]
+fn reporting_usage_query_defaults_and_cursor_roundtrip() {
+    // Given: no optional filters and a stable inference cursor tuple.
+    let params = ReportingUsageQueryParams::default();
+    let created_at = ts("2026-07-01T12:34:56Z");
+    let id = Uuid::parse_str("018f7e4c-1234-7abc-9234-123456789abc").unwrap();
+    let cursor = ReportingUsageCursor::new(created_at, ReportingUsageRowSource::Inference, id);
+
+    // When: the boundary DTO is parsed and the cursor is encoded/decoded.
+    let query = ReportingUsageQuery::try_from(params).unwrap();
+    let encoded = cursor.encode().unwrap();
+    let decoded = ReportingUsageCursor::decode(&encoded).unwrap();
+
+    // Then: defaults match the public contract and the cursor is stable and URL-safe.
+    assert_eq!(query.source, ReportingUsageSource::All);
+    assert_eq!(query.limit.value(), 100);
+    assert!(query.start_time.is_some());
+    assert!(query.end_time.is_some());
+    assert_eq!(decoded, cursor);
+    assert_eq!(cursor.encode().unwrap(), encoded);
+    assert!(!encoded.contains('+'));
+    assert!(!encoded.contains('/'));
+    assert!(!encoded.contains('='));
+}
+
+#[test]
+fn reporting_usage_query_normalizes_open_ended_ranges() {
+    // Given: open-ended reporting queries that would otherwise be unbounded.
+    let before_default = Utc::now();
+    let default_query =
+        ReportingUsageQuery::try_from(ReportingUsageQueryParams::default()).unwrap();
+    let after_default = Utc::now();
+    let explicit_end = ts("2026-07-01T00:00:00Z");
+    let end_only = ReportingUsageQueryParams {
+        end_time: Some(explicit_end.to_rfc3339()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let recent_start = Utc::now() - Duration::days(1);
+    let start_only = ReportingUsageQueryParams {
+        start_time: Some(recent_start.to_rfc3339()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let stale_start = ReportingUsageQueryParams {
+        start_time: Some((Utc::now() - Duration::days(367)).to_rfc3339()),
+        ..ReportingUsageQueryParams::default()
+    };
+
+    // When: the boundary DTOs are parsed.
+    let end_only_query = ReportingUsageQuery::try_from(end_only).unwrap();
+    let start_only_query = ReportingUsageQuery::try_from(start_only).unwrap();
+    let stale_result = ReportingUsageQuery::try_from(stale_start);
+
+    // Then: every accepted query has an effective range no wider than 366 days.
+    let default_start = default_query.start_time.unwrap();
+    let default_end = default_query.end_time.unwrap();
+    assert!(default_end >= before_default);
+    assert!(default_end <= after_default);
+    assert_eq!(default_end - default_start, Duration::days(366));
+    assert_eq!(end_only_query.end_time, Some(explicit_end));
+    assert_eq!(
+        end_only_query.start_time,
+        Some(explicit_end - Duration::days(366))
+    );
+    assert_eq!(start_only_query.start_time, Some(recent_start));
+    assert!(start_only_query.end_time.unwrap() >= recent_start);
+    assert!(matches!(
+        stale_result,
+        Err(ReportingUsageQueryError::TimeRangeTooLarge { max_days: 366 })
+    ));
+}
+
+#[test]
+fn reporting_usage_query_rejects_invalid_range_source_and_cursor() {
+    // Given: malformed query values for each boundary validation class.
+    let bad_order = ReportingUsageQueryParams {
+        start_time: Some("2026-07-02T00:00:00Z".to_string()),
+        end_time: Some("2026-07-01T00:00:00Z".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let too_wide = ReportingUsageQueryParams {
+        start_time: Some("2026-01-01T00:00:00Z".to_string()),
+        end_time: Some("2027-01-03T00:00:00Z".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let bad_source = ReportingUsageQueryParams {
+        source: Some("database".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let excessive_limit = ReportingUsageQueryParams {
+        limit: Some(1001),
+        ..ReportingUsageQueryParams::default()
+    };
+    let malformed_cursor = ReportingUsageQueryParams {
+        cursor: Some("not%base64url".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let wrong_cursor_schema = ReportingUsageQueryParams {
+        cursor: Some(
+            ReportingUsageCursor::encode_raw_for_tests(&json!({
+                "created_at": "2026-07-01T00:00:00Z"
+            }))
+            .unwrap(),
+        ),
+        ..ReportingUsageQueryParams::default()
+    };
+
+    // When/Then: each invalid shape is rejected with the intended typed error.
+    assert!(matches!(
+        ReportingUsageQuery::try_from(bad_order),
+        Err(ReportingUsageQueryError::InvalidTimeRange)
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(too_wide),
+        Err(ReportingUsageQueryError::TimeRangeTooLarge { max_days: 366 })
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(bad_source),
+        Err(ReportingUsageQueryError::InvalidSource(_))
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(excessive_limit),
+        Err(ReportingUsageQueryError::LimitTooLarge { max: 1000 })
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(malformed_cursor),
+        Err(ReportingUsageQueryError::InvalidCursor)
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(wrong_cursor_schema),
+        Err(ReportingUsageQueryError::InvalidCursor)
+    ));
+}
+
+#[test]
+fn reporting_usage_query_manual_codec_serializes_response_and_cursor() {
+    // Given: a valid query, export row, summary body, and stable cursor tuple.
+    let created_at = ts("2026-07-01T12:34:56Z");
+    let row_id = Uuid::parse_str("018f7e4c-1234-7abc-9234-123456789abc").unwrap();
+    let workspace_id = Uuid::parse_str("018f7e4c-2222-7abc-9234-123456789abc").unwrap();
+    let api_key_id = Uuid::parse_str("018f7e4c-3333-7abc-9234-123456789abc").unwrap();
+    let cursor = ReportingUsageCursor::new(created_at, ReportingUsageRowSource::Inference, row_id);
+    let query = ReportingUsageQuery::try_from(ReportingUsageQueryParams {
+        start_time: Some("2026-07-01T00:00:00Z".to_string()),
+        end_time: Some("2026-07-02T00:00:00Z".to_string()),
+        source: Some("all".to_string()),
+        limit: Some(1),
+        ..ReportingUsageQueryParams::default()
+    })
+    .unwrap();
+
+    let export = ReportingUsageExportResponse {
+        data: vec![ReportingUsageExportRow {
+            source: ReportingUsageRowSource::Inference,
+            id: row_id,
+            created_at,
+            workspace_id,
+            api_key_id,
+            total_cost_nano_usd: 42,
+            total_cost_usd: Some("$0.000000042".to_string()),
+            inference: Some(ReportingInferenceUsage {
+                model: "test-model".to_string(),
+                inference_type: "chat_completion".to_string(),
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_read_tokens: 3,
+                total_tokens: 33,
+                input_cost_nano_usd: 10,
+                output_cost_nano_usd: 29,
+                cache_read_cost_nano_usd: None,
+                total_cost_nano_usd: 42,
+                response_id: None,
+                inference_id: Some(row_id),
+                image_count: None,
+            }),
+            service: None,
+        }],
+        next_cursor: Some(cursor.encode().unwrap()),
+    };
+    let summary = ReportingUsageSummaryResponse {
+        source: ReportingUsageSource::All,
+        start_time: query.start_time.unwrap(),
+        end_time: query.end_time.unwrap(),
+        totals: ReportingUsageTotals {
+            request_count: 1,
+            service_usage_count: 0,
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 3,
+            total_tokens: 33,
+            inference_cost_nano_usd: 42,
+            service_cost_nano_usd: 0,
+            total_cost_nano_usd: 42,
+            total_cost_usd: Some("$0.000000042".to_string()),
+        },
+        by_workspace: Vec::new(),
+        by_api_key: Vec::new(),
+        by_model: Vec::new(),
+        by_service: Vec::new(),
+        by_day: Vec::new(),
+    };
+
+    // When: response bodies serialize and the cursor is decoded.
+    let encoded = cursor.encode().unwrap();
+    let decoded = ReportingUsageCursor::decode(&encoded).unwrap();
+    let export_json = serde_json::to_string(&export).unwrap();
+    let summary_json = serde_json::to_string(&summary).unwrap();
+
+    // Then: the cursor tuple and response JSON are exact enough for CLI/data QA.
+    assert_eq!(decoded.created_at, created_at);
+    assert_eq!(decoded.source, ReportingUsageRowSource::Inference);
+    assert_eq!(decoded.id, row_id);
+    assert!(export_json.contains("\"total_cost_nano_usd\":42"));
+    assert!(export_json.contains("\"cache_read_tokens\":3"));
+    assert!(!export_json.contains("cache_read_cost_nano_usd"));
+    assert!(summary_json.contains("\"inference_cost_nano_usd\":42"));
+    println!("cursor={encoded}");
+    println!(
+        "cursor_tuple={}|{}|{}",
+        decoded.created_at.to_rfc3339(),
+        decoded.source.as_str(),
+        decoded.id
+    );
+    println!("export_json={export_json}");
+    println!("summary_json={summary_json}");
+}

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -9,9 +9,12 @@ use axum::{
     response::Json as ResponseJson,
     Extension,
 };
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
-use services::{organization::OrganizationError, usage::UsageServiceTrait};
+use services::{
+    organization::OrganizationError,
+    usage::{InferenceUsageHistoryQuery, InferenceUsageReportRow, UsageServiceTrait},
+};
 use subtle::ConstantTimeEq;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -224,6 +227,23 @@ pub struct UsageHistoryQuery {
     pub limit: i64,
     #[serde(default)]
     pub offset: i64,
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+}
+
+impl UsageHistoryQuery {
+    const fn has_filters(&self) -> bool {
+        self.start_date.is_some()
+            || self.end_date.is_some()
+            || self.start_time.is_some()
+            || self.end_time.is_some()
+            || self.workspace_id.is_some()
+            || self.api_key_id.is_some()
+    }
 }
 
 /// Service usage history entry (platform services like web_search).
@@ -344,6 +364,10 @@ pub async fn get_organization_usage_history(
 
     let organization_id = check_org_membership(&app_state, user, &org_id).await?;
 
+    if query.has_filters() {
+        return get_filtered_organization_usage_history(&app_state, organization_id, &query).await;
+    }
+
     let (history, total) = app_state
         .usage_service
         .get_usage_history(organization_id, Some(query.limit), Some(query.offset))
@@ -388,6 +412,179 @@ pub async fn get_organization_usage_history(
         limit: query.limit,
         offset: query.offset,
     }))
+}
+
+async fn get_filtered_organization_usage_history(
+    app_state: &AppState,
+    organization_id: Uuid,
+    query: &UsageHistoryQuery,
+) -> Result<ResponseJson<UsageHistoryResponse>, UsageError> {
+    let report_query = usage_history_report_query(organization_id, query)?;
+    let (history, total) = app_state
+        .usage_service
+        .list_inference_usage_history(report_query)
+        .await
+        .map_err(|_| internal_usage_history_error("Failed to retrieve usage history"))?;
+
+    let data = history
+        .into_iter()
+        .map(usage_report_row_response)
+        .collect::<Result<Vec<_>, _>>()?;
+    let total = usize::try_from(total)
+        .map_err(|_| internal_usage_history_error("Invalid usage history total"))?;
+
+    Ok(ResponseJson(UsageHistoryResponse {
+        data,
+        total,
+        limit: query.limit,
+        offset: query.offset,
+    }))
+}
+
+fn usage_history_report_query(
+    organization_id: Uuid,
+    query: &UsageHistoryQuery,
+) -> Result<InferenceUsageHistoryQuery, UsageError> {
+    let params = crate::routes::reporting_usage::ReportingUsageQueryParams {
+        start_time: usage_history_start_time(query)?,
+        end_time: usage_history_end_time(query)?,
+        source: Some("inference".to_string()),
+        workspace_id: query.workspace_id,
+        api_key_id: query.api_key_id,
+        model: None,
+        inference_type: None,
+        service_name: None,
+        limit: Some(
+            u16::try_from(query.limit)
+                .map_err(|_| usage_history_query_bad_request("Limit cannot exceed 1000"))?,
+        ),
+        cursor: None,
+    };
+    let parsed = crate::routes::reporting_usage::ReportingUsageQuery::try_from(params)
+        .map_err(usage_history_query_error)?;
+
+    Ok(InferenceUsageHistoryQuery {
+        organization_id,
+        start_time: parsed.start_time,
+        end_time: parsed.end_time,
+        workspace_id: parsed.workspace_id,
+        api_key_id: parsed.api_key_id,
+        limit: query.limit,
+        offset: query.offset,
+    })
+}
+
+fn usage_history_start_time(query: &UsageHistoryQuery) -> Result<Option<String>, UsageError> {
+    match query.start_time.as_ref() {
+        Some(value) => Ok(Some(value.clone())),
+        None => normalize_usage_history_date(query.start_date.as_deref(), DateBoundary::Start),
+    }
+}
+
+fn usage_history_end_time(query: &UsageHistoryQuery) -> Result<Option<String>, UsageError> {
+    match query.end_time.as_ref() {
+        Some(value) => Ok(Some(value.clone())),
+        None => normalize_usage_history_date(query.end_date.as_deref(), DateBoundary::End),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DateBoundary {
+    Start,
+    End,
+}
+
+fn normalize_usage_history_date(
+    value: Option<&str>,
+    boundary: DateBoundary,
+) -> Result<Option<String>, UsageError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    if DateTime::parse_from_rfc3339(raw).is_ok() {
+        return Ok(Some(raw.to_string()));
+    }
+
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d").map_err(|_| {
+        usage_history_query_error(
+            crate::routes::reporting_usage::ReportingUsageQueryError::InvalidTimestamp,
+        )
+    })?;
+    let time = match boundary {
+        DateBoundary::Start => date.and_hms_nano_opt(0, 0, 0, 0),
+        DateBoundary::End => date.and_hms_nano_opt(23, 59, 59, 999_999_999),
+    }
+    .ok_or_else(|| {
+        usage_history_query_error(
+            crate::routes::reporting_usage::ReportingUsageQueryError::InvalidTimestamp,
+        )
+    })?;
+
+    Ok(Some(
+        DateTime::<Utc>::from_naive_utc_and_offset(time, Utc).to_rfc3339(),
+    ))
+}
+
+fn usage_report_row_response(
+    row: InferenceUsageReportRow,
+) -> Result<UsageHistoryEntryResponse, UsageError> {
+    Ok(UsageHistoryEntryResponse {
+        id: row.id.to_string(),
+        workspace_id: row.workspace_id.to_string(),
+        api_key_id: row.api_key_id.to_string(),
+        model: row.model,
+        input_tokens: checked_usage_history_i32(row.input_tokens, "input_tokens")?,
+        output_tokens: checked_usage_history_i32(row.output_tokens, "output_tokens")?,
+        cache_read_tokens: checked_usage_history_i32(row.cache_read_tokens, "cache_read_tokens")?,
+        total_tokens: checked_usage_history_i32(row.total_tokens, "total_tokens")?,
+        total_cost: row.total_cost_nano_usd,
+        total_cost_display: format_amount(row.total_cost_nano_usd),
+        inference_type: row.inference_type,
+        created_at: row.created_at.to_rfc3339(),
+        stop_reason: row.stop_reason,
+        response_id: row.response_id.map(|id| id.to_string()),
+        provider_request_id: None,
+        inference_id: row.inference_id.map(|id| id.to_string()),
+        image_count: row.image_count,
+    })
+}
+
+fn checked_usage_history_i32(value: i64, field: &str) -> Result<i32, UsageError> {
+    i32::try_from(value)
+        .map_err(|_| internal_usage_history_error(&format!("Invalid usage history {field}")))
+}
+
+fn usage_history_query_error(
+    error: crate::routes::reporting_usage::ReportingUsageQueryError,
+) -> UsageError {
+    (
+        StatusCode::BAD_REQUEST,
+        ResponseJson(ErrorResponse::new(
+            error.to_string(),
+            "invalid_reporting_usage_query".to_string(),
+        )),
+    )
+}
+
+fn usage_history_query_bad_request(message: &str) -> UsageError {
+    (
+        StatusCode::BAD_REQUEST,
+        ResponseJson(ErrorResponse::new(
+            message.to_string(),
+            "invalid_parameter".to_string(),
+        )),
+    )
+}
+
+fn internal_usage_history_error(message: &str) -> UsageError {
+    tracing::error!("{message}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        ResponseJson(ErrorResponse::new(
+            message.to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
 }
 
 /// Get service usage history for an organization

--- a/crates/api/src/routes/workspaces.rs
+++ b/crates/api/src/routes/workspaces.rs
@@ -154,6 +154,48 @@ impl From<WorkspaceOrderDirection> for services::workspace::WorkspaceOrderDirect
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ListApiKeysParams {
+    #[serde(default = "crate::routes::common::default_limit")]
+    pub limit: i64,
+    #[serde(default)]
+    pub offset: i64,
+    pub order_by: Option<ApiKeyOrderBy>,
+    pub order_direction: Option<ApiKeyOrderDirection>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiKeyOrderBy {
+    CreatedAt,
+    Usage,
+}
+
+impl From<ApiKeyOrderBy> for services::workspace::ApiKeyOrderBy {
+    fn from(value: ApiKeyOrderBy) -> Self {
+        match value {
+            ApiKeyOrderBy::CreatedAt => Self::CreatedAt,
+            ApiKeyOrderBy::Usage => Self::Usage,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiKeyOrderDirection {
+    Asc,
+    Desc,
+}
+
+impl From<ApiKeyOrderDirection> for services::workspace::ApiKeyOrderDirection {
+    fn from(value: ApiKeyOrderDirection) -> Self {
+        match value {
+            ApiKeyOrderDirection::Asc => Self::Asc,
+            ApiKeyOrderDirection::Desc => Self::Desc,
+        }
+    }
+}
+
 // ============================================
 // Workspace Management Routes
 // ============================================
@@ -772,7 +814,9 @@ pub async fn create_workspace_api_key(
     params(
         ("workspace_id" = Uuid, Path, description = "Workspace ID"),
         ("limit" = Option<i64>, Query, description = "Maximum number of results (default: 20)"),
-        ("offset" = Option<i64>, Query, description = "Number of results to skip (default: 0)")
+        ("offset" = Option<i64>, Query, description = "Number of results to skip (default: 0)"),
+        ("order_by" = Option<ApiKeyOrderBy>, Query, description = "Field to order by: created_at or usage"),
+        ("order_direction" = Option<ApiKeyOrderDirection>, Query, description = "Sort direction: asc or desc")
     ),
     responses(
         (status = 200, description = "Paginated list of workspace API keys", body = ListApiKeysResponse),
@@ -789,7 +833,7 @@ pub async fn list_workspace_api_keys(
     State(app_state): State<AppState>,
     Extension(user): Extension<AuthenticatedUser>,
     Path(workspace_id): Path<Uuid>,
-    Query(params): Query<ListParams>,
+    Query(params): Query<ListApiKeysParams>,
 ) -> Result<Json<ListApiKeysResponse>, (StatusCode, Json<ErrorResponse>)> {
     debug!(
         "Listing API keys for workspace: {} by user: {} (limit: {}, offset: {})",
@@ -837,9 +881,18 @@ pub async fn list_workspace_api_keys(
     };
 
     // Use workspace service to list workspace API keys with pagination and usage data
+    let order_by = params.order_by.map(Into::into);
+    let order_direction = params.order_direction.map(Into::into);
     match app_state
         .workspace_service
-        .list_api_keys_paginated(workspace_id_typed, user_id, params.limit, params.offset)
+        .list_api_keys_paginated(
+            workspace_id_typed,
+            user_id,
+            params.limit,
+            params.offset,
+            order_by,
+            order_direction,
+        )
         .await
     {
         Ok(api_keys) => {

--- a/crates/api/tests/e2e_all/api_keys.rs
+++ b/crates/api/tests/e2e_all/api_keys.rs
@@ -89,6 +89,97 @@ async fn test_list_workspace_api_keys() {
 }
 
 #[tokio::test]
+async fn test_list_workspace_api_keys_orders_by_usage() {
+    let (server, database) = setup_test_server_with_database().await;
+    let org = create_org(&server).await;
+    let workspaces = list_workspaces(&server, org.id.clone()).await;
+    let workspace = workspaces.first().unwrap();
+    let model_name = setup_qwen_model(&server).await;
+
+    let unused_key =
+        create_api_key_in_workspace(&server, workspace.id.clone(), "Unused Key".to_string()).await;
+    let low_spend_key =
+        create_api_key_in_workspace(&server, workspace.id.clone(), "Low Spend Key".to_string())
+            .await;
+    let high_spend_key =
+        create_api_key_in_workspace(&server, workspace.id.clone(), "High Spend Key".to_string())
+            .await;
+
+    let organization_id = uuid::Uuid::parse_str(&org.id).unwrap();
+    let workspace_id = uuid::Uuid::parse_str(&workspace.id).unwrap();
+    let low_spend_key_id = uuid::Uuid::parse_str(&low_spend_key.id).unwrap();
+    let high_spend_key_id = uuid::Uuid::parse_str(&high_spend_key.id).unwrap();
+    let client = database.pool().get().await.unwrap();
+    let model_id: uuid::Uuid = client
+        .query_one(
+            "SELECT id FROM models WHERE model_name = $1",
+            &[&model_name],
+        )
+        .await
+        .unwrap()
+        .get(0);
+
+    for (api_key_id, total_cost) in [
+        (low_spend_key_id, 100_000_000_i64),
+        (high_spend_key_id, 300_000_000_i64),
+    ] {
+        client
+            .execute(
+                r#"
+                INSERT INTO organization_usage_log (
+                    id, organization_id, workspace_id, api_key_id,
+                    model_id, model_name, input_tokens, output_tokens,
+                    total_tokens, input_cost, output_cost, total_cost,
+                    inference_type, created_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, 10, 10, 20, 1, 1, $7,
+                          'chat_completion', NOW())
+                "#,
+                &[
+                    &uuid::Uuid::new_v4(),
+                    &organization_id,
+                    &workspace_id,
+                    &api_key_id,
+                    &model_id,
+                    &model_name,
+                    &total_cost,
+                ],
+            )
+            .await
+            .unwrap();
+    }
+
+    let desc_response = server
+        .get(
+            format!(
+                "/v1/workspaces/{}/api-keys?limit=2&order_by=usage&order_direction=desc",
+                workspace.id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .await;
+    assert_eq!(desc_response.status_code(), 200);
+    let desc_list = desc_response.json::<api::models::ListApiKeysResponse>();
+    assert_eq!(desc_list.api_keys[0].id, high_spend_key.id);
+    assert_eq!(desc_list.api_keys[1].id, low_spend_key.id);
+
+    let asc_response = server
+        .get(
+            format!(
+                "/v1/workspaces/{}/api-keys?limit=2&order_by=usage&order_direction=asc",
+                workspace.id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .await;
+    assert_eq!(asc_response.status_code(), 200);
+    let asc_list = asc_response.json::<api::models::ListApiKeysResponse>();
+    assert_eq!(asc_list.api_keys[0].id, unused_key.id);
+    assert_eq!(asc_list.api_keys[1].id, low_spend_key.id);
+}
+
+#[tokio::test]
 async fn test_api_key_prevents_duplicate_names_in_workspace() {
     let server = setup_test_server().await;
     let org = create_org(&server).await;

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -52,6 +52,7 @@ mod privacy_classify;
 mod privacy_redact;
 mod provider_errors;
 mod reasoning;
+mod reporting_usage;
 mod repositories;
 mod rerank;
 mod response_signature_verification;

--- a/crates/api/tests/e2e_all/reporting_usage.rs
+++ b/crates/api/tests/e2e_all/reporting_usage.rs
@@ -1,0 +1,94 @@
+use crate::common::{get_session_id, setup_test_server_with_database, MOCK_USER_AGENT};
+use chrono::{Duration, Utc};
+use database::Database;
+use serde_json::Value;
+use std::sync::Arc;
+
+mod token_auth;
+mod token_management;
+mod usage_export;
+mod usage_export_fixture;
+mod usage_summary;
+
+include!("reporting_usage/session_history.rs");
+
+fn bearer(token: &str) -> String {
+    format!("Bearer {token}")
+}
+
+fn assert_json_has_no_secret_fields(value: &Value) {
+    let text = value.to_string();
+    assert!(
+        !text.contains("token_hash"),
+        "JSON response must not expose token_hash: {text}"
+    );
+    assert!(
+        !text.contains("raw_token"),
+        "JSON response must not expose raw_token: {text}"
+    );
+    assert_no_raw_token_field(value);
+}
+
+fn assert_no_raw_token_field(value: &Value) {
+    match value {
+        Value::Object(map) => {
+            assert!(
+                !map.contains_key("token"),
+                "JSON response must not expose raw token field: {value}"
+            );
+            for child in map.values() {
+                assert_no_raw_token_field(child);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                assert_no_raw_token_field(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redact_create_response(value: &Value) -> Value {
+    let mut redacted = value.clone();
+    if let Value::Object(map) = &mut redacted {
+        map.insert(
+            "token".to_string(),
+            Value::String("rpt-<redacted>".to_string()),
+        );
+    }
+    redacted
+}
+
+async fn setup_reporting_usage_server() -> (axum_test::TestServer, Arc<Database>) {
+    init_reporting_usage_tracing();
+    setup_test_server_with_database().await
+}
+
+fn init_reporting_usage_tracing() {
+    let filter = tracing_subscriber::EnvFilter::new("debug,tokio_postgres=info");
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(filter)
+        .try_init();
+}
+
+async fn create_reporting_token(server: &axum_test::TestServer, org_id: &str) -> String {
+    let response = server
+        .post(format!("/v1/organizations/{org_id}/reporting-tokens").as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "name": "reporting auth probe",
+            "expires_at": (Utc::now() + Duration::days(30)).to_rfc3339(),
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 201, "{}", response.text());
+    response
+        .json::<Value>()
+        .get("token")
+        .and_then(Value::as_str)
+        .expect("create response should include raw reporting token once")
+        .to_string()
+}

--- a/crates/api/tests/e2e_all/reporting_usage/session_history.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/session_history.rs
@@ -1,0 +1,225 @@
+use crate::common::{
+    create_api_key_in_workspace, create_org, list_workspaces, setup_qwen_model,
+};
+use chrono::{DateTime, TimeZone};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn session_usage_history_filters() {
+    // Given: one org has usage on two dates and another row on the filtered date in a different workspace/API key.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_session_history_fixture(&server, &database).await;
+
+    // When: the session-authenticated history endpoint receives dashboard-style filters.
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/history?start_date=2026-07-02&end_date=2026-07-02&workspace_id={}&api_key_id={}&limit=10&offset=0",
+                fixture.org_id, fixture.workspace_id, fixture.api_key_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: only the row matching the date, workspace, and API key filters is returned.
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body = response.json::<api::routes::usage::UsageHistoryResponse>();
+    assert_eq!(body.total, 1, "filtered total should count only matching rows");
+    assert_eq!(body.limit, 10);
+    assert_eq!(body.offset, 0);
+    assert_eq!(body.data.len(), 1);
+    let row = &body.data[0];
+    assert_eq!(row.workspace_id, fixture.workspace_id);
+    assert_eq!(row.api_key_id, fixture.api_key_id);
+    assert_eq!(row.created_at, ts(2026, 7, 2).to_rfc3339());
+    assert_eq!(row.total_cost, 700);
+    assert_eq!(row.stop_reason.as_deref(), Some("completed"));
+    assert_eq!(row.provider_request_id, None);
+
+    let manual = serde_json::json!({
+        "status": 200,
+        "total": body.total,
+        "limit": body.limit,
+        "offset": body.offset,
+        "data": body.data,
+    });
+    assert_no_private_session_history_fields(&manual);
+    println!("manual GET /usage/history filtered session 200 {manual}");
+}
+
+#[tokio::test]
+async fn session_usage_history_rejects_invalid_filter_range() {
+    // Given: an organization with session-authenticated usage history access.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_session_history_fixture(&server, &database).await;
+
+    // When: the dashboard-style date range is inverted.
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/history?start_date=2026-07-03&end_date=2026-07-01&limit=10&offset=0",
+                fixture.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: the session route rejects the malformed filter with the existing error envelope.
+    assert_eq!(response.status_code(), 400, "{}", response.text());
+    let body = response.json::<Value>();
+    assert_no_private_session_history_fields(&body);
+    println!("manual GET /usage/history invalid session range 400 {body}");
+}
+
+struct SessionHistoryFixture {
+    org_id: String,
+    workspace_id: String,
+    api_key_id: String,
+}
+
+async fn seed_session_history_fixture(
+    server: &axum_test::TestServer,
+    database: &Arc<Database>,
+) -> SessionHistoryFixture {
+    let org = create_org(server).await;
+    let model = setup_qwen_model(server).await;
+    let workspaces = list_workspaces(server, org.id.clone()).await;
+    let workspace_id = workspaces
+        .first()
+        .expect("default workspace should exist")
+        .id
+        .clone();
+    let api_key = create_api_key_in_workspace(
+        server,
+        workspace_id.clone(),
+        "session history filtered key".to_string(),
+    )
+    .await;
+
+    let other_workspace = create_workspace(server, &org.id).await;
+    let other_api_key = create_api_key_in_workspace(
+        server,
+        other_workspace.clone(),
+        "session history excluded key".to_string(),
+    )
+    .await;
+
+    insert_inference_usage_row(
+        database,
+        &org.id,
+        &workspace_id,
+        &api_key.id,
+        &model,
+        ts(2026, 7, 1),
+        500,
+    )
+    .await;
+    insert_inference_usage_row(
+        database,
+        &org.id,
+        &workspace_id,
+        &api_key.id,
+        &model,
+        ts(2026, 7, 2),
+        700,
+    )
+    .await;
+    insert_inference_usage_row(
+        database,
+        &org.id,
+        &other_workspace,
+        &other_api_key.id,
+        &model,
+        ts(2026, 7, 2),
+        900,
+    )
+    .await;
+
+    SessionHistoryFixture {
+        org_id: org.id,
+        workspace_id,
+        api_key_id: api_key.id,
+    }
+}
+
+async fn create_workspace(server: &axum_test::TestServer, org_id: &str) -> String {
+    let request = api::routes::workspaces::CreateWorkspaceRequest {
+        name: format!("session-history-{}", Uuid::new_v4()),
+        description: Some("session history filter fixture".to_string()),
+    };
+    let response = server
+        .post(format!("/v1/organizations/{org_id}/workspaces").as_str())
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&request)
+        .await;
+    assert_eq!(response.status_code(), 201, "{}", response.text());
+    response
+        .json::<api::routes::workspaces::WorkspaceResponse>()
+        .id
+}
+
+async fn insert_inference_usage_row(
+    database: &Arc<Database>,
+    org_id: &str,
+    workspace_id: &str,
+    api_key_id: &str,
+    model: &str,
+    created_at: DateTime<Utc>,
+    total_cost: i64,
+) {
+    let client = database.pool().get().await.expect("db connection");
+    let model_id: Uuid = client
+        .query_one("SELECT id FROM models WHERE model_name = $1", &[&model])
+        .await
+        .expect("model id")
+        .get("id");
+
+    client
+        .execute(
+            r#"
+            INSERT INTO organization_usage_log (
+                id, organization_id, workspace_id, api_key_id, model_id, model_name,
+                input_tokens, output_tokens, cache_read_tokens, total_tokens,
+                input_cost, output_cost, total_cost, request_type, inference_type,
+                created_at, inference_id, stop_reason
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, 4, 3, 1, 8, $7, 300, $8,
+                NULL, 'chat_completion', $9, $10, 'completed')
+            "#,
+            &[
+                &Uuid::new_v4(),
+                &Uuid::parse_str(org_id).expect("org uuid"),
+                &Uuid::parse_str(workspace_id).expect("workspace uuid"),
+                &Uuid::parse_str(api_key_id).expect("api key uuid"),
+                &model_id,
+                &model,
+                &(total_cost - 300),
+                &total_cost,
+                &created_at,
+                &Some(Uuid::new_v4()),
+            ],
+        )
+        .await
+        .expect("insert inference usage");
+}
+
+fn assert_no_private_session_history_fields(value: &Value) {
+    let text = value.to_string();
+    for private in ["prompt", "response_body", "file", "token_hash", "Authorization", "Bearer"] {
+        assert!(
+            !text.contains(private),
+            "private field leaked: {private}: {text}"
+        );
+    }
+}
+
+fn ts(year: i32, month: u32, day: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, 0, 0, 0)
+        .single()
+        .expect("fixture timestamp")
+}

--- a/crates/api/tests/e2e_all/reporting_usage/token_auth.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/token_auth.rs
@@ -1,0 +1,212 @@
+use super::{bearer, create_reporting_token, setup_reporting_usage_server};
+use crate::common::{create_org, get_session_id, MOCK_USER_AGENT, MOCK_USER_ID};
+use chrono::{Duration, Utc};
+use serde_json::Value;
+use services::reporting_tokens::ports::{
+    CreateOrganizationReportingTokenRequest, OrganizationReportingTokenRepository as _,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn reporting_token_auth_allows_reporting_only() {
+    // Given: a reporting token issued for an organization.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let raw_token = create_reporting_token(&server, &org.id).await;
+
+    // When: the token calls the reporting-authenticated probe route.
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/reporting-token-auth-probe",
+                org.id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: the probe sees the read-only reporting token context.
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body = response.json::<Value>();
+    assert_eq!(body["organization_id"], org.id);
+    assert_eq!(body["token_prefix"], raw_token[..12]);
+    assert_eq!(body["scope"], "usage:read");
+    assert!(
+        body.get("token").is_none(),
+        "probe response must not expose raw reporting token"
+    );
+    let listed = server
+        .get(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await
+        .json::<Value>();
+    let used_token = listed["reporting_tokens"]
+        .as_array()
+        .expect("reporting_tokens should be an array")
+        .iter()
+        .find(|token| token["token_prefix"] == raw_token[..12])
+        .expect("validated token should still be listed");
+    assert!(
+        used_token["last_used_at"].as_str().is_some(),
+        "successful reporting-token auth should update last_used_at"
+    );
+    println!("manual GET /usage/reporting-token-auth-probe 200 {body}");
+}
+
+#[tokio::test]
+async fn reporting_token_auth_rejects_invalid_revoked_expired_and_org_mismatch() {
+    // Given: active, revoked, and expired reporting tokens across two organizations.
+    let (server, database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let other_org = create_org(&server).await;
+    let active_token = create_reporting_token(&server, &org.id).await;
+    let revoked_token = create_reporting_token(&server, &org.id).await;
+    let expired = database
+        .organization_reporting_tokens
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id: Uuid::parse_str(&org.id).expect("org id should be uuid"),
+            name: "expired reporting token".to_string(),
+            created_by_user_id: Uuid::parse_str(MOCK_USER_ID).expect("mock user id should be uuid"),
+            expires_at: Some(Utc::now() - Duration::minutes(1)),
+        })
+        .await
+        .expect("expired reporting token fixture should be created");
+    let revoked_list = server
+        .get(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await
+        .json::<Value>();
+    let revoked_id = revoked_list["reporting_tokens"]
+        .as_array()
+        .expect("reporting_tokens should be an array")
+        .iter()
+        .find(|token| token["token_prefix"] == revoked_token[..12])
+        .and_then(|token| token["id"].as_str())
+        .expect("revoked token id should be listed before revoke")
+        .to_string();
+    let revoke_response = server
+        .delete(format!("/v1/organizations/{}/reporting-tokens/{revoked_id}", org.id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(
+        revoke_response.status_code(),
+        204,
+        "{}",
+        revoke_response.text()
+    );
+
+    let probe_url = format!(
+        "/v1/organizations/{}/usage/reporting-token-auth-probe",
+        org.id
+    );
+
+    // When/Then: missing, non-Bearer, malformed, revoked, and expired credentials are rejected.
+    let missing = server.get(&probe_url).await;
+    assert_eq!(missing.status_code(), 401, "{}", missing.text());
+
+    let non_bearer = server
+        .get(&probe_url)
+        .add_header("Authorization", "Basic rpt-not-a-bearer")
+        .await;
+    assert_eq!(non_bearer.status_code(), 401, "{}", non_bearer.text());
+
+    let malformed = server
+        .get(&probe_url)
+        .add_header("Authorization", "Bearer rpt-short")
+        .await;
+    assert_eq!(malformed.status_code(), 401, "{}", malformed.text());
+
+    let revoked = server
+        .get(&probe_url)
+        .add_header("Authorization", bearer(&revoked_token))
+        .await;
+    assert_eq!(revoked.status_code(), 401, "{}", revoked.text());
+
+    let expired_response = server
+        .get(&probe_url)
+        .add_header("Authorization", bearer(&expired.raw_token))
+        .await;
+    assert_eq!(
+        expired_response.status_code(),
+        401,
+        "{}",
+        expired_response.text()
+    );
+
+    // When: a valid reporting token is used against a different organization's route.
+    let mismatch = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/reporting-token-auth-probe",
+                other_org.id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&active_token))
+        .await;
+
+    // Then: the route rejects the org mismatch after authentication.
+    assert_eq!(mismatch.status_code(), 403, "{}", mismatch.text());
+}
+
+#[tokio::test]
+async fn reporting_token_cannot_infer_or_mutate() {
+    // Given: a reporting token issued for an organization.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let raw_token = create_reporting_token(&server, &org.id).await;
+
+    // When: the reporting token attempts to call data-plane and management routes.
+    let inference = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", bearer(&raw_token))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "messages": [{"role": "user", "content": "hello"}]
+        }))
+        .await;
+    let workspace_mutation = server
+        .post(format!("/v1/organizations/{}/workspaces", org.id).as_str())
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "must not create" }))
+        .await;
+    let token_management = server
+        .post(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "must not create" }))
+        .await;
+    let session_management = server
+        .delete("/v1/users/me/tokens")
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: reporting tokens do not authorize inference, workspace, token management,
+    // or session management routes.
+    assert_eq!(inference.status_code(), 401, "{}", inference.text());
+    assert_eq!(
+        workspace_mutation.status_code(),
+        401,
+        "{}",
+        workspace_mutation.text()
+    );
+    assert_eq!(
+        token_management.status_code(),
+        401,
+        "{}",
+        token_management.text()
+    );
+    assert_eq!(
+        session_management.status_code(),
+        401,
+        "{}",
+        session_management.text()
+    );
+}

--- a/crates/api/tests/e2e_all/reporting_usage/token_management.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/token_management.rs
@@ -1,0 +1,187 @@
+use super::{
+    assert_json_has_no_secret_fields, bearer, redact_create_response, setup_reporting_usage_server,
+};
+use crate::common::{create_org, get_session_id, setup_unique_test_session, MOCK_USER_AGENT};
+use chrono::{Duration, Utc};
+use serde_json::Value;
+
+#[tokio::test]
+async fn reporting_token_management() {
+    // Given: an organization owned by the authenticated session user.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let url = format!("/v1/organizations/{}/reporting-tokens", org.id);
+
+    // When: the owner creates a reporting token.
+    let create_response = server
+        .post(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "name": "finance export",
+            "expires_at": (Utc::now() + Duration::days(30)).to_rfc3339(),
+        }))
+        .await;
+
+    // Then: the create response exposes the raw token exactly once and no hash.
+    assert_eq!(
+        create_response.status_code(),
+        201,
+        "{}",
+        create_response.text()
+    );
+    let created = create_response.json::<Value>();
+    let raw_token = created
+        .get("token")
+        .and_then(Value::as_str)
+        .expect("create response should include raw reporting token once");
+    assert!(
+        raw_token.starts_with("rpt-"),
+        "raw reporting token should use rpt- prefix"
+    );
+    assert_eq!(
+        created.to_string().matches(raw_token).count(),
+        1,
+        "raw reporting token should appear exactly once in create response"
+    );
+    assert!(
+        !created.to_string().contains("token_hash"),
+        "create response must not expose token_hash"
+    );
+    println!(
+        "manual POST /reporting-tokens 201 {}",
+        redact_create_response(&created)
+    );
+    let token_id = created
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("create response should include token id")
+        .to_string();
+
+    // When: the owner lists reporting tokens.
+    let list_response = server
+        .get(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: list includes metadata only and never includes raw token material.
+    assert_eq!(list_response.status_code(), 200, "{}", list_response.text());
+    let listed = list_response.json::<Value>();
+    assert_json_has_no_secret_fields(&listed);
+    println!("manual GET /reporting-tokens 200 {listed}");
+    let tokens = listed
+        .get("reporting_tokens")
+        .and_then(Value::as_array)
+        .expect("list response should include reporting_tokens array");
+    assert_eq!(
+        tokens.len(),
+        1,
+        "created token should be listed while active"
+    );
+    assert_eq!(tokens[0]["id"], token_id);
+    assert_eq!(tokens[0]["name"], "finance export");
+
+    // When: the owner revokes the reporting token.
+    let revoke_response = server
+        .delete(format!("{url}/{token_id}").as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: the token is revoked and absent from active listings.
+    assert_eq!(
+        revoke_response.status_code(),
+        204,
+        "{}",
+        revoke_response.text()
+    );
+    println!("manual DELETE /reporting-tokens/{{token_id}} 204");
+    let after_revoke_response = server
+        .get(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(
+        after_revoke_response.status_code(),
+        200,
+        "{}",
+        after_revoke_response.text()
+    );
+    let after_revoke = after_revoke_response.json::<Value>();
+    assert_json_has_no_secret_fields(&after_revoke);
+    println!("manual GET /reporting-tokens after revoke 200 {after_revoke}");
+    assert_eq!(
+        after_revoke["reporting_tokens"]
+            .as_array()
+            .expect("reporting_tokens should be an array")
+            .len(),
+        0,
+        "revoked token should not appear in active token list"
+    );
+}
+
+#[tokio::test]
+async fn reporting_token_management_forbidden_for_non_member() {
+    // Given: an organization owned by the default test session and a second user
+    // who is not a member of that organization.
+    let (server, database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let (other_session, _email) = setup_unique_test_session(&database).await;
+
+    // When: the non-member attempts to create a reporting token.
+    let response = server
+        .post(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&other_session))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "unauthorized export" }))
+        .await;
+
+    // Then: the management route denies cross-org access.
+    assert_eq!(response.status_code(), 403, "{}", response.text());
+}
+
+#[tokio::test]
+async fn reporting_token_management_rejects_malformed_input() {
+    // Given: an organization owned by the authenticated session user.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let url = format!("/v1/organizations/{}/reporting-tokens", org.id);
+
+    // When/Then: empty names are rejected.
+    let empty_name = server
+        .post(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "" }))
+        .await;
+    assert_eq!(empty_name.status_code(), 400, "{}", empty_name.text());
+
+    // When/Then: invalid organization ids are rejected at the HTTP boundary.
+    let invalid_org = server
+        .get("/v1/organizations/not-a-uuid/reporting-tokens")
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(invalid_org.status_code(), 400, "{}", invalid_org.text());
+
+    // When/Then: invalid token ids are rejected at the HTTP boundary.
+    let invalid_token = server
+        .delete(format!("{url}/not-a-uuid").as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(invalid_token.status_code(), 400, "{}", invalid_token.text());
+
+    // When/Then: already-expired reporting tokens are rejected.
+    let past_expiry = server
+        .post(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "name": "already expired",
+            "expires_at": (Utc::now() - Duration::minutes(1)).to_rfc3339(),
+        }))
+        .await;
+    assert_eq!(past_expiry.status_code(), 400, "{}", past_expiry.text());
+}

--- a/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
@@ -1,0 +1,233 @@
+use super::usage_export_fixture::{
+    assert_no_private_export_fields, redacted_export, seed_export_fixture, url_ts, ExportFixture,
+};
+use super::{bearer, setup_reporting_usage_server};
+use crate::common::{create_org, get_session_id, MOCK_USER_AGENT};
+use serde_json::Value;
+
+#[tokio::test]
+async fn usage_export() {
+    // Given: one organization with inference and service usage sharing a timestamp.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let base = format!(
+        "/v1/organizations/{}/usage/export?start_time={}&end_time={}&workspace_id={}&api_key_id={}",
+        fixture.org_id,
+        url_ts(2026, 7, 1),
+        url_ts(2026, 7, 4),
+        fixture.workspace_id,
+        fixture.api_key_id
+    );
+
+    // When: the mixed export is fetched with a small page size.
+    let first = server
+        .get(format!("{base}&source=all&limit=2").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: rows are merged by created_at, source, id and return a cursor.
+    assert_eq!(first.status_code(), 200, "{}", first.text());
+    let first_body = first.json::<Value>();
+    assert_no_private_export_fields(&first_body);
+    let first_rows = first_body["data"]
+        .as_array()
+        .expect("data should be an array");
+    assert_eq!(first_rows.len(), 2);
+    assert_eq!(first_rows[0]["source"], "service");
+    assert_eq!(first_rows[1]["source"], "service");
+    let cursor = first_body["next_cursor"]
+        .as_str()
+        .expect("first page should include next_cursor");
+    println!(
+        "manual GET /usage/export source=all limit=2 200 {}",
+        redacted_export(&first_body)
+    );
+
+    // When: the next cursor is used.
+    let second = server
+        .get(format!("{base}&source=all&limit=2&cursor={cursor}").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: continuation returns the tied inference row without duplicate/skip.
+    assert_eq!(second.status_code(), 200, "{}", second.text());
+    let second_body = second.json::<Value>();
+    assert_no_private_export_fields(&second_body);
+    let second_rows = second_body["data"]
+        .as_array()
+        .expect("data should be an array");
+    assert_eq!(second_rows.len(), 2);
+    assert_eq!(second_rows[0]["source"], "inference");
+    assert_eq!(second_rows[1]["source"], "inference");
+    assert!(second_body.get("next_cursor").is_none());
+
+    // When/Then: source-specific filters return only applicable rows.
+    let inference = get_export(
+        &server,
+        &fixture,
+        format!("{base}&source=inference&model={}", fixture.model),
+    )
+    .await;
+    assert_eq!(inference["data"].as_array().expect("array").len(), 2);
+    assert!(inference["data"].as_array().expect("array")[0]["service"].is_null());
+
+    let service = get_export(
+        &server,
+        &fixture,
+        format!(
+            "{base}&source=service&service_name={}",
+            fixture.service_name
+        ),
+    )
+    .await;
+    assert_eq!(service["data"].as_array().expect("array").len(), 2);
+    assert!(service["data"].as_array().expect("array")[0]["inference"].is_null());
+
+    let empty = get_export(
+        &server,
+        &fixture,
+        format!("{base}&source=inference&model=none"),
+    )
+    .await;
+    assert!(empty["data"].as_array().expect("array").is_empty());
+    assert!(empty.get("next_cursor").is_none());
+}
+
+#[tokio::test]
+async fn usage_export_omits_cache_read_cost_when_not_separately_persisted() {
+    // Given: persisted inference usage includes cached tokens but no separate cache-read cost column.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let url = format!(
+        "/v1/organizations/{}/usage/export?start_time={}&end_time={}&source=inference&workspace_id={}&api_key_id={}&model={}",
+        fixture.org_id,
+        url_ts(2026, 7, 1),
+        url_ts(2026, 7, 4),
+        fixture.workspace_id,
+        fixture.api_key_id,
+        fixture.model
+    );
+
+    // When: inference usage is exported.
+    let body = get_export(&server, &fixture, url).await;
+
+    // Then: the cache token count is reported, but no cache-read cost is invented.
+    let rows = body["data"].as_array().expect("data should be an array");
+    assert_eq!(rows.len(), 2);
+    let inference = &rows[0]["inference"];
+    assert_eq!(inference["cache_read_tokens"].as_i64(), Some(1));
+    assert_eq!(inference["input_cost_nano_usd"].as_i64(), Some(400));
+    assert_eq!(inference["output_cost_nano_usd"].as_i64(), Some(300));
+    assert_eq!(inference["total_cost_nano_usd"].as_i64(), Some(700));
+    assert!(
+        inference.get("cache_read_cost_nano_usd").is_none(),
+        "cache-read cost split should be omitted when unavailable: {inference}"
+    );
+    println!(
+        "manual GET /usage/export source=inference cache_read_cost_nano_usd omitted contract 200 {}",
+        redacted_export(&body)
+    );
+}
+
+#[tokio::test]
+async fn usage_export_rejects_bad_input_and_bad_auth_scope() {
+    // Given: two organizations and one active reporting token.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let other_org = create_org(&server).await;
+
+    // When/Then: malformed input is rejected by the shared validators.
+    let invalid_range = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?start_time={}&end_time={}",
+                fixture.org_id,
+                url_ts(2026, 7, 4),
+                url_ts(2026, 7, 1)
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(invalid_range.status_code(), 400, "{}", invalid_range.text());
+
+    let invalid_cursor = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?cursor=bad",
+                fixture.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(
+        invalid_cursor.status_code(),
+        400,
+        "{}",
+        invalid_cursor.text()
+    );
+
+    // When: a token from one org calls another org export.
+    let mismatch = server
+        .get(format!("/v1/organizations/{}/usage/export", other_org.id).as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+
+    // Then: org mismatch uses the established forbidden envelope.
+    assert_eq!(mismatch.status_code(), 403, "{}", mismatch.text());
+    println!(
+        "manual GET /usage/export org mismatch 403 {}",
+        mismatch.text()
+    );
+
+    // When/Then: revoked reporting tokens cannot export usage.
+    revoke_reporting_token(&server, &fixture).await;
+    let revoked = server
+        .get(format!("/v1/organizations/{}/usage/export", fixture.org_id).as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(revoked.status_code(), 401, "{}", revoked.text());
+}
+
+async fn get_export(server: &axum_test::TestServer, fixture: &ExportFixture, url: String) -> Value {
+    let response = server
+        .get(&url)
+        .add_header("Authorization", bearer(&fixture.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body = response.json::<Value>();
+    assert_no_private_export_fields(&body);
+    body
+}
+
+async fn revoke_reporting_token(server: &axum_test::TestServer, fixture: &ExportFixture) {
+    let list = server
+        .get(format!("/v1/organizations/{}/reporting-tokens", fixture.org_id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await
+        .json::<Value>();
+    let token_id = list["reporting_tokens"]
+        .as_array()
+        .expect("tokens array")
+        .iter()
+        .find(|token| token["token_prefix"] == fixture.token[..12])
+        .and_then(|token| token["id"].as_str())
+        .expect("token id");
+    let response = server
+        .delete(
+            format!(
+                "/v1/organizations/{}/reporting-tokens/{token_id}",
+                fixture.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(response.status_code(), 204, "{}", response.text());
+}

--- a/crates/api/tests/e2e_all/reporting_usage/usage_export_fixture.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_export_fixture.rs
@@ -1,0 +1,174 @@
+use super::create_reporting_token;
+use crate::common::{
+    create_api_key_in_workspace, create_org, get_or_create_web_search_service, list_workspaces,
+    setup_qwen_model,
+};
+use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+use database::Database;
+use serde_json::Value;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub struct ExportFixture {
+    pub org_id: String,
+    pub token: String,
+    pub workspace_id: String,
+    pub api_key_id: String,
+    pub model: String,
+    pub service_name: String,
+}
+
+pub async fn seed_export_fixture(
+    server: &axum_test::TestServer,
+    database: &Arc<Database>,
+) -> ExportFixture {
+    let org = create_org(server).await;
+    let workspaces = list_workspaces(server, org.id.clone()).await;
+    let workspace_id = workspaces
+        .first()
+        .expect("workspace should exist")
+        .id
+        .clone();
+    let api_key = create_api_key_in_workspace(
+        server,
+        workspace_id.clone(),
+        "reporting export key".to_string(),
+    )
+    .await;
+    let model = setup_qwen_model(server).await;
+    let service = get_or_create_web_search_service(server).await;
+    let token = create_reporting_token(server, &org.id).await;
+
+    insert_inference_usage(database, &org.id, &workspace_id, &api_key.id, &model).await;
+    insert_service_usage(database, &org.id, &workspace_id, &api_key.id, service.id).await;
+
+    ExportFixture {
+        org_id: org.id,
+        token,
+        workspace_id,
+        api_key_id: api_key.id,
+        model,
+        service_name: service.service_name,
+    }
+}
+
+pub fn assert_no_private_export_fields(value: &Value) {
+    let text = value.to_string();
+    for private in [
+        "provider_request_id",
+        "prompt",
+        "response_body",
+        "file",
+        "token_hash",
+        "Authorization",
+        "Bearer",
+        "rpt-",
+    ] {
+        assert!(
+            !text.contains(private),
+            "private field leaked: {private}: {text}"
+        );
+    }
+}
+
+pub fn redacted_export(value: &Value) -> Value {
+    let mut redacted = value.clone();
+    if let Some(cursor) = redacted.get_mut("next_cursor") {
+        *cursor = Value::String("<redacted-cursor>".to_string());
+    }
+    redacted
+}
+
+pub fn ts(year: i32, month: u32, day: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, 0, 0, 0)
+        .single()
+        .expect("fixture timestamp")
+}
+
+pub fn url_ts(year: i32, month: u32, day: u32) -> String {
+    ts(year, month, day).to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+async fn insert_inference_usage(
+    database: &Arc<Database>,
+    org_id: &str,
+    workspace_id: &str,
+    api_key_id: &str,
+    model: &str,
+) {
+    let client = database.pool().get().await.expect("db connection");
+    let model_id: Uuid = client
+        .query_one("SELECT id FROM models WHERE model_name = $1", &[&model])
+        .await
+        .expect("model id")
+        .get("id");
+    for (created_at, input_tokens, total_cost) in
+        [(ts(2026, 7, 2), 7, 700_i64), (ts(2026, 7, 1), 5, 500_i64)]
+    {
+        client
+            .execute(
+                r#"
+                INSERT INTO organization_usage_log (
+                    id, organization_id, workspace_id, api_key_id, model_id, model_name,
+                    input_tokens, output_tokens, cache_read_tokens, total_tokens,
+                    input_cost, output_cost, total_cost, request_type, inference_type,
+                    created_at, inference_id, stop_reason
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, 3, 1, $8, $9, 300, $10,
+                    NULL, 'chat_completion', $11, $12, 'completed')
+                "#,
+                &[
+                    &Uuid::new_v4(),
+                    &Uuid::parse_str(org_id).expect("org uuid"),
+                    &Uuid::parse_str(workspace_id).expect("workspace uuid"),
+                    &Uuid::parse_str(api_key_id).expect("api key uuid"),
+                    &model_id,
+                    &model,
+                    &input_tokens,
+                    &(input_tokens + 3),
+                    &(total_cost - 300),
+                    &total_cost,
+                    &created_at,
+                    &Some(Uuid::new_v4()),
+                ],
+            )
+            .await
+            .expect("insert inference usage");
+    }
+}
+
+async fn insert_service_usage(
+    database: &Arc<Database>,
+    org_id: &str,
+    workspace_id: &str,
+    api_key_id: &str,
+    service_id: Uuid,
+) {
+    let client = database.pool().get().await.expect("db connection");
+    for (created_at, quantity, total_cost) in
+        [(ts(2026, 7, 3), 1, 100_i64), (ts(2026, 7, 2), 2, 200_i64)]
+    {
+        client
+            .execute(
+                r#"
+                INSERT INTO organization_service_usage_log (
+                    id, organization_id, workspace_id, api_key_id, service_id,
+                    quantity, total_cost, inference_id, created_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, $8)
+                "#,
+                &[
+                    &Uuid::new_v4(),
+                    &Uuid::parse_str(org_id).expect("org uuid"),
+                    &Uuid::parse_str(workspace_id).expect("workspace uuid"),
+                    &Uuid::parse_str(api_key_id).expect("api key uuid"),
+                    &service_id,
+                    &quantity,
+                    &total_cost,
+                    &created_at,
+                ],
+            )
+            .await
+            .expect("insert service usage");
+    }
+}

--- a/crates/api/tests/e2e_all/reporting_usage/usage_summary.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_summary.rs
@@ -1,0 +1,246 @@
+use super::{
+    bearer, create_reporting_token, setup_reporting_usage_server,
+    usage_export_fixture::{
+        assert_no_private_export_fields, seed_export_fixture, url_ts, ExportFixture,
+    },
+};
+use crate::common::create_org;
+use chrono::{DateTime, Duration, Utc};
+use serde_json::Value;
+
+#[tokio::test]
+async fn usage_summary_returns_all_source_breakdowns_and_reconciles_cost() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+
+    let response = server
+        .get(default_summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let json = response.json::<Value>();
+    assert_no_private_export_fields(&json);
+    assert_totals(&json, 2, 2, 12, 6, 2, 18, 1_200, 300);
+    assert_eq!(json["totals"]["total_cost_nano_usd"], 1_500);
+    assert_eq!(json["by_workspace"][0]["request_count"], 2);
+    assert_eq!(json["by_workspace"][0]["service_usage_count"], 2);
+    assert_eq!(json["by_workspace"][0]["total_cost_nano_usd"], 1_500);
+    assert_eq!(json["by_api_key"][0]["request_count"], 2);
+    assert_eq!(json["by_api_key"][0]["service_usage_count"], 2);
+    assert_eq!(json["by_model"][0]["model"], fixture.model);
+    assert_eq!(json["by_model"][0]["total_cost_nano_usd"], 1_200);
+    assert_eq!(json["by_service"][0]["service_name"], fixture.service_name);
+    assert_eq!(json["by_service"][0]["usage_count"], 2);
+    assert_eq!(json["by_service"][0]["quantity"], 3);
+    assert_eq!(json["by_service"][0]["total_cost_nano_usd"], 300);
+    assert_day(&json, "2026-07-01", 1, 0, 500, 0);
+    assert_day(&json, "2026-07-02", 1, 1, 700, 200);
+    assert_day(&json, "2026-07-03", 0, 1, 0, 100);
+    println!(
+        "manual GET /usage/summary source=all 200 {}",
+        redacted_summary(&json)
+    );
+}
+
+#[tokio::test]
+async fn usage_summary_applies_source_specific_zero_and_empty_contracts() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+
+    let inference = get_default_summary(&server, &fixture, "source=inference").await;
+    assert_totals(&inference, 2, 0, 12, 6, 2, 18, 1_200, 0);
+    assert!(inference["by_service"]
+        .as_array()
+        .expect("by_service")
+        .is_empty());
+    assert_eq!(inference["by_model"][0]["total_cost_nano_usd"], 1_200);
+
+    let service = get_default_summary(&server, &fixture, "source=service").await;
+    assert_totals(&service, 0, 2, 0, 0, 0, 0, 0, 300);
+    assert!(service["by_model"].as_array().expect("by_model").is_empty());
+    assert_eq!(service["by_service"][0]["total_cost_nano_usd"], 300);
+}
+
+#[tokio::test]
+async fn usage_summary_honors_date_boundaries_and_filters() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let query = format!(
+        "source=all&start_time={}&end_time={}&workspace_id={}&api_key_id={}",
+        url_ts(2026, 7, 2),
+        url_ts(2026, 7, 2),
+        fixture.workspace_id,
+        fixture.api_key_id
+    );
+
+    let json = get_summary(&server, &fixture, &query).await;
+
+    assert_totals(&json, 1, 1, 7, 3, 1, 10, 700, 200);
+    assert_eq!(json["by_day"].as_array().expect("by_day").len(), 1);
+    assert_day(&json, "2026-07-02", 1, 1, 700, 200);
+}
+
+#[tokio::test]
+async fn usage_summary_normalizes_open_ended_range_defaults() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let before_request = Utc::now();
+
+    let response = server
+        .get(summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    let after_request = Utc::now();
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let json = response.json::<Value>();
+    let start_time = json_timestamp(&json, "start_time");
+    let end_time = json_timestamp(&json, "end_time");
+    assert!(end_time >= before_request);
+    assert!(end_time <= after_request);
+    assert_eq!(end_time - start_time, Duration::days(366));
+    assert_totals(&json, 2, 2, 12, 6, 2, 18, 1_200, 300);
+    println!(
+        "manual GET /usage/summary source=all open-ended 200 {}",
+        redacted_summary(&json)
+    );
+}
+
+#[tokio::test]
+async fn usage_summary_rejects_invalid_range_org_mismatch_and_revoked_token() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+
+    let invalid = server
+        .get(
+            summary_url(
+                &fixture,
+                format!(
+                    "start_time={}&end_time={}",
+                    url_ts(2026, 7, 4),
+                    url_ts(2026, 7, 1)
+                )
+                .as_str(),
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(invalid.status_code(), 400, "{}", invalid.text());
+    println!(
+        "manual GET /usage/summary invalid range 400 {}",
+        invalid.text()
+    );
+
+    let other_org = create_org(&server).await;
+    let other_token = create_reporting_token(&server, &other_org.id).await;
+    let mismatch = server
+        .get(default_summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer(&other_token))
+        .await;
+    assert_eq!(mismatch.status_code(), 403, "{}", mismatch.text());
+
+    let revoked = server
+        .get(default_summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer("rpt-revoked-or-malformed"))
+        .await;
+    assert_eq!(revoked.status_code(), 401, "{}", revoked.text());
+}
+
+async fn get_default_summary(
+    server: &axum_test::TestServer,
+    fixture: &ExportFixture,
+    query: &str,
+) -> Value {
+    get_summary(server, fixture, default_summary_query(query).as_str()).await
+}
+
+async fn get_summary(
+    server: &axum_test::TestServer,
+    fixture: &ExportFixture,
+    query: &str,
+) -> Value {
+    let response = server
+        .get(summary_url(fixture, query).as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    response.json::<Value>()
+}
+
+fn summary_url(fixture: &ExportFixture, query: &str) -> String {
+    format!(
+        "/v1/organizations/{}/usage/summary?{}",
+        fixture.org_id, query
+    )
+}
+
+fn default_summary_url(fixture: &ExportFixture, query: &str) -> String {
+    summary_url(fixture, default_summary_query(query).as_str())
+}
+
+fn default_summary_query(query: &str) -> String {
+    format!(
+        "start_time={}&end_time={}&{}",
+        url_ts(2026, 7, 1),
+        url_ts(2026, 7, 3),
+        query
+    )
+}
+
+fn assert_totals(
+    json: &Value,
+    request_count: i64,
+    service_usage_count: i64,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    total_tokens: i64,
+    inference_cost: i64,
+    service_cost: i64,
+) {
+    let totals = &json["totals"];
+    assert_eq!(totals["request_count"], request_count);
+    assert_eq!(totals["service_usage_count"], service_usage_count);
+    assert_eq!(totals["input_tokens"], input_tokens);
+    assert_eq!(totals["output_tokens"], output_tokens);
+    assert_eq!(totals["cache_read_tokens"], cache_read_tokens);
+    assert_eq!(totals["total_tokens"], total_tokens);
+    assert_eq!(totals["inference_cost_nano_usd"], inference_cost);
+    assert_eq!(totals["service_cost_nano_usd"], service_cost);
+    assert_eq!(totals["total_cost_nano_usd"], inference_cost + service_cost);
+}
+
+fn assert_day(
+    json: &Value,
+    day: &str,
+    request_count: i64,
+    service_usage_count: i64,
+    inference_cost: i64,
+    service_cost: i64,
+) {
+    let days = json["by_day"].as_array().expect("by_day array");
+    let day_row = days
+        .iter()
+        .find(|row| row["day"] == day)
+        .unwrap_or_else(|| panic!("missing day {day}: {days:?}"));
+    assert_eq!(day_row["request_count"], request_count);
+    assert_eq!(day_row["service_usage_count"], service_usage_count);
+    assert_eq!(day_row["inference_cost_nano_usd"], inference_cost);
+    assert_eq!(day_row["service_cost_nano_usd"], service_cost);
+    assert_eq!(
+        day_row["total_cost_nano_usd"],
+        inference_cost + service_cost
+    );
+}
+
+fn json_timestamp(json: &Value, field: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(json[field].as_str().expect(field))
+        .expect(field)
+        .with_timezone(&Utc)
+}
+
+fn redacted_summary(value: &Value) -> Value {
+    value.clone()
+}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -12,10 +12,10 @@ pub use constants::*;
 pub use models::*;
 pub use pool::DbPool;
 pub use repositories::{
-    ApiKeyRepository, McpConnectorRepository, OAuthStateRepository, PgAttestationRepository,
-    PgConversationRepository, PgOrganizationInvitationRepository, PgOrganizationRepository,
-    PgResponseItemsRepository, PgResponseRepository, PostgresNearNonceRepository,
-    SessionRepository, UserRepository,
+    ApiKeyRepository, McpConnectorRepository, OAuthStateRepository,
+    OrganizationReportingTokenRepository, PgAttestationRepository, PgConversationRepository,
+    PgOrganizationInvitationRepository, PgOrganizationRepository, PgResponseItemsRepository,
+    PgResponseRepository, PostgresNearNonceRepository, SessionRepository, UserRepository,
 };
 pub use shutdown_coordinator::{ShutdownCoordinator, ShutdownStage, ShutdownStageResult};
 
@@ -35,6 +35,7 @@ pub struct Database {
     pub organizations: PgOrganizationRepository,
     pub users: UserRepository,
     pub api_keys: ApiKeyRepository,
+    pub organization_reporting_tokens: OrganizationReportingTokenRepository,
     pub sessions: SessionRepository,
     pub mcp_connectors: McpConnectorRepository,
     pub conversations: PgConversationRepository,
@@ -52,6 +53,7 @@ impl Database {
             organizations: PgOrganizationRepository::new(pool.clone()),
             users: UserRepository::new(pool.clone()),
             api_keys: ApiKeyRepository::new(pool.clone()),
+            organization_reporting_tokens: OrganizationReportingTokenRepository::new(pool.clone()),
             sessions: SessionRepository::new(pool.clone()),
             mcp_connectors: McpConnectorRepository::new(pool.clone()),
             conversations: PgConversationRepository::new(pool.clone()),

--- a/crates/database/src/migrations/out_of_band/usage_reporting_indexes.sql
+++ b/crates/database/src/migrations/out_of_band/usage_reporting_indexes.sql
@@ -1,0 +1,24 @@
+-- Usage reporting production indexes.
+--
+-- Run this script manually with psql outside refinery and outside an explicit
+-- transaction block before enabling high-volume reporting queries in production.
+-- These indexes target append-heavy usage tables, so they use CONCURRENTLY to
+-- avoid blocking writes during index builds.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_reporting_org_created_id
+    ON organization_usage_log (organization_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_reporting_org_workspace_created_id
+    ON organization_usage_log (organization_id, workspace_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_reporting_org_api_key_created_id
+    ON organization_usage_log (organization_id, api_key_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_service_usage_reporting_org_created_id
+    ON organization_service_usage_log (organization_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_service_usage_reporting_org_workspace_created_id
+    ON organization_service_usage_log (organization_id, workspace_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_service_usage_reporting_org_api_key_created_id
+    ON organization_service_usage_log (organization_id, api_key_id, created_at DESC, id DESC);

--- a/crates/database/src/migrations/sql/V0070__add_organization_reporting_tokens.sql
+++ b/crates/database/src/migrations/sql/V0070__add_organization_reporting_tokens.sql
@@ -1,0 +1,24 @@
+CREATE TABLE organization_reporting_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL CHECK (length(trim(name)) > 0),
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    token_prefix VARCHAR(16) NOT NULL,
+    created_by_user_id UUID NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+    revoked_by_user_id UUID REFERENCES users(id)
+);
+
+CREATE INDEX idx_org_reporting_tokens_hash
+    ON organization_reporting_tokens(token_hash);
+
+CREATE INDEX idx_org_reporting_tokens_active_org
+    ON organization_reporting_tokens(organization_id, created_at DESC, id DESC)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX idx_org_reporting_tokens_expiry
+    ON organization_reporting_tokens(expires_at)
+    WHERE revoked_at IS NULL AND expires_at IS NOT NULL;

--- a/crates/database/src/repositories/api_key.rs
+++ b/crates/database/src/repositories/api_key.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use services::common::{extract_api_key_prefix, generate_api_key, hash_api_key, RepositoryError};
-use services::workspace::ports::CreateApiKeyRequest;
+use services::workspace::ports::{ApiKeyOrderBy, ApiKeyOrderDirection, CreateApiKeyRequest};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -237,7 +237,25 @@ impl ApiKeyRepository {
         workspace_id: Uuid,
         limit: i64,
         offset: i64,
+        order_by: Option<ApiKeyOrderBy>,
+        order_direction: Option<ApiKeyOrderDirection>,
     ) -> Result<Vec<ApiKey>, RepositoryError> {
+        let order_by = order_by.unwrap_or(ApiKeyOrderBy::CreatedAt);
+        let order_direction = order_direction.unwrap_or(ApiKeyOrderDirection::Desc);
+
+        let order_by_column = match order_by {
+            ApiKeyOrderBy::CreatedAt => "ak.created_at",
+            ApiKeyOrderBy::Usage => "usage",
+        };
+        let order_dir = match order_direction {
+            ApiKeyOrderDirection::Asc => "ASC",
+            ApiKeyOrderDirection::Desc => "DESC",
+        };
+        let tie_breaker = match order_by {
+            ApiKeyOrderBy::CreatedAt => ", ak.id ASC",
+            ApiKeyOrderBy::Usage => ", ak.created_at DESC, ak.id ASC",
+        };
+
         let rows = retry_db!("list_api_keys_by_workspace_paginated", {
             let client = self
                 .pool
@@ -248,7 +266,8 @@ impl ApiKeyRepository {
 
             client
                 .query(
-                    r#"
+                    &format!(
+                        r#"
                 SELECT 
                     ak.id,
                     ak.key_hash,
@@ -267,9 +286,10 @@ impl ApiKeyRepository {
                 LEFT JOIN organization_usage_log usg ON ak.id = usg.api_key_id
                 WHERE ak.workspace_id = $1 AND ak.deleted_at IS NULL
                 GROUP BY ak.id
-                ORDER BY ak.created_at DESC
+                ORDER BY {order_by_column} {order_dir}{tie_breaker}
                 LIMIT $2 OFFSET $3
-                "#,
+                "#
+                    ),
                     &[&workspace_id, &limit, &offset],
                 )
                 .await
@@ -620,9 +640,11 @@ impl services::workspace::ports::ApiKeyRepository for ApiKeyRepository {
         workspace_id: services::workspace::WorkspaceId,
         limit: i64,
         offset: i64,
+        order_by: Option<services::workspace::ApiKeyOrderBy>,
+        order_direction: Option<services::workspace::ApiKeyOrderDirection>,
     ) -> Result<Vec<services::workspace::ApiKey>, RepositoryError> {
         let api_keys = self
-            .list_by_workspace_paginated(workspace_id.0, limit, offset)
+            .list_by_workspace_paginated(workspace_id.0, limit, offset, order_by, order_direction)
             .await?;
         Ok(api_keys
             .into_iter()

--- a/crates/database/src/repositories/mod.rs
+++ b/crates/database/src/repositories/mod.rs
@@ -16,8 +16,13 @@ pub mod organization;
 pub mod organization_invitation;
 pub mod organization_limits;
 pub mod organization_limits_repository_impl;
+pub mod organization_reporting_token;
+mod organization_reporting_token_row;
 pub mod organization_service_usage;
+mod organization_service_usage_reporting_summary;
 pub mod organization_usage;
+mod organization_usage_reporting;
+mod organization_usage_reporting_summary;
 pub mod response;
 pub mod response_item;
 pub mod retry;
@@ -48,6 +53,7 @@ pub use oauth_state::{OAuthStateRepository, OAuthStateRow};
 pub use organization::PgOrganizationRepository;
 pub use organization_invitation::PgOrganizationInvitationRepository;
 pub use organization_limits::OrganizationLimitsRepository;
+pub use organization_reporting_token::OrganizationReportingTokenRepository;
 pub use organization_service_usage::{
     OrganizationServiceUsageRepository, RecordServiceUsageRequest,
 };

--- a/crates/database/src/repositories/organization_reporting_token.rs
+++ b/crates/database/src/repositories/organization_reporting_token.rs
@@ -1,0 +1,263 @@
+use crate::pool::DbPool;
+use crate::repositories::organization_reporting_token_row::OrganizationReportingTokenRow;
+use crate::repositories::utils::map_db_error;
+use crate::retry_db;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use services::common::{
+    extract_reporting_token_prefix, generate_reporting_token, hash_reporting_token,
+    is_valid_reporting_token_format, RepositoryError,
+};
+use services::reporting_tokens::ports::{
+    CreateOrganizationReportingTokenRequest, CreatedOrganizationReportingToken,
+    OrganizationReportingToken, ValidatedOrganizationReportingToken,
+};
+use uuid::Uuid;
+
+pub struct OrganizationReportingTokenRepository {
+    pool: DbPool,
+}
+
+impl OrganizationReportingTokenRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    async fn create_token(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError> {
+        let name = request.name.trim().to_string();
+        if name.is_empty() {
+            return Err(RepositoryError::ValidationFailed(
+                "reporting token name cannot be empty".to_string(),
+            ));
+        }
+
+        let id = Uuid::new_v4();
+        let raw_token = generate_reporting_token();
+        let token_hash = hash_reporting_token(&raw_token);
+        let token_prefix = extract_reporting_token_prefix(&raw_token);
+
+        let row = retry_db!("create_organization_reporting_token", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_one(
+                    r#"
+                    INSERT INTO organization_reporting_tokens (
+                        id, organization_id, name, token_hash, token_prefix,
+                        created_by_user_id, expires_at
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    RETURNING *
+                    "#,
+                    &[
+                        &id,
+                        &request.organization_id,
+                        &name,
+                        &token_hash,
+                        &token_prefix,
+                        &request.created_by_user_id,
+                        &request.expires_at,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        let db_token = OrganizationReportingTokenRow::from_row(row)
+            .map_err(RepositoryError::DataConversionError)?;
+        Ok(CreatedOrganizationReportingToken {
+            token: db_token.into_service_token(),
+            raw_token,
+        })
+    }
+
+    async fn validate_token(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError> {
+        if !is_valid_reporting_token_format(raw_token) {
+            return Ok(None);
+        }
+
+        let token_hash = hash_reporting_token(raw_token);
+        let row = retry_db!("validate_organization_reporting_token", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_opt(
+                    r#"
+                    UPDATE organization_reporting_tokens
+                    SET last_used_at = NOW()
+                    WHERE token_hash = $1
+                      AND revoked_at IS NULL
+                      AND (expires_at IS NULL OR expires_at > NOW())
+                    RETURNING *
+                    "#,
+                    &[&token_hash],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        match row {
+            Some(row) => {
+                let db_token = OrganizationReportingTokenRow::from_row(row)
+                    .map_err(RepositoryError::DataConversionError)?;
+                Ok(Some(db_token.into_validated_token()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn get_token_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError> {
+        let row = retry_db!("get_organization_reporting_token_by_id", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_opt(
+                    "SELECT * FROM organization_reporting_tokens WHERE id = $1",
+                    &[&token_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        match row {
+            Some(row) => {
+                let db_token = OrganizationReportingTokenRow::from_row(row)
+                    .map_err(RepositoryError::DataConversionError)?;
+                Ok(Some(db_token.into_service_token()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn list_active_tokens_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError> {
+        let rows = retry_db!("list_active_organization_reporting_tokens", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT *
+                    FROM organization_reporting_tokens
+                    WHERE organization_id = $1
+                      AND revoked_at IS NULL
+                      AND (expires_at IS NULL OR expires_at > NOW())
+                    ORDER BY created_at DESC, id DESC
+                    "#,
+                    &[&organization_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        rows.into_iter()
+            .map(|row| {
+                let db_token = OrganizationReportingTokenRow::from_row(row)?;
+                Ok(db_token.into_service_token())
+            })
+            .collect::<Result<Vec<_>>>()
+            .map_err(RepositoryError::DataConversionError)
+    }
+
+    async fn revoke_token(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError> {
+        let rows_affected = retry_db!("revoke_organization_reporting_token", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .execute(
+                    r#"
+                    UPDATE organization_reporting_tokens
+                    SET revoked_at = NOW(), revoked_by_user_id = $2
+                    WHERE id = $1 AND revoked_at IS NULL
+                    "#,
+                    &[&token_id, &revoked_by_user_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows_affected > 0)
+    }
+}
+
+#[async_trait]
+impl services::reporting_tokens::ports::OrganizationReportingTokenRepository
+    for OrganizationReportingTokenRepository
+{
+    async fn create(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError> {
+        self.create_token(request).await
+    }
+
+    async fn validate(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError> {
+        self.validate_token(raw_token).await
+    }
+
+    async fn get_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError> {
+        self.get_token_by_id(token_id).await
+    }
+
+    async fn list_active_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError> {
+        self.list_active_tokens_by_organization(organization_id)
+            .await
+    }
+
+    async fn revoke(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError> {
+        self.revoke_token(token_id, revoked_by_user_id).await
+    }
+}

--- a/crates/database/src/repositories/organization_reporting_token_row.rs
+++ b/crates/database/src/repositories/organization_reporting_token_row.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use services::reporting_tokens::ports::{
+    OrganizationReportingToken, ValidatedOrganizationReportingToken,
+    REPORTING_TOKEN_SCOPE_USAGE_READ,
+};
+use uuid::Uuid;
+
+pub struct OrganizationReportingTokenRow {
+    id: Uuid,
+    organization_id: Uuid,
+    name: String,
+    token_prefix: String,
+    created_by_user_id: Uuid,
+    created_at: DateTime<Utc>,
+    expires_at: Option<DateTime<Utc>>,
+    last_used_at: Option<DateTime<Utc>>,
+    revoked_at: Option<DateTime<Utc>>,
+    revoked_by_user_id: Option<Uuid>,
+}
+
+impl OrganizationReportingTokenRow {
+    pub fn from_row(row: tokio_postgres::Row) -> Result<Self> {
+        Ok(Self {
+            id: row.get("id"),
+            organization_id: row.get("organization_id"),
+            name: row.get("name"),
+            token_prefix: row.get("token_prefix"),
+            created_by_user_id: row.get("created_by_user_id"),
+            created_at: row.get("created_at"),
+            expires_at: row.get("expires_at"),
+            last_used_at: row.get("last_used_at"),
+            revoked_at: row.get("revoked_at"),
+            revoked_by_user_id: row.get("revoked_by_user_id"),
+        })
+    }
+
+    pub fn into_service_token(self) -> OrganizationReportingToken {
+        OrganizationReportingToken {
+            id: self.id,
+            organization_id: self.organization_id,
+            name: self.name,
+            token_prefix: self.token_prefix,
+            created_by_user_id: self.created_by_user_id,
+            created_at: self.created_at,
+            expires_at: self.expires_at,
+            last_used_at: self.last_used_at,
+            revoked_at: self.revoked_at,
+            revoked_by_user_id: self.revoked_by_user_id,
+            scope: REPORTING_TOKEN_SCOPE_USAGE_READ,
+        }
+    }
+
+    pub fn into_validated_token(self) -> ValidatedOrganizationReportingToken {
+        ValidatedOrganizationReportingToken {
+            id: self.id,
+            organization_id: self.organization_id,
+            token_prefix: self.token_prefix,
+            last_used_at: self.last_used_at,
+            scope: REPORTING_TOKEN_SCOPE_USAGE_READ,
+        }
+    }
+}

--- a/crates/database/src/repositories/organization_service_usage.rs
+++ b/crates/database/src/repositories/organization_service_usage.rs
@@ -5,6 +5,7 @@ use crate::retry_db;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use services::common::RepositoryError;
+use services::service_usage::ports::{ServiceUsageReportEntry, ServiceUsageReportFilters};
 use tokio_postgres::Row;
 use uuid::Uuid;
 
@@ -21,7 +22,7 @@ pub struct RecordServiceUsageRequest {
 
 #[derive(Debug, Clone)]
 pub struct OrganizationServiceUsageRepository {
-    pool: DbPool,
+    pub(crate) pool: DbPool,
 }
 
 impl OrganizationServiceUsageRepository {
@@ -89,6 +90,64 @@ impl OrganizationServiceUsageRepository {
 
         let logs = rows.iter().map(|row| self.row_to_log(row)).collect();
         Ok((logs, total))
+    }
+
+    pub async fn list_reporting_usage(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> Result<Vec<ServiceUsageReportEntry>> {
+        if let (Some(start_time), Some(end_time)) = (filters.start_time, filters.end_time) {
+            anyhow::ensure!(end_time >= start_time, "invalid reporting date range");
+        }
+
+        let cursor_created_at = filters.cursor.map(|cursor| cursor.created_at);
+        let cursor_id = filters.cursor.map(|cursor| cursor.id);
+        let rows = retry_db!("list_service_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT
+                        usage_log.id, usage_log.organization_id, usage_log.workspace_id,
+                        usage_log.api_key_id, usage_log.service_id, services.service_name,
+                        usage_log.quantity, usage_log.total_cost, usage_log.inference_id,
+                        usage_log.created_at
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TEXT IS NULL OR services.service_name = $2)
+                      AND ($3::UUID IS NULL OR usage_log.workspace_id = $3)
+                      AND ($4::UUID IS NULL OR usage_log.api_key_id = $4)
+                      AND ($5::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $5)
+                      AND ($6::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $6)
+                      AND ($7::TIMESTAMPTZ IS NULL OR $8::UUID IS NULL
+                           OR (usage_log.created_at, usage_log.id) < ($7, $8))
+                    ORDER BY usage_log.created_at DESC, usage_log.id DESC
+                    LIMIT $9
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.service_name,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &cursor_created_at,
+                        &cursor_id,
+                        &filters.limit,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows.iter().map(Self::row_to_report_entry).collect())
     }
 
     /// Record service usage and update organization_balance. Idempotent when inference_id is set:
@@ -198,6 +257,21 @@ impl OrganizationServiceUsageRepository {
             workspace_id: row.get("workspace_id"),
             api_key_id: row.get("api_key_id"),
             service_id: row.get("service_id"),
+            quantity: row.get("quantity"),
+            total_cost: row.get("total_cost"),
+            inference_id: row.get("inference_id"),
+            created_at: row.get("created_at"),
+        }
+    }
+
+    fn row_to_report_entry(row: &Row) -> ServiceUsageReportEntry {
+        ServiceUsageReportEntry {
+            id: row.get("id"),
+            organization_id: row.get("organization_id"),
+            workspace_id: row.get("workspace_id"),
+            api_key_id: row.get("api_key_id"),
+            service_id: row.get("service_id"),
+            service_name: row.get("service_name"),
             quantity: row.get("quantity"),
             total_cost: row.get("total_cost"),
             inference_id: row.get("inference_id"),

--- a/crates/database/src/repositories/organization_service_usage_reporting_summary.rs
+++ b/crates/database/src/repositories/organization_service_usage_reporting_summary.rs
@@ -1,0 +1,224 @@
+use crate::repositories::{utils::map_db_error, OrganizationServiceUsageRepository};
+use crate::retry_db;
+use anyhow::{Context, Result};
+use services::{
+    common::RepositoryError,
+    reporting_usage::{
+        ReportingUsageSummaryFilters, ServiceApiKeySummary, ServiceDaySummary, ServiceNameSummary,
+        ServiceUsageSummary, ServiceUsageSummaryRepository, ServiceUsageTotals,
+        ServiceWorkspaceSummary,
+    },
+};
+use tokio_postgres::Row;
+
+impl OrganizationServiceUsageRepository {
+    pub async fn summarize_service_usage_report(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<ServiceUsageSummary> {
+        let summary = retry_db!("summarize_service_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let totals = client
+                .query_one(
+                    r#"
+                    SELECT COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_workspace = client
+                .query(
+                    r#"
+                    SELECT usage_log.workspace_id, COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY usage_log.workspace_id
+                    ORDER BY 3 DESC, usage_log.workspace_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_api_key = client
+                .query(
+                    r#"
+                    SELECT usage_log.api_key_id, COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY usage_log.api_key_id
+                    ORDER BY 3 DESC, usage_log.api_key_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_service = client
+                .query(
+                    r#"
+                    SELECT services.service_name, COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.quantity), 0)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY services.service_name
+                    ORDER BY 4 DESC, services.service_name ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_day = client
+                .query(
+                    r#"
+                    SELECT TO_CHAR(DATE_TRUNC('day', usage_log.created_at), 'YYYY-MM-DD'),
+                           COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY DATE_TRUNC('day', usage_log.created_at)
+                    ORDER BY 1 ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok::<_, RepositoryError>(ServiceUsageSummary {
+                totals: ServiceUsageTotals {
+                    usage_count: totals.get(0),
+                    total_cost_nano_usd: totals.get(1),
+                },
+                by_workspace: by_workspace.iter().map(workspace_from_row).collect(),
+                by_api_key: by_api_key.iter().map(api_key_from_row).collect(),
+                by_service: by_service.iter().map(service_from_row).collect(),
+                by_day: by_day.iter().map(day_from_row).collect(),
+            })
+        })?;
+
+        Ok(summary)
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceUsageSummaryRepository for OrganizationServiceUsageRepository {
+    async fn summarize_service_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<ServiceUsageSummary> {
+        self.summarize_service_usage_report(filters).await
+    }
+}
+
+fn workspace_from_row(row: &Row) -> ServiceWorkspaceSummary {
+    ServiceWorkspaceSummary {
+        workspace_id: row.get(0),
+        usage_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn api_key_from_row(row: &Row) -> ServiceApiKeySummary {
+    ServiceApiKeySummary {
+        api_key_id: row.get(0),
+        usage_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn service_from_row(row: &Row) -> ServiceNameSummary {
+    ServiceNameSummary {
+        service_name: row.get(0),
+        usage_count: row.get(1),
+        quantity: row.get(2),
+        total_cost_nano_usd: row.get(3),
+    }
+}
+
+fn day_from_row(row: &Row) -> ServiceDaySummary {
+    ServiceDaySummary {
+        day: row.get(0),
+        usage_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}

--- a/crates/database/src/repositories/organization_usage.rs
+++ b/crates/database/src/repositories/organization_usage.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct OrganizationUsageRepository {
-    pool: DbPool,
+    pub(crate) pool: DbPool,
 }
 
 impl OrganizationUsageRepository {

--- a/crates/database/src/repositories/organization_usage_reporting.rs
+++ b/crates/database/src/repositories/organization_usage_reporting.rs
@@ -1,0 +1,204 @@
+use crate::repositories::{utils::map_db_error, OrganizationUsageRepository};
+use crate::retry_db;
+use anyhow::{Context, Result};
+use services::common::RepositoryError;
+use services::usage::{
+    InferenceUsageHistoryQuery, InferenceUsageReportQuery, InferenceUsageReportRow,
+};
+use tokio_postgres::Row;
+
+impl OrganizationUsageRepository {
+    pub async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>> {
+        validate_query(&query)?;
+
+        let cursor = query.cursor;
+        let cursor_created_at = cursor.map(|value| value.created_at);
+        let cursor_id = cursor.map(|value| value.id);
+        let limit = i64::from(query.limit);
+
+        let rows = retry_db!("list_inference_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT
+                        id, organization_id, workspace_id, api_key_id, created_at,
+                        model_name, inference_type, input_tokens, output_tokens,
+                        cache_read_tokens, total_tokens, input_cost, output_cost,
+                        total_cost, response_id, inference_id, stop_reason, image_count
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                      AND (
+                          $8::TIMESTAMPTZ IS NULL
+                          OR created_at < $8
+                          OR (created_at = $8 AND id < $9::UUID)
+                      )
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT $10
+                    "#,
+                    &[
+                        &query.organization_id,
+                        &query.start_time,
+                        &query.end_time,
+                        &query.workspace_id,
+                        &query.api_key_id,
+                        &query.model,
+                        &query.inference_type,
+                        &cursor_created_at,
+                        &cursor_id,
+                        &limit,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows.iter().map(row_to_report).collect())
+    }
+
+    pub async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64)> {
+        validate_history_query(&query)?;
+
+        let (rows, total) = retry_db!("list_inference_usage_history", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let rows = client
+                .query(
+                    r#"
+                    SELECT
+                        id, organization_id, workspace_id, api_key_id, created_at,
+                        model_name, inference_type, input_tokens, output_tokens,
+                        cache_read_tokens, total_tokens, input_cost, output_cost,
+                        total_cost, response_id, inference_id, stop_reason, image_count
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT $6 OFFSET $7
+                    "#,
+                    &[
+                        &query.organization_id,
+                        &query.start_time,
+                        &query.end_time,
+                        &query.workspace_id,
+                        &query.api_key_id,
+                        &query.limit,
+                        &query.offset,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let count = client
+                .query_one(
+                    r#"
+                    SELECT COUNT(*)::BIGINT AS count
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                    "#,
+                    &[
+                        &query.organization_id,
+                        &query.start_time,
+                        &query.end_time,
+                        &query.workspace_id,
+                        &query.api_key_id,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok::<(Vec<Row>, i64), RepositoryError>((rows, count.get("count")))
+        })?;
+
+        Ok((rows.iter().map(row_to_report).collect(), total))
+    }
+}
+
+fn validate_query(query: &InferenceUsageReportQuery) -> Result<()> {
+    if query.limit == 0 {
+        return Err(RepositoryError::ValidationFailed("limit must be positive".to_string()).into());
+    }
+    if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
+        if end < start {
+            return Err(RepositoryError::ValidationFailed(
+                "end_time must be greater than or equal to start_time".to_string(),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_history_query(query: &InferenceUsageHistoryQuery) -> Result<()> {
+    if query.limit <= 0 {
+        return Err(RepositoryError::ValidationFailed("limit must be positive".to_string()).into());
+    }
+    if query.offset < 0 {
+        return Err(
+            RepositoryError::ValidationFailed("offset must be non-negative".to_string()).into(),
+        );
+    }
+    if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
+        if end < start {
+            return Err(RepositoryError::ValidationFailed(
+                "end_time must be greater than or equal to start_time".to_string(),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn row_to_report(row: &Row) -> InferenceUsageReportRow {
+    InferenceUsageReportRow {
+        id: row.get("id"),
+        organization_id: row.get("organization_id"),
+        workspace_id: row.get("workspace_id"),
+        api_key_id: row.get("api_key_id"),
+        created_at: row.get("created_at"),
+        model: row.get("model_name"),
+        inference_type: row.get("inference_type"),
+        input_tokens: i64::from(row.get::<_, i32>("input_tokens")),
+        output_tokens: i64::from(row.get::<_, i32>("output_tokens")),
+        cache_read_tokens: i64::from(row.get::<_, i32>("cache_read_tokens")),
+        total_tokens: i64::from(row.get::<_, i32>("total_tokens")),
+        input_cost_nano_usd: row.get("input_cost"),
+        output_cost_nano_usd: row.get("output_cost"),
+        cache_read_cost_nano_usd: None,
+        total_cost_nano_usd: row.get("total_cost"),
+        response_id: row.get("response_id"),
+        inference_id: row.get("inference_id"),
+        stop_reason: row.get("stop_reason"),
+        image_count: row.get("image_count"),
+    }
+}

--- a/crates/database/src/repositories/organization_usage_reporting_summary.rs
+++ b/crates/database/src/repositories/organization_usage_reporting_summary.rs
@@ -1,0 +1,255 @@
+use crate::repositories::{utils::map_db_error, OrganizationUsageRepository};
+use crate::retry_db;
+use anyhow::{Context, Result};
+use services::{
+    common::RepositoryError,
+    reporting_usage::{
+        InferenceApiKeySummary, InferenceDaySummary, InferenceModelSummary, InferenceUsageSummary,
+        InferenceUsageSummaryRepository, InferenceUsageTotals, InferenceWorkspaceSummary,
+        ReportingUsageSummaryFilters,
+    },
+};
+use tokio_postgres::Row;
+
+impl OrganizationUsageRepository {
+    pub async fn summarize_inference_usage_report(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<InferenceUsageSummary> {
+        let summary = retry_db!("summarize_inference_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let totals = client
+                .query_one(
+                    r#"
+                    SELECT COUNT(*)::bigint,
+                           COALESCE(SUM(input_tokens), 0)::bigint,
+                           COALESCE(SUM(output_tokens), 0)::bigint,
+                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
+                           COALESCE(SUM(total_tokens), 0)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_workspace = client
+                .query(
+                    r#"
+                    SELECT workspace_id, COUNT(*)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY workspace_id
+                    ORDER BY 3 DESC, workspace_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_api_key = client
+                .query(
+                    r#"
+                    SELECT api_key_id, COUNT(*)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY api_key_id
+                    ORDER BY 3 DESC, api_key_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_model = client
+                .query(
+                    r#"
+                    SELECT model_name, COUNT(*)::bigint,
+                           COALESCE(SUM(input_tokens), 0)::bigint,
+                           COALESCE(SUM(output_tokens), 0)::bigint,
+                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
+                           COALESCE(SUM(total_tokens), 0)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY model_name
+                    ORDER BY 7 DESC, model_name ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_day = client
+                .query(
+                    r#"
+                    SELECT TO_CHAR(DATE_TRUNC('day', created_at), 'YYYY-MM-DD'),
+                           COUNT(*)::bigint,
+                           COALESCE(SUM(input_tokens), 0)::bigint,
+                           COALESCE(SUM(output_tokens), 0)::bigint,
+                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
+                           COALESCE(SUM(total_tokens), 0)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY DATE_TRUNC('day', created_at)
+                    ORDER BY 1 ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok::<_, RepositoryError>(InferenceUsageSummary {
+                totals: totals_from_row(&totals),
+                by_workspace: by_workspace.iter().map(workspace_from_row).collect(),
+                by_api_key: by_api_key.iter().map(api_key_from_row).collect(),
+                by_model: by_model.iter().map(model_from_row).collect(),
+                by_day: by_day.iter().map(day_from_row).collect(),
+            })
+        })?;
+
+        Ok(summary)
+    }
+}
+
+#[async_trait::async_trait]
+impl InferenceUsageSummaryRepository for OrganizationUsageRepository {
+    async fn summarize_inference_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<InferenceUsageSummary> {
+        self.summarize_inference_usage_report(filters).await
+    }
+}
+
+fn totals_from_row(row: &Row) -> InferenceUsageTotals {
+    InferenceUsageTotals {
+        request_count: row.get(0),
+        input_tokens: row.get(1),
+        output_tokens: row.get(2),
+        cache_read_tokens: row.get(3),
+        total_tokens: row.get(4),
+        total_cost_nano_usd: row.get(5),
+    }
+}
+
+fn workspace_from_row(row: &Row) -> InferenceWorkspaceSummary {
+    InferenceWorkspaceSummary {
+        workspace_id: row.get(0),
+        request_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn api_key_from_row(row: &Row) -> InferenceApiKeySummary {
+    InferenceApiKeySummary {
+        api_key_id: row.get(0),
+        request_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn model_from_row(row: &Row) -> InferenceModelSummary {
+    InferenceModelSummary {
+        model: row.get(0),
+        request_count: row.get(1),
+        input_tokens: row.get(2),
+        output_tokens: row.get(3),
+        cache_read_tokens: row.get(4),
+        total_tokens: row.get(5),
+        total_cost_nano_usd: row.get(6),
+    }
+}
+
+fn day_from_row(row: &Row) -> InferenceDaySummary {
+    InferenceDaySummary {
+        day: row.get(0),
+        request_count: row.get(1),
+        input_tokens: row.get(2),
+        output_tokens: row.get(3),
+        cache_read_tokens: row.get(4),
+        total_tokens: row.get(5),
+        total_cost_nano_usd: row.get(6),
+    }
+}

--- a/crates/database/src/repositories/service_usage_repository_impl.rs
+++ b/crates/database/src/repositories/service_usage_repository_impl.rs
@@ -4,7 +4,8 @@ use crate::repositories::{
 };
 use async_trait::async_trait;
 use services::service_usage::ports::{
-    RecordServiceUsageParams, ServiceUsageLogEntry, ServiceUsageRepositoryTrait,
+    RecordServiceUsageParams, ServiceUsageLogEntry, ServiceUsageReportEntry,
+    ServiceUsageReportFilters, ServiceUsageRepositoryTrait,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -93,5 +94,12 @@ impl ServiceUsageRepositoryTrait for ServiceUsageRepositoryImpl {
             .collect();
 
         Ok((entries, total))
+    }
+
+    async fn list_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> anyhow::Result<Vec<ServiceUsageReportEntry>> {
+        self.usage_repo.list_reporting_usage(filters).await
     }
 }

--- a/crates/database/src/repositories/usage_repository_impl.rs
+++ b/crates/database/src/repositories/usage_repository_impl.rs
@@ -2,7 +2,8 @@ use crate::models::RecordUsageRequest;
 use crate::repositories::OrganizationUsageRepository;
 use chrono::{DateTime, Utc};
 use services::usage::ports::{
-    InferenceCost, OrganizationBalanceInfo, UsageByModelEntry, UsageLogEntry,
+    InferenceCost, InferenceUsageHistoryQuery, InferenceUsageReportQuery, InferenceUsageReportRow,
+    OrganizationBalanceInfo, UsageByModelEntry, UsageLogEntry,
 };
 use uuid::Uuid;
 
@@ -225,5 +226,19 @@ impl services::usage::ports::UsageRepository for OrganizationUsageRepository {
                 request_count: r.request_count,
             })
             .collect())
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> anyhow::Result<Vec<InferenceUsageReportRow>> {
+        self.list_inference_usage_report(query).await
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> anyhow::Result<(Vec<InferenceUsageReportRow>, i64)> {
+        self.list_inference_usage_history(query).await
     }
 }

--- a/crates/database/tests/organization_reporting_token.rs
+++ b/crates/database/tests/organization_reporting_token.rs
@@ -1,0 +1,196 @@
+use chrono::{Duration, Utc};
+use database::{migrations, DbPool};
+use deadpool::Runtime;
+use deadpool_postgres::Config;
+use services::common::REPORTING_TOKEN_PREFIX;
+use services::reporting_tokens::ports::{
+    CreateOrganizationReportingTokenRequest, OrganizationReportingTokenRepository as _,
+    REPORTING_TOKEN_SCOPE_USAGE_READ,
+};
+use tokio::sync::OnceCell;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+static MIGRATED: OnceCell<()> = OnceCell::const_new();
+
+fn pool_config() -> Config {
+    let mut config = Config::new();
+    config.host = Some(std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string()));
+    config.port = Some(
+        std::env::var("PGPORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())
+            .unwrap_or(5432),
+    );
+    config.dbname =
+        Some(std::env::var("PGDATABASE").unwrap_or_else(|_| "platform_api".to_string()));
+    config.user = Some(std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string()));
+    config.password = Some(std::env::var("PGPASSWORD").unwrap_or_else(|_| "postgres".to_string()));
+    config
+}
+
+async fn test_pool() -> anyhow::Result<DbPool> {
+    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    MIGRATED
+        .get_or_try_init(|| async { migrations::run(&pool).await })
+        .await?;
+    Ok(pool)
+}
+
+async fn insert_org_and_user(pool: &DbPool) -> anyhow::Result<(Uuid, Uuid)> {
+    let client = pool.get().await?;
+    let org_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let suffix = Uuid::new_v4().simple().to_string();
+    let now = Utc::now();
+
+    client
+        .execute(
+            r#"
+            INSERT INTO users (
+                id, email, username, display_name, avatar_url, created_at, updated_at,
+                last_login_at, is_active, auth_provider, provider_user_id
+            )
+            VALUES ($1, $2, $3, NULL, NULL, $4, $4, NULL, true, 'test', $5)
+            "#,
+            &[
+                &user_id,
+                &format!("reporting-{suffix}@example.test"),
+                &format!("reporting-{suffix}"),
+                &now,
+                &format!("provider-{suffix}"),
+            ],
+        )
+        .await?;
+
+    client
+        .execute(
+            r#"
+            INSERT INTO organizations (id, name, description, created_at, updated_at, is_active)
+            VALUES ($1, $2, NULL, $3, $3, true)
+            "#,
+            &[&org_id, &format!("reporting-org-{suffix}"), &now],
+        )
+        .await?;
+
+    Ok((org_id, user_id))
+}
+
+#[tokio::test]
+async fn organization_reporting_token_create_validate_active() -> anyhow::Result<()> {
+    // Given: an organization and creator exist.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+    let expires_at = Utc::now() + Duration::days(1);
+
+    // When: a reporting token is created and then validated by its raw secret.
+    let created = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "warehouse sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: Some(expires_at),
+        })
+        .await?;
+    let validated = repository.validate(&created.raw_token).await?;
+
+    // Then: the raw token is returned once, only its hash/prefix is persisted, and validation
+    // returns org-scoped usage-read context without exposing a raw token or hash.
+    assert!(created.raw_token.starts_with(REPORTING_TOKEN_PREFIX));
+    assert!(created
+        .token
+        .token_prefix
+        .starts_with(REPORTING_TOKEN_PREFIX));
+    assert_ne!(created.token.token_prefix, created.raw_token);
+    assert_eq!(created.token.scope, REPORTING_TOKEN_SCOPE_USAGE_READ);
+
+    let row = pool
+        .get()
+        .await?
+        .query_one(
+            r#"
+            SELECT token_hash, token_prefix
+            FROM organization_reporting_tokens
+            WHERE id = $1
+            "#,
+            &[&created.token.id],
+        )
+        .await?;
+    let token_hash: String = row.get("token_hash");
+    let token_prefix: String = row.get("token_prefix");
+    assert_ne!(token_hash, created.raw_token);
+    assert_eq!(token_prefix, created.token.token_prefix);
+
+    let validated = validated.expect("active reporting token should validate");
+    assert_eq!(validated.id, created.token.id);
+    assert_eq!(validated.organization_id, organization_id);
+    assert_eq!(validated.token_prefix, created.token.token_prefix);
+    assert_eq!(validated.scope, REPORTING_TOKEN_SCOPE_USAGE_READ);
+    assert!(validated.last_used_at.is_some());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_reporting_token_rejects_revoked_and_expired() -> anyhow::Result<()> {
+    // Given: one expired reporting token and one active reporting token.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+
+    let expired = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "expired sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: Some(Utc::now() - Duration::minutes(1)),
+        })
+        .await?;
+    let revoked = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "revoked sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: Some(Utc::now() + Duration::days(1)),
+        })
+        .await?;
+
+    // When: the active token is revoked and both secrets are validated.
+    assert!(repository.revoke(revoked.token.id, user_id).await?);
+
+    // Then: expired and revoked reporting tokens are rejected.
+    assert!(repository.validate(&expired.raw_token).await?.is_none());
+    assert!(repository.validate(&revoked.raw_token).await?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_reporting_token_rejects_malformed_inputs_and_empty_name() -> anyhow::Result<()>
+{
+    // Given: an organization and creator exist.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+
+    // When: malformed token material and an empty token name are submitted.
+    let malformed = repository.validate("sk-not-a-reporting-token").await?;
+    let empty_name = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "   ".to_string(),
+            created_by_user_id: user_id,
+            expires_at: None,
+        })
+        .await;
+
+    // Then: malformed tokens do not validate and empty names fail validation.
+    assert!(malformed.is_none());
+    assert!(empty_name.is_err());
+
+    Ok(())
+}

--- a/crates/database/tests/organization_service_usage_reporting.rs
+++ b/crates/database/tests/organization_service_usage_reporting.rs
@@ -1,0 +1,145 @@
+use services::service_usage::ports::{ServiceUsageReportCursor, ServiceUsageReportFilters};
+use uuid::Uuid;
+
+#[path = "support/service_usage_reporting_pool.rs"]
+mod service_usage_reporting_pool;
+#[path = "support/service_usage_reporting_rows.rs"]
+mod service_usage_reporting_rows;
+#[path = "support/service_usage_reporting_support.rs"]
+mod service_usage_reporting_support;
+
+use service_usage_reporting_support::{seed_usage_fixture, test_pool, ts};
+
+#[tokio::test]
+async fn organization_service_usage_reporting_filters_and_cursor() -> anyhow::Result<()> {
+    // Given: service usage rows for multiple services, workspaces, API keys, and timestamps.
+    let pool = test_pool().await?;
+    let fixture = seed_usage_fixture(&pool).await?;
+    let repository = database::repositories::OrganizationServiceUsageRepository::new(pool);
+
+    // When: the reporting query is narrowed to one service/workspace/API-key/date window.
+    let filtered = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some(fixture.web_search_name.clone()),
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            start_time: Some(ts("2026-07-02T00:00:00Z")),
+            end_time: Some(ts("2026-07-02T00:00:00Z")),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+
+    // Then: only rows matching every reporting filter are returned in stable tuple order.
+    let ids: Vec<Uuid> = filtered.iter().map(|row| row.id).collect();
+    assert_eq!(
+        ids,
+        vec![fixture.same_time_high_id, fixture.same_time_low_id]
+    );
+    assert!(filtered
+        .iter()
+        .all(|row| row.service_id == fixture.web_search_id));
+    assert!(filtered
+        .iter()
+        .all(|row| row.workspace_id == fixture.workspace_id));
+    assert!(filtered
+        .iter()
+        .all(|row| row.api_key_id == fixture.api_key_id));
+    assert!(filtered
+        .iter()
+        .all(|row| row.service_name == fixture.web_search_name.as_str()));
+
+    let first_page = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some(fixture.web_search_name.clone()),
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            limit: 2,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+    let cursor_row = first_page
+        .last()
+        .expect("first reporting page should contain cursor row");
+    let second_page = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some(fixture.web_search_name.clone()),
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            cursor: Some(ServiceUsageReportCursor {
+                created_at: cursor_row.created_at,
+                id: cursor_row.id,
+            }),
+            limit: 2,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+    let second_page_ids: Vec<Uuid> = second_page.iter().map(|row| row.id).collect();
+    assert_eq!(
+        second_page_ids,
+        vec![fixture.same_time_low_id, fixture.older_id]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_service_usage_reporting_excludes_other_orgs() -> anyhow::Result<()> {
+    // Given: another organization has a matching service usage row.
+    let pool = test_pool().await?;
+    let fixture = seed_usage_fixture(&pool).await?;
+    let repository = database::repositories::OrganizationServiceUsageRepository::new(pool);
+
+    // When: reporting usage is requested for the other organization with this org's filters.
+    let rows = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.other_org_id,
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+
+    // Then: no cross-organization rows are returned.
+    assert!(rows.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_service_usage_reporting_rejects_invalid_range_and_unknown_service_is_empty(
+) -> anyhow::Result<()> {
+    // Given: service usage exists for one organization.
+    let pool = test_pool().await?;
+    let fixture = seed_usage_fixture(&pool).await?;
+    let repository = database::repositories::OrganizationServiceUsageRepository::new(pool);
+
+    // When: an invalid date range and an unknown service name are queried.
+    let invalid_range = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            start_time: Some(ts("2026-07-04T00:00:00Z")),
+            end_time: Some(ts("2026-07-03T00:00:00Z")),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await;
+    let unknown_service = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some("unknown_service".to_string()),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+
+    // Then: invalid ranges fail closed and unknown service names do not leak other data.
+    assert!(invalid_range.is_err());
+    assert!(unknown_service.is_empty());
+
+    Ok(())
+}

--- a/crates/database/tests/organization_usage_reporting.rs
+++ b/crates/database/tests/organization_usage_reporting.rs
@@ -1,0 +1,268 @@
+mod support;
+
+use database::repositories::OrganizationUsageRepository;
+use services::usage::ports::{InferenceUsageReportCursor, InferenceUsageReportQuery};
+use support::{
+    cleanup_usage_fixtures, insert_model, insert_org_fixture, insert_usage, test_pool, ts,
+    UsageSeed,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn organization_usage_reporting_filters_and_cursor() -> anyhow::Result<()> {
+    // Given: two org-scoped rows sharing a timestamp plus rows excluded by filters.
+    let pool = test_pool().await?;
+    let repository = OrganizationUsageRepository::new(pool.clone());
+    let org = insert_org_fixture(&pool).await?;
+    let other_org = insert_org_fixture(&pool).await?;
+    let model = insert_model(&pool, "report-model-a").await?;
+    let other_model = insert_model(&pool, "report-model-b").await?;
+    let model_id = model.id;
+    let other_model_id = other_model.id;
+    let response_id = Uuid::new_v4();
+    let shared_time = ts(2026, 1, 2, 0);
+    let mut tied_ids = [Uuid::new_v4(), Uuid::new_v4()];
+    tied_ids.sort();
+    let second_id = tied_ids[0];
+    let first_id = tied_ids[1];
+
+    for seed in [
+        UsageSeed {
+            id: first_id,
+            org_id: org.org_id,
+            workspace_id: org.workspace_a_id,
+            api_key_id: org.api_key_a_id,
+            model: model.clone(),
+            created_at: shared_time,
+            inference_type: "chat_completion",
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_tokens: 2,
+            input_cost: 100,
+            output_cost: 200,
+            total_cost: 300,
+            response_id: Some(response_id),
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-secret-first",
+        },
+        UsageSeed {
+            id: second_id,
+            org_id: org.org_id,
+            workspace_id: org.workspace_a_id,
+            api_key_id: org.api_key_a_id,
+            model: model.clone(),
+            created_at: shared_time,
+            inference_type: "chat_completion",
+            input_tokens: 11,
+            output_tokens: 6,
+            cache_read_tokens: 3,
+            input_cost: 110,
+            output_cost: 220,
+            total_cost: 330,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-secret-second",
+        },
+        UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: org.org_id,
+            workspace_id: org.workspace_b_id,
+            api_key_id: org.api_key_b_id,
+            model: other_model,
+            created_at: shared_time,
+            inference_type: "embedding",
+            input_tokens: 9,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            input_cost: 90,
+            output_cost: 0,
+            total_cost: 90,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-filtered",
+        },
+        UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: other_org.org_id,
+            workspace_id: other_org.workspace_a_id,
+            api_key_id: other_org.api_key_a_id,
+            model: model.clone(),
+            created_at: shared_time,
+            inference_type: "chat_completion",
+            input_tokens: 99,
+            output_tokens: 99,
+            cache_read_tokens: 0,
+            input_cost: 990,
+            output_cost: 990,
+            total_cost: 1980,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-other-org",
+        },
+    ] {
+        insert_usage(&pool, &seed).await?;
+    }
+
+    // When: a filtered report is fetched with a one-row keyset page.
+    let first_page = repository
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            organization_id: org.org_id,
+            start_time: Some(ts(2026, 1, 1, 0)),
+            end_time: Some(ts(2026, 1, 3, 0)),
+            workspace_id: Some(org.workspace_a_id),
+            api_key_id: Some(org.api_key_a_id),
+            model: Some(model.name.clone()),
+            inference_type: Some("chat_completion".to_string()),
+            limit: 1,
+            cursor: None,
+        })
+        .await?;
+
+    // Then: ordering uses created_at DESC, id DESC and exposes reporting-safe fields only.
+    assert_eq!(first_page.len(), 1);
+    assert_eq!(first_page[0].id, first_id);
+    assert_eq!(first_page[0].response_id, Some(response_id));
+    assert_eq!(first_page[0].input_tokens, 10);
+    assert_eq!(first_page[0].output_tokens, 5);
+    assert_eq!(first_page[0].cache_read_tokens, 2);
+    assert_eq!(first_page[0].total_tokens, 15);
+    assert_eq!(first_page[0].input_cost_nano_usd, 100);
+    assert_eq!(first_page[0].output_cost_nano_usd, 200);
+    assert_eq!(first_page[0].total_cost_nano_usd, 300);
+    let first_page_json = serde_json::to_string(&first_page)?;
+    assert!(!first_page_json.contains("provider_request_id"));
+    println!("first_page_json={first_page_json}");
+
+    // When: the next page starts after the first row's cursor tuple.
+    let second_page = repository
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            organization_id: org.org_id,
+            start_time: Some(ts(2026, 1, 1, 0)),
+            end_time: Some(ts(2026, 1, 3, 0)),
+            workspace_id: Some(org.workspace_a_id),
+            api_key_id: Some(org.api_key_a_id),
+            model: Some(model.name.clone()),
+            inference_type: Some("chat_completion".to_string()),
+            limit: 1,
+            cursor: Some(InferenceUsageReportCursor {
+                created_at: first_page[0].created_at,
+                id: first_page[0].id,
+            }),
+        })
+        .await?;
+
+    // Then: cursor continuation returns the tied row with the lower id.
+    assert_eq!(second_page.len(), 1);
+    assert_eq!(second_page[0].id, second_id);
+    assert_eq!(second_page[0].organization_id, org.org_id);
+    assert_eq!(second_page[0].workspace_id, org.workspace_a_id);
+    assert_eq!(second_page[0].api_key_id, org.api_key_a_id);
+    println!(
+        "cursor_continuation={} -> {}",
+        first_page[0].id, second_page[0].id
+    );
+    cleanup_usage_fixtures(
+        &pool,
+        &[org.org_id, other_org.org_id],
+        &[model_id, other_model_id],
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_usage_reporting_excludes_other_orgs() -> anyhow::Result<()> {
+    // Given: one row in each of two organizations.
+    let pool = test_pool().await?;
+    let repository = OrganizationUsageRepository::new(pool.clone());
+    let org = insert_org_fixture(&pool).await?;
+    let other_org = insert_org_fixture(&pool).await?;
+    let model = insert_model(&pool, "report-isolation-model").await?;
+    let model_id = model.id;
+    insert_usage(
+        &pool,
+        &UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: org.org_id,
+            workspace_id: org.workspace_a_id,
+            api_key_id: org.api_key_a_id,
+            model: model.clone(),
+            created_at: ts(2026, 2, 1, 0),
+            inference_type: "chat_completion",
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_tokens: 0,
+            input_cost: 10,
+            output_cost: 20,
+            total_cost: 30,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-owned",
+        },
+    )
+    .await?;
+    insert_usage(
+        &pool,
+        &UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: other_org.org_id,
+            workspace_id: other_org.workspace_a_id,
+            api_key_id: other_org.api_key_a_id,
+            model,
+            created_at: ts(2026, 2, 1, 1),
+            inference_type: "chat_completion",
+            input_tokens: 2,
+            output_tokens: 2,
+            cache_read_tokens: 0,
+            input_cost: 20,
+            output_cost: 40,
+            total_cost: 60,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-other",
+        },
+    )
+    .await?;
+
+    // When: the first organization fetches reporting rows, including impossible filters.
+    let rows = repository
+        .list_inference_usage_report(InferenceUsageReportQuery::for_organization(org.org_id))
+        .await?;
+    let bad_workspace_rows = repository
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            workspace_id: Some(other_org.workspace_a_id),
+            ..InferenceUsageReportQuery::for_organization(org.org_id)
+        })
+        .await?;
+
+    // Then: only rows belonging to the requested organization are returned.
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].organization_id, org.org_id);
+    assert!(bad_workspace_rows.is_empty());
+    println!("org_rows_json={}", serde_json::to_string(&rows)?);
+    println!("bad_workspace_rows={}", bad_workspace_rows.len());
+    cleanup_usage_fixtures(&pool, &[org.org_id, other_org.org_id], &[model_id]).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_usage_reporting_rejects_invalid_date_range() -> anyhow::Result<()> {
+    // Given: a repository query with end_time before start_time.
+    let pool = test_pool().await?;
+    let repository = OrganizationUsageRepository::new(pool);
+    let query = InferenceUsageReportQuery {
+        start_time: Some(ts(2026, 3, 2, 0)),
+        end_time: Some(ts(2026, 3, 1, 0)),
+        ..InferenceUsageReportQuery::for_organization(Uuid::new_v4())
+    };
+
+    // When: the malformed range is submitted.
+    let result = repository.list_inference_usage_report(query).await;
+
+    // Then: repository validation rejects it before SQL execution.
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/crates/database/tests/support/mod.rs
+++ b/crates/database/tests/support/mod.rs
@@ -1,0 +1,238 @@
+use chrono::{DateTime, TimeZone, Utc};
+use database::{migrations, DbPool};
+use deadpool::Runtime;
+use deadpool_postgres::Config;
+use tokio::sync::OnceCell;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+static MIGRATED: OnceCell<()> = OnceCell::const_new();
+
+pub struct OrgFixture {
+    pub org_id: Uuid,
+    pub workspace_a_id: Uuid,
+    pub workspace_b_id: Uuid,
+    pub api_key_a_id: Uuid,
+    pub api_key_b_id: Uuid,
+}
+
+#[derive(Clone)]
+pub struct ModelFixture {
+    pub id: Uuid,
+    pub name: String,
+}
+
+pub struct UsageSeed {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub model: ModelFixture,
+    pub created_at: DateTime<Utc>,
+    pub inference_type: &'static str,
+    pub input_tokens: i32,
+    pub output_tokens: i32,
+    pub cache_read_tokens: i32,
+    pub input_cost: i64,
+    pub output_cost: i64,
+    pub total_cost: i64,
+    pub response_id: Option<Uuid>,
+    pub inference_id: Uuid,
+    pub provider_request_id: &'static str,
+}
+
+pub fn ts(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, hour, 0, 0).unwrap()
+}
+
+pub async fn test_pool() -> anyhow::Result<DbPool> {
+    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    MIGRATED
+        .get_or_try_init(|| async { migrations::run(&pool).await })
+        .await?;
+    Ok(pool)
+}
+
+pub async fn insert_org_fixture(pool: &DbPool) -> anyhow::Result<OrgFixture> {
+    let client = pool.get().await?;
+    let org_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let workspace_a_id = Uuid::new_v4();
+    let workspace_b_id = Uuid::new_v4();
+    let api_key_a_id = Uuid::new_v4();
+    let api_key_b_id = Uuid::new_v4();
+    let suffix = org_id.simple().to_string();
+    let now = Utc::now();
+
+    client
+        .execute(
+            "INSERT INTO users (id, email, username, created_at, updated_at, is_active, auth_provider, provider_user_id)
+             VALUES ($1, $2, $3, $4, $4, true, 'test', $5)",
+            &[
+                &user_id,
+                &format!("usage-report-{suffix}@example.test"),
+                &format!("usage-report-{suffix}"),
+                &now,
+                &format!("provider-{suffix}"),
+            ],
+        )
+        .await?;
+    client
+        .execute(
+            "INSERT INTO organizations (id, name, description, created_at, updated_at, is_active)
+             VALUES ($1, $2, NULL, $3, $3, true)",
+            &[&org_id, &format!("usage-report-org-{suffix}"), &now],
+        )
+        .await?;
+
+    for (workspace_id, name) in [
+        (workspace_a_id, "usage-report-a"),
+        (workspace_b_id, "usage-report-b"),
+    ] {
+        client
+            .execute(
+                "INSERT INTO workspaces (id, name, description, organization_id, created_by_user_id, created_at, updated_at, is_active, settings)
+                 VALUES ($1, $2, NULL, $3, $4, $5, $5, true, '{}'::jsonb)",
+                &[
+                    &workspace_id,
+                    &format!("{name}-{suffix}"),
+                    &org_id,
+                    &user_id,
+                    &now,
+                ],
+            )
+            .await?;
+    }
+
+    for (api_key_id, workspace_id, name) in [
+        (api_key_a_id, workspace_a_id, "usage-report-key-a"),
+        (api_key_b_id, workspace_b_id, "usage-report-key-b"),
+    ] {
+        client
+            .execute(
+                "INSERT INTO api_keys (id, key_hash, name, workspace_id, created_by_user_id, created_at, is_active, key_prefix)
+                 VALUES ($1, $2, $3, $4, $5, $6, true, $7)",
+                &[
+                    &api_key_id,
+                    &format!("hash-{api_key_id}"),
+                    &format!("{name}-{suffix}"),
+                    &workspace_id,
+                    &user_id,
+                    &now,
+                    &format!("sk-{}", &suffix[..8]),
+                ],
+            )
+            .await?;
+    }
+
+    Ok(OrgFixture {
+        org_id,
+        workspace_a_id,
+        workspace_b_id,
+        api_key_a_id,
+        api_key_b_id,
+    })
+}
+
+pub async fn insert_model(pool: &DbPool, name: &str) -> anyhow::Result<ModelFixture> {
+    let client = pool.get().await?;
+    let id = Uuid::new_v4();
+    let now = Utc::now();
+    client
+        .execute(
+            "INSERT INTO models (id, model_name, model_display_name, model_description, input_cost_per_token, output_cost_per_token, context_length, verifiable, is_active, created_at, updated_at)
+             VALUES ($1, $2, $2, 'reporting test model', 10, 20, 4096, true, true, $3, $3)",
+            &[&id, &format!("{name}-{id}"), &now],
+        )
+        .await?;
+    let row = client
+        .query_one("SELECT model_name FROM models WHERE id = $1", &[&id])
+        .await?;
+    Ok(ModelFixture {
+        id,
+        name: row.get("model_name"),
+    })
+}
+
+pub async fn insert_usage(pool: &DbPool, seed: &UsageSeed) -> anyhow::Result<()> {
+    let client = pool.get().await?;
+    if let Some(response_id) = seed.response_id {
+        client
+            .execute(
+                "INSERT INTO responses (id, model, status, instructions, conversation_id, previous_response_id, usage, metadata, created_at, updated_at, workspace_id, api_key_id)
+                 VALUES ($1, $2, 'completed', NULL, NULL, NULL, '{}'::jsonb, '{}'::jsonb, $3, $3, $4, $5)",
+                &[
+                    &response_id,
+                    &seed.model.name,
+                    &seed.created_at,
+                    &seed.workspace_id,
+                    &seed.api_key_id,
+                ],
+            )
+            .await?;
+    }
+    client
+        .execute(
+            "INSERT INTO organization_usage_log (
+                id, organization_id, workspace_id, api_key_id, response_id, model_id, model_name,
+                input_tokens, output_tokens, cache_read_tokens, total_tokens,
+                input_cost, output_cost, total_cost, request_type, inference_type, created_at,
+                inference_id, provider_request_id, stop_reason
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULL, $15, $16, $17, $18, 'completed')",
+            &[
+                &seed.id,
+                &seed.org_id,
+                &seed.workspace_id,
+                &seed.api_key_id,
+                &seed.response_id,
+                &seed.model.id,
+                &seed.model.name,
+                &seed.input_tokens,
+                &seed.output_tokens,
+                &seed.cache_read_tokens,
+                &(seed.input_tokens + seed.output_tokens),
+                &seed.input_cost,
+                &seed.output_cost,
+                &seed.total_cost,
+                &seed.inference_type,
+                &seed.created_at,
+                &Some(seed.inference_id),
+                &Some(seed.provider_request_id),
+            ],
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn cleanup_usage_fixtures(
+    pool: &DbPool,
+    org_ids: &[Uuid],
+    model_ids: &[Uuid],
+) -> anyhow::Result<()> {
+    let client = pool.get().await?;
+    let org_ids = org_ids.to_vec();
+    let model_ids = model_ids.to_vec();
+    client
+        .execute("DELETE FROM organizations WHERE id = ANY($1)", &[&org_ids])
+        .await?;
+    client
+        .execute("DELETE FROM models WHERE id = ANY($1)", &[&model_ids])
+        .await?;
+    Ok(())
+}
+
+fn pool_config() -> Config {
+    let mut config = Config::new();
+    config.host = Some(std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string()));
+    config.port = Some(
+        std::env::var("PGPORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())
+            .unwrap_or(5432),
+    );
+    config.dbname =
+        Some(std::env::var("PGDATABASE").unwrap_or_else(|_| "platform_api".to_string()));
+    config.user = Some(std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string()));
+    config.password = Some(std::env::var("PGPASSWORD").unwrap_or_else(|_| "postgres".to_string()));
+    config
+}

--- a/crates/database/tests/support/service_usage_reporting_pool.rs
+++ b/crates/database/tests/support/service_usage_reporting_pool.rs
@@ -1,0 +1,31 @@
+use database::{migrations, DbPool};
+use deadpool::Runtime;
+use deadpool_postgres::Config;
+use tokio::sync::OnceCell;
+use tokio_postgres::NoTls;
+
+static MIGRATED: OnceCell<()> = OnceCell::const_new();
+
+pub async fn test_pool() -> anyhow::Result<DbPool> {
+    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    MIGRATED
+        .get_or_try_init(|| async { migrations::run(&pool).await })
+        .await?;
+    Ok(pool)
+}
+
+fn pool_config() -> Config {
+    let mut config = Config::new();
+    config.host = Some(std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string()));
+    config.port = Some(
+        std::env::var("PGPORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())
+            .unwrap_or(5432),
+    );
+    config.dbname =
+        Some(std::env::var("PGDATABASE").unwrap_or_else(|_| "platform_api".to_string()));
+    config.user = Some(std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string()));
+    config.password = Some(std::env::var("PGPASSWORD").unwrap_or_else(|_| "postgres".to_string()));
+    config
+}

--- a/crates/database/tests/support/service_usage_reporting_rows.rs
+++ b/crates/database/tests/support/service_usage_reporting_rows.rs
@@ -1,0 +1,138 @@
+use chrono::{DateTime, Utc};
+use database::DbPool;
+use uuid::Uuid;
+
+pub struct ServiceUsageRowIds {
+    pub latest_id: Uuid,
+    pub same_time_high_id: Uuid,
+    pub same_time_low_id: Uuid,
+    pub older_id: Uuid,
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub web_search_id: Uuid,
+    pub other_workspace_id: Uuid,
+    pub other_api_key_id: Uuid,
+    pub file_search_id: Uuid,
+    pub other_org_id: Uuid,
+    pub other_org_workspace_id: Uuid,
+    pub other_org_api_key_id: Uuid,
+}
+
+pub struct UsageRow {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub service_id: Uuid,
+    pub quantity: i32,
+    pub total_cost: i64,
+    pub created_at: DateTime<Utc>,
+}
+
+pub fn ts(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("fixture timestamp is valid RFC3339")
+        .with_timezone(&Utc)
+}
+
+pub fn service_usage_rows(ids: ServiceUsageRowIds) -> [UsageRow; 7] {
+    [
+        UsageRow {
+            id: ids.latest_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 1,
+            total_cost: 100,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+        UsageRow {
+            id: ids.same_time_high_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 2,
+            total_cost: 200,
+            created_at: ts("2026-07-02T00:00:00Z"),
+        },
+        UsageRow {
+            id: ids.same_time_low_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 3,
+            total_cost: 300,
+            created_at: ts("2026-07-02T00:00:00Z"),
+        },
+        UsageRow {
+            id: ids.older_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 4,
+            total_cost: 400,
+            created_at: ts("2026-06-30T00:00:00Z"),
+        },
+        UsageRow {
+            id: Uuid::new_v4(),
+            org_id: ids.org_id,
+            workspace_id: ids.other_workspace_id,
+            api_key_id: ids.other_api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 5,
+            total_cost: 500,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+        UsageRow {
+            id: Uuid::new_v4(),
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.file_search_id,
+            quantity: 6,
+            total_cost: 600,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+        UsageRow {
+            id: Uuid::new_v4(),
+            org_id: ids.other_org_id,
+            workspace_id: ids.other_org_workspace_id,
+            api_key_id: ids.other_org_api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 7,
+            total_cost: 700,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+    ]
+}
+
+pub async fn insert_usage(pool: &DbPool, row: &UsageRow) -> anyhow::Result<()> {
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO organization_service_usage_log (
+                id, organization_id, workspace_id, api_key_id, service_id,
+                quantity, total_cost, inference_id, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, $8)
+            "#,
+            &[
+                &row.id,
+                &row.org_id,
+                &row.workspace_id,
+                &row.api_key_id,
+                &row.service_id,
+                &row.quantity,
+                &row.total_cost,
+                &row.created_at,
+            ],
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/database/tests/support/service_usage_reporting_support.rs
+++ b/crates/database/tests/support/service_usage_reporting_support.rs
@@ -1,0 +1,245 @@
+use chrono::Utc;
+use database::DbPool;
+use uuid::Uuid;
+
+pub use crate::service_usage_reporting_pool::test_pool;
+pub use crate::service_usage_reporting_rows::ts;
+use crate::service_usage_reporting_rows::{insert_usage, service_usage_rows, ServiceUsageRowIds};
+
+pub struct UsageFixture {
+    pub org_id: Uuid,
+    pub other_org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub web_search_id: Uuid,
+    pub web_search_name: String,
+    pub same_time_high_id: Uuid,
+    pub same_time_low_id: Uuid,
+    pub older_id: Uuid,
+}
+
+struct WorkspaceSeed<'a> {
+    org_id: Uuid,
+    user_id: Uuid,
+    suffix: &'a str,
+}
+
+struct ApiKeySeed<'a> {
+    workspace_id: Uuid,
+    user_id: Uuid,
+    suffix: &'a str,
+}
+
+pub async fn seed_usage_fixture(pool: &DbPool) -> anyhow::Result<UsageFixture> {
+    let suffix = Uuid::new_v4().simple().to_string();
+    let user_id = insert_user(pool, &suffix).await?;
+    let org_id = insert_org(pool, &suffix).await?;
+    let other_org_id = insert_org(pool, &format!("{suffix}-other")).await?;
+    let workspace_id = insert_workspace(
+        pool,
+        WorkspaceSeed {
+            org_id,
+            user_id,
+            suffix: &suffix,
+        },
+    )
+    .await?;
+    let other_workspace_id = insert_workspace(
+        pool,
+        WorkspaceSeed {
+            org_id,
+            user_id,
+            suffix: &format!("{suffix}-ws"),
+        },
+    )
+    .await?;
+    let other_org_workspace_id = insert_workspace(
+        pool,
+        WorkspaceSeed {
+            org_id: other_org_id,
+            user_id,
+            suffix: &format!("{suffix}-other-ws"),
+        },
+    )
+    .await?;
+    let api_key_id = insert_api_key(
+        pool,
+        ApiKeySeed {
+            workspace_id,
+            user_id,
+            suffix: &suffix,
+        },
+    )
+    .await?;
+    let other_api_key_id = insert_api_key(
+        pool,
+        ApiKeySeed {
+            workspace_id: other_workspace_id,
+            user_id,
+            suffix: &format!("{suffix}-key"),
+        },
+    )
+    .await?;
+    let other_org_api_key_id = insert_api_key(
+        pool,
+        ApiKeySeed {
+            workspace_id: other_org_workspace_id,
+            user_id,
+            suffix: &format!("{suffix}-other-key"),
+        },
+    )
+    .await?;
+    let web_search_name = format!("web_search_{suffix}");
+    let web_search_id = insert_service(pool, &web_search_name).await?;
+    let file_search_id = insert_service(pool, &format!("file_search_{suffix}")).await?;
+    let latest_id = Uuid::new_v4();
+    let first_same_time_id = Uuid::new_v4();
+    let second_same_time_id = Uuid::new_v4();
+    let same_time_high_id = first_same_time_id.max(second_same_time_id);
+    let same_time_low_id = first_same_time_id.min(second_same_time_id);
+    let older_id = Uuid::new_v4();
+
+    for row in service_usage_rows(ServiceUsageRowIds {
+        latest_id,
+        same_time_high_id,
+        same_time_low_id,
+        older_id,
+        org_id,
+        workspace_id,
+        api_key_id,
+        web_search_id,
+        other_workspace_id,
+        other_api_key_id,
+        file_search_id,
+        other_org_id,
+        other_org_workspace_id,
+        other_org_api_key_id,
+    }) {
+        insert_usage(pool, &row).await?;
+    }
+
+    Ok(UsageFixture {
+        org_id,
+        other_org_id,
+        workspace_id,
+        api_key_id,
+        web_search_id,
+        web_search_name,
+        same_time_high_id,
+        same_time_low_id,
+        older_id,
+    })
+}
+
+async fn insert_user(pool: &DbPool, suffix: &str) -> anyhow::Result<Uuid> {
+    let user_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO users (
+                id, email, username, display_name, avatar_url, created_at, updated_at,
+                last_login_at, is_active, auth_provider, provider_user_id
+            )
+            VALUES ($1, $2, $3, NULL, NULL, $4, $4, NULL, true, 'test', $5)
+            "#,
+            &[
+                &user_id,
+                &format!("service-report-{suffix}@example.test"),
+                &format!("service-report-{suffix}"),
+                &now,
+                &format!("provider-{suffix}"),
+            ],
+        )
+        .await?;
+    Ok(user_id)
+}
+
+async fn insert_org(pool: &DbPool, suffix: &str) -> anyhow::Result<Uuid> {
+    let org_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO organizations (id, name, description, created_at, updated_at, is_active)
+            VALUES ($1, $2, NULL, $3, $3, true)
+            "#,
+            &[&org_id, &format!("service-report-org-{suffix}"), &now],
+        )
+        .await?;
+    Ok(org_id)
+}
+
+async fn insert_workspace(pool: &DbPool, seed: WorkspaceSeed<'_>) -> anyhow::Result<Uuid> {
+    let workspace_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO workspaces (
+                id, name, description, organization_id, created_by_user_id,
+                created_at, updated_at, is_active, settings
+            )
+            VALUES ($1, $2, NULL, $3, $4, $5, $5, true, '{}'::jsonb)
+            "#,
+            &[
+                &workspace_id,
+                &format!("service-report-workspace-{}", seed.suffix),
+                &seed.org_id,
+                &seed.user_id,
+                &now,
+            ],
+        )
+        .await?;
+    Ok(workspace_id)
+}
+
+async fn insert_api_key(pool: &DbPool, seed: ApiKeySeed<'_>) -> anyhow::Result<Uuid> {
+    let api_key_id = Uuid::new_v4();
+    let now = Utc::now();
+    let key_prefix = format!("sk-{}", &seed.suffix[..8]);
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO api_keys (
+                id, key_hash, key_prefix, name, workspace_id, created_by_user_id,
+                created_at, expires_at, last_used_at, is_active, deleted_at, spend_limit
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NULL, true, NULL, NULL)
+            "#,
+            &[
+                &api_key_id,
+                &format!("service-report-hash-{}", seed.suffix),
+                &key_prefix,
+                &format!("service-report-key-{}", seed.suffix),
+                &seed.workspace_id,
+                &seed.user_id,
+                &now,
+            ],
+        )
+        .await?;
+    Ok(api_key_id)
+}
+
+async fn insert_service(pool: &DbPool, service_name: &str) -> anyhow::Result<Uuid> {
+    let service_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO services (
+                id, service_name, display_name, description, unit, cost_per_unit,
+                is_active, created_at, updated_at
+            )
+            VALUES ($1, $2, $3, NULL, 'request', 100, true, $4, $4)
+            "#,
+            &[&service_id, &service_name, &service_name, &now],
+        )
+        .await?;
+    Ok(service_id)
+}

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -565,8 +565,9 @@ mod tests {
         UpdateOrganizationMemberRequest, UpdateOrganizationRequest,
     };
     use crate::workspace::{
-        ApiKey, ApiKeyId, ApiKeyRepository, CreateApiKeyRequest, Workspace, WorkspaceId,
-        WorkspaceOrderBy, WorkspaceOrderDirection, WorkspaceRepository,
+        ApiKey, ApiKeyId, ApiKeyOrderBy, ApiKeyOrderDirection, ApiKeyRepository,
+        CreateApiKeyRequest, Workspace, WorkspaceId, WorkspaceOrderBy, WorkspaceOrderDirection,
+        WorkspaceRepository,
     };
     use bloomfilter::Bloom;
     use chrono::Utc;
@@ -733,6 +734,8 @@ mod tests {
             _: WorkspaceId,
             _: i64,
             _: i64,
+            _: Option<ApiKeyOrderBy>,
+            _: Option<ApiKeyOrderDirection>,
         ) -> Result<Vec<ApiKey>, RepositoryError> {
             unimplemented!()
         }

--- a/crates/services/src/common.rs
+++ b/crates/services/src/common.rs
@@ -3,6 +3,8 @@ use uuid::Uuid;
 
 pub const API_KEY_PREFIX: &str = "sk-";
 pub const API_KEY_LENGTH: usize = 35;
+pub const REPORTING_TOKEN_PREFIX: &str = "rpt-";
+pub const REPORTING_TOKEN_LENGTH: usize = 36;
 
 /// Maximum serialized size for metadata blobs (e.g. conversation metadata, response metadata)
 pub const MAX_METADATA_SIZE_BYTES: usize = 16 * 1024;
@@ -44,6 +46,26 @@ pub fn extract_api_key_prefix(key: &str) -> String {
 
 pub fn is_valid_api_key_format(key: &str) -> bool {
     key.starts_with(API_KEY_PREFIX) && key.len() == API_KEY_LENGTH
+}
+
+pub fn generate_reporting_token() -> String {
+    format!(
+        "{}{}",
+        REPORTING_TOKEN_PREFIX,
+        Uuid::new_v4().to_string().replace("-", "")
+    )
+}
+
+pub fn hash_reporting_token(token: &str) -> String {
+    hash_api_key(token)
+}
+
+pub fn extract_reporting_token_prefix(token: &str) -> String {
+    token[..12.min(token.len())].to_string()
+}
+
+pub fn is_valid_reporting_token_format(token: &str) -> bool {
+    token.starts_with(REPORTING_TOKEN_PREFIX) && token.len() == REPORTING_TOKEN_LENGTH
 }
 
 /// Shared error types for repository operations across all domains.

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -14,6 +14,8 @@ pub mod mcp;
 pub mod metrics;
 pub mod models;
 pub mod organization;
+pub mod reporting_tokens;
+pub mod reporting_usage;
 pub mod responses;
 pub mod service_usage;
 pub mod usage;

--- a/crates/services/src/reporting_tokens/mod.rs
+++ b/crates/services/src/reporting_tokens/mod.rs
@@ -1,0 +1,3 @@
+pub mod ports;
+
+pub use ports::*;

--- a/crates/services/src/reporting_tokens/ports.rs
+++ b/crates/services/src/reporting_tokens/ports.rs
@@ -1,0 +1,82 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::common::RepositoryError;
+
+pub const REPORTING_TOKEN_SCOPE_USAGE_READ: ReportingTokenScope = ReportingTokenScope::UsageRead;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub enum ReportingTokenScope {
+    #[serde(rename = "usage:read")]
+    UsageRead,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrganizationReportingToken {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub name: String,
+    pub token_prefix: String,
+    pub created_by_user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub revoked_by_user_id: Option<Uuid>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreatedOrganizationReportingToken {
+    pub token: OrganizationReportingToken,
+    pub raw_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidatedOrganizationReportingToken {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub token_prefix: String,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateOrganizationReportingTokenRequest {
+    pub organization_id: Uuid,
+    pub name: String,
+    pub created_by_user_id: Uuid,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[async_trait]
+pub trait OrganizationReportingTokenRepository: Send + Sync {
+    async fn create(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError>;
+
+    async fn validate(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError>;
+
+    async fn get_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError>;
+
+    async fn list_active_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError>;
+
+    async fn revoke(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError>;
+}

--- a/crates/services/src/reporting_usage.rs
+++ b/crates/services/src/reporting_usage.rs
@@ -1,0 +1,129 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportingUsageSummaryFilters {
+    pub organization_id: Uuid,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<String>,
+    pub service_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InferenceUsageSummary {
+    pub totals: InferenceUsageTotals,
+    pub by_workspace: Vec<InferenceWorkspaceSummary>,
+    pub by_api_key: Vec<InferenceApiKeySummary>,
+    pub by_model: Vec<InferenceModelSummary>,
+    pub by_day: Vec<InferenceDaySummary>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InferenceUsageTotals {
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InferenceWorkspaceSummary {
+    pub workspace_id: Uuid,
+    pub request_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InferenceApiKeySummary {
+    pub api_key_id: Uuid,
+    pub request_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceModelSummary {
+    pub model: String,
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceDaySummary {
+    pub day: String,
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServiceUsageSummary {
+    pub totals: ServiceUsageTotals,
+    pub by_workspace: Vec<ServiceWorkspaceSummary>,
+    pub by_api_key: Vec<ServiceApiKeySummary>,
+    pub by_service: Vec<ServiceNameSummary>,
+    pub by_day: Vec<ServiceDaySummary>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ServiceUsageTotals {
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServiceWorkspaceSummary {
+    pub workspace_id: Uuid,
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServiceApiKeySummary {
+    pub api_key_id: Uuid,
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceNameSummary {
+    pub service_name: String,
+    pub usage_count: i64,
+    pub quantity: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceDaySummary {
+    pub day: String,
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[async_trait::async_trait]
+pub trait InferenceUsageSummaryRepository: Send + Sync {
+    async fn summarize_inference_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> anyhow::Result<InferenceUsageSummary>;
+}
+
+#[async_trait::async_trait]
+pub trait ServiceUsageSummaryRepository: Send + Sync {
+    async fn summarize_service_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> anyhow::Result<ServiceUsageSummary>;
+}

--- a/crates/services/src/service_usage/mod.rs
+++ b/crates/services/src/service_usage/mod.rs
@@ -2,7 +2,8 @@ pub mod ports;
 
 pub use ports::ServiceUsageServiceTrait;
 use ports::{
-    RecordServiceUsageParams, RecordServiceUsageWithPricingParams, ServiceUsageRepositoryTrait,
+    RecordServiceUsageParams, RecordServiceUsageWithPricingParams, ServiceUsageReportEntry,
+    ServiceUsageReportFilters, ServiceUsageRepositoryTrait,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -74,6 +75,16 @@ impl ServiceUsageServiceTrait for ServiceUsageService {
     ) -> Result<(Vec<ports::ServiceUsageLogEntry>, i64), ServiceUsageError> {
         self.repo
             .list_usage_logs(organization_id, service_name, limit, offset)
+            .await
+            .map_err(|e| ServiceUsageError::InternalError(e.to_string()))
+    }
+
+    async fn get_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> Result<Vec<ServiceUsageReportEntry>, ServiceUsageError> {
+        self.repo
+            .list_usage_report(filters)
             .await
             .map_err(|e| ServiceUsageError::InternalError(e.to_string()))
     }

--- a/crates/services/src/service_usage/ports.rs
+++ b/crates/services/src/service_usage/ports.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -69,6 +70,53 @@ pub struct ServiceUsageLogEntry {
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServiceUsageReportCursor {
+    pub created_at: DateTime<Utc>,
+    pub id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceUsageReportFilters {
+    pub organization_id: Uuid,
+    pub service_name: Option<String>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub cursor: Option<ServiceUsageReportCursor>,
+    pub limit: i64,
+}
+
+impl Default for ServiceUsageReportFilters {
+    fn default() -> Self {
+        Self {
+            organization_id: Uuid::default(),
+            service_name: None,
+            workspace_id: None,
+            api_key_id: None,
+            start_time: None,
+            end_time: None,
+            cursor: None,
+            limit: 100,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceUsageReportEntry {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub service_id: Uuid,
+    pub service_name: String,
+    pub quantity: i32,
+    pub total_cost: i64,
+    pub inference_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
 /// Port for the service usage service. Implemented by ServiceUsageService.
 #[async_trait]
 pub trait ServiceUsageServiceTrait: Send + Sync {
@@ -93,6 +141,11 @@ pub trait ServiceUsageServiceTrait: Send + Sync {
         limit: i64,
         offset: i64,
     ) -> Result<(Vec<ServiceUsageLogEntry>, i64), super::ServiceUsageError>;
+
+    async fn get_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> Result<Vec<ServiceUsageReportEntry>, super::ServiceUsageError>;
 }
 
 /// Port for recording platform service usage (e.g. web_search).
@@ -116,4 +169,9 @@ pub trait ServiceUsageRepositoryTrait: Send + Sync {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<(Vec<ServiceUsageLogEntry>, i64)>;
+
+    async fn list_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> anyhow::Result<Vec<ServiceUsageReportEntry>>;
 }

--- a/crates/services/src/test_utils.rs
+++ b/crates/services/src/test_utils.rs
@@ -6,9 +6,9 @@ use crate::{
         AttestationError,
     },
     usage::{
-        CostBreakdown, InferenceType, OrganizationBalanceInfo, OrganizationLimit,
-        RecordUsageApiRequest, RecordUsageServiceRequest, UsageCheckResult, UsageError,
-        UsageLogEntry, UsageServiceTrait,
+        CostBreakdown, InferenceType, InferenceUsageHistoryQuery, InferenceUsageReportQuery,
+        InferenceUsageReportRow, OrganizationBalanceInfo, OrganizationLimit, RecordUsageApiRequest,
+        RecordUsageServiceRequest, UsageCheckResult, UsageError, UsageLogEntry, UsageServiceTrait,
     },
 };
 use async_trait::async_trait;
@@ -295,6 +295,20 @@ impl UsageServiceTrait for MockUsageService {
     ) -> Result<Vec<crate::usage::UsageByModelEntry>, UsageError> {
         Ok(vec![])
     }
+
+    async fn list_inference_usage_report(
+        &self,
+        _query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError> {
+        Ok(vec![])
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        _query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError> {
+        Ok((vec![], 0))
+    }
 }
 
 /// A usage service that captures requests for testing
@@ -533,5 +547,19 @@ impl UsageServiceTrait for CapturingUsageService {
         _start_date: chrono::DateTime<chrono::Utc>,
     ) -> Result<Vec<crate::usage::UsageByModelEntry>, UsageError> {
         Ok(vec![])
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        _query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError> {
+        Ok(vec![])
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        _query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError> {
+        Ok((vec![], 0))
     }
 }

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -1,4 +1,5 @@
 pub mod ports;
+pub mod reporting;
 
 use crate::metrics::{
     consts::{
@@ -9,6 +10,7 @@ use crate::metrics::{
     MetricsServiceTrait,
 };
 pub use ports::*;
+pub use reporting::*;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -751,6 +753,30 @@ impl UsageServiceTrait for UsageServiceImpl {
             .get_usage_by_model(organization_id, start_date)
             .await
             .map_err(|e| UsageError::InternalError(format!("Failed to get usage by model: {e}")))
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError> {
+        self.usage_repository
+            .list_inference_usage_report(query)
+            .await
+            .map_err(|e| {
+                UsageError::InternalError(format!("Failed to list inference usage report: {e}"))
+            })
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError> {
+        self.usage_repository
+            .list_inference_usage_history(query)
+            .await
+            .map_err(|e| {
+                UsageError::InternalError(format!("Failed to list inference usage history: {e}"))
+            })
     }
 }
 

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -1,4 +1,8 @@
 use crate::responses::models::ResponseId;
+pub use crate::usage::reporting::{
+    InferenceUsageHistoryQuery, InferenceUsageReportCursor, InferenceUsageReportQuery,
+    InferenceUsageReportRow,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -288,6 +292,16 @@ pub trait UsageServiceTrait: Send + Sync {
         organization_id: Uuid,
         start_date: DateTime<Utc>,
     ) -> Result<Vec<UsageByModelEntry>, UsageError>;
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError>;
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError>;
 }
 
 // ============================================
@@ -354,6 +368,16 @@ pub trait UsageRepository: Send + Sync {
         organization_id: Uuid,
         start_date: DateTime<Utc>,
     ) -> anyhow::Result<Vec<UsageByModelEntry>>;
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> anyhow::Result<Vec<InferenceUsageReportRow>>;
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> anyhow::Result<(Vec<InferenceUsageReportRow>, i64)>;
 }
 
 #[async_trait::async_trait]

--- a/crates/services/src/usage/reporting.rs
+++ b/crates/services/src/usage/reporting.rs
@@ -1,0 +1,72 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceUsageReportCursor {
+    pub created_at: DateTime<Utc>,
+    pub id: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceUsageReportQuery {
+    pub organization_id: Uuid,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<String>,
+    pub limit: u16,
+    pub cursor: Option<InferenceUsageReportCursor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceUsageHistoryQuery {
+    pub organization_id: Uuid,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+impl InferenceUsageReportQuery {
+    pub const fn for_organization(organization_id: Uuid) -> Self {
+        Self {
+            organization_id,
+            start_time: None,
+            end_time: None,
+            workspace_id: None,
+            api_key_id: None,
+            model: None,
+            inference_type: None,
+            limit: 100,
+            cursor: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceUsageReportRow {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub model: String,
+    pub inference_type: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub input_cost_nano_usd: i64,
+    pub output_cost_nano_usd: i64,
+    pub cache_read_cost_nano_usd: Option<i64>,
+    pub total_cost_nano_usd: i64,
+    pub response_id: Option<Uuid>,
+    pub inference_id: Option<Uuid>,
+    pub stop_reason: Option<String>,
+    pub image_count: Option<i32>,
+}

--- a/crates/services/src/workspace/mod.rs
+++ b/crates/services/src/workspace/mod.rs
@@ -253,6 +253,8 @@ impl WorkspaceServiceTrait for WorkspaceServiceImpl {
         requester_id: UserId,
         limit: i64,
         offset: i64,
+        order_by: Option<ApiKeyOrderBy>,
+        order_direction: Option<ApiKeyOrderDirection>,
     ) -> Result<Vec<ApiKey>, WorkspaceError> {
         // Check permissions
         self.check_workspace_permission(workspace_id.clone(), requester_id)
@@ -260,7 +262,7 @@ impl WorkspaceServiceTrait for WorkspaceServiceImpl {
 
         // List API keys with pagination (repository now includes usage data via JOIN)
         self.api_key_repository
-            .list_by_workspace_paginated(workspace_id, limit, offset)
+            .list_by_workspace_paginated(workspace_id, limit, offset, order_by, order_direction)
             .await
             .map_err(|e| {
                 WorkspaceError::InternalError(format!(

--- a/crates/services/src/workspace/ports.rs
+++ b/crates/services/src/workspace/ports.rs
@@ -106,6 +106,20 @@ pub enum WorkspaceOrderDirection {
     Desc,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiKeyOrderBy {
+    CreatedAt,
+    Usage,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiKeyOrderDirection {
+    Asc,
+    Desc,
+}
+
 // Repository trait for workspace data access
 #[async_trait]
 pub trait WorkspaceRepository: Send + Sync {
@@ -182,6 +196,8 @@ pub trait ApiKeyRepository: Send + Sync {
         workspace_id: WorkspaceId,
         limit: i64,
         offset: i64,
+        order_by: Option<ApiKeyOrderBy>,
+        order_direction: Option<ApiKeyOrderDirection>,
     ) -> Result<Vec<ApiKey>, RepositoryError>;
 
     async fn delete(&self, id: ApiKeyId) -> Result<bool, RepositoryError>;
@@ -281,6 +297,8 @@ pub trait WorkspaceServiceTrait: Send + Sync {
         requester_id: UserId,
         limit: i64,
         offset: i64,
+        order_by: Option<ApiKeyOrderBy>,
+        order_direction: Option<ApiKeyOrderDirection>,
     ) -> Result<Vec<ApiKey>, WorkspaceError>;
 
     /// Get a specific API key by ID with permission checking


### PR DESCRIPTION
## Summary

Adds a customer-facing programmatic usage reporting surface for organizations:

- read-only `rpt-` reporting tokens with session-authenticated owner/admin management endpoints
- reporting-token auth middleware scoped only to reporting endpoints
- `GET /v1/organizations/{org_id}/usage/export` for cursor-paginated row-level usage export
- `GET /v1/organizations/{org_id}/usage/summary` for aggregate usage and cost breakdowns
- inference + service usage support with `source=inference|service|all`, defaulting to `all`
- OpenAPI registration and focused e2e/database coverage
- out-of-band concurrent index SQL for hot usage tables instead of normal refinery index migrations

## Notes

- Reporting responses keep integer nano-USD fields as the source of truth.
- `cache_read_cost_nano_usd` is omitted when Cloud API does not persist a separate cache-read cost split; `cache_read_tokens` and `total_cost_nano_usd` remain present.
- `inference.inference_id` is the v1 customer-facing reporting correlation id.
- Provider request ids, provider attribution fields, token hashes, raw tokens, raw prompts/outputs, uploaded file content, and Stripe/payment data are intentionally excluded.
- Production high-volume use should run `crates/database/src/migrations/out_of_band/usage_reporting_indexes.sql` outside refinery/transactions.

## Validation

- `git diff --check`
- `cargo test -p api reporting_usage_query --lib -- --nocapture` passed
- `DEV=1 BRAVE_SEARCH_PRO_API_KEY=dummy TEST_DATABASE_NAME=platform_api_global_debug_e2e_serial_<ts> cargo test -p api --test e2e_all reporting_usage::usage_ -- --nocapture --test-threads=1` passed 8 tests
- Live local Cloud API `curl -i` flow passed: create reporting token, export, summary, open-ended range cap, invalid ranges, wrong-org 403, revoke, revoked-token 401
- `cargo test -p api test_openapi_spec_generation -- --nocapture` passed in final verification evidence
- Full `make preflight` remains locally blocked by the known missing dstack/CVM socket after targeted gates pass

## Related PRs

- Docs PR: pending; will link after creation
