### PR TITLE
feat: add programmatic usage reporting

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -10,7 +10,10 @@ use crate::ohttp_gateway::{OhttpAttestation, OhttpGateway};
 use crate::routes::mcp_server::{handle_mcp_request, McpRouteState};
 use crate::routes::ohttp::{ohttp_config, ohttp_relay};
 use crate::{
-    middleware::{auth::auth_middleware_with_api_key, auth_middleware, AuthState},
+    middleware::{
+        auth::{auth_middleware_with_api_key, auth_middleware_with_reporting_token},
+        auth_middleware, AuthState,
+    },
     openapi::ApiDoc,
     routes::{
         api::{build_management_router, AppState},
@@ -222,6 +225,11 @@ pub fn init_auth_services(database: Arc<Database>, config: &ApiConfig) -> AuthCo
         oauth_manager_arc.clone(),
         auth_service.clone(),
         workspace_repository.clone(),
+        Arc::new(
+            database::repositories::OrganizationReportingTokenRepository::new(
+                database.pool().clone(),
+            ),
+        ) as Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
         admin_access_token_repository,
         config.auth.admin_domains.clone(),
         config.auth.encoding_key.clone(),
@@ -1139,6 +1147,12 @@ pub fn build_app_with_config(
         attestation_service: domain_services.attestation_service.clone(),
         usage_service: domain_services.usage_service.clone(),
         service_usage_service: domain_services.service_usage_service.clone(),
+        reporting_token_repository: Arc::new(
+            database::repositories::OrganizationReportingTokenRepository::new(
+                database.pool().clone(),
+            ),
+        )
+            as Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
         user_service: domain_services.user_service.clone(),
         files_service: domain_services.files_service.clone(),
         inference_provider_pool: domain_services.inference_provider_pool.clone(),
@@ -1263,6 +1277,19 @@ pub fn build_app_with_config(
         domain_services.usage_service.clone(),
         &auth_components.auth_state_middleware,
     );
+    let reporting_usage_routes = build_reporting_usage_routes(
+        domain_services.usage_service.clone(),
+        domain_services.service_usage_service.clone(),
+        Arc::new(database::repositories::OrganizationUsageRepository::new(
+            database.pool().clone(),
+        )),
+        Arc::new(
+            database::repositories::OrganizationServiceUsageRepository::new(
+                database.pool().clone(),
+            ),
+        ),
+        &auth_components.auth_state_middleware,
+    );
 
     // Build OpenAPI and documentation routes
     let openapi_routes = build_openapi_routes();
@@ -1326,6 +1353,7 @@ pub fn build_app_with_config(
                 .merge(files_routes)
                 .merge(feature_request_routes)
                 .merge(billing_routes)
+                .merge(reporting_usage_routes)
                 .merge(gateway_routes)
                 .merge(internal_routes)
                 .merge(health_routes)
@@ -1782,6 +1810,57 @@ pub fn build_billing_routes(
             auth_state_middleware.clone(),
             middleware::auth::auth_middleware_with_workspace_context,
         ))
+}
+
+pub fn build_reporting_usage_routes(
+    usage_service: Arc<dyn services::usage::UsageServiceTrait + Send + Sync>,
+    service_usage_service: Arc<dyn services::service_usage::ServiceUsageServiceTrait + Send + Sync>,
+    inference_summary_repo: Arc<dyn services::reporting_usage::InferenceUsageSummaryRepository>,
+    service_summary_repo: Arc<dyn services::reporting_usage::ServiceUsageSummaryRepository>,
+    auth_state_middleware: &AuthState,
+) -> Router {
+    let export_state = crate::routes::reporting_usage::ReportingUsageExportState::new(
+        usage_service,
+        service_usage_service,
+    );
+    let summary_state = crate::routes::reporting_usage::ReportingUsageSummaryState::new(
+        inference_summary_repo,
+        service_summary_repo,
+    );
+    let export_router = Router::new()
+        .route(
+            "/organizations/{org_id}/usage/export",
+            get(crate::routes::reporting_usage::export_usage),
+        )
+        .with_state(export_state);
+    let summary_router = Router::new()
+        .route(
+            "/organizations/{org_id}/usage/summary",
+            get(crate::routes::reporting_usage::summary_usage),
+        )
+        .with_state(summary_state);
+    let router = Router::new().merge(export_router).merge(summary_router);
+
+    #[cfg(debug_assertions)]
+    {
+        router
+            .route(
+                "/organizations/{org_id}/usage/reporting-token-auth-probe",
+                get(crate::routes::reporting_usage::reporting_token_auth_probe),
+            )
+            .layer(from_fn_with_state(
+                auth_state_middleware.clone(),
+                auth_middleware_with_reporting_token,
+            ))
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        router.layer(from_fn_with_state(
+            auth_state_middleware.clone(),
+            auth_middleware_with_reporting_token,
+        ))
+    }
 }
 
 /// Build gateway routes for external model gateways to validate API keys.
@@ -2277,9 +2356,71 @@ mod tests {
         assert!(components.security_schemes.contains_key("session_token"));
         assert!(components.security_schemes.contains_key("refresh_token"));
         assert!(components.security_schemes.contains_key("api_key"));
+        assert!(components.security_schemes.contains_key("reporting_token"));
+
+        let spec_json = serde_json::to_value(&spec).unwrap();
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/reporting-tokens",
+            "post",
+            "session_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/reporting-tokens",
+            "get",
+            "session_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/reporting-tokens/{token_id}",
+            "delete",
+            "session_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/usage/export",
+            "get",
+            "reporting_token",
+        );
+        assert_reporting_path_security(
+            &spec_json,
+            "/v1/organizations/{org_id}/usage/summary",
+            "get",
+            "reporting_token",
+        );
+        println!(
+            "OPENAPI_REPORTING_CONTRACT={}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "reporting_tokens": spec_json["paths"]["/v1/organizations/{org_id}/reporting-tokens"],
+                "reporting_token_revoke": spec_json["paths"]["/v1/organizations/{org_id}/reporting-tokens/{token_id}"],
+                "usage_export": spec_json["paths"]["/v1/organizations/{org_id}/usage/export"],
+                "usage_summary": spec_json["paths"]["/v1/organizations/{org_id}/usage/summary"],
+                "reporting_token_scheme": spec_json["components"]["securitySchemes"]["reporting_token"],
+            }))
+            .unwrap()
+        );
 
         // Verify servers are not hardcoded (will be set dynamically on client)
         assert!(spec.servers.is_none() || spec.servers.as_ref().unwrap().is_empty());
+    }
+
+    fn assert_reporting_path_security(
+        spec: &serde_json::Value,
+        path: &str,
+        method: &str,
+        scheme: &str,
+    ) {
+        let operation = &spec["paths"][path][method];
+        assert!(
+            operation.is_object(),
+            "missing OpenAPI operation: {method} {path}"
+        );
+        assert_eq!(
+            operation["security"],
+            serde_json::json!([{ scheme: [] }]),
+            "{method} {path} must use only {scheme} security"
+        );
     }
 
     #[test]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -226,10 +226,12 @@ pub fn init_auth_services(database: Arc<Database>, config: &ApiConfig) -> AuthCo
         auth_service.clone(),
         workspace_repository.clone(),
         Arc::new(
-            database::repositories::OrganizationReportingTokenRepository::new(
-                database.pool().clone(),
-            ),
-        ) as Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
+            services::reporting_tokens::OrganizationReportingTokenServiceImpl::new(Arc::new(
+                database::repositories::OrganizationReportingTokenRepository::new(
+                    database.pool().clone(),
+                ),
+            )),
+        ) as Arc<dyn services::reporting_tokens::OrganizationReportingTokenService>,
         admin_access_token_repository,
         config.auth.admin_domains.clone(),
         config.auth.encoding_key.clone(),
@@ -316,6 +318,7 @@ pub async fn init_domain_services_with_pool(
     // fallback counter (cloud_api.provider.requests) from the one layer that
     // knows which trust tier served each request.
     inference_provider_pool.set_metrics_service(metrics_service.clone());
+    let reporting_statement_timeout = config.usage_reporting.database_statement_timeout();
 
     // Create shared repositories
     let conversation_repo = Arc::new(database::PgConversationRepository::new(
@@ -371,9 +374,12 @@ pub async fn init_domain_services_with_pool(
     ));
 
     // Prepare repositories for usage service (will be created after workspace service)
-    let usage_repository = Arc::new(database::repositories::OrganizationUsageRepository::new(
-        database.pool().clone(),
-    ));
+    let usage_repository = Arc::new(
+        database::repositories::OrganizationUsageRepository::with_reporting_statement_timeout(
+            database.pool().clone(),
+            reporting_statement_timeout,
+        ),
+    );
     let limits_repository_for_usage = Arc::new(
         database::repositories::OrganizationLimitsRepository::new(database.pool().clone()),
     );
@@ -482,7 +488,10 @@ pub async fn init_domain_services_with_pool(
         database.pool().clone(),
     ));
     let org_service_usage_repo = Arc::new(
-        database::repositories::OrganizationServiceUsageRepository::new(database.pool().clone()),
+        database::repositories::OrganizationServiceUsageRepository::with_reporting_statement_timeout(
+            database.pool().clone(),
+            reporting_statement_timeout,
+        ),
     );
     let service_usage_repo = Arc::new(database::repositories::ServiceUsageRepositoryImpl::new(
         service_repo,
@@ -1147,12 +1156,14 @@ pub fn build_app_with_config(
         attestation_service: domain_services.attestation_service.clone(),
         usage_service: domain_services.usage_service.clone(),
         service_usage_service: domain_services.service_usage_service.clone(),
-        reporting_token_repository: Arc::new(
-            database::repositories::OrganizationReportingTokenRepository::new(
-                database.pool().clone(),
-            ),
+        reporting_token_service: Arc::new(
+            services::reporting_tokens::OrganizationReportingTokenServiceImpl::new(Arc::new(
+                database::repositories::OrganizationReportingTokenRepository::new(
+                    database.pool().clone(),
+                ),
+            )),
         )
-            as Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
+            as Arc<dyn services::reporting_tokens::OrganizationReportingTokenService>,
         user_service: domain_services.user_service.clone(),
         files_service: domain_services.files_service.clone(),
         inference_provider_pool: domain_services.inference_provider_pool.clone(),
@@ -1277,19 +1288,28 @@ pub fn build_app_with_config(
         domain_services.usage_service.clone(),
         &auth_components.auth_state_middleware,
     );
-    let reporting_usage_routes = build_reporting_usage_routes(
-        domain_services.usage_service.clone(),
-        domain_services.service_usage_service.clone(),
-        Arc::new(database::repositories::OrganizationUsageRepository::new(
-            database.pool().clone(),
-        )),
-        Arc::new(
-            database::repositories::OrganizationServiceUsageRepository::new(
+    let reporting_usage_routes = if config.usage_reporting.enabled {
+        let summary_repository = Arc::new(
+            database::repositories::PostgresReportingUsageSummaryRepository::with_statement_timeout(
                 database.pool().clone(),
+                config.usage_reporting.database_statement_timeout(),
             ),
-        ),
-        &auth_components.auth_state_middleware,
-    );
+        )
+            as Arc<dyn services::reporting_usage::ReportingUsageSummaryRepository>;
+        let summary_service = Arc::new(services::reporting_usage::ReportingUsageService::new(
+            summary_repository,
+        ));
+        build_reporting_usage_routes(
+            domain_services.usage_service.clone(),
+            domain_services.service_usage_service.clone(),
+            summary_service,
+            middleware::ReportingGuardState::from_config(&config.usage_reporting),
+            &auth_components.auth_state_middleware,
+        )
+    } else {
+        tracing::info!("Programmatic usage reporting routes are disabled");
+        Router::new()
+    };
 
     // Build OpenAPI and documentation routes
     let openapi_routes = build_openapi_routes();
@@ -1815,18 +1835,16 @@ pub fn build_billing_routes(
 pub fn build_reporting_usage_routes(
     usage_service: Arc<dyn services::usage::UsageServiceTrait + Send + Sync>,
     service_usage_service: Arc<dyn services::service_usage::ServiceUsageServiceTrait + Send + Sync>,
-    inference_summary_repo: Arc<dyn services::reporting_usage::InferenceUsageSummaryRepository>,
-    service_summary_repo: Arc<dyn services::reporting_usage::ServiceUsageSummaryRepository>,
+    summary_service: Arc<services::reporting_usage::ReportingUsageService>,
+    guard_state: middleware::ReportingGuardState,
     auth_state_middleware: &AuthState,
 ) -> Router {
     let export_state = crate::routes::reporting_usage::ReportingUsageExportState::new(
         usage_service,
         service_usage_service,
     );
-    let summary_state = crate::routes::reporting_usage::ReportingUsageSummaryState::new(
-        inference_summary_repo,
-        service_summary_repo,
-    );
+    let summary_state =
+        crate::routes::reporting_usage::ReportingUsageSummaryState::new(summary_service);
     let export_router = Router::new()
         .route(
             "/organizations/{org_id}/usage/export",
@@ -1842,25 +1860,24 @@ pub fn build_reporting_usage_routes(
     let router = Router::new().merge(export_router).merge(summary_router);
 
     #[cfg(debug_assertions)]
-    {
-        router
-            .route(
-                "/organizations/{org_id}/usage/reporting-token-auth-probe",
-                get(crate::routes::reporting_usage::reporting_token_auth_probe),
-            )
-            .layer(from_fn_with_state(
-                auth_state_middleware.clone(),
-                auth_middleware_with_reporting_token,
-            ))
-    }
+    let router = router.route(
+        "/organizations/{org_id}/usage/reporting-token-auth-probe",
+        get(crate::routes::reporting_usage::reporting_token_auth_probe),
+    );
 
-    #[cfg(not(debug_assertions))]
-    {
-        router.layer(from_fn_with_state(
+    router
+        .layer(from_fn_with_state(
+            guard_state.clone(),
+            middleware::reporting_token_guard_middleware,
+        ))
+        .layer(from_fn_with_state(
             auth_state_middleware.clone(),
             auth_middleware_with_reporting_token,
         ))
-    }
+        .layer(from_fn_with_state(
+            guard_state,
+            middleware::reporting_global_guard_middleware,
+        ))
 }
 
 /// Build gateway routes for external model gateways to validate API keys.
@@ -2542,6 +2559,7 @@ mod tests {
             github_dispatch: config::GitHubDispatchConfig::default(),
             infra: config::InfraConfig::default(),
             staking_farm: config::StakingFarmConfig::default(),
+            usage_reporting: config::UsageReportingConfig::default(),
             ita: config::ItaAttestationConfig::default(),
         };
 
@@ -2648,6 +2666,7 @@ mod tests {
             github_dispatch: config::GitHubDispatchConfig::default(),
             infra: config::InfraConfig::default(),
             staking_farm: config::StakingFarmConfig::default(),
+            usage_reporting: config::UsageReportingConfig::default(),
             ita: config::ItaAttestationConfig::default(),
         };
 

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -20,6 +20,11 @@ async fn main() {
 
     // Initialize core services
     let database = init_database(&config.database).await;
+    if config.usage_reporting.enabled {
+        database::ensure_usage_reporting_indexes(database.pool())
+            .await
+            .expect("Usage reporting index prerequisites are not satisfied");
+    }
     let auth_components = init_auth_services(database.clone(), &config);
 
     // Initialize OpenTelemetry pipeline

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -187,7 +187,7 @@ pub async fn auth_middleware(
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
-                    "Invalid authorization header format".to_string(),
+                    "Authorization header does not start with 'Bearer '".to_string(),
                     "unauthorized".to_string(),
                 )),
             ))
@@ -671,9 +671,9 @@ async fn authenticate_reporting_token(
     state: &AuthState,
     token: &str,
 ) -> Result<AuthenticatedReportingToken, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
-    debug!("Calling reporting token repository to validate token");
+    debug!("Calling reporting token service to validate token");
 
-    match state.reporting_token_repository.validate(token).await {
+    match state.reporting_token_service.validate(token).await {
         Ok(Some(validated)) => Ok(reporting_token_extension(validated)),
         Ok(None) => {
             debug!("Invalid or expired reporting token");
@@ -771,8 +771,8 @@ pub struct AuthState {
     pub oauth_manager: Arc<OAuthManager>,
     pub auth_service: Arc<dyn AuthServiceTrait>,
     pub workspace_repository: Arc<dyn services::workspace::WorkspaceRepository>,
-    pub reporting_token_repository:
-        Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
+    pub reporting_token_service:
+        Arc<dyn services::reporting_tokens::OrganizationReportingTokenService>,
     pub admin_access_token_repository: Arc<database::repositories::AdminAccessTokenRepository>,
     pub admin_domains: Vec<String>,
     pub encoding_key: String,
@@ -783,8 +783,8 @@ impl AuthState {
         oauth_manager: Arc<OAuthManager>,
         auth_service: Arc<dyn AuthServiceTrait>,
         workspace_repository: Arc<dyn services::workspace::WorkspaceRepository>,
-        reporting_token_repository: Arc<
-            dyn services::reporting_tokens::OrganizationReportingTokenRepository,
+        reporting_token_service: Arc<
+            dyn services::reporting_tokens::OrganizationReportingTokenService,
         >,
         admin_access_token_repository: Arc<database::repositories::AdminAccessTokenRepository>,
         admin_domains: Vec<String>,
@@ -794,7 +794,7 @@ impl AuthState {
             oauth_manager,
             auth_service,
             workspace_repository,
-            reporting_token_repository,
+            reporting_token_service,
             admin_access_token_repository,
             admin_domains,
             encoding_key,

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -6,6 +6,8 @@ use axum::{
 };
 use database::User as DbUser;
 use services::auth::{AuthError, AuthServiceTrait, OAuthManager, SessionToken};
+use services::common::REPORTING_TOKEN_PREFIX;
+use services::reporting_tokens::{ReportingTokenScope, ValidatedOrganizationReportingToken};
 use std::sync::Arc;
 use tracing::{debug, error};
 
@@ -48,6 +50,14 @@ pub struct AuthenticatedApiKey {
     pub organization: services::organization::Organization,
 }
 
+#[derive(Clone, Debug)]
+pub struct AuthenticatedReportingToken {
+    pub id: uuid::Uuid,
+    pub organization_id: uuid::Uuid,
+    pub token_prefix: String,
+    pub scope: ReportingTokenScope,
+}
+
 pub async fn auth_middleware_with_api_key(
     State(state): State<AuthState>,
     request: Request,
@@ -68,7 +78,7 @@ pub async fn auth_middleware_with_api_key(
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
             authenticate_api_key(&state, token).await
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
@@ -120,7 +130,7 @@ pub async fn auth_middleware_with_workspace_context(
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
             authenticate_api_key_with_context(&state, token).await
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
@@ -173,11 +183,11 @@ pub async fn auth_middleware(
             debug!("Extracted Bearer token");
             authenticate_session_access(&state, token.to_string()).await
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
-                    "Authorization header does not start with 'Bearer '".to_string(),
+                    "Invalid authorization header format".to_string(),
                     "unauthorized".to_string(),
                 )),
             ))
@@ -200,6 +210,55 @@ pub async fn auth_middleware(
             Ok(next.run(request).await)
         }
         Err(status) => Err(status),
+    }
+}
+
+pub async fn auth_middleware_with_reporting_token(
+    State(state): State<AuthState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|h| h.to_str().ok());
+
+    tracing::debug!(
+        has_authorization = auth_header.is_some(),
+        "Auth reporting token middleware"
+    );
+
+    let auth_result = if let Some(auth_value) = auth_header {
+        debug!("Found Authorization header");
+        if let Some(token) = auth_value.strip_prefix("Bearer ") {
+            authenticate_reporting_token(&state, token).await
+        } else {
+            debug!("Authorization header uses unsupported scheme");
+            Err((
+                StatusCode::UNAUTHORIZED,
+                axum::Json(crate::models::ErrorResponse::new(
+                    "Invalid authorization header format".to_string(),
+                    "invalid_auth_header".to_string(),
+                )),
+            ))
+        }
+    } else {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            axum::Json(crate::models::ErrorResponse::new(
+                "Missing authorization header".to_string(),
+                "missing_auth_header".to_string(),
+            )),
+        ))
+    };
+
+    match auth_result {
+        Ok(reporting_token) => {
+            let mut request = request;
+            request.extensions_mut().insert(reporting_token);
+            Ok(next.run(request).await)
+        }
+        Err(error) => Err(error),
     }
 }
 
@@ -294,11 +353,11 @@ pub async fn admin_middleware(
                 authenticate_session_access(&state, token.to_string()).await
             }
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err((
                 StatusCode::UNAUTHORIZED,
                 axum::Json(crate::models::ErrorResponse::new(
-                    "Authorization header does not start with 'Bearer '".to_string(),
+                    "Invalid authorization header format".to_string(),
                     "unauthorized".to_string(),
                 )),
             ))
@@ -411,6 +470,17 @@ async fn authenticate_session_access(
     state: &AuthState,
     token: String, // jwt
 ) -> Result<DbUser, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
+    if token.starts_with(REPORTING_TOKEN_PREFIX) {
+        debug!("Reporting token rejected by session middleware");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            axum::Json(crate::models::ErrorResponse::new(
+                "Invalid or expired access token".to_string(),
+                "unauthorized".to_string(),
+            )),
+        ));
+    }
+
     debug!("Authenticating session access token");
     // Use auth service
 
@@ -480,6 +550,10 @@ pub async fn refresh_middleware(
         debug!("Found Authorization header");
         if let Some(token) = auth_value.strip_prefix("Bearer ") {
             debug!("Extracted Bearer token");
+            if token.starts_with(REPORTING_TOKEN_PREFIX) {
+                debug!("Reporting token rejected by refresh middleware");
+                return Err(StatusCode::UNAUTHORIZED);
+            }
             if let Some(user_agent_value) = user_agent {
                 authenticate_session_refresh(
                     &state,
@@ -492,7 +566,7 @@ pub async fn refresh_middleware(
                 Err(StatusCode::UNAUTHORIZED)
             }
         } else {
-            debug!("Authorization header does not start with 'Bearer '");
+            debug!("Authorization header uses unsupported scheme");
             Err(StatusCode::UNAUTHORIZED)
         }
     } else {
@@ -593,6 +667,48 @@ async fn authenticate_api_key(
     }
 }
 
+async fn authenticate_reporting_token(
+    state: &AuthState,
+    token: &str,
+) -> Result<AuthenticatedReportingToken, (StatusCode, axum::Json<crate::models::ErrorResponse>)> {
+    debug!("Calling reporting token repository to validate token");
+
+    match state.reporting_token_repository.validate(token).await {
+        Ok(Some(validated)) => Ok(reporting_token_extension(validated)),
+        Ok(None) => {
+            debug!("Invalid or expired reporting token");
+            Err((
+                StatusCode::UNAUTHORIZED,
+                axum::Json(crate::models::ErrorResponse::new(
+                    "Invalid or expired reporting token".to_string(),
+                    "invalid_reporting_token".to_string(),
+                )),
+            ))
+        }
+        Err(_) => {
+            error!("Failed to validate reporting token");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(crate::models::ErrorResponse::new(
+                    "Failed to validate reporting token".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            ))
+        }
+    }
+}
+
+fn reporting_token_extension(
+    validated: ValidatedOrganizationReportingToken,
+) -> AuthenticatedReportingToken {
+    AuthenticatedReportingToken {
+        id: validated.id,
+        organization_id: validated.organization_id,
+        token_prefix: validated.token_prefix,
+        scope: validated.scope,
+    }
+}
+
 /// Authenticate using API key and resolve workspace/organization context
 async fn authenticate_api_key_with_context(
     state: &AuthState,
@@ -655,6 +771,8 @@ pub struct AuthState {
     pub oauth_manager: Arc<OAuthManager>,
     pub auth_service: Arc<dyn AuthServiceTrait>,
     pub workspace_repository: Arc<dyn services::workspace::WorkspaceRepository>,
+    pub reporting_token_repository:
+        Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
     pub admin_access_token_repository: Arc<database::repositories::AdminAccessTokenRepository>,
     pub admin_domains: Vec<String>,
     pub encoding_key: String,
@@ -665,6 +783,9 @@ impl AuthState {
         oauth_manager: Arc<OAuthManager>,
         auth_service: Arc<dyn AuthServiceTrait>,
         workspace_repository: Arc<dyn services::workspace::WorkspaceRepository>,
+        reporting_token_repository: Arc<
+            dyn services::reporting_tokens::OrganizationReportingTokenRepository,
+        >,
         admin_access_token_repository: Arc<database::repositories::AdminAccessTokenRepository>,
         admin_domains: Vec<String>,
         encoding_key: String,
@@ -673,6 +794,7 @@ impl AuthState {
             oauth_manager,
             auth_service,
             workspace_repository,
+            reporting_token_repository,
             admin_access_token_repository,
             admin_domains,
             encoding_key,

--- a/crates/api/src/middleware/mod.rs
+++ b/crates/api/src/middleware/mod.rs
@@ -7,6 +7,7 @@ pub mod auth;
 pub mod body_hash;
 pub mod metrics;
 pub mod rate_limit;
+pub mod reporting_guard;
 pub mod request_correlation;
 pub mod usage;
 
@@ -18,5 +19,9 @@ pub use auth::{
 pub use body_hash::{body_hash_middleware, RequestBodyHash};
 pub use metrics::{http_metrics_middleware, MetricsState};
 pub use rate_limit::{api_key_rate_limit_middleware, RateLimitState};
+pub use reporting_guard::{
+    reporting_global_guard_middleware, reporting_token_guard_middleware, ReportingGuardState,
+    ReportingRequestDeadline,
+};
 pub use request_correlation::{request_correlation_middleware, RequestCorrelation};
 pub use usage::{usage_check_middleware, UsageState};

--- a/crates/api/src/middleware/mod.rs
+++ b/crates/api/src/middleware/mod.rs
@@ -11,7 +11,10 @@ pub mod request_correlation;
 pub mod usage;
 
 // Re-export commonly used items
-pub use auth::{admin_middleware, auth_middleware, AdminUser, AuthState, AuthenticatedUser};
+pub use auth::{
+    admin_middleware, auth_middleware, AdminUser, AuthState, AuthenticatedReportingToken,
+    AuthenticatedUser,
+};
 pub use body_hash::{body_hash_middleware, RequestBodyHash};
 pub use metrics::{http_metrics_middleware, MetricsState};
 pub use rate_limit::{api_key_rate_limit_middleware, RateLimitState};

--- a/crates/api/src/middleware/reporting_guard.rs
+++ b/crates/api/src/middleware/reporting_guard.rs
@@ -1,0 +1,200 @@
+use super::AuthenticatedReportingToken;
+use crate::models::ErrorResponse;
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::Response,
+    Json,
+};
+use moka::future::Cache;
+use std::{
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use uuid::Uuid;
+
+const RATE_WINDOW: Duration = Duration::from_secs(60);
+const TOKEN_CACHE_CAPACITY: u64 = 50_000;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ReportingRequestDeadline(Instant);
+
+impl ReportingRequestDeadline {
+    pub const fn instant(self) -> Instant {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct Counter(AtomicU32);
+
+impl Counter {
+    const fn new() -> Self {
+        Self(AtomicU32::new(0))
+    }
+
+    fn increment(&self) -> u32 {
+        self.0.fetch_add(1, Ordering::Relaxed) + 1
+    }
+}
+
+#[derive(Clone)]
+pub struct ReportingGuardState {
+    global_requests: Cache<(), Arc<Counter>>,
+    token_requests: Cache<Uuid, Arc<Counter>>,
+    global_concurrency: Arc<Semaphore>,
+    token_concurrency: Cache<Uuid, Arc<Semaphore>>,
+    global_requests_per_minute: u32,
+    token_requests_per_minute: u32,
+    token_max_concurrent_requests: usize,
+    request_timeout: Duration,
+}
+
+impl ReportingGuardState {
+    pub fn from_config(config: &config::UsageReportingConfig) -> Self {
+        Self::new(
+            config.global_requests_per_minute,
+            config.token_requests_per_minute,
+            config.max_concurrent_requests,
+            config.token_max_concurrent_requests,
+            Duration::from_secs(config.request_timeout_seconds),
+        )
+    }
+
+    pub fn new(
+        global_requests_per_minute: u32,
+        token_requests_per_minute: u32,
+        max_concurrent_requests: usize,
+        token_max_concurrent_requests: usize,
+        request_timeout: Duration,
+    ) -> Self {
+        Self {
+            global_requests: Cache::builder()
+                .time_to_live(RATE_WINDOW)
+                .max_capacity(1)
+                .build(),
+            token_requests: Cache::builder()
+                .time_to_live(RATE_WINDOW)
+                .max_capacity(TOKEN_CACHE_CAPACITY)
+                .build(),
+            global_concurrency: Arc::new(Semaphore::new(max_concurrent_requests)),
+            token_concurrency: Cache::builder().max_capacity(TOKEN_CACHE_CAPACITY).build(),
+            global_requests_per_minute,
+            token_requests_per_minute,
+            token_max_concurrent_requests,
+            request_timeout,
+        }
+    }
+
+    async fn check_global_limit(&self) -> bool {
+        let counter = self
+            .global_requests
+            .get_with((), async { Arc::new(Counter::new()) })
+            .await;
+        counter.increment() <= self.global_requests_per_minute
+    }
+
+    async fn check_token_limit(&self, token_id: Uuid) -> bool {
+        let counter = self
+            .token_requests
+            .get_with(token_id, async { Arc::new(Counter::new()) })
+            .await;
+        counter.increment() <= self.token_requests_per_minute
+    }
+
+    fn try_acquire(&self) -> Option<OwnedSemaphorePermit> {
+        self.global_concurrency.clone().try_acquire_owned().ok()
+    }
+
+    async fn try_acquire_token(&self, token_id: Uuid) -> Option<OwnedSemaphorePermit> {
+        self.token_concurrency
+            .get_with(token_id, async {
+                Arc::new(Semaphore::new(self.token_max_concurrent_requests))
+            })
+            .await
+            .try_acquire_owned()
+            .ok()
+    }
+}
+
+type GuardError = (StatusCode, Json<ErrorResponse>);
+
+pub async fn reporting_global_guard_middleware(
+    State(state): State<ReportingGuardState>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, GuardError> {
+    if !state.check_global_limit().await {
+        return Err(rate_limit_error(
+            "Programmatic usage reporting rate limit exceeded. Retry later.",
+        ));
+    }
+    let _permit = state.try_acquire().ok_or_else(|| {
+        rate_limit_error("Too many reporting requests are in progress. Retry shortly.")
+    })?;
+
+    let deadline = Instant::now() + state.request_timeout;
+    request
+        .extensions_mut()
+        .insert(ReportingRequestDeadline(deadline));
+    tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), next.run(request))
+        .await
+        .map_err(|_| {
+            (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(ErrorResponse::new(
+                    "Usage reporting request timed out".to_string(),
+                    "reporting_request_timeout".to_string(),
+                )),
+            )
+        })
+}
+
+pub async fn reporting_token_guard_middleware(
+    State(state): State<ReportingGuardState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, GuardError> {
+    let token_id = request
+        .extensions()
+        .get::<AuthenticatedReportingToken>()
+        .map(|token| token.id)
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "Reporting authentication context is missing".to_string(),
+                    "internal_server_error".to_string(),
+                )),
+            )
+        })?;
+    let _permit = state.try_acquire_token(token_id).await.ok_or_else(|| {
+        rate_limit_error("Too many concurrent requests for this reporting token.")
+    })?;
+    if !state.check_token_limit(token_id).await {
+        return Err(rate_limit_error(
+            "Reporting token rate limit exceeded. Retry later.",
+        ));
+    }
+
+    Ok(next.run(request).await)
+}
+
+fn rate_limit_error(message: &str) -> GuardError {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(ErrorResponse::new(
+            message.to_string(),
+            "rate_limit_exceeded".to_string(),
+        )),
+    )
+}
+
+#[cfg(test)]
+#[path = "reporting_guard_tests.rs"]
+mod tests;

--- a/crates/api/src/middleware/reporting_guard_tests.rs
+++ b/crates/api/src/middleware/reporting_guard_tests.rs
@@ -1,0 +1,116 @@
+use super::{
+    reporting_global_guard_middleware, reporting_token_guard_middleware, ReportingGuardState,
+};
+use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::from_fn_with_state,
+    routing::get,
+    Extension, Router,
+};
+use http_body_util::BodyExt as _;
+use services::reporting_tokens::REPORTING_TOKEN_SCOPE_USAGE_READ;
+use std::time::Duration;
+use tower::ServiceExt as _;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn global_reporting_limit_caps_all_credentials() {
+    let state = ReportingGuardState::new(2, 10, 1, 1, Duration::from_secs(1));
+
+    assert!(state.check_global_limit().await);
+    assert!(state.check_global_limit().await);
+    assert!(!state.check_global_limit().await);
+}
+
+#[tokio::test]
+async fn reporting_token_limits_are_independent() {
+    let state = ReportingGuardState::new(10, 1, 1, 1, Duration::from_secs(1));
+    let first = Uuid::new_v4();
+    let second = Uuid::new_v4();
+
+    assert!(state.check_token_limit(first).await);
+    assert!(!state.check_token_limit(first).await);
+    assert!(state.check_token_limit(second).await);
+}
+
+#[tokio::test]
+async fn reporting_concurrency_is_fail_fast() {
+    let state = ReportingGuardState::new(10, 10, 1, 1, Duration::from_secs(1));
+    let permit = state.try_acquire().expect("first request should acquire");
+
+    assert!(state.try_acquire().is_none());
+    drop(permit);
+    assert!(state.try_acquire().is_some());
+}
+
+#[tokio::test]
+async fn per_token_concurrency_is_fail_fast() {
+    let state = ReportingGuardState::new(10, 10, 2, 1, Duration::from_secs(1));
+    let token_id = Uuid::new_v4();
+    let permit = state
+        .try_acquire_token(token_id)
+        .await
+        .expect("first request should acquire");
+
+    assert!(state.try_acquire_token(token_id).await.is_none());
+    drop(permit);
+    assert!(state.try_acquire_token(token_id).await.is_some());
+}
+
+#[tokio::test]
+async fn token_guard_runs_after_auth_context_and_returns_json_429() {
+    let token_id = Uuid::new_v4();
+    let token = AuthenticatedReportingToken {
+        id: token_id,
+        organization_id: Uuid::new_v4(),
+        token_prefix: "rpt-example".to_string(),
+        scope: REPORTING_TOKEN_SCOPE_USAGE_READ,
+    };
+    let state = ReportingGuardState::new(10, 1, 2, 1, Duration::from_secs(1));
+    let router = Router::new()
+        .route("/", get(|| async { StatusCode::OK }))
+        .layer(from_fn_with_state(state, reporting_token_guard_middleware))
+        .layer(Extension(token));
+
+    let first = router
+        .clone()
+        .oneshot(Request::new(Body::empty()))
+        .await
+        .unwrap();
+    let second = router.oneshot(Request::new(Body::empty())).await.unwrap();
+
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    let body = second.into_body().collect().await.unwrap().to_bytes();
+    let error: ErrorResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(error.error.r#type, "rate_limit_exceeded");
+}
+
+#[tokio::test]
+async fn token_guard_rejects_missing_auth_context() {
+    let state = ReportingGuardState::new(10, 10, 2, 1, Duration::from_secs(1));
+    let router = Router::new()
+        .route("/", get(|| async { StatusCode::OK }))
+        .layer(from_fn_with_state(state, reporting_token_guard_middleware));
+
+    let response = router.oneshot(Request::new(Body::empty())).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn global_guard_times_out_stalled_requests() {
+    let state = ReportingGuardState::new(10, 10, 1, 1, Duration::ZERO);
+    let router = Router::new()
+        .route(
+            "/",
+            get(|| async { std::future::pending::<StatusCode>().await }),
+        )
+        .layer(from_fn_with_state(state, reporting_global_guard_middleware));
+
+    let response = router.oneshot(Request::new(Body::empty())).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+}

--- a/crates/api/src/middleware/usage.rs
+++ b/crates/api/src/middleware/usage.rs
@@ -240,7 +240,8 @@ pub async fn usage_check_middleware(
 mod tests {
     use super::*;
     use services::usage::{
-        CostBreakdown, InferenceCost, OrganizationBalanceInfo, OrganizationCreditLimit,
+        CostBreakdown, InferenceCost, InferenceUsageHistoryQuery, InferenceUsageReportQuery,
+        InferenceUsageReportRow, OrganizationBalanceInfo, OrganizationCreditLimit,
         OrganizationLimit, RecordUsageApiRequest, RecordUsageServiceRequest, UsageByModelEntry,
         UsageError, UsageLogEntry,
     };
@@ -388,6 +389,20 @@ mod tests {
             _start_date: chrono::DateTime<chrono::Utc>,
         ) -> Result<Vec<UsageByModelEntry>, UsageError> {
             unimplemented!()
+        }
+
+        async fn list_inference_usage_report(
+            &self,
+            _query: InferenceUsageReportQuery,
+        ) -> Result<Vec<InferenceUsageReportRow>, UsageError> {
+            Ok(vec![])
+        }
+
+        async fn list_inference_usage_history(
+            &self,
+            _query: InferenceUsageHistoryQuery,
+        ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError> {
+            Ok((vec![], 0))
         }
     }
 

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -311,6 +311,7 @@ use utoipa::{Modify, OpenApi};
             crate::routes::reporting_usage::ReportingUsageRowSource,
             crate::routes::reporting_usage::ReportingUsageExportResponse,
             crate::routes::reporting_usage::ReportingUsageExportRow,
+            crate::routes::reporting_usage::ReportingUsageDetails,
             crate::routes::reporting_usage::ReportingInferenceUsage,
             crate::routes::reporting_usage::ReportingServiceUsage,
             crate::routes::reporting_usage::ReportingUsageSummaryResponse,

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -7,7 +7,7 @@ use utoipa::{Modify, OpenApi};
 #[openapi(
     info(
         title = "NEAR AI Cloud API",
-        description = "A comprehensive cloud API for AI model inference, conversation management, and organization administration.\n\n## Authentication\n\nThis API supports three authentication methods:\n\n1. **Access Token (JWT)**: Use `Authorization: Bearer <jwt_token>` with a short-lived JWT access token for most API endpoints. Obtain this by calling POST /users/me/access_tokens with a refresh token.\n2. **Refresh Token**: Use `Authorization: Bearer <refresh_token>` (prefix: `rt_`) only with POST /users/me/access_tokens to create new JWT access tokens. Obtained from OAuth login.\n3. **API Key (Programmatic Access)**: Use `Authorization: Bearer sk-<api_key>` with an API key (prefix: `sk-`)\n\nClick the **Authorize** button above to configure authentication.",
+        description = "A comprehensive cloud API for AI model inference, conversation management, and organization administration.\n\n## Authentication\n\nThis API supports four authentication methods:\n\n1. **Access Token (JWT)**: Use `Authorization: Bearer <jwt_token>` with a short-lived JWT access token for most API endpoints. Obtain this by calling POST /users/me/access_tokens with a refresh token.\n2. **Refresh Token**: Use `Authorization: Bearer <refresh_token>` (prefix: `rt_`) only with POST /users/me/access_tokens to create new JWT access tokens. Obtained from OAuth login.\n3. **API Key (Programmatic Access)**: Use `Authorization: Bearer sk-<api_key>` with an API key (prefix: `sk-`).\n4. **Reporting Token (Read-only Usage Reporting)**: Use `Authorization: Bearer rpt-<reporting_token>` only with usage reporting endpoints.\n\nClick the **Authorize** button above to configure authentication.",
         version = "1.0.0",
         contact(
             name = "NEAR AI Team",
@@ -34,6 +34,7 @@ use utoipa::{Modify, OpenApi};
         (name = "Users", description = "User profile and token management"),
         (name = "Invitations", description = "Token-based invitation handling"),
         (name = "Usage", description = "Usage tracking and billing information"),
+        (name = "Reporting", description = "Read-only customer usage reporting"),
         (name = "Billing", description = "Billing costs endpoint (HuggingFace integration)"),
         (name = "Staking Farm", description = "House of Stake farm credit configuration and synchronization"),
         (name = "Health", description = "Health check endpoints"),
@@ -131,6 +132,12 @@ use utoipa::{Modify, OpenApi};
         crate::routes::staking_farm::get_staking_farm_config,
         crate::routes::staking_farm::get_organization_staking_farm,
         crate::routes::staking_farm::sync_organization_staking_farm,
+        // Customer reporting endpoints
+        crate::routes::reporting_tokens::create_reporting_token,
+        crate::routes::reporting_tokens::list_reporting_tokens,
+        crate::routes::reporting_tokens::revoke_reporting_token,
+        crate::routes::reporting_usage::export::export_usage,
+        crate::routes::reporting_usage::summary::summary_usage,
         // Feature request endpoints
         crate::routes::feature_requests::submit_feature_request,
         crate::routes::feature_requests::list_admin_feature_requests,
@@ -294,6 +301,25 @@ use utoipa::{Modify, OpenApi};
             // Staking farm models
             crate::routes::staking_farm::StakingFarmConfigResponse,
             crate::routes::staking_farm::StakingFarmStateResponse,
+            // Customer reporting models
+            services::reporting_tokens::ReportingTokenScope,
+            crate::routes::reporting_tokens::CreateReportingTokenRequest,
+            crate::routes::reporting_tokens::CreateReportingTokenResponse,
+            crate::routes::reporting_tokens::ReportingTokenResponse,
+            crate::routes::reporting_tokens::ListReportingTokensResponse,
+            crate::routes::reporting_usage::ReportingUsageSource,
+            crate::routes::reporting_usage::ReportingUsageRowSource,
+            crate::routes::reporting_usage::ReportingUsageExportResponse,
+            crate::routes::reporting_usage::ReportingUsageExportRow,
+            crate::routes::reporting_usage::ReportingInferenceUsage,
+            crate::routes::reporting_usage::ReportingServiceUsage,
+            crate::routes::reporting_usage::ReportingUsageSummaryResponse,
+            crate::routes::reporting_usage::ReportingUsageTotals,
+            crate::routes::reporting_usage::ReportingWorkspaceSummary,
+            crate::routes::reporting_usage::ReportingApiKeySummary,
+            crate::routes::reporting_usage::ReportingModelSummary,
+            crate::routes::reporting_usage::ReportingServiceSummary,
+            crate::routes::reporting_usage::ReportingDaySummary,
             // Feature request models
             crate::routes::feature_requests::FeatureRequestKind,
             crate::routes::feature_requests::SubmitFeatureRequest,
@@ -373,6 +399,16 @@ impl Modify for SecurityAddon {
                         .description(Some(
                             "API key for programmatic access (Authorization: Bearer sk-<api_key>)",
                         ))
+                        .build(),
+                ),
+            );
+            components.add_security_scheme(
+                "reporting_token",
+                SecurityScheme::Http(
+                    HttpBuilder::new()
+                        .scheme(HttpAuthScheme::Bearer)
+                        .bearer_format("reporting_token")
+                        .description(Some("Read-only reporting token for usage reporting endpoints (Authorization: Bearer rpt-<reporting_token>)"))
                         .build(),
                 ),
             );

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -26,8 +26,8 @@ pub struct AppState {
     pub usage_service: Arc<dyn services::usage::UsageServiceTrait + Send + Sync>,
     pub service_usage_service:
         Arc<dyn services::service_usage::ServiceUsageServiceTrait + Send + Sync>,
-    pub reporting_token_repository:
-        Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
+    pub reporting_token_service:
+        Arc<dyn services::reporting_tokens::OrganizationReportingTokenService>,
     pub user_service: Arc<dyn services::user::UserServiceTrait + Send + Sync>,
     pub files_service: Arc<dyn FileServiceTrait + Send + Sync>,
     pub inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -26,6 +26,8 @@ pub struct AppState {
     pub usage_service: Arc<dyn services::usage::UsageServiceTrait + Send + Sync>,
     pub service_usage_service:
         Arc<dyn services::service_usage::ServiceUsageServiceTrait + Send + Sync>,
+    pub reporting_token_repository:
+        Arc<dyn services::reporting_tokens::OrganizationReportingTokenRepository>,
     pub user_service: Arc<dyn services::user::UserServiceTrait + Send + Sync>,
     pub files_service: Arc<dyn FileServiceTrait + Send + Sync>,
     pub inference_provider_pool: Arc<services::inference_provider_pool::InferenceProviderPool>,
@@ -152,6 +154,15 @@ pub fn build_management_router(app_state: AppState, auth_state: AuthState) -> Ro
         .route(
             "/{id}/usage/timeseries",
             get(crate::routes::usage::get_user_organization_timeseries),
+        )
+        .route(
+            "/{id}/reporting-tokens",
+            get(crate::routes::reporting_tokens::list_reporting_tokens)
+                .post(crate::routes::reporting_tokens::create_reporting_token),
+        )
+        .route(
+            "/{id}/reporting-tokens/{token_id}",
+            delete(crate::routes::reporting_tokens::revoke_reporting_token),
         );
 
     // User routes (require access token authentication)

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -17,6 +17,8 @@ pub mod models;
 pub mod ohttp;
 pub mod organization_members;
 pub mod organizations;
+pub mod reporting_tokens;
+pub mod reporting_usage;
 pub mod responses;
 pub mod services;
 pub mod staking_farm;

--- a/crates/api/src/routes/reporting_tokens.rs
+++ b/crates/api/src/routes/reporting_tokens.rs
@@ -1,0 +1,269 @@
+use crate::{
+    conversions::authenticated_user_to_user_id, middleware::AuthenticatedUser,
+    models::ErrorResponse, routes::api::AppState,
+};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use services::{
+    common::RepositoryError,
+    organization::{MemberRole, OrganizationError, OrganizationId},
+    reporting_tokens::{CreateOrganizationReportingTokenRequest, OrganizationReportingToken},
+};
+use uuid::Uuid;
+
+mod schemas;
+
+pub use schemas::{
+    CreateReportingTokenRequest, CreateReportingTokenResponse, ListReportingTokensResponse,
+    ReportingTokenResponse,
+};
+
+type RouteError = (StatusCode, Json<ErrorResponse>);
+
+/// Create a read-only reporting token.
+///
+/// Organization owners and admins can create reporting tokens for usage
+/// export and summary endpoints. The raw `rpt-` token is returned once.
+#[utoipa::path(
+    post,
+    path = "/v1/organizations/{org_id}/reporting-tokens",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID")
+    ),
+    request_body = CreateReportingTokenRequest,
+    responses(
+        (status = 201, description = "Reporting token created", body = CreateReportingTokenResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn create_reporting_token(
+    State(app_state): State<AppState>,
+    axum::Extension(user): axum::Extension<AuthenticatedUser>,
+    Path(org_id): Path<Uuid>,
+    Json(request): Json<CreateReportingTokenRequest>,
+) -> Result<(StatusCode, Json<CreateReportingTokenResponse>), RouteError> {
+    request.validate().map_err(bad_request)?;
+    require_reporting_token_manager(&app_state, user.clone(), org_id).await?;
+
+    let user_id = authenticated_user_to_user_id(user).0;
+    let created = app_state
+        .reporting_token_repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id: org_id,
+            name: request.name.trim().to_string(),
+            created_by_user_id: user_id,
+            expires_at: request.expires_at,
+        })
+        .await
+        .map_err(map_repository_error)?;
+
+    let token = created.token;
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateReportingTokenResponse {
+            id: token.id,
+            organization_id: token.organization_id,
+            name: token.name,
+            token: created.raw_token,
+            token_prefix: token.token_prefix,
+            created_by_user_id: token.created_by_user_id,
+            created_at: token.created_at,
+            expires_at: token.expires_at,
+            last_used_at: token.last_used_at,
+            scope: token.scope,
+        }),
+    ))
+}
+
+/// List active reporting tokens for an organization.
+///
+/// The response includes non-secret prefixes and audit timestamps. It never
+/// includes raw reporting tokens or stored hashes.
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/reporting-tokens",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID")
+    ),
+    responses(
+        (status = 200, description = "Active reporting tokens", body = ListReportingTokensResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn list_reporting_tokens(
+    State(app_state): State<AppState>,
+    axum::Extension(user): axum::Extension<AuthenticatedUser>,
+    Path(org_id): Path<Uuid>,
+) -> Result<Json<ListReportingTokensResponse>, RouteError> {
+    require_reporting_token_manager(&app_state, user, org_id).await?;
+
+    let tokens = app_state
+        .reporting_token_repository
+        .list_active_by_organization(org_id)
+        .await
+        .map_err(map_repository_error)?;
+    let reporting_tokens: Vec<ReportingTokenResponse> =
+        tokens.into_iter().map(token_response).collect();
+    let total = i64::try_from(reporting_tokens.len()).map_err(|_| internal_error())?;
+
+    Ok(Json(ListReportingTokensResponse {
+        reporting_tokens,
+        total,
+    }))
+}
+
+/// Revoke a reporting token.
+///
+/// Revoked reporting tokens can no longer authenticate usage reporting
+/// requests.
+#[utoipa::path(
+    delete,
+    path = "/v1/organizations/{org_id}/reporting-tokens/{token_id}",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID"),
+        ("token_id" = Uuid, Path, description = "Reporting token ID")
+    ),
+    responses(
+        (status = 204, description = "Reporting token revoked"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Reporting token not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("session_token" = [])
+    )
+)]
+pub async fn revoke_reporting_token(
+    State(app_state): State<AppState>,
+    axum::Extension(user): axum::Extension<AuthenticatedUser>,
+    Path((org_id, token_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RouteError> {
+    require_reporting_token_manager(&app_state, user.clone(), org_id).await?;
+
+    let token = app_state
+        .reporting_token_repository
+        .get_by_id(token_id)
+        .await
+        .map_err(map_repository_error)?
+        .filter(|token| token.organization_id == org_id)
+        .ok_or_else(not_found)?;
+
+    if token.revoked_at.is_some() {
+        return Err(not_found());
+    }
+
+    let user_id = authenticated_user_to_user_id(user).0;
+    match app_state
+        .reporting_token_repository
+        .revoke(token_id, user_id)
+        .await
+        .map_err(map_repository_error)?
+    {
+        true => Ok(StatusCode::NO_CONTENT),
+        false => Err(not_found()),
+    }
+}
+
+async fn require_reporting_token_manager(
+    app_state: &AppState,
+    user: AuthenticatedUser,
+    org_id: Uuid,
+) -> Result<(), RouteError> {
+    let user_id = authenticated_user_to_user_id(user);
+    let role = app_state
+        .organization_service
+        .get_user_role(OrganizationId(org_id), user_id)
+        .await
+        .map_err(map_organization_error)?;
+
+    match role {
+        Some(MemberRole::Owner | MemberRole::Admin) => Ok(()),
+        Some(MemberRole::Member) | None => Err(forbidden()),
+    }
+}
+
+fn token_response(token: OrganizationReportingToken) -> ReportingTokenResponse {
+    ReportingTokenResponse {
+        id: token.id,
+        organization_id: token.organization_id,
+        name: token.name,
+        token_prefix: token.token_prefix,
+        created_by_user_id: token.created_by_user_id,
+        created_at: token.created_at,
+        expires_at: token.expires_at,
+        last_used_at: token.last_used_at,
+        scope: token.scope,
+    }
+}
+
+fn map_organization_error(error: OrganizationError) -> RouteError {
+    match error {
+        OrganizationError::NotFound => not_found(),
+        OrganizationError::Unauthorized(_) => forbidden(),
+        _ => internal_error(),
+    }
+}
+
+fn map_repository_error(error: RepositoryError) -> RouteError {
+    match error {
+        RepositoryError::NotFound(_) => not_found(),
+        RepositoryError::RequiredFieldMissing(message)
+        | RepositoryError::ValidationFailed(message) => bad_request(message),
+        _ => internal_error(),
+    }
+}
+
+fn bad_request(message: String) -> RouteError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(message, "bad_request".to_string())),
+    )
+}
+
+fn forbidden() -> RouteError {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new(
+            "You are not authorized to manage reporting tokens for this organization.".to_string(),
+            "forbidden".to_string(),
+        )),
+    )
+}
+
+fn not_found() -> RouteError {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new(
+            "Reporting token not found".to_string(),
+            "not_found".to_string(),
+        )),
+    )
+}
+
+fn internal_error() -> RouteError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            "Failed to manage reporting tokens".to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
+}

--- a/crates/api/src/routes/reporting_tokens.rs
+++ b/crates/api/src/routes/reporting_tokens.rs
@@ -57,7 +57,7 @@ pub async fn create_reporting_token(
 
     let user_id = authenticated_user_to_user_id(user).0;
     let created = app_state
-        .reporting_token_repository
+        .reporting_token_service
         .create(CreateOrganizationReportingTokenRequest {
             organization_id: org_id,
             name: request.name.trim().to_string(),
@@ -114,7 +114,7 @@ pub async fn list_reporting_tokens(
     require_reporting_token_manager(&app_state, user, org_id).await?;
 
     let tokens = app_state
-        .reporting_token_repository
+        .reporting_token_service
         .list_active_by_organization(org_id)
         .await
         .map_err(map_repository_error)?;
@@ -159,7 +159,7 @@ pub async fn revoke_reporting_token(
     require_reporting_token_manager(&app_state, user.clone(), org_id).await?;
 
     let token = app_state
-        .reporting_token_repository
+        .reporting_token_service
         .get_by_id(token_id)
         .await
         .map_err(map_repository_error)?
@@ -172,7 +172,7 @@ pub async fn revoke_reporting_token(
 
     let user_id = authenticated_user_to_user_id(user).0;
     match app_state
-        .reporting_token_repository
+        .reporting_token_service
         .revoke(token_id, user_id)
         .await
         .map_err(map_repository_error)?

--- a/crates/api/src/routes/reporting_tokens/schemas.rs
+++ b/crates/api/src/routes/reporting_tokens/schemas.rs
@@ -23,6 +23,7 @@ pub struct ReportingTokenResponse {
     pub created_by_user_id: Uuid,
     pub created_at: DateTime<Utc>,
     pub expires_at: Option<DateTime<Utc>>,
+    /// Approximate last-authentication timestamp, refreshed at most once every 15 minutes.
     pub last_used_at: Option<DateTime<Utc>>,
     pub scope: ReportingTokenScope,
 }
@@ -39,6 +40,7 @@ pub struct CreateReportingTokenResponse {
     pub created_by_user_id: Uuid,
     pub created_at: DateTime<Utc>,
     pub expires_at: Option<DateTime<Utc>>,
+    /// Approximate last-authentication timestamp, refreshed at most once every 15 minutes.
     pub last_used_at: Option<DateTime<Utc>>,
     pub scope: ReportingTokenScope,
 }
@@ -55,7 +57,7 @@ impl CreateReportingTokenRequest {
         if name.is_empty() {
             return Err("name is required".to_string());
         }
-        if name.len() > 255 {
+        if name.chars().count() > 255 {
             return Err("name must be at most 255 characters".to_string());
         }
         if let Some(expires_at) = self.expires_at {
@@ -64,5 +66,28 @@ impl CreateReportingTokenRequest {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reporting_token_name_limit_counts_characters_not_utf8_bytes() {
+        let valid = CreateReportingTokenRequest {
+            name: "é".repeat(255),
+            expires_at: None,
+        };
+        let invalid = CreateReportingTokenRequest {
+            name: "é".repeat(256),
+            expires_at: None,
+        };
+
+        assert!(valid.validate().is_ok());
+        assert_eq!(
+            invalid.validate(),
+            Err("name must be at most 255 characters".to_string())
+        );
     }
 }

--- a/crates/api/src/routes/reporting_tokens/schemas.rs
+++ b/crates/api/src/routes/reporting_tokens/schemas.rs
@@ -1,0 +1,68 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use services::reporting_tokens::ReportingTokenScope;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateReportingTokenRequest {
+    /// Human-readable name for the reporting token.
+    pub name: String,
+    /// Optional expiration time. Must be in the future.
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ReportingTokenResponse {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub name: String,
+    /// Non-secret token prefix for display and audit correlation.
+    pub token_prefix: String,
+    pub created_by_user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct CreateReportingTokenResponse {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub name: String,
+    /// Raw reporting token. Returned only once when the token is created.
+    pub token: String,
+    /// Non-secret token prefix for display and audit correlation.
+    pub token_prefix: String,
+    pub created_by_user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListReportingTokensResponse {
+    pub reporting_tokens: Vec<ReportingTokenResponse>,
+    pub total: i64,
+}
+
+impl CreateReportingTokenRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        let name = self.name.trim();
+        if name.is_empty() {
+            return Err("name is required".to_string());
+        }
+        if name.len() > 255 {
+            return Err("name must be at most 255 characters".to_string());
+        }
+        if let Some(expires_at) = self.expires_at {
+            if expires_at <= Utc::now() {
+                return Err("expires_at must be in the future".to_string());
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/api/src/routes/reporting_usage/cursor.rs
+++ b/crates/api/src/routes/reporting_usage/cursor.rs
@@ -1,0 +1,192 @@
+use super::query::{
+    validate_time_range, ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams,
+    ReportingUsageRowSource, ReportingUsageSource,
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use services::usage::InferenceType;
+use uuid::Uuid;
+
+const REPORTING_USAGE_CURSOR_VERSION: u8 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReportingUsageCursor {
+    pub created_at: DateTime<Utc>,
+    pub source: ReportingUsageRowSource,
+    pub id: Uuid,
+    context: ReportingUsageCursorContext,
+}
+
+impl ReportingUsageCursor {
+    pub fn for_query(
+        organization_id: Uuid,
+        created_at: DateTime<Utc>,
+        source: ReportingUsageRowSource,
+        id: Uuid,
+        query: &ReportingUsageQuery,
+    ) -> Result<Self, ReportingUsageQueryError> {
+        let (Some(start_time), Some(end_time)) = (query.start_time, query.end_time) else {
+            return Err(ReportingUsageQueryError::InvalidCursor);
+        };
+        Ok(Self {
+            created_at,
+            source,
+            id,
+            context: ReportingUsageCursorContext {
+                organization_id,
+                start_time,
+                end_time,
+                source: query.source,
+                workspace_id: query.workspace_id,
+                api_key_id: query.api_key_id,
+                model: query.model.clone(),
+                inference_type: query.inference_type,
+                service_name: query.service_name.clone(),
+            },
+        })
+    }
+
+    pub fn validate_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<(), ReportingUsageQueryError> {
+        if self.context.organization_id == organization_id {
+            Ok(())
+        } else {
+            Err(ReportingUsageQueryError::InvalidCursor)
+        }
+    }
+
+    pub fn with_position(&self, source: ReportingUsageRowSource, id: Uuid) -> Self {
+        Self {
+            created_at: self.created_at,
+            source,
+            id,
+            context: self.context.clone(),
+        }
+    }
+
+    pub fn encode(&self) -> Result<String, ReportingUsageQueryError> {
+        let payload = ReportingUsageCursorPayload {
+            version: REPORTING_USAGE_CURSOR_VERSION,
+            created_at: self.created_at,
+            source: self.source,
+            id: self.id,
+            context: self.context.clone(),
+        };
+        let bytes =
+            serde_json::to_vec(&payload).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+
+    pub fn decode(value: &str) -> Result<Self, ReportingUsageQueryError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        let payload: ReportingUsageCursorPayload =
+            serde_json::from_slice(&bytes).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        if payload.version != REPORTING_USAGE_CURSOR_VERSION {
+            return Err(ReportingUsageQueryError::InvalidCursor);
+        }
+        validate_time_range(payload.context.start_time, payload.context.end_time)
+            .map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        Ok(Self {
+            created_at: payload.created_at,
+            source: payload.source,
+            id: payload.id,
+            context: payload.context,
+        })
+    }
+
+    pub(super) fn restore_context(
+        &self,
+        params: &ReportingUsageQueryParams,
+        start_time: Option<DateTime<Utc>>,
+        end_time: Option<DateTime<Utc>>,
+        source: Option<ReportingUsageSource>,
+        inference_type: Option<InferenceType>,
+    ) -> Result<ReportingUsageCursorFilters, ReportingUsageQueryError> {
+        let context = &self.context;
+        let conflicts = start_time.is_some_and(|value| value != context.start_time)
+            || end_time.is_some_and(|value| value != context.end_time)
+            || source.is_some_and(|value| value != context.source)
+            || params
+                .workspace_id
+                .is_some_and(|value| Some(value) != context.workspace_id)
+            || params
+                .api_key_id
+                .is_some_and(|value| Some(value) != context.api_key_id)
+            || params
+                .model
+                .as_deref()
+                .is_some_and(|value| context.model.as_deref() != Some(value))
+            || inference_type.is_some_and(|value| Some(value) != context.inference_type)
+            || params
+                .service_name
+                .as_deref()
+                .is_some_and(|value| context.service_name.as_deref() != Some(value));
+        if conflicts {
+            return Err(ReportingUsageQueryError::InvalidCursor);
+        }
+        Ok(context.filters())
+    }
+
+    #[cfg(test)]
+    pub fn encode_raw_for_tests(
+        value: &serde_json::Value,
+    ) -> Result<String, ReportingUsageQueryError> {
+        let bytes =
+            serde_json::to_vec(value).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReportingUsageCursorPayload {
+    #[serde(rename = "v")]
+    version: u8,
+    created_at: DateTime<Utc>,
+    source: ReportingUsageRowSource,
+    id: Uuid,
+    context: ReportingUsageCursorContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ReportingUsageCursorContext {
+    organization_id: Uuid,
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+    source: ReportingUsageSource,
+    workspace_id: Option<Uuid>,
+    api_key_id: Option<Uuid>,
+    model: Option<String>,
+    inference_type: Option<InferenceType>,
+    service_name: Option<String>,
+}
+
+impl ReportingUsageCursorContext {
+    fn filters(&self) -> ReportingUsageCursorFilters {
+        ReportingUsageCursorFilters {
+            start_time: self.start_time,
+            end_time: self.end_time,
+            source: self.source,
+            workspace_id: self.workspace_id,
+            api_key_id: self.api_key_id,
+            model: self.model.clone(),
+            inference_type: self.inference_type,
+            service_name: self.service_name.clone(),
+        }
+    }
+}
+
+pub(super) struct ReportingUsageCursorFilters {
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub source: ReportingUsageSource,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<InferenceType>,
+    pub service_name: Option<String>,
+}

--- a/crates/api/src/routes/reporting_usage/export.rs
+++ b/crates/api/src/routes/reporting_usage/export.rs
@@ -1,0 +1,251 @@
+use super::{
+    export_rows::{source_rank, ExportRow},
+    ReportingUsageCursor, ReportingUsageExportResponse, ReportingUsageExportRow,
+    ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams,
+    ReportingUsageRowSource, ReportingUsageSource, RouteError,
+};
+use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Extension, Json,
+};
+use services::{
+    service_usage::{
+        ports::{ServiceUsageReportCursor, ServiceUsageReportFilters},
+        ServiceUsageServiceTrait,
+    },
+    usage::{InferenceUsageReportCursor, InferenceUsageReportQuery, UsageServiceTrait},
+};
+use std::cmp::Reverse;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ReportingUsageExportState {
+    usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
+    service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
+}
+
+impl ReportingUsageExportState {
+    pub fn new(
+        usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
+        service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
+    ) -> Self {
+        Self {
+            usage_service,
+            service_usage_service,
+        }
+    }
+}
+
+/// Export organization usage and cost rows.
+///
+/// Requires a reporting token scoped to the organization in the path. Results
+/// are returned in descending `(created_at, source, id)` order with opaque
+/// cursor pagination.
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/usage/export",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID"),
+        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. The range between start_time and end_time must not exceed 366 days."),
+        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Must be greater than or equal to start_time when both are provided."),
+        ("source" = Option<ReportingUsageSource>, Query, description = "Usage source to export. Defaults to all."),
+        ("workspace_id" = Option<Uuid>, Query, description = "Filter by workspace ID."),
+        ("api_key_id" = Option<Uuid>, Query, description = "Filter by API key ID."),
+        ("model" = Option<String>, Query, description = "Filter inference rows by model name."),
+        ("inference_type" = Option<String>, Query, description = "Filter inference rows by inference type."),
+        ("service_name" = Option<String>, Query, description = "Filter service rows by platform service name."),
+        ("limit" = Option<u16>, Query, description = "Maximum rows to return. Defaults to 100 and must not exceed 1000."),
+        ("cursor" = Option<String>, Query, description = "Opaque cursor returned by the previous export page.")
+    ),
+    responses(
+        (status = 200, description = "Usage export page", body = ReportingUsageExportResponse),
+        (status = 400, description = "Invalid filters or cursor", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Reporting token is not scoped to this organization", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("reporting_token" = [])
+    )
+)]
+pub async fn export_usage(
+    State(state): State<ReportingUsageExportState>,
+    Extension(reporting_token): Extension<AuthenticatedReportingToken>,
+    Path(org_id): Path<Uuid>,
+    Query(params): Query<ReportingUsageQueryParams>,
+) -> Result<Json<ReportingUsageExportResponse>, RouteError> {
+    ensure_token_matches_org(&reporting_token, org_id)?;
+    let query = ReportingUsageQuery::try_from(params).map_err(query_error)?;
+    validate_cursor_source(&query)?;
+
+    let limit = usize::from(query.limit.value());
+    let fetch_limit = query.limit.value() + 1;
+    let rows = match query.source {
+        ReportingUsageSource::All => list_all_rows(&state, org_id, &query, fetch_limit).await?,
+        ReportingUsageSource::Inference => {
+            list_inference_rows(&state, org_id, &query, fetch_limit, query.cursor.clone()).await?
+        }
+        ReportingUsageSource::Service => {
+            list_service_rows(&state, org_id, &query, fetch_limit, query.cursor.clone()).await?
+        }
+    };
+
+    Ok(Json(page_response(rows, limit)?))
+}
+
+async fn list_all_rows(
+    state: &ReportingUsageExportState,
+    org_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let inference_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Inference);
+    let service_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Service);
+    let mut rows = list_inference_rows(state, org_id, query, fetch_limit, inference_cursor).await?;
+    rows.extend(list_service_rows(state, org_id, query, fetch_limit, service_cursor).await?);
+    rows.sort_by_key(|row| Reverse(row.sort_key()));
+    rows.truncate(usize::from(fetch_limit));
+    Ok(rows)
+}
+
+async fn list_inference_rows(
+    state: &ReportingUsageExportState,
+    org_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    cursor: Option<ReportingUsageCursor>,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let rows = state
+        .usage_service
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            organization_id: org_id,
+            start_time: query.start_time,
+            end_time: query.end_time,
+            workspace_id: query.workspace_id,
+            api_key_id: query.api_key_id,
+            model: query.model.clone(),
+            inference_type: query.inference_type.map(|value| value.as_str().to_string()),
+            limit: fetch_limit,
+            cursor: cursor.map(|value| InferenceUsageReportCursor {
+                created_at: value.created_at,
+                id: value.id,
+            }),
+        })
+        .await
+        .map_err(|_| internal_error("Failed to list inference usage export"))?;
+
+    Ok(rows.into_iter().map(ExportRow::Inference).collect())
+}
+
+async fn list_service_rows(
+    state: &ReportingUsageExportState,
+    org_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    cursor: Option<ReportingUsageCursor>,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let rows = state
+        .service_usage_service
+        .get_usage_report(&ServiceUsageReportFilters {
+            organization_id: org_id,
+            service_name: query.service_name.clone(),
+            workspace_id: query.workspace_id,
+            api_key_id: query.api_key_id,
+            start_time: query.start_time,
+            end_time: query.end_time,
+            cursor: cursor.map(|value| ServiceUsageReportCursor {
+                created_at: value.created_at,
+                id: value.id,
+            }),
+            limit: i64::from(fetch_limit),
+        })
+        .await
+        .map_err(|_| internal_error("Failed to list service usage export"))?;
+
+    Ok(rows.into_iter().map(ExportRow::Service).collect())
+}
+
+fn page_response(
+    rows: Vec<ExportRow>,
+    limit: usize,
+) -> Result<ReportingUsageExportResponse, RouteError> {
+    let has_more = rows.len() > limit;
+    let data: Vec<ReportingUsageExportRow> = rows.into_iter().take(limit).map(Into::into).collect();
+    let next_cursor = if has_more {
+        data.last()
+            .map(|row| ReportingUsageCursor::new(row.created_at, row.source, row.id).encode())
+            .transpose()
+            .map_err(query_error)?
+    } else {
+        None
+    };
+    Ok(ReportingUsageExportResponse { data, next_cursor })
+}
+
+fn ensure_token_matches_org(
+    reporting_token: &AuthenticatedReportingToken,
+    org_id: Uuid,
+) -> Result<(), RouteError> {
+    if reporting_token.organization_id == org_id {
+        return Ok(());
+    }
+    Err((
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new(
+            "Reporting token is not authorized for this organization.".to_string(),
+            "forbidden".to_string(),
+        )),
+    ))
+}
+
+fn validate_cursor_source(query: &ReportingUsageQuery) -> Result<(), RouteError> {
+    match (
+        query.source,
+        query.cursor.as_ref().map(|cursor| cursor.source),
+    ) {
+        (ReportingUsageSource::Inference, Some(ReportingUsageRowSource::Service))
+        | (ReportingUsageSource::Service, Some(ReportingUsageRowSource::Inference)) => {
+            Err(query_error(ReportingUsageQueryError::InvalidCursor))
+        }
+        _ => Ok(()),
+    }
+}
+
+fn source_cursor(
+    cursor: Option<&ReportingUsageCursor>,
+    row_source: ReportingUsageRowSource,
+) -> Option<ReportingUsageCursor> {
+    let cursor = cursor?;
+    let row_rank = source_rank(row_source);
+    let cursor_rank = source_rank(cursor.source);
+    let id = match row_rank.cmp(&cursor_rank) {
+        std::cmp::Ordering::Greater => Uuid::nil(),
+        std::cmp::Ordering::Equal => cursor.id,
+        std::cmp::Ordering::Less => Uuid::from_u128(u128::MAX),
+    };
+    Some(ReportingUsageCursor::new(cursor.created_at, row_source, id))
+}
+
+fn query_error(error: ReportingUsageQueryError) -> RouteError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(
+            error.to_string(),
+            "invalid_reporting_usage_query".to_string(),
+        )),
+    )
+}
+
+fn internal_error(message: &str) -> RouteError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            message.to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
+}

--- a/crates/api/src/routes/reporting_usage/export.rs
+++ b/crates/api/src/routes/reporting_usage/export.rs
@@ -1,43 +1,20 @@
 use super::{
-    export_rows::{source_rank, ExportRow},
+    ensure_token_matches_org, export_rows::ExportRow, export_sources::list_rows, query_error,
     ReportingUsageCursor, ReportingUsageExportResponse, ReportingUsageExportRow,
     ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams,
     ReportingUsageRowSource, ReportingUsageSource, RouteError,
 };
-use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use crate::{
+    middleware::{AuthenticatedReportingToken, ReportingRequestDeadline},
+    models::ErrorResponse,
+};
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
     Extension, Json,
 };
-use services::{
-    service_usage::{
-        ports::{ServiceUsageReportCursor, ServiceUsageReportFilters},
-        ServiceUsageServiceTrait,
-    },
-    usage::{InferenceUsageReportCursor, InferenceUsageReportQuery, UsageServiceTrait},
-};
-use std::cmp::Reverse;
-use std::sync::Arc;
 use uuid::Uuid;
 
-#[derive(Clone)]
-pub struct ReportingUsageExportState {
-    usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
-    service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
-}
-
-impl ReportingUsageExportState {
-    pub fn new(
-        usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
-        service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
-    ) -> Self {
-        Self {
-            usage_service,
-            service_usage_service,
-        }
-    }
-}
+pub use super::export_sources::ReportingUsageExportState;
 
 /// Export organization usage and cost rows.
 ///
@@ -50,8 +27,8 @@ impl ReportingUsageExportState {
     tag = "Reporting",
     params(
         ("org_id" = Uuid, Path, description = "Organization ID"),
-        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. The range between start_time and end_time must not exceed 366 days."),
-        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Must be greater than or equal to start_time when both are provided."),
+        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. Defaults to 366 days before the effective end_time."),
+        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Defaults to the request time. The effective range must not exceed 366 days."),
         ("source" = Option<ReportingUsageSource>, Query, description = "Usage source to export. Defaults to all."),
         ("workspace_id" = Option<Uuid>, Query, description = "Filter by workspace ID."),
         ("api_key_id" = Option<Uuid>, Query, description = "Filter by API key ID."),
@@ -66,6 +43,8 @@ impl ReportingUsageExportState {
         (status = 400, description = "Invalid filters or cursor", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Reporting token is not scoped to this organization", body = ErrorResponse),
+        (status = 429, description = "Reporting rate or concurrency limit exceeded", body = ErrorResponse),
+        (status = 504, description = "Reporting request timed out", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     security(
@@ -75,109 +54,42 @@ impl ReportingUsageExportState {
 pub async fn export_usage(
     State(state): State<ReportingUsageExportState>,
     Extension(reporting_token): Extension<AuthenticatedReportingToken>,
+    Extension(request_deadline): Extension<ReportingRequestDeadline>,
     Path(org_id): Path<Uuid>,
     Query(params): Query<ReportingUsageQueryParams>,
 ) -> Result<Json<ReportingUsageExportResponse>, RouteError> {
     ensure_token_matches_org(&reporting_token, org_id)?;
     let query = ReportingUsageQuery::try_from(params).map_err(query_error)?;
+    validate_cursor_organization(&query, org_id)?;
     validate_cursor_source(&query)?;
 
     let limit = usize::from(query.limit.value());
     let fetch_limit = query.limit.value() + 1;
-    let rows = match query.source {
-        ReportingUsageSource::All => list_all_rows(&state, org_id, &query, fetch_limit).await?,
-        ReportingUsageSource::Inference => {
-            list_inference_rows(&state, org_id, &query, fetch_limit, query.cursor.clone()).await?
-        }
-        ReportingUsageSource::Service => {
-            list_service_rows(&state, org_id, &query, fetch_limit, query.cursor.clone()).await?
-        }
-    };
+    let rows = list_rows(&state, org_id, &query, fetch_limit, request_deadline).await?;
 
-    Ok(Json(page_response(rows, limit)?))
-}
-
-async fn list_all_rows(
-    state: &ReportingUsageExportState,
-    org_id: Uuid,
-    query: &ReportingUsageQuery,
-    fetch_limit: u16,
-) -> Result<Vec<ExportRow>, RouteError> {
-    let inference_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Inference);
-    let service_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Service);
-    let mut rows = list_inference_rows(state, org_id, query, fetch_limit, inference_cursor).await?;
-    rows.extend(list_service_rows(state, org_id, query, fetch_limit, service_cursor).await?);
-    rows.sort_by_key(|row| Reverse(row.sort_key()));
-    rows.truncate(usize::from(fetch_limit));
-    Ok(rows)
-}
-
-async fn list_inference_rows(
-    state: &ReportingUsageExportState,
-    org_id: Uuid,
-    query: &ReportingUsageQuery,
-    fetch_limit: u16,
-    cursor: Option<ReportingUsageCursor>,
-) -> Result<Vec<ExportRow>, RouteError> {
-    let rows = state
-        .usage_service
-        .list_inference_usage_report(InferenceUsageReportQuery {
-            organization_id: org_id,
-            start_time: query.start_time,
-            end_time: query.end_time,
-            workspace_id: query.workspace_id,
-            api_key_id: query.api_key_id,
-            model: query.model.clone(),
-            inference_type: query.inference_type.map(|value| value.as_str().to_string()),
-            limit: fetch_limit,
-            cursor: cursor.map(|value| InferenceUsageReportCursor {
-                created_at: value.created_at,
-                id: value.id,
-            }),
-        })
-        .await
-        .map_err(|_| internal_error("Failed to list inference usage export"))?;
-
-    Ok(rows.into_iter().map(ExportRow::Inference).collect())
-}
-
-async fn list_service_rows(
-    state: &ReportingUsageExportState,
-    org_id: Uuid,
-    query: &ReportingUsageQuery,
-    fetch_limit: u16,
-    cursor: Option<ReportingUsageCursor>,
-) -> Result<Vec<ExportRow>, RouteError> {
-    let rows = state
-        .service_usage_service
-        .get_usage_report(&ServiceUsageReportFilters {
-            organization_id: org_id,
-            service_name: query.service_name.clone(),
-            workspace_id: query.workspace_id,
-            api_key_id: query.api_key_id,
-            start_time: query.start_time,
-            end_time: query.end_time,
-            cursor: cursor.map(|value| ServiceUsageReportCursor {
-                created_at: value.created_at,
-                id: value.id,
-            }),
-            limit: i64::from(fetch_limit),
-        })
-        .await
-        .map_err(|_| internal_error("Failed to list service usage export"))?;
-
-    Ok(rows.into_iter().map(ExportRow::Service).collect())
+    Ok(Json(page_response(rows, limit, org_id, &query)?))
 }
 
 fn page_response(
     rows: Vec<ExportRow>,
     limit: usize,
+    organization_id: Uuid,
+    query: &ReportingUsageQuery,
 ) -> Result<ReportingUsageExportResponse, RouteError> {
     let has_more = rows.len() > limit;
     let data: Vec<ReportingUsageExportRow> = rows.into_iter().take(limit).map(Into::into).collect();
     let next_cursor = if has_more {
         data.last()
-            .map(|row| ReportingUsageCursor::new(row.created_at, row.source, row.id).encode())
+            .map(|row| {
+                ReportingUsageCursor::for_query(
+                    organization_id,
+                    row.created_at,
+                    row.source(),
+                    row.id,
+                    query,
+                )
+                .and_then(|cursor| cursor.encode())
+            })
             .transpose()
             .map_err(query_error)?
     } else {
@@ -186,20 +98,17 @@ fn page_response(
     Ok(ReportingUsageExportResponse { data, next_cursor })
 }
 
-fn ensure_token_matches_org(
-    reporting_token: &AuthenticatedReportingToken,
-    org_id: Uuid,
+fn validate_cursor_organization(
+    query: &ReportingUsageQuery,
+    organization_id: Uuid,
 ) -> Result<(), RouteError> {
-    if reporting_token.organization_id == org_id {
-        return Ok(());
-    }
-    Err((
-        StatusCode::FORBIDDEN,
-        Json(ErrorResponse::new(
-            "Reporting token is not authorized for this organization.".to_string(),
-            "forbidden".to_string(),
-        )),
-    ))
+    query
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.validate_organization(organization_id))
+        .transpose()
+        .map_err(query_error)?;
+    Ok(())
 }
 
 fn validate_cursor_source(query: &ReportingUsageQuery) -> Result<(), RouteError> {
@@ -213,39 +122,4 @@ fn validate_cursor_source(query: &ReportingUsageQuery) -> Result<(), RouteError>
         }
         _ => Ok(()),
     }
-}
-
-fn source_cursor(
-    cursor: Option<&ReportingUsageCursor>,
-    row_source: ReportingUsageRowSource,
-) -> Option<ReportingUsageCursor> {
-    let cursor = cursor?;
-    let row_rank = source_rank(row_source);
-    let cursor_rank = source_rank(cursor.source);
-    let id = match row_rank.cmp(&cursor_rank) {
-        std::cmp::Ordering::Greater => Uuid::nil(),
-        std::cmp::Ordering::Equal => cursor.id,
-        std::cmp::Ordering::Less => Uuid::from_u128(u128::MAX),
-    };
-    Some(ReportingUsageCursor::new(cursor.created_at, row_source, id))
-}
-
-fn query_error(error: ReportingUsageQueryError) -> RouteError {
-    (
-        StatusCode::BAD_REQUEST,
-        Json(ErrorResponse::new(
-            error.to_string(),
-            "invalid_reporting_usage_query".to_string(),
-        )),
-    )
-}
-
-fn internal_error(message: &str) -> RouteError {
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(ErrorResponse::new(
-            message.to_string(),
-            "internal_server_error".to_string(),
-        )),
-    )
 }

--- a/crates/api/src/routes/reporting_usage/export_rows.rs
+++ b/crates/api/src/routes/reporting_usage/export_rows.rs
@@ -1,0 +1,101 @@
+use super::{
+    ReportingInferenceUsage, ReportingServiceUsage, ReportingUsageExportRow,
+    ReportingUsageRowSource,
+};
+use services::{service_usage::ports::ServiceUsageReportEntry, usage::InferenceUsageReportRow};
+use uuid::Uuid;
+
+pub(super) enum ExportRow {
+    Inference(InferenceUsageReportRow),
+    Service(ServiceUsageReportEntry),
+}
+
+impl ExportRow {
+    pub(super) fn sort_key(&self) -> (chrono::DateTime<chrono::Utc>, u8, Uuid) {
+        (self.created_at(), source_rank(self.source()), self.id())
+    }
+
+    fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
+        match self {
+            Self::Inference(row) => row.created_at,
+            Self::Service(row) => row.created_at,
+        }
+    }
+
+    fn source(&self) -> ReportingUsageRowSource {
+        match self {
+            Self::Inference(_) => ReportingUsageRowSource::Inference,
+            Self::Service(_) => ReportingUsageRowSource::Service,
+        }
+    }
+
+    fn id(&self) -> Uuid {
+        match self {
+            Self::Inference(row) => row.id,
+            Self::Service(row) => row.id,
+        }
+    }
+}
+
+impl From<ExportRow> for ReportingUsageExportRow {
+    fn from(row: ExportRow) -> Self {
+        match row {
+            ExportRow::Inference(row) => inference_export_row(row),
+            ExportRow::Service(row) => service_export_row(row),
+        }
+    }
+}
+
+fn inference_export_row(row: InferenceUsageReportRow) -> ReportingUsageExportRow {
+    ReportingUsageExportRow {
+        source: ReportingUsageRowSource::Inference,
+        id: row.id,
+        created_at: row.created_at,
+        workspace_id: row.workspace_id,
+        api_key_id: row.api_key_id,
+        total_cost_nano_usd: row.total_cost_nano_usd,
+        total_cost_usd: None,
+        inference: Some(ReportingInferenceUsage {
+            model: row.model,
+            inference_type: row.inference_type,
+            input_tokens: row.input_tokens,
+            output_tokens: row.output_tokens,
+            cache_read_tokens: row.cache_read_tokens,
+            total_tokens: row.total_tokens,
+            input_cost_nano_usd: row.input_cost_nano_usd,
+            output_cost_nano_usd: row.output_cost_nano_usd,
+            cache_read_cost_nano_usd: row.cache_read_cost_nano_usd,
+            total_cost_nano_usd: row.total_cost_nano_usd,
+            response_id: row.response_id,
+            inference_id: row.inference_id,
+            image_count: row.image_count,
+        }),
+        service: None,
+    }
+}
+
+fn service_export_row(row: ServiceUsageReportEntry) -> ReportingUsageExportRow {
+    ReportingUsageExportRow {
+        source: ReportingUsageRowSource::Service,
+        id: row.id,
+        created_at: row.created_at,
+        workspace_id: row.workspace_id,
+        api_key_id: row.api_key_id,
+        total_cost_nano_usd: row.total_cost,
+        total_cost_usd: None,
+        inference: None,
+        service: Some(ReportingServiceUsage {
+            service_name: row.service_name,
+            quantity: i64::from(row.quantity),
+            total_cost_nano_usd: row.total_cost,
+            inference_id: row.inference_id,
+        }),
+    }
+}
+
+pub(super) const fn source_rank(source: ReportingUsageRowSource) -> u8 {
+    match source {
+        ReportingUsageRowSource::Inference => 0,
+        ReportingUsageRowSource::Service => 1,
+    }
+}

--- a/crates/api/src/routes/reporting_usage/export_rows.rs
+++ b/crates/api/src/routes/reporting_usage/export_rows.rs
@@ -1,5 +1,5 @@
 use super::{
-    ReportingInferenceUsage, ReportingServiceUsage, ReportingUsageExportRow,
+    ReportingInferenceUsage, ReportingServiceUsage, ReportingUsageDetails, ReportingUsageExportRow,
     ReportingUsageRowSource,
 };
 use services::{service_usage::ports::ServiceUsageReportEntry, usage::InferenceUsageReportRow};
@@ -48,48 +48,48 @@ impl From<ExportRow> for ReportingUsageExportRow {
 
 fn inference_export_row(row: InferenceUsageReportRow) -> ReportingUsageExportRow {
     ReportingUsageExportRow {
-        source: ReportingUsageRowSource::Inference,
         id: row.id,
         created_at: row.created_at,
         workspace_id: row.workspace_id,
         api_key_id: row.api_key_id,
         total_cost_nano_usd: row.total_cost_nano_usd,
         total_cost_usd: None,
-        inference: Some(ReportingInferenceUsage {
-            model: row.model,
-            inference_type: row.inference_type,
-            input_tokens: row.input_tokens,
-            output_tokens: row.output_tokens,
-            cache_read_tokens: row.cache_read_tokens,
-            total_tokens: row.total_tokens,
-            input_cost_nano_usd: row.input_cost_nano_usd,
-            output_cost_nano_usd: row.output_cost_nano_usd,
-            cache_read_cost_nano_usd: row.cache_read_cost_nano_usd,
-            total_cost_nano_usd: row.total_cost_nano_usd,
-            response_id: row.response_id,
-            inference_id: row.inference_id,
-            image_count: row.image_count,
-        }),
-        service: None,
+        usage: ReportingUsageDetails::Inference {
+            inference: ReportingInferenceUsage {
+                model: row.model,
+                inference_type: row.inference_type,
+                input_tokens: row.input_tokens,
+                output_tokens: row.output_tokens,
+                cache_read_tokens: row.cache_read_tokens,
+                total_tokens: row.total_tokens,
+                input_cost_nano_usd: row.input_cost_nano_usd,
+                output_cost_nano_usd: row.output_cost_nano_usd,
+                cache_read_cost_nano_usd: row.cache_read_cost_nano_usd,
+                total_cost_nano_usd: row.total_cost_nano_usd,
+                response_id: row.response_id,
+                inference_id: row.inference_id,
+                image_count: row.image_count,
+            },
+        },
     }
 }
 
 fn service_export_row(row: ServiceUsageReportEntry) -> ReportingUsageExportRow {
     ReportingUsageExportRow {
-        source: ReportingUsageRowSource::Service,
         id: row.id,
         created_at: row.created_at,
         workspace_id: row.workspace_id,
         api_key_id: row.api_key_id,
         total_cost_nano_usd: row.total_cost,
         total_cost_usd: None,
-        inference: None,
-        service: Some(ReportingServiceUsage {
-            service_name: row.service_name,
-            quantity: i64::from(row.quantity),
-            total_cost_nano_usd: row.total_cost,
-            inference_id: row.inference_id,
-        }),
+        usage: ReportingUsageDetails::Service {
+            service: ReportingServiceUsage {
+                service_name: row.service_name,
+                quantity: i64::from(row.quantity),
+                total_cost_nano_usd: row.total_cost,
+                inference_id: row.inference_id,
+            },
+        },
     }
 }
 

--- a/crates/api/src/routes/reporting_usage/export_sources.rs
+++ b/crates/api/src/routes/reporting_usage/export_sources.rs
@@ -1,0 +1,180 @@
+use super::{
+    export_rows::{source_rank, ExportRow},
+    internal_error, timeout_error, ReportingUsageCursor, ReportingUsageQuery,
+    ReportingUsageRowSource, ReportingUsageSource, RouteError,
+};
+use crate::middleware::ReportingRequestDeadline;
+use services::{
+    service_usage::{
+        ports::{ServiceUsageReportCursor, ServiceUsageReportFilters},
+        ServiceUsageServiceTrait,
+    },
+    usage::{InferenceUsageReportCursor, InferenceUsageReportQuery, UsageServiceTrait},
+};
+use std::{cmp::Reverse, sync::Arc};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ReportingUsageExportState {
+    usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
+    service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
+}
+
+impl ReportingUsageExportState {
+    pub fn new(
+        usage_service: Arc<dyn UsageServiceTrait + Send + Sync>,
+        service_usage_service: Arc<dyn ServiceUsageServiceTrait + Send + Sync>,
+    ) -> Self {
+        Self {
+            usage_service,
+            service_usage_service,
+        }
+    }
+}
+
+pub async fn list_rows(
+    state: &ReportingUsageExportState,
+    organization_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    request_deadline: ReportingRequestDeadline,
+) -> Result<Vec<ExportRow>, RouteError> {
+    match query.source {
+        ReportingUsageSource::All => {
+            list_all_rows(state, organization_id, query, fetch_limit, request_deadline).await
+        }
+        ReportingUsageSource::Inference => {
+            list_inference_rows(
+                state,
+                organization_id,
+                query,
+                fetch_limit,
+                query.cursor.clone(),
+                request_deadline,
+            )
+            .await
+        }
+        ReportingUsageSource::Service => {
+            list_service_rows(
+                state,
+                organization_id,
+                query,
+                fetch_limit,
+                query.cursor.clone(),
+                request_deadline,
+            )
+            .await
+        }
+    }
+}
+
+async fn list_all_rows(
+    state: &ReportingUsageExportState,
+    organization_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    request_deadline: ReportingRequestDeadline,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let inference_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Inference);
+    let service_cursor = source_cursor(query.cursor.as_ref(), ReportingUsageRowSource::Service);
+    let (mut rows, service_rows) = tokio::try_join!(
+        list_inference_rows(
+            state,
+            organization_id,
+            query,
+            fetch_limit,
+            inference_cursor,
+            request_deadline,
+        ),
+        list_service_rows(
+            state,
+            organization_id,
+            query,
+            fetch_limit,
+            service_cursor,
+            request_deadline,
+        ),
+    )?;
+    rows.extend(service_rows);
+    rows.sort_by_key(|row| Reverse(row.sort_key()));
+    rows.truncate(usize::from(fetch_limit));
+    Ok(rows)
+}
+
+async fn list_inference_rows(
+    state: &ReportingUsageExportState,
+    organization_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    cursor: Option<ReportingUsageCursor>,
+    request_deadline: ReportingRequestDeadline,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let rows = state
+        .usage_service
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            organization_id,
+            start_time: query.start_time,
+            end_time: query.end_time,
+            workspace_id: query.workspace_id,
+            api_key_id: query.api_key_id,
+            model: query.model.clone(),
+            inference_type: query.inference_type.map(|value| value.as_str().to_string()),
+            limit: fetch_limit,
+            cursor: cursor.map(|value| InferenceUsageReportCursor {
+                created_at: value.created_at,
+                id: value.id,
+            }),
+            deadline: Some(request_deadline.instant()),
+        })
+        .await
+        .map_err(|error| match error {
+            services::usage::UsageError::ReportingTimeout => timeout_error(),
+            _ => internal_error("Failed to list inference usage export"),
+        })?;
+    Ok(rows.into_iter().map(ExportRow::Inference).collect())
+}
+
+async fn list_service_rows(
+    state: &ReportingUsageExportState,
+    organization_id: Uuid,
+    query: &ReportingUsageQuery,
+    fetch_limit: u16,
+    cursor: Option<ReportingUsageCursor>,
+    request_deadline: ReportingRequestDeadline,
+) -> Result<Vec<ExportRow>, RouteError> {
+    let rows = state
+        .service_usage_service
+        .get_usage_report(&ServiceUsageReportFilters {
+            organization_id,
+            service_name: query.service_name.clone(),
+            workspace_id: query.workspace_id,
+            api_key_id: query.api_key_id,
+            start_time: query.start_time,
+            end_time: query.end_time,
+            cursor: cursor.map(|value| ServiceUsageReportCursor {
+                created_at: value.created_at,
+                id: value.id,
+            }),
+            limit: i64::from(fetch_limit),
+            deadline: Some(request_deadline.instant()),
+        })
+        .await
+        .map_err(|error| match error {
+            services::service_usage::ServiceUsageError::ReportingTimeout => timeout_error(),
+            _ => internal_error("Failed to list service usage export"),
+        })?;
+    Ok(rows.into_iter().map(ExportRow::Service).collect())
+}
+
+fn source_cursor(
+    cursor: Option<&ReportingUsageCursor>,
+    row_source: ReportingUsageRowSource,
+) -> Option<ReportingUsageCursor> {
+    let cursor = cursor?;
+    let id = match source_rank(row_source).cmp(&source_rank(cursor.source)) {
+        std::cmp::Ordering::Greater => Uuid::nil(),
+        std::cmp::Ordering::Equal => cursor.id,
+        std::cmp::Ordering::Less => Uuid::from_u128(u128::MAX),
+    };
+    Some(cursor.with_position(row_source, id))
+}

--- a/crates/api/src/routes/reporting_usage/mod.rs
+++ b/crates/api/src/routes/reporting_usage/mod.rs
@@ -1,0 +1,59 @@
+pub mod export;
+mod export_rows;
+mod query;
+mod schemas;
+pub mod summary;
+mod summary_merge;
+
+use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use axum::{extract::Path, http::StatusCode, Json};
+use serde::Serialize;
+use uuid::Uuid;
+
+pub use export::{export_usage, ReportingUsageExportState};
+pub use query::{
+    ReportingUsageCursor, ReportingUsageLimit, ReportingUsageQuery, ReportingUsageQueryError,
+    ReportingUsageQueryParams, ReportingUsageRowSource, ReportingUsageSource,
+};
+pub use schemas::{
+    ReportingApiKeySummary, ReportingDaySummary, ReportingInferenceUsage, ReportingModelSummary,
+    ReportingServiceSummary, ReportingServiceUsage, ReportingUsageExportResponse,
+    ReportingUsageExportRow, ReportingUsageSummaryResponse, ReportingUsageTotals,
+    ReportingWorkspaceSummary,
+};
+pub use summary::{summary_usage, ReportingUsageSummaryState};
+
+type RouteError = (StatusCode, Json<ErrorResponse>);
+
+#[derive(Debug, Serialize)]
+pub struct ReportingTokenAuthProbeResponse {
+    pub token_id: Uuid,
+    pub organization_id: Uuid,
+    pub token_prefix: String,
+    pub scope: services::reporting_tokens::ReportingTokenScope,
+}
+
+pub async fn reporting_token_auth_probe(
+    axum::Extension(reporting_token): axum::Extension<AuthenticatedReportingToken>,
+    Path(org_id): Path<Uuid>,
+) -> Result<Json<ReportingTokenAuthProbeResponse>, RouteError> {
+    if reporting_token.organization_id != org_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "Reporting token is not authorized for this organization.".to_string(),
+                "forbidden".to_string(),
+            )),
+        ));
+    }
+
+    Ok(Json(ReportingTokenAuthProbeResponse {
+        token_id: reporting_token.id,
+        organization_id: reporting_token.organization_id,
+        token_prefix: reporting_token.token_prefix,
+        scope: reporting_token.scope,
+    }))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/api/src/routes/reporting_usage/mod.rs
+++ b/crates/api/src/routes/reporting_usage/mod.rs
@@ -1,5 +1,7 @@
+mod cursor;
 pub mod export;
 mod export_rows;
+mod export_sources;
 mod query;
 mod schemas;
 pub mod summary;
@@ -10,16 +12,17 @@ use axum::{extract::Path, http::StatusCode, Json};
 use serde::Serialize;
 use uuid::Uuid;
 
+pub use cursor::ReportingUsageCursor;
 pub use export::{export_usage, ReportingUsageExportState};
 pub use query::{
-    ReportingUsageCursor, ReportingUsageLimit, ReportingUsageQuery, ReportingUsageQueryError,
-    ReportingUsageQueryParams, ReportingUsageRowSource, ReportingUsageSource,
+    ReportingUsageLimit, ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams,
+    ReportingUsageRowSource, ReportingUsageSource,
 };
 pub use schemas::{
     ReportingApiKeySummary, ReportingDaySummary, ReportingInferenceUsage, ReportingModelSummary,
-    ReportingServiceSummary, ReportingServiceUsage, ReportingUsageExportResponse,
-    ReportingUsageExportRow, ReportingUsageSummaryResponse, ReportingUsageTotals,
-    ReportingWorkspaceSummary,
+    ReportingServiceSummary, ReportingServiceUsage, ReportingUsageDetails,
+    ReportingUsageExportResponse, ReportingUsageExportRow, ReportingUsageSummaryResponse,
+    ReportingUsageTotals, ReportingWorkspaceSummary,
 };
 pub use summary::{summary_usage, ReportingUsageSummaryState};
 
@@ -37,15 +40,7 @@ pub async fn reporting_token_auth_probe(
     axum::Extension(reporting_token): axum::Extension<AuthenticatedReportingToken>,
     Path(org_id): Path<Uuid>,
 ) -> Result<Json<ReportingTokenAuthProbeResponse>, RouteError> {
-    if reporting_token.organization_id != org_id {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse::new(
-                "Reporting token is not authorized for this organization.".to_string(),
-                "forbidden".to_string(),
-            )),
-        ));
-    }
+    ensure_token_matches_org(&reporting_token, org_id)?;
 
     Ok(Json(ReportingTokenAuthProbeResponse {
         token_id: reporting_token.id,
@@ -53,6 +48,52 @@ pub async fn reporting_token_auth_probe(
         token_prefix: reporting_token.token_prefix,
         scope: reporting_token.scope,
     }))
+}
+
+fn ensure_token_matches_org(
+    reporting_token: &AuthenticatedReportingToken,
+    org_id: Uuid,
+) -> Result<(), RouteError> {
+    if reporting_token.organization_id == org_id {
+        return Ok(());
+    }
+    Err((
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new(
+            "Reporting token is not authorized for this organization.".to_string(),
+            "forbidden".to_string(),
+        )),
+    ))
+}
+
+fn query_error(error: ReportingUsageQueryError) -> RouteError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(
+            error.to_string(),
+            "invalid_reporting_usage_query".to_string(),
+        )),
+    )
+}
+
+fn timeout_error() -> RouteError {
+    (
+        StatusCode::GATEWAY_TIMEOUT,
+        Json(ErrorResponse::new(
+            "Usage reporting request timed out".to_string(),
+            "reporting_request_timeout".to_string(),
+        )),
+    )
+}
+
+fn internal_error(message: &str) -> RouteError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            message.to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
 }
 
 #[cfg(test)]

--- a/crates/api/src/routes/reporting_usage/query.rs
+++ b/crates/api/src/routes/reporting_usage/query.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use super::cursor::{ReportingUsageCursor, ReportingUsageCursorFilters};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use services::usage::InferenceType;
@@ -10,7 +10,6 @@ use uuid::Uuid;
 const DEFAULT_REPORTING_USAGE_LIMIT: u16 = 100;
 const MAX_REPORTING_USAGE_LIMIT: u16 = 1000;
 const MAX_REPORTING_USAGE_RANGE_DAYS: i64 = 366;
-const REPORTING_USAGE_CURSOR_VERSION: u8 = 1;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -129,105 +128,65 @@ impl TryFrom<ReportingUsageQueryParams> for ReportingUsageQuery {
     type Error = ReportingUsageQueryError;
 
     fn try_from(params: ReportingUsageQueryParams) -> Result<Self, Self::Error> {
-        let (start_time, end_time) = normalize_time_range(
-            parse_optional_time(params.start_time.as_deref())?,
-            parse_optional_time(params.end_time.as_deref())?,
-        )?;
+        let requested_start_time = parse_optional_time(params.start_time.as_deref())?;
+        let requested_end_time = parse_optional_time(params.end_time.as_deref())?;
+        let requested_source = params
+            .source
+            .as_deref()
+            .map(ReportingUsageSource::from_str)
+            .transpose()?;
+        let requested_inference_type = params
+            .inference_type
+            .as_deref()
+            .map(InferenceType::from_str)
+            .transpose()
+            .map_err(ReportingUsageQueryError::InvalidInferenceType)?;
+        let cursor = params
+            .cursor
+            .as_deref()
+            .map(ReportingUsageCursor::decode)
+            .transpose()?;
+        let context = match cursor.as_ref() {
+            Some(cursor) => cursor.restore_context(
+                &params,
+                requested_start_time,
+                requested_end_time,
+                requested_source,
+                requested_inference_type,
+            )?,
+            None => {
+                let (start_time, end_time) =
+                    normalize_time_range(requested_start_time, requested_end_time)?;
+                ReportingUsageCursorFilters {
+                    start_time,
+                    end_time,
+                    source: requested_source.unwrap_or_default(),
+                    workspace_id: params.workspace_id,
+                    api_key_id: params.api_key_id,
+                    model: params.model,
+                    inference_type: requested_inference_type,
+                    service_name: params.service_name,
+                }
+            }
+        };
 
         Ok(Self {
-            start_time: Some(start_time),
-            end_time: Some(end_time),
-            source: params
-                .source
-                .as_deref()
-                .map(ReportingUsageSource::from_str)
-                .transpose()?
-                .unwrap_or_default(),
-            workspace_id: params.workspace_id,
-            api_key_id: params.api_key_id,
-            model: params.model,
-            inference_type: params
-                .inference_type
-                .as_deref()
-                .map(InferenceType::from_str)
-                .transpose()
-                .map_err(ReportingUsageQueryError::InvalidInferenceType)?,
-            service_name: params.service_name,
+            start_time: Some(context.start_time),
+            end_time: Some(context.end_time),
+            source: context.source,
+            workspace_id: context.workspace_id,
+            api_key_id: context.api_key_id,
+            model: context.model,
+            inference_type: context.inference_type,
+            service_name: context.service_name,
             limit: params
                 .limit
                 .map(ReportingUsageLimit::new)
                 .transpose()?
                 .unwrap_or_default(),
-            cursor: params
-                .cursor
-                .as_deref()
-                .map(ReportingUsageCursor::decode)
-                .transpose()?,
+            cursor,
         })
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ReportingUsageCursor {
-    pub created_at: DateTime<Utc>,
-    pub source: ReportingUsageRowSource,
-    pub id: Uuid,
-}
-
-impl ReportingUsageCursor {
-    pub const fn new(created_at: DateTime<Utc>, source: ReportingUsageRowSource, id: Uuid) -> Self {
-        Self {
-            created_at,
-            source,
-            id,
-        }
-    }
-
-    pub fn encode(&self) -> Result<String, ReportingUsageQueryError> {
-        let payload = ReportingUsageCursorPayload {
-            version: REPORTING_USAGE_CURSOR_VERSION,
-            created_at: self.created_at,
-            source: self.source,
-            id: self.id,
-        };
-        let bytes =
-            serde_json::to_vec(&payload).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
-        Ok(URL_SAFE_NO_PAD.encode(bytes))
-    }
-
-    pub fn decode(value: &str) -> Result<Self, ReportingUsageQueryError> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(value)
-            .map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
-        let payload: ReportingUsageCursorPayload =
-            serde_json::from_slice(&bytes).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
-        if payload.version != REPORTING_USAGE_CURSOR_VERSION {
-            return Err(ReportingUsageQueryError::InvalidCursor);
-        }
-        Ok(Self {
-            created_at: payload.created_at,
-            source: payload.source,
-            id: payload.id,
-        })
-    }
-
-    #[cfg(test)]
-    pub fn encode_raw_for_tests(
-        value: &serde_json::Value,
-    ) -> Result<String, ReportingUsageQueryError> {
-        let bytes =
-            serde_json::to_vec(value).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
-        Ok(URL_SAFE_NO_PAD.encode(bytes))
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ReportingUsageCursorPayload {
-    #[serde(rename = "v")]
-    version: u8,
-    created_at: DateTime<Utc>,
-    source: ReportingUsageRowSource,
-    id: Uuid,
 }
 
 fn parse_optional_time(
@@ -242,7 +201,7 @@ fn parse_optional_time(
         .transpose()
 }
 
-fn validate_time_range(
+pub(super) fn validate_time_range(
     start_time: DateTime<Utc>,
     end_time: DateTime<Utc>,
 ) -> Result<(), ReportingUsageQueryError> {

--- a/crates/api/src/routes/reporting_usage/query.rs
+++ b/crates/api/src/routes/reporting_usage/query.rs
@@ -1,0 +1,269 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use services::usage::InferenceType;
+use std::str::FromStr;
+use thiserror::Error;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+const DEFAULT_REPORTING_USAGE_LIMIT: u16 = 100;
+const MAX_REPORTING_USAGE_LIMIT: u16 = 1000;
+const MAX_REPORTING_USAGE_RANGE_DAYS: i64 = 366;
+const REPORTING_USAGE_CURSOR_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportingUsageSource {
+    #[default]
+    All,
+    Inference,
+    Service,
+}
+
+impl FromStr for ReportingUsageSource {
+    type Err = ReportingUsageQueryError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "all" => Ok(Self::All),
+            "inference" => Ok(Self::Inference),
+            "service" => Ok(Self::Service),
+            other => Err(ReportingUsageQueryError::InvalidSource(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportingUsageRowSource {
+    Inference,
+    Service,
+}
+
+impl ReportingUsageRowSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Inference => "inference",
+            Self::Service => "service",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToSchema)]
+pub struct ReportingUsageLimit(u16);
+
+impl ReportingUsageLimit {
+    pub const fn value(self) -> u16 {
+        self.0
+    }
+
+    fn new(value: u16) -> Result<Self, ReportingUsageQueryError> {
+        if value == 0 {
+            return Err(ReportingUsageQueryError::LimitNotPositive);
+        }
+        if value > MAX_REPORTING_USAGE_LIMIT {
+            return Err(ReportingUsageQueryError::LimitTooLarge {
+                max: MAX_REPORTING_USAGE_LIMIT,
+            });
+        }
+        Ok(Self(value))
+    }
+}
+
+impl Default for ReportingUsageLimit {
+    fn default() -> Self {
+        Self(DEFAULT_REPORTING_USAGE_LIMIT)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportingUsageQuery {
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub source: ReportingUsageSource,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<InferenceType>,
+    pub service_name: Option<String>,
+    pub limit: ReportingUsageLimit,
+    pub cursor: Option<ReportingUsageCursor>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ReportingUsageQueryParams {
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub source: Option<String>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<String>,
+    pub service_name: Option<String>,
+    pub limit: Option<u16>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ReportingUsageQueryError {
+    #[error("start_time and end_time must be RFC3339 timestamps")]
+    InvalidTimestamp,
+    #[error("end_time must be greater than or equal to start_time")]
+    InvalidTimeRange,
+    #[error("time range must not exceed {max_days} days")]
+    TimeRangeTooLarge { max_days: i64 },
+    #[error("invalid source: {0}")]
+    InvalidSource(String),
+    #[error("invalid inference_type: {0}")]
+    InvalidInferenceType(String),
+    #[error("limit must be positive")]
+    LimitNotPositive,
+    #[error("limit must not exceed {max}")]
+    LimitTooLarge { max: u16 },
+    #[error("invalid cursor")]
+    InvalidCursor,
+}
+
+impl TryFrom<ReportingUsageQueryParams> for ReportingUsageQuery {
+    type Error = ReportingUsageQueryError;
+
+    fn try_from(params: ReportingUsageQueryParams) -> Result<Self, Self::Error> {
+        let (start_time, end_time) = normalize_time_range(
+            parse_optional_time(params.start_time.as_deref())?,
+            parse_optional_time(params.end_time.as_deref())?,
+        )?;
+
+        Ok(Self {
+            start_time: Some(start_time),
+            end_time: Some(end_time),
+            source: params
+                .source
+                .as_deref()
+                .map(ReportingUsageSource::from_str)
+                .transpose()?
+                .unwrap_or_default(),
+            workspace_id: params.workspace_id,
+            api_key_id: params.api_key_id,
+            model: params.model,
+            inference_type: params
+                .inference_type
+                .as_deref()
+                .map(InferenceType::from_str)
+                .transpose()
+                .map_err(ReportingUsageQueryError::InvalidInferenceType)?,
+            service_name: params.service_name,
+            limit: params
+                .limit
+                .map(ReportingUsageLimit::new)
+                .transpose()?
+                .unwrap_or_default(),
+            cursor: params
+                .cursor
+                .as_deref()
+                .map(ReportingUsageCursor::decode)
+                .transpose()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReportingUsageCursor {
+    pub created_at: DateTime<Utc>,
+    pub source: ReportingUsageRowSource,
+    pub id: Uuid,
+}
+
+impl ReportingUsageCursor {
+    pub const fn new(created_at: DateTime<Utc>, source: ReportingUsageRowSource, id: Uuid) -> Self {
+        Self {
+            created_at,
+            source,
+            id,
+        }
+    }
+
+    pub fn encode(&self) -> Result<String, ReportingUsageQueryError> {
+        let payload = ReportingUsageCursorPayload {
+            version: REPORTING_USAGE_CURSOR_VERSION,
+            created_at: self.created_at,
+            source: self.source,
+            id: self.id,
+        };
+        let bytes =
+            serde_json::to_vec(&payload).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+
+    pub fn decode(value: &str) -> Result<Self, ReportingUsageQueryError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        let payload: ReportingUsageCursorPayload =
+            serde_json::from_slice(&bytes).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        if payload.version != REPORTING_USAGE_CURSOR_VERSION {
+            return Err(ReportingUsageQueryError::InvalidCursor);
+        }
+        Ok(Self {
+            created_at: payload.created_at,
+            source: payload.source,
+            id: payload.id,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn encode_raw_for_tests(
+        value: &serde_json::Value,
+    ) -> Result<String, ReportingUsageQueryError> {
+        let bytes =
+            serde_json::to_vec(value).map_err(|_| ReportingUsageQueryError::InvalidCursor)?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReportingUsageCursorPayload {
+    #[serde(rename = "v")]
+    version: u8,
+    created_at: DateTime<Utc>,
+    source: ReportingUsageRowSource,
+    id: Uuid,
+}
+
+fn parse_optional_time(
+    value: Option<&str>,
+) -> Result<Option<DateTime<Utc>>, ReportingUsageQueryError> {
+    value
+        .map(|timestamp| {
+            DateTime::parse_from_rfc3339(timestamp)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|_| ReportingUsageQueryError::InvalidTimestamp)
+        })
+        .transpose()
+}
+
+fn validate_time_range(
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+) -> Result<(), ReportingUsageQueryError> {
+    if end_time < start_time {
+        return Err(ReportingUsageQueryError::InvalidTimeRange);
+    }
+    if end_time - start_time > Duration::days(MAX_REPORTING_USAGE_RANGE_DAYS) {
+        return Err(ReportingUsageQueryError::TimeRangeTooLarge {
+            max_days: MAX_REPORTING_USAGE_RANGE_DAYS,
+        });
+    }
+    Ok(())
+}
+
+fn normalize_time_range(
+    start_time: Option<DateTime<Utc>>,
+    end_time: Option<DateTime<Utc>>,
+) -> Result<(DateTime<Utc>, DateTime<Utc>), ReportingUsageQueryError> {
+    let end_time = end_time.unwrap_or_else(Utc::now);
+    let start_time =
+        start_time.unwrap_or_else(|| end_time - Duration::days(MAX_REPORTING_USAGE_RANGE_DAYS));
+    validate_time_range(start_time, end_time)?;
+    Ok((start_time, end_time))
+}

--- a/crates/api/src/routes/reporting_usage/schemas.rs
+++ b/crates/api/src/routes/reporting_usage/schemas.rs
@@ -14,7 +14,6 @@ pub struct ReportingUsageExportResponse {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct ReportingUsageExportRow {
-    pub source: ReportingUsageRowSource,
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
     pub workspace_id: Uuid,
@@ -22,10 +21,24 @@ pub struct ReportingUsageExportRow {
     pub total_cost_nano_usd: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_cost_usd: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub inference: Option<ReportingInferenceUsage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub service: Option<ReportingServiceUsage>,
+    #[serde(flatten)]
+    pub usage: ReportingUsageDetails,
+}
+
+impl ReportingUsageExportRow {
+    pub const fn source(&self) -> ReportingUsageRowSource {
+        match &self.usage {
+            ReportingUsageDetails::Inference { .. } => ReportingUsageRowSource::Inference,
+            ReportingUsageDetails::Service { .. } => ReportingUsageRowSource::Service,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "source", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReportingUsageDetails {
+    Inference { inference: ReportingInferenceUsage },
+    Service { service: ReportingServiceUsage },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/crates/api/src/routes/reporting_usage/schemas.rs
+++ b/crates/api/src/routes/reporting_usage/schemas.rs
@@ -1,0 +1,140 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::{ReportingUsageRowSource, ReportingUsageSource};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageExportResponse {
+    pub data: Vec<ReportingUsageExportRow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageExportRow {
+    pub source: ReportingUsageRowSource,
+    pub id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference: Option<ReportingInferenceUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<ReportingServiceUsage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingInferenceUsage {
+    pub model: String,
+    pub inference_type: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub input_cost_nano_usd: i64,
+    pub output_cost_nano_usd: i64,
+    /// Omitted when Cloud API has not persisted a separate cache-read cost split.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_cost_nano_usd: Option<i64>,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<Uuid>,
+    /// Customer-facing request correlation id for v1 reporting.
+    ///
+    /// Reporting intentionally excludes upstream provider request ids and provider-attribution fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_count: Option<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingServiceUsage {
+    pub service_name: String,
+    pub quantity: i64,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageSummaryResponse {
+    pub source: ReportingUsageSource,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub totals: ReportingUsageTotals,
+    pub by_workspace: Vec<ReportingWorkspaceSummary>,
+    pub by_api_key: Vec<ReportingApiKeySummary>,
+    pub by_model: Vec<ReportingModelSummary>,
+    pub by_service: Vec<ReportingServiceSummary>,
+    pub by_day: Vec<ReportingDaySummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingUsageTotals {
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub inference_cost_nano_usd: i64,
+    pub service_cost_nano_usd: i64,
+    pub total_cost_nano_usd: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingWorkspaceSummary {
+    pub workspace_id: Uuid,
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingApiKeySummary {
+    pub api_key_id: Uuid,
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingModelSummary {
+    pub model: String,
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingServiceSummary {
+    pub service_name: String,
+    pub usage_count: i64,
+    pub quantity: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ReportingDaySummary {
+    pub day: String,
+    pub request_count: i64,
+    pub service_usage_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub inference_cost_nano_usd: i64,
+    pub service_cost_nano_usd: i64,
+    pub total_cost_nano_usd: i64,
+}

--- a/crates/api/src/routes/reporting_usage/summary.rs
+++ b/crates/api/src/routes/reporting_usage/summary.rs
@@ -1,35 +1,30 @@
 use super::{
-    ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams, ReportingUsageSource,
-    ReportingUsageSummaryResponse, RouteError,
+    ensure_token_matches_org, internal_error, query_error, timeout_error, ReportingUsageQuery,
+    ReportingUsageQueryParams, ReportingUsageSource, ReportingUsageSummaryResponse, RouteError,
 };
-use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use crate::{
+    middleware::{AuthenticatedReportingToken, ReportingRequestDeadline},
+    models::ErrorResponse,
+};
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
     Extension, Json,
 };
 use services::reporting_usage::{
-    InferenceUsageSummary, InferenceUsageSummaryRepository, ReportingUsageSummaryFilters,
-    ServiceUsageSummary, ServiceUsageSummaryRepository,
+    ReportingUsageError, ReportingUsageService, ReportingUsageSummaryFilters,
+    ReportingUsageSummarySource,
 };
 use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct ReportingUsageSummaryState {
-    inference_repo: Arc<dyn InferenceUsageSummaryRepository>,
-    service_repo: Arc<dyn ServiceUsageSummaryRepository>,
+    service: Arc<ReportingUsageService>,
 }
 
 impl ReportingUsageSummaryState {
-    pub fn new(
-        inference_repo: Arc<dyn InferenceUsageSummaryRepository>,
-        service_repo: Arc<dyn ServiceUsageSummaryRepository>,
-    ) -> Self {
-        Self {
-            inference_repo,
-            service_repo,
-        }
+    pub fn new(service: Arc<ReportingUsageService>) -> Self {
+        Self { service }
     }
 }
 
@@ -43,8 +38,8 @@ impl ReportingUsageSummaryState {
     tag = "Reporting",
     params(
         ("org_id" = Uuid, Path, description = "Organization ID"),
-        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. The range between start_time and end_time must not exceed 366 days."),
-        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Must be greater than or equal to start_time when both are provided."),
+        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. Defaults to 366 days before the effective end_time."),
+        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Defaults to the request time. The effective range must not exceed 366 days."),
         ("source" = Option<ReportingUsageSource>, Query, description = "Usage source to summarize. Defaults to all."),
         ("workspace_id" = Option<Uuid>, Query, description = "Filter by workspace ID."),
         ("api_key_id" = Option<Uuid>, Query, description = "Filter by API key ID."),
@@ -57,6 +52,8 @@ impl ReportingUsageSummaryState {
         (status = 400, description = "Invalid filters", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
         (status = 403, description = "Reporting token is not scoped to this organization", body = ErrorResponse),
+        (status = 429, description = "Reporting rate or concurrency limit exceeded", body = ErrorResponse),
+        (status = 504, description = "Reporting request timed out", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     security(
@@ -66,38 +63,39 @@ impl ReportingUsageSummaryState {
 pub async fn summary_usage(
     State(state): State<ReportingUsageSummaryState>,
     Extension(reporting_token): Extension<AuthenticatedReportingToken>,
+    Extension(request_deadline): Extension<ReportingRequestDeadline>,
     Path(org_id): Path<Uuid>,
     Query(params): Query<ReportingUsageQueryParams>,
 ) -> Result<Json<ReportingUsageSummaryResponse>, RouteError> {
     ensure_token_matches_org(&reporting_token, org_id)?;
     let query = ReportingUsageQuery::try_from(params).map_err(query_error)?;
-    let filters = summary_filters(org_id, &query);
-
-    let inference = match query.source {
-        ReportingUsageSource::All | ReportingUsageSource::Inference => state
-            .inference_repo
-            .summarize_inference_usage(&filters)
-            .await
-            .map_err(|_| internal_error("Failed to summarize inference usage"))?,
-        ReportingUsageSource::Service => InferenceUsageSummary::default(),
-    };
-    let service = match query.source {
-        ReportingUsageSource::All | ReportingUsageSource::Service => state
-            .service_repo
-            .summarize_service_usage(&filters)
-            .await
-            .map_err(|_| internal_error("Failed to summarize service usage"))?,
-        ReportingUsageSource::Inference => ServiceUsageSummary::default(),
-    };
+    query
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.validate_organization(org_id))
+        .transpose()
+        .map_err(query_error)?;
+    let filters = summary_filters(org_id, &query, request_deadline);
+    let summary = state
+        .service
+        .summarize(&filters)
+        .await
+        .map_err(|error| match error {
+            ReportingUsageError::Timeout => timeout_error(),
+            ReportingUsageError::Internal(_) => internal_error("Failed to summarize usage"),
+        })?;
 
     Ok(Json(super::summary_merge::summary_response(
-        query, inference, service,
+        query,
+        summary.inference,
+        summary.service,
     )))
 }
 
 fn summary_filters(
     organization_id: Uuid,
     query: &ReportingUsageQuery,
+    request_deadline: ReportingRequestDeadline,
 ) -> ReportingUsageSummaryFilters {
     ReportingUsageSummaryFilters {
         organization_id,
@@ -108,41 +106,11 @@ fn summary_filters(
         model: query.model.clone(),
         inference_type: query.inference_type.map(|value| value.as_str().to_string()),
         service_name: query.service_name.clone(),
+        source: match query.source {
+            ReportingUsageSource::All => ReportingUsageSummarySource::All,
+            ReportingUsageSource::Inference => ReportingUsageSummarySource::Inference,
+            ReportingUsageSource::Service => ReportingUsageSummarySource::Service,
+        },
+        deadline: Some(request_deadline.instant()),
     }
-}
-
-fn ensure_token_matches_org(
-    reporting_token: &AuthenticatedReportingToken,
-    org_id: Uuid,
-) -> Result<(), RouteError> {
-    if reporting_token.organization_id == org_id {
-        return Ok(());
-    }
-    Err((
-        StatusCode::FORBIDDEN,
-        Json(ErrorResponse::new(
-            "Reporting token is not authorized for this organization.".to_string(),
-            "forbidden".to_string(),
-        )),
-    ))
-}
-
-fn query_error(error: ReportingUsageQueryError) -> RouteError {
-    (
-        StatusCode::BAD_REQUEST,
-        Json(ErrorResponse::new(
-            error.to_string(),
-            "invalid_reporting_usage_query".to_string(),
-        )),
-    )
-}
-
-fn internal_error(message: &str) -> RouteError {
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(ErrorResponse::new(
-            message.to_string(),
-            "internal_server_error".to_string(),
-        )),
-    )
 }

--- a/crates/api/src/routes/reporting_usage/summary.rs
+++ b/crates/api/src/routes/reporting_usage/summary.rs
@@ -1,0 +1,148 @@
+use super::{
+    ReportingUsageQuery, ReportingUsageQueryError, ReportingUsageQueryParams, ReportingUsageSource,
+    ReportingUsageSummaryResponse, RouteError,
+};
+use crate::{middleware::AuthenticatedReportingToken, models::ErrorResponse};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Extension, Json,
+};
+use services::reporting_usage::{
+    InferenceUsageSummary, InferenceUsageSummaryRepository, ReportingUsageSummaryFilters,
+    ServiceUsageSummary, ServiceUsageSummaryRepository,
+};
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ReportingUsageSummaryState {
+    inference_repo: Arc<dyn InferenceUsageSummaryRepository>,
+    service_repo: Arc<dyn ServiceUsageSummaryRepository>,
+}
+
+impl ReportingUsageSummaryState {
+    pub fn new(
+        inference_repo: Arc<dyn InferenceUsageSummaryRepository>,
+        service_repo: Arc<dyn ServiceUsageSummaryRepository>,
+    ) -> Self {
+        Self {
+            inference_repo,
+            service_repo,
+        }
+    }
+}
+
+/// Summarize organization usage and costs.
+///
+/// Requires a reporting token scoped to the organization in the path. Totals
+/// include inference and platform service usage by default.
+#[utoipa::path(
+    get,
+    path = "/v1/organizations/{org_id}/usage/summary",
+    tag = "Reporting",
+    params(
+        ("org_id" = Uuid, Path, description = "Organization ID"),
+        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. The range between start_time and end_time must not exceed 366 days."),
+        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Must be greater than or equal to start_time when both are provided."),
+        ("source" = Option<ReportingUsageSource>, Query, description = "Usage source to summarize. Defaults to all."),
+        ("workspace_id" = Option<Uuid>, Query, description = "Filter by workspace ID."),
+        ("api_key_id" = Option<Uuid>, Query, description = "Filter by API key ID."),
+        ("model" = Option<String>, Query, description = "Filter inference usage by model name."),
+        ("inference_type" = Option<String>, Query, description = "Filter inference usage by inference type."),
+        ("service_name" = Option<String>, Query, description = "Filter service usage by platform service name.")
+    ),
+    responses(
+        (status = 200, description = "Usage summary", body = ReportingUsageSummaryResponse),
+        (status = 400, description = "Invalid filters", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Reporting token is not scoped to this organization", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    security(
+        ("reporting_token" = [])
+    )
+)]
+pub async fn summary_usage(
+    State(state): State<ReportingUsageSummaryState>,
+    Extension(reporting_token): Extension<AuthenticatedReportingToken>,
+    Path(org_id): Path<Uuid>,
+    Query(params): Query<ReportingUsageQueryParams>,
+) -> Result<Json<ReportingUsageSummaryResponse>, RouteError> {
+    ensure_token_matches_org(&reporting_token, org_id)?;
+    let query = ReportingUsageQuery::try_from(params).map_err(query_error)?;
+    let filters = summary_filters(org_id, &query);
+
+    let inference = match query.source {
+        ReportingUsageSource::All | ReportingUsageSource::Inference => state
+            .inference_repo
+            .summarize_inference_usage(&filters)
+            .await
+            .map_err(|_| internal_error("Failed to summarize inference usage"))?,
+        ReportingUsageSource::Service => InferenceUsageSummary::default(),
+    };
+    let service = match query.source {
+        ReportingUsageSource::All | ReportingUsageSource::Service => state
+            .service_repo
+            .summarize_service_usage(&filters)
+            .await
+            .map_err(|_| internal_error("Failed to summarize service usage"))?,
+        ReportingUsageSource::Inference => ServiceUsageSummary::default(),
+    };
+
+    Ok(Json(super::summary_merge::summary_response(
+        query, inference, service,
+    )))
+}
+
+fn summary_filters(
+    organization_id: Uuid,
+    query: &ReportingUsageQuery,
+) -> ReportingUsageSummaryFilters {
+    ReportingUsageSummaryFilters {
+        organization_id,
+        start_time: query.start_time,
+        end_time: query.end_time,
+        workspace_id: query.workspace_id,
+        api_key_id: query.api_key_id,
+        model: query.model.clone(),
+        inference_type: query.inference_type.map(|value| value.as_str().to_string()),
+        service_name: query.service_name.clone(),
+    }
+}
+
+fn ensure_token_matches_org(
+    reporting_token: &AuthenticatedReportingToken,
+    org_id: Uuid,
+) -> Result<(), RouteError> {
+    if reporting_token.organization_id == org_id {
+        return Ok(());
+    }
+    Err((
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse::new(
+            "Reporting token is not authorized for this organization.".to_string(),
+            "forbidden".to_string(),
+        )),
+    ))
+}
+
+fn query_error(error: ReportingUsageQueryError) -> RouteError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(
+            error.to_string(),
+            "invalid_reporting_usage_query".to_string(),
+        )),
+    )
+}
+
+fn internal_error(message: &str) -> RouteError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            message.to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
+}

--- a/crates/api/src/routes/reporting_usage/summary_merge.rs
+++ b/crates/api/src/routes/reporting_usage/summary_merge.rs
@@ -1,0 +1,204 @@
+use super::{
+    ReportingApiKeySummary, ReportingDaySummary, ReportingModelSummary, ReportingServiceSummary,
+    ReportingUsageQuery, ReportingUsageSummaryResponse, ReportingUsageTotals,
+    ReportingWorkspaceSummary,
+};
+use chrono::{DateTime, Utc};
+use services::reporting_usage::{InferenceUsageSummary, ServiceUsageSummary};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+pub(super) fn summary_response(
+    query: ReportingUsageQuery,
+    inference: InferenceUsageSummary,
+    service: ServiceUsageSummary,
+) -> ReportingUsageSummaryResponse {
+    ReportingUsageSummaryResponse {
+        source: query.source,
+        start_time: query.start_time.unwrap_or(DateTime::<Utc>::UNIX_EPOCH),
+        end_time: query.end_time.unwrap_or_else(Utc::now),
+        totals: totals(&inference, &service),
+        by_workspace: by_workspace(&inference, &service),
+        by_api_key: by_api_key(&inference, &service),
+        by_model: by_model(&inference),
+        by_service: by_service(&service),
+        by_day: by_day(&service, &inference),
+    }
+}
+
+fn totals(
+    inference: &InferenceUsageSummary,
+    service: &ServiceUsageSummary,
+) -> ReportingUsageTotals {
+    let inference_cost = inference.totals.total_cost_nano_usd;
+    let service_cost = service.totals.total_cost_nano_usd;
+    ReportingUsageTotals {
+        request_count: inference.totals.request_count,
+        service_usage_count: service.totals.usage_count,
+        input_tokens: inference.totals.input_tokens,
+        output_tokens: inference.totals.output_tokens,
+        cache_read_tokens: inference.totals.cache_read_tokens,
+        total_tokens: inference.totals.total_tokens,
+        inference_cost_nano_usd: inference_cost,
+        service_cost_nano_usd: service_cost,
+        total_cost_nano_usd: inference_cost + service_cost,
+        total_cost_usd: None,
+    }
+}
+
+fn by_workspace(
+    inference: &InferenceUsageSummary,
+    service: &ServiceUsageSummary,
+) -> Vec<ReportingWorkspaceSummary> {
+    let mut rows: BTreeMap<Uuid, ReportingWorkspaceSummary> = BTreeMap::new();
+    for item in &inference.by_workspace {
+        rows.insert(
+            item.workspace_id,
+            ReportingWorkspaceSummary {
+                workspace_id: item.workspace_id,
+                request_count: item.request_count,
+                service_usage_count: 0,
+                total_cost_nano_usd: item.total_cost_nano_usd,
+            },
+        );
+    }
+    for item in &service.by_workspace {
+        let row = rows
+            .entry(item.workspace_id)
+            .or_insert(ReportingWorkspaceSummary {
+                workspace_id: item.workspace_id,
+                request_count: 0,
+                service_usage_count: 0,
+                total_cost_nano_usd: 0,
+            });
+        row.service_usage_count += item.usage_count;
+        row.total_cost_nano_usd += item.total_cost_nano_usd;
+    }
+    sorted_workspace(rows)
+}
+
+fn by_api_key(
+    inference: &InferenceUsageSummary,
+    service: &ServiceUsageSummary,
+) -> Vec<ReportingApiKeySummary> {
+    let mut rows: BTreeMap<Uuid, ReportingApiKeySummary> = BTreeMap::new();
+    for item in &inference.by_api_key {
+        rows.insert(
+            item.api_key_id,
+            ReportingApiKeySummary {
+                api_key_id: item.api_key_id,
+                request_count: item.request_count,
+                service_usage_count: 0,
+                total_cost_nano_usd: item.total_cost_nano_usd,
+            },
+        );
+    }
+    for item in &service.by_api_key {
+        let row = rows
+            .entry(item.api_key_id)
+            .or_insert(ReportingApiKeySummary {
+                api_key_id: item.api_key_id,
+                request_count: 0,
+                service_usage_count: 0,
+                total_cost_nano_usd: 0,
+            });
+        row.service_usage_count += item.usage_count;
+        row.total_cost_nano_usd += item.total_cost_nano_usd;
+    }
+    sorted_api_key(rows)
+}
+
+fn by_model(inference: &InferenceUsageSummary) -> Vec<ReportingModelSummary> {
+    inference
+        .by_model
+        .iter()
+        .map(|item| ReportingModelSummary {
+            model: item.model.clone(),
+            request_count: item.request_count,
+            input_tokens: item.input_tokens,
+            output_tokens: item.output_tokens,
+            cache_read_tokens: item.cache_read_tokens,
+            total_tokens: item.total_tokens,
+            total_cost_nano_usd: item.total_cost_nano_usd,
+        })
+        .collect()
+}
+
+fn by_service(service: &ServiceUsageSummary) -> Vec<ReportingServiceSummary> {
+    service
+        .by_service
+        .iter()
+        .map(|item| ReportingServiceSummary {
+            service_name: item.service_name.clone(),
+            usage_count: item.usage_count,
+            quantity: item.quantity,
+            total_cost_nano_usd: item.total_cost_nano_usd,
+        })
+        .collect()
+}
+
+fn by_day(
+    service: &ServiceUsageSummary,
+    inference: &InferenceUsageSummary,
+) -> Vec<ReportingDaySummary> {
+    let mut rows: BTreeMap<String, ReportingDaySummary> = BTreeMap::new();
+    for item in &inference.by_day {
+        rows.insert(
+            item.day.clone(),
+            ReportingDaySummary {
+                day: item.day.clone(),
+                request_count: item.request_count,
+                service_usage_count: 0,
+                input_tokens: item.input_tokens,
+                output_tokens: item.output_tokens,
+                cache_read_tokens: item.cache_read_tokens,
+                total_tokens: item.total_tokens,
+                inference_cost_nano_usd: item.total_cost_nano_usd,
+                service_cost_nano_usd: 0,
+                total_cost_nano_usd: item.total_cost_nano_usd,
+            },
+        );
+    }
+    for item in &service.by_day {
+        let row = rows.entry(item.day.clone()).or_insert(ReportingDaySummary {
+            day: item.day.clone(),
+            request_count: 0,
+            service_usage_count: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            total_tokens: 0,
+            inference_cost_nano_usd: 0,
+            service_cost_nano_usd: 0,
+            total_cost_nano_usd: 0,
+        });
+        row.service_usage_count += item.usage_count;
+        row.service_cost_nano_usd += item.total_cost_nano_usd;
+        row.total_cost_nano_usd += item.total_cost_nano_usd;
+    }
+    rows.into_values().collect()
+}
+
+fn sorted_workspace(
+    rows: BTreeMap<Uuid, ReportingWorkspaceSummary>,
+) -> Vec<ReportingWorkspaceSummary> {
+    let mut values: Vec<_> = rows.into_values().collect();
+    values.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+    });
+    values
+}
+
+fn sorted_api_key(rows: BTreeMap<Uuid, ReportingApiKeySummary>) -> Vec<ReportingApiKeySummary> {
+    let mut values: Vec<_> = rows.into_values().collect();
+    values.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.api_key_id.cmp(&right.api_key_id))
+    });
+    values
+}

--- a/crates/api/src/routes/reporting_usage/tests.rs
+++ b/crates/api/src/routes/reporting_usage/tests.rs
@@ -1,11 +1,12 @@
 use super::{
-    ReportingInferenceUsage, ReportingUsageCursor, ReportingUsageExportResponse,
-    ReportingUsageExportRow, ReportingUsageQuery, ReportingUsageQueryError,
-    ReportingUsageQueryParams, ReportingUsageRowSource, ReportingUsageSource,
-    ReportingUsageSummaryResponse, ReportingUsageTotals,
+    ReportingInferenceUsage, ReportingUsageCursor, ReportingUsageDetails,
+    ReportingUsageExportResponse, ReportingUsageExportRow, ReportingUsageQuery,
+    ReportingUsageQueryError, ReportingUsageQueryParams, ReportingUsageRowSource,
+    ReportingUsageSource, ReportingUsageSummaryResponse, ReportingUsageTotals,
 };
 use chrono::{DateTime, Duration, Utc};
 use serde_json::json;
+use utoipa::OpenApi as _;
 use uuid::Uuid;
 
 fn ts(value: &str) -> DateTime<Utc> {
@@ -14,16 +15,27 @@ fn ts(value: &str) -> DateTime<Utc> {
         .with_timezone(&Utc)
 }
 
+fn organization_id() -> Uuid {
+    Uuid::parse_str("018f7e4c-1111-7abc-9234-123456789abc").unwrap()
+}
+
 #[test]
 fn reporting_usage_query_defaults_and_cursor_roundtrip() {
     // Given: no optional filters and a stable inference cursor tuple.
     let params = ReportingUsageQueryParams::default();
     let created_at = ts("2026-07-01T12:34:56Z");
     let id = Uuid::parse_str("018f7e4c-1234-7abc-9234-123456789abc").unwrap();
-    let cursor = ReportingUsageCursor::new(created_at, ReportingUsageRowSource::Inference, id);
 
     // When: the boundary DTO is parsed and the cursor is encoded/decoded.
     let query = ReportingUsageQuery::try_from(params).unwrap();
+    let cursor = ReportingUsageCursor::for_query(
+        organization_id(),
+        created_at,
+        ReportingUsageRowSource::Inference,
+        id,
+        &query,
+    )
+    .unwrap();
     let encoded = cursor.encode().unwrap();
     let decoded = ReportingUsageCursor::decode(&encoded).unwrap();
 
@@ -33,10 +45,85 @@ fn reporting_usage_query_defaults_and_cursor_roundtrip() {
     assert!(query.start_time.is_some());
     assert!(query.end_time.is_some());
     assert_eq!(decoded, cursor);
+    assert!(decoded.validate_organization(organization_id()).is_ok());
+    assert_eq!(
+        decoded.validate_organization(Uuid::new_v4()),
+        Err(ReportingUsageQueryError::InvalidCursor)
+    );
     assert_eq!(cursor.encode().unwrap(), encoded);
     assert!(!encoded.contains('+'));
     assert!(!encoded.contains('/'));
     assert!(!encoded.contains('='));
+}
+
+#[test]
+fn reporting_usage_cursor_restores_omitted_context_and_rejects_conflicts() {
+    // Given: a first-page query with an explicit window and every supported filter.
+    let workspace_id = Uuid::parse_str("018f7e4c-2222-7abc-9234-123456789abc").unwrap();
+    let api_key_id = Uuid::parse_str("018f7e4c-3333-7abc-9234-123456789abc").unwrap();
+    let first_page = ReportingUsageQuery::try_from(ReportingUsageQueryParams {
+        start_time: Some("2026-07-01T00:00:00Z".to_string()),
+        end_time: Some("2026-07-02T00:00:00Z".to_string()),
+        source: Some("inference".to_string()),
+        workspace_id: Some(workspace_id),
+        api_key_id: Some(api_key_id),
+        model: Some("test-model".to_string()),
+        inference_type: Some("chat_completion".to_string()),
+        service_name: Some("web_search".to_string()),
+        limit: Some(1),
+        cursor: None,
+    })
+    .unwrap();
+    let cursor = ReportingUsageCursor::for_query(
+        organization_id(),
+        ts("2026-07-01T12:34:56Z"),
+        ReportingUsageRowSource::Inference,
+        Uuid::parse_str("018f7e4c-1234-7abc-9234-123456789abc").unwrap(),
+        &first_page,
+    )
+    .unwrap()
+    .encode()
+    .unwrap();
+
+    // When: page two supplies only the opaque cursor.
+    let continuation = ReportingUsageQuery::try_from(ReportingUsageQueryParams {
+        cursor: Some(cursor.clone()),
+        ..ReportingUsageQueryParams::default()
+    })
+    .unwrap();
+
+    // Then: the cursor restores the exact effective window and filter context.
+    assert_eq!(continuation.start_time, first_page.start_time);
+    assert_eq!(continuation.end_time, first_page.end_time);
+    assert_eq!(continuation.source, first_page.source);
+    assert_eq!(continuation.workspace_id, first_page.workspace_id);
+    assert_eq!(continuation.api_key_id, first_page.api_key_id);
+    assert_eq!(continuation.model, first_page.model);
+    assert_eq!(continuation.inference_type, first_page.inference_type);
+    assert_eq!(continuation.service_name, first_page.service_name);
+
+    // When/Then: explicitly changing any bound context invalidates the cursor.
+    let conflicting_source = ReportingUsageQueryParams {
+        source: Some("service".to_string()),
+        cursor: Some(cursor.clone()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let conflicting_start = ReportingUsageQueryParams {
+        start_time: Some("2026-07-01T00:00:01Z".to_string()),
+        cursor: Some(cursor.clone()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let conflicting_workspace = ReportingUsageQueryParams {
+        workspace_id: Some(Uuid::new_v4()),
+        cursor: Some(cursor),
+        ..ReportingUsageQueryParams::default()
+    };
+    for params in [conflicting_source, conflicting_start, conflicting_workspace] {
+        assert!(matches!(
+            ReportingUsageQuery::try_from(params),
+            Err(ReportingUsageQueryError::InvalidCursor)
+        ));
+    }
 }
 
 #[test]
@@ -154,7 +241,6 @@ fn reporting_usage_query_manual_codec_serializes_response_and_cursor() {
     let row_id = Uuid::parse_str("018f7e4c-1234-7abc-9234-123456789abc").unwrap();
     let workspace_id = Uuid::parse_str("018f7e4c-2222-7abc-9234-123456789abc").unwrap();
     let api_key_id = Uuid::parse_str("018f7e4c-3333-7abc-9234-123456789abc").unwrap();
-    let cursor = ReportingUsageCursor::new(created_at, ReportingUsageRowSource::Inference, row_id);
     let query = ReportingUsageQuery::try_from(ReportingUsageQueryParams {
         start_time: Some("2026-07-01T00:00:00Z".to_string()),
         end_time: Some("2026-07-02T00:00:00Z".to_string()),
@@ -163,32 +249,40 @@ fn reporting_usage_query_manual_codec_serializes_response_and_cursor() {
         ..ReportingUsageQueryParams::default()
     })
     .unwrap();
+    let cursor = ReportingUsageCursor::for_query(
+        organization_id(),
+        created_at,
+        ReportingUsageRowSource::Inference,
+        row_id,
+        &query,
+    )
+    .unwrap();
 
     let export = ReportingUsageExportResponse {
         data: vec![ReportingUsageExportRow {
-            source: ReportingUsageRowSource::Inference,
             id: row_id,
             created_at,
             workspace_id,
             api_key_id,
             total_cost_nano_usd: 42,
             total_cost_usd: Some("$0.000000042".to_string()),
-            inference: Some(ReportingInferenceUsage {
-                model: "test-model".to_string(),
-                inference_type: "chat_completion".to_string(),
-                input_tokens: 10,
-                output_tokens: 20,
-                cache_read_tokens: 3,
-                total_tokens: 33,
-                input_cost_nano_usd: 10,
-                output_cost_nano_usd: 29,
-                cache_read_cost_nano_usd: None,
-                total_cost_nano_usd: 42,
-                response_id: None,
-                inference_id: Some(row_id),
-                image_count: None,
-            }),
-            service: None,
+            usage: ReportingUsageDetails::Inference {
+                inference: ReportingInferenceUsage {
+                    model: "test-model".to_string(),
+                    inference_type: "chat_completion".to_string(),
+                    input_tokens: 10,
+                    output_tokens: 20,
+                    cache_read_tokens: 3,
+                    total_tokens: 33,
+                    input_cost_nano_usd: 10,
+                    output_cost_nano_usd: 29,
+                    cache_read_cost_nano_usd: None,
+                    total_cost_nano_usd: 42,
+                    response_id: None,
+                    inference_id: Some(row_id),
+                    image_count: None,
+                },
+            },
         }],
         next_cursor: Some(cursor.encode().unwrap()),
     };
@@ -229,6 +323,12 @@ fn reporting_usage_query_manual_codec_serializes_response_and_cursor() {
     assert!(export_json.contains("\"cache_read_tokens\":3"));
     assert!(!export_json.contains("cache_read_cost_nano_usd"));
     assert!(summary_json.contains("\"inference_cost_nano_usd\":42"));
+    let mut invalid_row = serde_json::to_value(&export.data[0]).unwrap();
+    invalid_row
+        .as_object_mut()
+        .unwrap()
+        .insert("service".to_string(), json!({}));
+    assert!(serde_json::from_value::<ReportingUsageExportRow>(invalid_row).is_err());
     println!("cursor={encoded}");
     println!(
         "cursor_tuple={}|{}|{}",
@@ -238,4 +338,12 @@ fn reporting_usage_query_manual_codec_serializes_response_and_cursor() {
     );
     println!("export_json={export_json}");
     println!("summary_json={summary_json}");
+}
+
+#[test]
+fn reporting_usage_export_details_schema_requires_exactly_one_variant() {
+    let spec = serde_json::to_value(crate::openapi::ApiDoc::openapi()).unwrap();
+    let details = &spec["components"]["schemas"]["ReportingUsageDetails"];
+
+    assert_eq!(details["oneOf"].as_array().map(Vec::len), Some(2));
 }

--- a/crates/api/src/routes/reporting_usage/tests.rs
+++ b/crates/api/src/routes/reporting_usage/tests.rs
@@ -1,0 +1,241 @@
+use super::{
+    ReportingInferenceUsage, ReportingUsageCursor, ReportingUsageExportResponse,
+    ReportingUsageExportRow, ReportingUsageQuery, ReportingUsageQueryError,
+    ReportingUsageQueryParams, ReportingUsageRowSource, ReportingUsageSource,
+    ReportingUsageSummaryResponse, ReportingUsageTotals,
+};
+use chrono::{DateTime, Duration, Utc};
+use serde_json::json;
+use uuid::Uuid;
+
+fn ts(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+#[test]
+fn reporting_usage_query_defaults_and_cursor_roundtrip() {
+    // Given: no optional filters and a stable inference cursor tuple.
+    let params = ReportingUsageQueryParams::default();
+    let created_at = ts("2026-07-01T12:34:56Z");
+    let id = Uuid::parse_str("018f7e4c-1234-7abc-9234-123456789abc").unwrap();
+    let cursor = ReportingUsageCursor::new(created_at, ReportingUsageRowSource::Inference, id);
+
+    // When: the boundary DTO is parsed and the cursor is encoded/decoded.
+    let query = ReportingUsageQuery::try_from(params).unwrap();
+    let encoded = cursor.encode().unwrap();
+    let decoded = ReportingUsageCursor::decode(&encoded).unwrap();
+
+    // Then: defaults match the public contract and the cursor is stable and URL-safe.
+    assert_eq!(query.source, ReportingUsageSource::All);
+    assert_eq!(query.limit.value(), 100);
+    assert!(query.start_time.is_some());
+    assert!(query.end_time.is_some());
+    assert_eq!(decoded, cursor);
+    assert_eq!(cursor.encode().unwrap(), encoded);
+    assert!(!encoded.contains('+'));
+    assert!(!encoded.contains('/'));
+    assert!(!encoded.contains('='));
+}
+
+#[test]
+fn reporting_usage_query_normalizes_open_ended_ranges() {
+    // Given: open-ended reporting queries that would otherwise be unbounded.
+    let before_default = Utc::now();
+    let default_query =
+        ReportingUsageQuery::try_from(ReportingUsageQueryParams::default()).unwrap();
+    let after_default = Utc::now();
+    let explicit_end = ts("2026-07-01T00:00:00Z");
+    let end_only = ReportingUsageQueryParams {
+        end_time: Some(explicit_end.to_rfc3339()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let recent_start = Utc::now() - Duration::days(1);
+    let start_only = ReportingUsageQueryParams {
+        start_time: Some(recent_start.to_rfc3339()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let stale_start = ReportingUsageQueryParams {
+        start_time: Some((Utc::now() - Duration::days(367)).to_rfc3339()),
+        ..ReportingUsageQueryParams::default()
+    };
+
+    // When: the boundary DTOs are parsed.
+    let end_only_query = ReportingUsageQuery::try_from(end_only).unwrap();
+    let start_only_query = ReportingUsageQuery::try_from(start_only).unwrap();
+    let stale_result = ReportingUsageQuery::try_from(stale_start);
+
+    // Then: every accepted query has an effective range no wider than 366 days.
+    let default_start = default_query.start_time.unwrap();
+    let default_end = default_query.end_time.unwrap();
+    assert!(default_end >= before_default);
+    assert!(default_end <= after_default);
+    assert_eq!(default_end - default_start, Duration::days(366));
+    assert_eq!(end_only_query.end_time, Some(explicit_end));
+    assert_eq!(
+        end_only_query.start_time,
+        Some(explicit_end - Duration::days(366))
+    );
+    assert_eq!(start_only_query.start_time, Some(recent_start));
+    assert!(start_only_query.end_time.unwrap() >= recent_start);
+    assert!(matches!(
+        stale_result,
+        Err(ReportingUsageQueryError::TimeRangeTooLarge { max_days: 366 })
+    ));
+}
+
+#[test]
+fn reporting_usage_query_rejects_invalid_range_source_and_cursor() {
+    // Given: malformed query values for each boundary validation class.
+    let bad_order = ReportingUsageQueryParams {
+        start_time: Some("2026-07-02T00:00:00Z".to_string()),
+        end_time: Some("2026-07-01T00:00:00Z".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let too_wide = ReportingUsageQueryParams {
+        start_time: Some("2026-01-01T00:00:00Z".to_string()),
+        end_time: Some("2027-01-03T00:00:00Z".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let bad_source = ReportingUsageQueryParams {
+        source: Some("database".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let excessive_limit = ReportingUsageQueryParams {
+        limit: Some(1001),
+        ..ReportingUsageQueryParams::default()
+    };
+    let malformed_cursor = ReportingUsageQueryParams {
+        cursor: Some("not%base64url".to_string()),
+        ..ReportingUsageQueryParams::default()
+    };
+    let wrong_cursor_schema = ReportingUsageQueryParams {
+        cursor: Some(
+            ReportingUsageCursor::encode_raw_for_tests(&json!({
+                "created_at": "2026-07-01T00:00:00Z"
+            }))
+            .unwrap(),
+        ),
+        ..ReportingUsageQueryParams::default()
+    };
+
+    // When/Then: each invalid shape is rejected with the intended typed error.
+    assert!(matches!(
+        ReportingUsageQuery::try_from(bad_order),
+        Err(ReportingUsageQueryError::InvalidTimeRange)
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(too_wide),
+        Err(ReportingUsageQueryError::TimeRangeTooLarge { max_days: 366 })
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(bad_source),
+        Err(ReportingUsageQueryError::InvalidSource(_))
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(excessive_limit),
+        Err(ReportingUsageQueryError::LimitTooLarge { max: 1000 })
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(malformed_cursor),
+        Err(ReportingUsageQueryError::InvalidCursor)
+    ));
+    assert!(matches!(
+        ReportingUsageQuery::try_from(wrong_cursor_schema),
+        Err(ReportingUsageQueryError::InvalidCursor)
+    ));
+}
+
+#[test]
+fn reporting_usage_query_manual_codec_serializes_response_and_cursor() {
+    // Given: a valid query, export row, summary body, and stable cursor tuple.
+    let created_at = ts("2026-07-01T12:34:56Z");
+    let row_id = Uuid::parse_str("018f7e4c-1234-7abc-9234-123456789abc").unwrap();
+    let workspace_id = Uuid::parse_str("018f7e4c-2222-7abc-9234-123456789abc").unwrap();
+    let api_key_id = Uuid::parse_str("018f7e4c-3333-7abc-9234-123456789abc").unwrap();
+    let cursor = ReportingUsageCursor::new(created_at, ReportingUsageRowSource::Inference, row_id);
+    let query = ReportingUsageQuery::try_from(ReportingUsageQueryParams {
+        start_time: Some("2026-07-01T00:00:00Z".to_string()),
+        end_time: Some("2026-07-02T00:00:00Z".to_string()),
+        source: Some("all".to_string()),
+        limit: Some(1),
+        ..ReportingUsageQueryParams::default()
+    })
+    .unwrap();
+
+    let export = ReportingUsageExportResponse {
+        data: vec![ReportingUsageExportRow {
+            source: ReportingUsageRowSource::Inference,
+            id: row_id,
+            created_at,
+            workspace_id,
+            api_key_id,
+            total_cost_nano_usd: 42,
+            total_cost_usd: Some("$0.000000042".to_string()),
+            inference: Some(ReportingInferenceUsage {
+                model: "test-model".to_string(),
+                inference_type: "chat_completion".to_string(),
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_read_tokens: 3,
+                total_tokens: 33,
+                input_cost_nano_usd: 10,
+                output_cost_nano_usd: 29,
+                cache_read_cost_nano_usd: None,
+                total_cost_nano_usd: 42,
+                response_id: None,
+                inference_id: Some(row_id),
+                image_count: None,
+            }),
+            service: None,
+        }],
+        next_cursor: Some(cursor.encode().unwrap()),
+    };
+    let summary = ReportingUsageSummaryResponse {
+        source: ReportingUsageSource::All,
+        start_time: query.start_time.unwrap(),
+        end_time: query.end_time.unwrap(),
+        totals: ReportingUsageTotals {
+            request_count: 1,
+            service_usage_count: 0,
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 3,
+            total_tokens: 33,
+            inference_cost_nano_usd: 42,
+            service_cost_nano_usd: 0,
+            total_cost_nano_usd: 42,
+            total_cost_usd: Some("$0.000000042".to_string()),
+        },
+        by_workspace: Vec::new(),
+        by_api_key: Vec::new(),
+        by_model: Vec::new(),
+        by_service: Vec::new(),
+        by_day: Vec::new(),
+    };
+
+    // When: response bodies serialize and the cursor is decoded.
+    let encoded = cursor.encode().unwrap();
+    let decoded = ReportingUsageCursor::decode(&encoded).unwrap();
+    let export_json = serde_json::to_string(&export).unwrap();
+    let summary_json = serde_json::to_string(&summary).unwrap();
+
+    // Then: the cursor tuple and response JSON are exact enough for CLI/data QA.
+    assert_eq!(decoded.created_at, created_at);
+    assert_eq!(decoded.source, ReportingUsageRowSource::Inference);
+    assert_eq!(decoded.id, row_id);
+    assert!(export_json.contains("\"total_cost_nano_usd\":42"));
+    assert!(export_json.contains("\"cache_read_tokens\":3"));
+    assert!(!export_json.contains("cache_read_cost_nano_usd"));
+    assert!(summary_json.contains("\"inference_cost_nano_usd\":42"));
+    println!("cursor={encoded}");
+    println!(
+        "cursor_tuple={}|{}|{}",
+        decoded.created_at.to_rfc3339(),
+        decoded.source.as_str(),
+        decoded.id
+    );
+    println!("export_json={export_json}");
+    println!("summary_json={summary_json}");
+}

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -271,6 +271,13 @@ impl UsageHistoryQuery {
             || self.workspace_id.is_some()
             || self.api_key_id.is_some()
     }
+
+    const fn has_time_filters(&self) -> bool {
+        self.start_date.is_some()
+            || self.end_date.is_some()
+            || self.start_time.is_some()
+            || self.end_time.is_some()
+    }
 }
 
 /// Service usage history entry (platform services like web_search).
@@ -360,7 +367,13 @@ pub async fn get_organization_balance(
     params(
         ("org_id" = String, Path, description = "Organization ID"),
         ("limit" = Option<i64>, Query, description = "Number of records to return (default: 100)"),
-        ("offset" = Option<i64>, Query, description = "Offset for pagination (default: 0)")
+        ("offset" = Option<i64>, Query, description = "Offset for pagination (default: 0)"),
+        ("start_date" = Option<String>, Query, description = "Inclusive UTC start date in YYYY-MM-DD or RFC3339 format."),
+        ("end_date" = Option<String>, Query, description = "Inclusive UTC end date in YYYY-MM-DD or RFC3339 format."),
+        ("start_time" = Option<String>, Query, description = "Inclusive RFC3339 start timestamp. Takes precedence over start_date."),
+        ("end_time" = Option<String>, Query, description = "Inclusive RFC3339 end timestamp. Takes precedence over end_date."),
+        ("workspace_id" = Option<Uuid>, Query, description = "Filter by workspace ID."),
+        ("api_key_id" = Option<Uuid>, Query, description = "Filter by API key ID.")
     ),
     responses(
         (status = 200, description = "Usage history", body = UsageHistoryResponse),
@@ -472,6 +485,18 @@ fn usage_history_report_query(
     organization_id: Uuid,
     query: &UsageHistoryQuery,
 ) -> Result<InferenceUsageHistoryQuery, UsageError> {
+    if !query.has_time_filters() {
+        return Ok(InferenceUsageHistoryQuery {
+            organization_id,
+            start_time: None,
+            end_time: None,
+            workspace_id: query.workspace_id,
+            api_key_id: query.api_key_id,
+            limit: query.limit,
+            offset: query.offset,
+        });
+    }
+
     let params = crate::routes::reporting_usage::ReportingUsageQueryParams {
         start_time: usage_history_start_time(query)?,
         end_time: usage_history_end_time(query)?,
@@ -570,7 +595,7 @@ fn usage_report_row_response(
         created_at: row.created_at.to_rfc3339(),
         stop_reason: row.stop_reason,
         response_id: row.response_id.map(|id| id.to_string()),
-        provider_request_id: None,
+        provider_request_id: row.provider_request_id,
         inference_id: row.inference_id.map(|id| id.to_string()),
         image_count: row.image_count,
     })

--- a/crates/api/src/routes/usage.rs
+++ b/crates/api/src/routes/usage.rs
@@ -9,9 +9,12 @@ use axum::{
     response::Json as ResponseJson,
     Extension,
 };
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
-use services::{organization::OrganizationError, usage::UsageServiceTrait};
+use services::{
+    organization::OrganizationError,
+    usage::{InferenceUsageHistoryQuery, InferenceUsageReportRow, UsageServiceTrait},
+};
 use subtle::ConstantTimeEq;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -251,6 +254,23 @@ pub struct UsageHistoryQuery {
     pub limit: i64,
     #[serde(default)]
     pub offset: i64,
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+}
+
+impl UsageHistoryQuery {
+    const fn has_filters(&self) -> bool {
+        self.start_date.is_some()
+            || self.end_date.is_some()
+            || self.start_time.is_some()
+            || self.end_time.is_some()
+            || self.workspace_id.is_some()
+            || self.api_key_id.is_some()
+    }
 }
 
 /// Service usage history entry (platform services like web_search).
@@ -371,6 +391,10 @@ pub async fn get_organization_usage_history(
 
     let organization_id = check_org_membership(&app_state, user, &org_id).await?;
 
+    if query.has_filters() {
+        return get_filtered_organization_usage_history(&app_state, organization_id, &query).await;
+    }
+
     let (history, total) = app_state
         .usage_service
         .get_usage_history(organization_id, Some(query.limit), Some(query.offset))
@@ -415,6 +439,179 @@ pub async fn get_organization_usage_history(
         limit: query.limit,
         offset: query.offset,
     }))
+}
+
+async fn get_filtered_organization_usage_history(
+    app_state: &AppState,
+    organization_id: Uuid,
+    query: &UsageHistoryQuery,
+) -> Result<ResponseJson<UsageHistoryResponse>, UsageError> {
+    let report_query = usage_history_report_query(organization_id, query)?;
+    let (history, total) = app_state
+        .usage_service
+        .list_inference_usage_history(report_query)
+        .await
+        .map_err(|_| internal_usage_history_error("Failed to retrieve usage history"))?;
+
+    let data = history
+        .into_iter()
+        .map(usage_report_row_response)
+        .collect::<Result<Vec<_>, _>>()?;
+    let total = usize::try_from(total)
+        .map_err(|_| internal_usage_history_error("Invalid usage history total"))?;
+
+    Ok(ResponseJson(UsageHistoryResponse {
+        data,
+        total,
+        limit: query.limit,
+        offset: query.offset,
+    }))
+}
+
+fn usage_history_report_query(
+    organization_id: Uuid,
+    query: &UsageHistoryQuery,
+) -> Result<InferenceUsageHistoryQuery, UsageError> {
+    let params = crate::routes::reporting_usage::ReportingUsageQueryParams {
+        start_time: usage_history_start_time(query)?,
+        end_time: usage_history_end_time(query)?,
+        source: Some("inference".to_string()),
+        workspace_id: query.workspace_id,
+        api_key_id: query.api_key_id,
+        model: None,
+        inference_type: None,
+        service_name: None,
+        limit: Some(
+            u16::try_from(query.limit)
+                .map_err(|_| usage_history_query_bad_request("Limit cannot exceed 1000"))?,
+        ),
+        cursor: None,
+    };
+    let parsed = crate::routes::reporting_usage::ReportingUsageQuery::try_from(params)
+        .map_err(usage_history_query_error)?;
+
+    Ok(InferenceUsageHistoryQuery {
+        organization_id,
+        start_time: parsed.start_time,
+        end_time: parsed.end_time,
+        workspace_id: parsed.workspace_id,
+        api_key_id: parsed.api_key_id,
+        limit: query.limit,
+        offset: query.offset,
+    })
+}
+
+fn usage_history_start_time(query: &UsageHistoryQuery) -> Result<Option<String>, UsageError> {
+    match query.start_time.as_ref() {
+        Some(value) => Ok(Some(value.clone())),
+        None => normalize_usage_history_date(query.start_date.as_deref(), DateBoundary::Start),
+    }
+}
+
+fn usage_history_end_time(query: &UsageHistoryQuery) -> Result<Option<String>, UsageError> {
+    match query.end_time.as_ref() {
+        Some(value) => Ok(Some(value.clone())),
+        None => normalize_usage_history_date(query.end_date.as_deref(), DateBoundary::End),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DateBoundary {
+    Start,
+    End,
+}
+
+fn normalize_usage_history_date(
+    value: Option<&str>,
+    boundary: DateBoundary,
+) -> Result<Option<String>, UsageError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    if DateTime::parse_from_rfc3339(raw).is_ok() {
+        return Ok(Some(raw.to_string()));
+    }
+
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d").map_err(|_| {
+        usage_history_query_error(
+            crate::routes::reporting_usage::ReportingUsageQueryError::InvalidTimestamp,
+        )
+    })?;
+    let time = match boundary {
+        DateBoundary::Start => date.and_hms_nano_opt(0, 0, 0, 0),
+        DateBoundary::End => date.and_hms_nano_opt(23, 59, 59, 999_999_999),
+    }
+    .ok_or_else(|| {
+        usage_history_query_error(
+            crate::routes::reporting_usage::ReportingUsageQueryError::InvalidTimestamp,
+        )
+    })?;
+
+    Ok(Some(
+        DateTime::<Utc>::from_naive_utc_and_offset(time, Utc).to_rfc3339(),
+    ))
+}
+
+fn usage_report_row_response(
+    row: InferenceUsageReportRow,
+) -> Result<UsageHistoryEntryResponse, UsageError> {
+    Ok(UsageHistoryEntryResponse {
+        id: row.id.to_string(),
+        workspace_id: row.workspace_id.to_string(),
+        api_key_id: row.api_key_id.to_string(),
+        model: row.model,
+        input_tokens: checked_usage_history_i32(row.input_tokens, "input_tokens")?,
+        output_tokens: checked_usage_history_i32(row.output_tokens, "output_tokens")?,
+        cache_read_tokens: checked_usage_history_i32(row.cache_read_tokens, "cache_read_tokens")?,
+        total_tokens: checked_usage_history_i32(row.total_tokens, "total_tokens")?,
+        total_cost: row.total_cost_nano_usd,
+        total_cost_display: format_amount(row.total_cost_nano_usd),
+        inference_type: row.inference_type,
+        created_at: row.created_at.to_rfc3339(),
+        stop_reason: row.stop_reason,
+        response_id: row.response_id.map(|id| id.to_string()),
+        provider_request_id: None,
+        inference_id: row.inference_id.map(|id| id.to_string()),
+        image_count: row.image_count,
+    })
+}
+
+fn checked_usage_history_i32(value: i64, field: &str) -> Result<i32, UsageError> {
+    i32::try_from(value)
+        .map_err(|_| internal_usage_history_error(&format!("Invalid usage history {field}")))
+}
+
+fn usage_history_query_error(
+    error: crate::routes::reporting_usage::ReportingUsageQueryError,
+) -> UsageError {
+    (
+        StatusCode::BAD_REQUEST,
+        ResponseJson(ErrorResponse::new(
+            error.to_string(),
+            "invalid_reporting_usage_query".to_string(),
+        )),
+    )
+}
+
+fn usage_history_query_bad_request(message: &str) -> UsageError {
+    (
+        StatusCode::BAD_REQUEST,
+        ResponseJson(ErrorResponse::new(
+            message.to_string(),
+            "invalid_parameter".to_string(),
+        )),
+    )
+}
+
+fn internal_usage_history_error(message: &str) -> UsageError {
+    tracing::error!("{message}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        ResponseJson(ErrorResponse::new(
+            message.to_string(),
+            "internal_server_error".to_string(),
+        )),
+    )
 }
 
 /// Get service usage history for an organization

--- a/crates/api/tests/common/db_setup.rs
+++ b/crates/api/tests/common/db_setup.rs
@@ -129,6 +129,7 @@ pub async fn create_test_pool() -> database::pool::DbPool {
     pg_config.dbname = Some(get_test_db_name());
     pg_config.user = Some(db_user());
     pg_config.password = Some(db_password());
+    pg_config.application_name = Some(format!("cloud-api-e2e-{}", uuid::Uuid::new_v4().simple()));
 
     pg_config.pool = Some(deadpool_postgres::PoolConfig {
         max_size: 4,

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -123,6 +123,10 @@ pub fn test_config() -> ApiConfig {
         github_dispatch: config::GitHubDispatchConfig::default(),
         infra: config::InfraConfig::default(),
         staking_farm: config::StakingFarmConfig::default(),
+        usage_reporting: config::UsageReportingConfig {
+            enabled: true,
+            ..config::UsageReportingConfig::default()
+        },
         ita: config::ItaAttestationConfig::default(),
     }
 }
@@ -410,6 +414,19 @@ where
     let (server, _pool, _mock) =
         build_test_server_components(infra.database.clone(), infra.config).await;
     server
+}
+
+pub async fn setup_test_server_with_config_and_database<F>(
+    mutate: F,
+) -> (axum_test::TestServer, Arc<Database>)
+where
+    F: FnOnce(&mut config::ApiConfig),
+{
+    let mut infra = setup_test_infrastructure().await;
+    mutate(&mut infra.config);
+    let database = infra.database.clone();
+    let (server, _pool, _mock) = build_test_server_components(database.clone(), infra.config).await;
+    (server, database)
 }
 
 pub async fn setup_test_server_with_database() -> (axum_test::TestServer, Arc<Database>) {

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -59,6 +59,7 @@ mod privacy_classify;
 mod privacy_redact;
 mod provider_errors;
 mod reasoning;
+mod reporting_usage;
 mod repositories;
 mod request_id_contract;
 mod rerank;

--- a/crates/api/tests/e2e_all/reporting_usage.rs
+++ b/crates/api/tests/e2e_all/reporting_usage.rs
@@ -1,0 +1,94 @@
+use crate::common::{get_session_id, setup_test_server_with_database, MOCK_USER_AGENT};
+use chrono::{Duration, Utc};
+use database::Database;
+use serde_json::Value;
+use std::sync::Arc;
+
+mod token_auth;
+mod token_management;
+mod usage_export;
+mod usage_export_fixture;
+mod usage_summary;
+
+include!("reporting_usage/session_history.rs");
+
+fn bearer(token: &str) -> String {
+    format!("Bearer {token}")
+}
+
+fn assert_json_has_no_secret_fields(value: &Value) {
+    let text = value.to_string();
+    assert!(
+        !text.contains("token_hash"),
+        "JSON response must not expose token_hash: {text}"
+    );
+    assert!(
+        !text.contains("raw_token"),
+        "JSON response must not expose raw_token: {text}"
+    );
+    assert_no_raw_token_field(value);
+}
+
+fn assert_no_raw_token_field(value: &Value) {
+    match value {
+        Value::Object(map) => {
+            assert!(
+                !map.contains_key("token"),
+                "JSON response must not expose raw token field: {value}"
+            );
+            for child in map.values() {
+                assert_no_raw_token_field(child);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                assert_no_raw_token_field(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redact_create_response(value: &Value) -> Value {
+    let mut redacted = value.clone();
+    if let Value::Object(map) = &mut redacted {
+        map.insert(
+            "token".to_string(),
+            Value::String("rpt-<redacted>".to_string()),
+        );
+    }
+    redacted
+}
+
+async fn setup_reporting_usage_server() -> (axum_test::TestServer, Arc<Database>) {
+    init_reporting_usage_tracing();
+    setup_test_server_with_database().await
+}
+
+fn init_reporting_usage_tracing() {
+    let filter = tracing_subscriber::EnvFilter::new("debug,tokio_postgres=info");
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(filter)
+        .try_init();
+}
+
+async fn create_reporting_token(server: &axum_test::TestServer, org_id: &str) -> String {
+    let response = server
+        .post(format!("/v1/organizations/{org_id}/reporting-tokens").as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "name": "reporting auth probe",
+            "expires_at": (Utc::now() + Duration::days(30)).to_rfc3339(),
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 201, "{}", response.text());
+    response
+        .json::<Value>()
+        .get("token")
+        .and_then(Value::as_str)
+        .expect("create response should include raw reporting token once")
+        .to_string()
+}

--- a/crates/api/tests/e2e_all/reporting_usage.rs
+++ b/crates/api/tests/e2e_all/reporting_usage.rs
@@ -1,4 +1,6 @@
-use crate::common::{get_session_id, setup_test_server_with_database, MOCK_USER_AGENT};
+use crate::common::{
+    get_session_id, setup_test_server_with_config, setup_test_server_with_database, MOCK_USER_AGENT,
+};
 use chrono::{Duration, Utc};
 use database::Database;
 use serde_json::Value;
@@ -63,6 +65,29 @@ fn redact_create_response(value: &Value) -> Value {
 async fn setup_reporting_usage_server() -> (axum_test::TestServer, Arc<Database>) {
     init_reporting_usage_tracing();
     setup_test_server_with_database().await
+}
+
+#[tokio::test]
+async fn disabled_reporting_hides_query_routes_but_keeps_management_and_openapi() {
+    let server = setup_test_server_with_config(|config| {
+        config.usage_reporting.enabled = false;
+    })
+    .await;
+    let org_id = uuid::Uuid::new_v4();
+
+    let export = server
+        .get(format!("/v1/organizations/{org_id}/usage/export").as_str())
+        .await;
+    assert_eq!(export.status_code(), 404, "{}", export.text());
+
+    let management = server
+        .get(format!("/v1/organizations/{org_id}/reporting-tokens").as_str())
+        .await;
+    assert_eq!(management.status_code(), 401, "{}", management.text());
+
+    let openapi = server.get("/api-docs/openapi.json").await;
+    assert_eq!(openapi.status_code(), 200, "{}", openapi.text());
+    assert!(openapi.text().contains("/usage/export"));
 }
 
 fn init_reporting_usage_tracing() {

--- a/crates/api/tests/e2e_all/reporting_usage/session_history.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/session_history.rs
@@ -2,6 +2,7 @@ use crate::common::{
     create_api_key_in_workspace, create_org, list_workspaces, setup_qwen_model,
 };
 use chrono::{DateTime, TimeZone};
+use utoipa::OpenApi;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -36,7 +37,10 @@ async fn session_usage_history_filters() {
     assert_eq!(row.created_at, ts(2026, 7, 2).to_rfc3339());
     assert_eq!(row.total_cost, 700);
     assert_eq!(row.stop_reason.as_deref(), Some("completed"));
-    assert_eq!(row.provider_request_id, None);
+    assert_eq!(
+        row.provider_request_id.as_deref(),
+        Some("provider-request-700")
+    );
 
     let manual = serde_json::json!({
         "status": 200,
@@ -47,6 +51,69 @@ async fn session_usage_history_filters() {
     });
     assert_no_private_session_history_fields(&manual);
     println!("manual GET /usage/history filtered session 200 {manual}");
+}
+
+#[tokio::test]
+async fn session_usage_history_workspace_and_api_key_filters_remain_unbounded() {
+    // Given: matching usage older than the reporting API's 366-day default window.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_session_history_fixture(&server, &database).await;
+
+    // When: only workspace and API-key filters are supplied to the legacy history route.
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/history?workspace_id={}&api_key_id={}&limit=10&offset=0",
+                fixture.org_id, fixture.workspace_id, fixture.api_key_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: all matching history is returned, including the old row.
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body = response.json::<api::routes::usage::UsageHistoryResponse>();
+    assert_eq!(body.total, 3);
+    assert_eq!(body.data.len(), 3);
+    assert!(body
+        .data
+        .iter()
+        .any(|row| row.created_at == ts(2024, 1, 1).to_rfc3339()));
+    assert!(body
+        .data
+        .iter()
+        .all(|row| row.provider_request_id.is_some()));
+}
+
+#[test]
+fn session_usage_history_openapi_lists_supported_filters() {
+    // Given: the generated public OpenAPI document.
+    let spec = serde_json::to_value(api::openapi::ApiDoc::openapi())
+        .expect("OpenAPI spec should serialize");
+
+    // When: the legacy organization history operation is inspected.
+    let parameters = spec["paths"]["/v1/organizations/{org_id}/usage/history"]["get"]
+        ["parameters"]
+        .as_array()
+        .expect("history parameters should be an array");
+    let names: Vec<&str> = parameters
+        .iter()
+        .filter_map(|parameter| parameter["name"].as_str())
+        .collect();
+
+    // Then: every accepted date/time and ownership filter is documented.
+    for name in [
+        "start_date",
+        "end_date",
+        "start_time",
+        "end_time",
+        "workspace_id",
+        "api_key_id",
+    ] {
+        assert!(names.contains(&name), "missing OpenAPI parameter {name}");
+    }
 }
 
 #[tokio::test]
@@ -114,8 +181,11 @@ async fn seed_session_history_fixture(
         &workspace_id,
         &api_key.id,
         &model,
-        ts(2026, 7, 1),
-        500,
+        SessionUsageRow {
+            created_at: ts(2026, 7, 1),
+            total_cost: 500,
+            provider_request_id: "provider-request-500",
+        },
     )
     .await;
     insert_inference_usage_row(
@@ -124,8 +194,11 @@ async fn seed_session_history_fixture(
         &workspace_id,
         &api_key.id,
         &model,
-        ts(2026, 7, 2),
-        700,
+        SessionUsageRow {
+            created_at: ts(2026, 7, 2),
+            total_cost: 700,
+            provider_request_id: "provider-request-700",
+        },
     )
     .await;
     insert_inference_usage_row(
@@ -134,8 +207,24 @@ async fn seed_session_history_fixture(
         &other_workspace,
         &other_api_key.id,
         &model,
-        ts(2026, 7, 2),
-        900,
+        SessionUsageRow {
+            created_at: ts(2026, 7, 2),
+            total_cost: 900,
+            provider_request_id: "provider-request-900",
+        },
+    )
+    .await;
+    insert_inference_usage_row(
+        database,
+        &org.id,
+        &workspace_id,
+        &api_key.id,
+        &model,
+        SessionUsageRow {
+            created_at: ts(2024, 1, 1),
+            total_cost: 300,
+            provider_request_id: "provider-request-300",
+        },
     )
     .await;
 
@@ -163,14 +252,19 @@ async fn create_workspace(server: &axum_test::TestServer, org_id: &str) -> Strin
         .id
 }
 
+struct SessionUsageRow {
+    created_at: DateTime<Utc>,
+    total_cost: i64,
+    provider_request_id: &'static str,
+}
+
 async fn insert_inference_usage_row(
     database: &Arc<Database>,
     org_id: &str,
     workspace_id: &str,
     api_key_id: &str,
     model: &str,
-    created_at: DateTime<Utc>,
-    total_cost: i64,
+    row: SessionUsageRow,
 ) {
     let client = database.pool().get().await.expect("db connection");
     let model_id: Uuid = client
@@ -186,10 +280,10 @@ async fn insert_inference_usage_row(
                 id, organization_id, workspace_id, api_key_id, model_id, model_name,
                 input_tokens, output_tokens, cache_read_tokens, total_tokens,
                 input_cost, output_cost, total_cost, request_type, inference_type,
-                created_at, inference_id, stop_reason
+                created_at, inference_id, provider_request_id, stop_reason
             )
             VALUES ($1, $2, $3, $4, $5, $6, 4, 3, 1, 8, $7, 300, $8,
-                NULL, 'chat_completion', $9, $10, 'completed')
+                NULL, 'chat_completion', $9, $10, $11, 'completed')
             "#,
             &[
                 &Uuid::new_v4(),
@@ -198,10 +292,11 @@ async fn insert_inference_usage_row(
                 &Uuid::parse_str(api_key_id).expect("api key uuid"),
                 &model_id,
                 &model,
-                &(total_cost - 300),
-                &total_cost,
-                &created_at,
+                &(row.total_cost - 300),
+                &row.total_cost,
+                &row.created_at,
                 &Some(Uuid::new_v4()),
+                &Some(row.provider_request_id),
             ],
         )
         .await

--- a/crates/api/tests/e2e_all/reporting_usage/session_history.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/session_history.rs
@@ -1,0 +1,225 @@
+use crate::common::{
+    create_api_key_in_workspace, create_org, list_workspaces, setup_qwen_model,
+};
+use chrono::{DateTime, TimeZone};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn session_usage_history_filters() {
+    // Given: one org has usage on two dates and another row on the filtered date in a different workspace/API key.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_session_history_fixture(&server, &database).await;
+
+    // When: the session-authenticated history endpoint receives dashboard-style filters.
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/history?start_date=2026-07-02&end_date=2026-07-02&workspace_id={}&api_key_id={}&limit=10&offset=0",
+                fixture.org_id, fixture.workspace_id, fixture.api_key_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: only the row matching the date, workspace, and API key filters is returned.
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body = response.json::<api::routes::usage::UsageHistoryResponse>();
+    assert_eq!(body.total, 1, "filtered total should count only matching rows");
+    assert_eq!(body.limit, 10);
+    assert_eq!(body.offset, 0);
+    assert_eq!(body.data.len(), 1);
+    let row = &body.data[0];
+    assert_eq!(row.workspace_id, fixture.workspace_id);
+    assert_eq!(row.api_key_id, fixture.api_key_id);
+    assert_eq!(row.created_at, ts(2026, 7, 2).to_rfc3339());
+    assert_eq!(row.total_cost, 700);
+    assert_eq!(row.stop_reason.as_deref(), Some("completed"));
+    assert_eq!(row.provider_request_id, None);
+
+    let manual = serde_json::json!({
+        "status": 200,
+        "total": body.total,
+        "limit": body.limit,
+        "offset": body.offset,
+        "data": body.data,
+    });
+    assert_no_private_session_history_fields(&manual);
+    println!("manual GET /usage/history filtered session 200 {manual}");
+}
+
+#[tokio::test]
+async fn session_usage_history_rejects_invalid_filter_range() {
+    // Given: an organization with session-authenticated usage history access.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_session_history_fixture(&server, &database).await;
+
+    // When: the dashboard-style date range is inverted.
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/history?start_date=2026-07-03&end_date=2026-07-01&limit=10&offset=0",
+                fixture.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: the session route rejects the malformed filter with the existing error envelope.
+    assert_eq!(response.status_code(), 400, "{}", response.text());
+    let body = response.json::<Value>();
+    assert_no_private_session_history_fields(&body);
+    println!("manual GET /usage/history invalid session range 400 {body}");
+}
+
+struct SessionHistoryFixture {
+    org_id: String,
+    workspace_id: String,
+    api_key_id: String,
+}
+
+async fn seed_session_history_fixture(
+    server: &axum_test::TestServer,
+    database: &Arc<Database>,
+) -> SessionHistoryFixture {
+    let org = create_org(server).await;
+    let model = setup_qwen_model(server).await;
+    let workspaces = list_workspaces(server, org.id.clone()).await;
+    let workspace_id = workspaces
+        .first()
+        .expect("default workspace should exist")
+        .id
+        .clone();
+    let api_key = create_api_key_in_workspace(
+        server,
+        workspace_id.clone(),
+        "session history filtered key".to_string(),
+    )
+    .await;
+
+    let other_workspace = create_workspace(server, &org.id).await;
+    let other_api_key = create_api_key_in_workspace(
+        server,
+        other_workspace.clone(),
+        "session history excluded key".to_string(),
+    )
+    .await;
+
+    insert_inference_usage_row(
+        database,
+        &org.id,
+        &workspace_id,
+        &api_key.id,
+        &model,
+        ts(2026, 7, 1),
+        500,
+    )
+    .await;
+    insert_inference_usage_row(
+        database,
+        &org.id,
+        &workspace_id,
+        &api_key.id,
+        &model,
+        ts(2026, 7, 2),
+        700,
+    )
+    .await;
+    insert_inference_usage_row(
+        database,
+        &org.id,
+        &other_workspace,
+        &other_api_key.id,
+        &model,
+        ts(2026, 7, 2),
+        900,
+    )
+    .await;
+
+    SessionHistoryFixture {
+        org_id: org.id,
+        workspace_id,
+        api_key_id: api_key.id,
+    }
+}
+
+async fn create_workspace(server: &axum_test::TestServer, org_id: &str) -> String {
+    let request = api::routes::workspaces::CreateWorkspaceRequest {
+        name: format!("session-history-{}", Uuid::new_v4()),
+        description: Some("session history filter fixture".to_string()),
+    };
+    let response = server
+        .post(format!("/v1/organizations/{org_id}/workspaces").as_str())
+        .add_header("Authorization", format!("Bearer {}", get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&request)
+        .await;
+    assert_eq!(response.status_code(), 201, "{}", response.text());
+    response
+        .json::<api::routes::workspaces::WorkspaceResponse>()
+        .id
+}
+
+async fn insert_inference_usage_row(
+    database: &Arc<Database>,
+    org_id: &str,
+    workspace_id: &str,
+    api_key_id: &str,
+    model: &str,
+    created_at: DateTime<Utc>,
+    total_cost: i64,
+) {
+    let client = database.pool().get().await.expect("db connection");
+    let model_id: Uuid = client
+        .query_one("SELECT id FROM models WHERE model_name = $1", &[&model])
+        .await
+        .expect("model id")
+        .get("id");
+
+    client
+        .execute(
+            r#"
+            INSERT INTO organization_usage_log (
+                id, organization_id, workspace_id, api_key_id, model_id, model_name,
+                input_tokens, output_tokens, cache_read_tokens, total_tokens,
+                input_cost, output_cost, total_cost, request_type, inference_type,
+                created_at, inference_id, stop_reason
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, 4, 3, 1, 8, $7, 300, $8,
+                NULL, 'chat_completion', $9, $10, 'completed')
+            "#,
+            &[
+                &Uuid::new_v4(),
+                &Uuid::parse_str(org_id).expect("org uuid"),
+                &Uuid::parse_str(workspace_id).expect("workspace uuid"),
+                &Uuid::parse_str(api_key_id).expect("api key uuid"),
+                &model_id,
+                &model,
+                &(total_cost - 300),
+                &total_cost,
+                &created_at,
+                &Some(Uuid::new_v4()),
+            ],
+        )
+        .await
+        .expect("insert inference usage");
+}
+
+fn assert_no_private_session_history_fields(value: &Value) {
+    let text = value.to_string();
+    for private in ["prompt", "response_body", "file", "token_hash", "Authorization", "Bearer"] {
+        assert!(
+            !text.contains(private),
+            "private field leaked: {private}: {text}"
+        );
+    }
+}
+
+fn ts(year: i32, month: u32, day: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, 0, 0, 0)
+        .single()
+        .expect("fixture timestamp")
+}

--- a/crates/api/tests/e2e_all/reporting_usage/token_auth.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/token_auth.rs
@@ -1,0 +1,212 @@
+use super::{bearer, create_reporting_token, setup_reporting_usage_server};
+use crate::common::{create_org, get_session_id, MOCK_USER_AGENT, MOCK_USER_ID};
+use chrono::{Duration, Utc};
+use serde_json::Value;
+use services::reporting_tokens::ports::{
+    CreateOrganizationReportingTokenRequest, OrganizationReportingTokenRepository as _,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn reporting_token_auth_allows_reporting_only() {
+    // Given: a reporting token issued for an organization.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let raw_token = create_reporting_token(&server, &org.id).await;
+
+    // When: the token calls the reporting-authenticated probe route.
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/reporting-token-auth-probe",
+                org.id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: the probe sees the read-only reporting token context.
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body = response.json::<Value>();
+    assert_eq!(body["organization_id"], org.id);
+    assert_eq!(body["token_prefix"], raw_token[..12]);
+    assert_eq!(body["scope"], "usage:read");
+    assert!(
+        body.get("token").is_none(),
+        "probe response must not expose raw reporting token"
+    );
+    let listed = server
+        .get(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await
+        .json::<Value>();
+    let used_token = listed["reporting_tokens"]
+        .as_array()
+        .expect("reporting_tokens should be an array")
+        .iter()
+        .find(|token| token["token_prefix"] == raw_token[..12])
+        .expect("validated token should still be listed");
+    assert!(
+        used_token["last_used_at"].as_str().is_some(),
+        "successful reporting-token auth should update last_used_at"
+    );
+    println!("manual GET /usage/reporting-token-auth-probe 200 {body}");
+}
+
+#[tokio::test]
+async fn reporting_token_auth_rejects_invalid_revoked_expired_and_org_mismatch() {
+    // Given: active, revoked, and expired reporting tokens across two organizations.
+    let (server, database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let other_org = create_org(&server).await;
+    let active_token = create_reporting_token(&server, &org.id).await;
+    let revoked_token = create_reporting_token(&server, &org.id).await;
+    let expired = database
+        .organization_reporting_tokens
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id: Uuid::parse_str(&org.id).expect("org id should be uuid"),
+            name: "expired reporting token".to_string(),
+            created_by_user_id: Uuid::parse_str(MOCK_USER_ID).expect("mock user id should be uuid"),
+            expires_at: Some(Utc::now() - Duration::minutes(1)),
+        })
+        .await
+        .expect("expired reporting token fixture should be created");
+    let revoked_list = server
+        .get(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await
+        .json::<Value>();
+    let revoked_id = revoked_list["reporting_tokens"]
+        .as_array()
+        .expect("reporting_tokens should be an array")
+        .iter()
+        .find(|token| token["token_prefix"] == revoked_token[..12])
+        .and_then(|token| token["id"].as_str())
+        .expect("revoked token id should be listed before revoke")
+        .to_string();
+    let revoke_response = server
+        .delete(format!("/v1/organizations/{}/reporting-tokens/{revoked_id}", org.id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(
+        revoke_response.status_code(),
+        204,
+        "{}",
+        revoke_response.text()
+    );
+
+    let probe_url = format!(
+        "/v1/organizations/{}/usage/reporting-token-auth-probe",
+        org.id
+    );
+
+    // When/Then: missing, non-Bearer, malformed, revoked, and expired credentials are rejected.
+    let missing = server.get(&probe_url).await;
+    assert_eq!(missing.status_code(), 401, "{}", missing.text());
+
+    let non_bearer = server
+        .get(&probe_url)
+        .add_header("Authorization", "Basic rpt-not-a-bearer")
+        .await;
+    assert_eq!(non_bearer.status_code(), 401, "{}", non_bearer.text());
+
+    let malformed = server
+        .get(&probe_url)
+        .add_header("Authorization", "Bearer rpt-short")
+        .await;
+    assert_eq!(malformed.status_code(), 401, "{}", malformed.text());
+
+    let revoked = server
+        .get(&probe_url)
+        .add_header("Authorization", bearer(&revoked_token))
+        .await;
+    assert_eq!(revoked.status_code(), 401, "{}", revoked.text());
+
+    let expired_response = server
+        .get(&probe_url)
+        .add_header("Authorization", bearer(&expired.raw_token))
+        .await;
+    assert_eq!(
+        expired_response.status_code(),
+        401,
+        "{}",
+        expired_response.text()
+    );
+
+    // When: a valid reporting token is used against a different organization's route.
+    let mismatch = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/reporting-token-auth-probe",
+                other_org.id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&active_token))
+        .await;
+
+    // Then: the route rejects the org mismatch after authentication.
+    assert_eq!(mismatch.status_code(), 403, "{}", mismatch.text());
+}
+
+#[tokio::test]
+async fn reporting_token_cannot_infer_or_mutate() {
+    // Given: a reporting token issued for an organization.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let raw_token = create_reporting_token(&server, &org.id).await;
+
+    // When: the reporting token attempts to call data-plane and management routes.
+    let inference = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", bearer(&raw_token))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "messages": [{"role": "user", "content": "hello"}]
+        }))
+        .await;
+    let workspace_mutation = server
+        .post(format!("/v1/organizations/{}/workspaces", org.id).as_str())
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "must not create" }))
+        .await;
+    let token_management = server
+        .post(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "must not create" }))
+        .await;
+    let session_management = server
+        .delete("/v1/users/me/tokens")
+        .add_header("Authorization", bearer(&raw_token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: reporting tokens do not authorize inference, workspace, token management,
+    // or session management routes.
+    assert_eq!(inference.status_code(), 401, "{}", inference.text());
+    assert_eq!(
+        workspace_mutation.status_code(),
+        401,
+        "{}",
+        workspace_mutation.text()
+    );
+    assert_eq!(
+        token_management.status_code(),
+        401,
+        "{}",
+        token_management.text()
+    );
+    assert_eq!(
+        session_management.status_code(),
+        401,
+        "{}",
+        session_management.text()
+    );
+}

--- a/crates/api/tests/e2e_all/reporting_usage/token_management.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/token_management.rs
@@ -1,0 +1,187 @@
+use super::{
+    assert_json_has_no_secret_fields, bearer, redact_create_response, setup_reporting_usage_server,
+};
+use crate::common::{create_org, get_session_id, setup_unique_test_session, MOCK_USER_AGENT};
+use chrono::{Duration, Utc};
+use serde_json::Value;
+
+#[tokio::test]
+async fn reporting_token_management() {
+    // Given: an organization owned by the authenticated session user.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let url = format!("/v1/organizations/{}/reporting-tokens", org.id);
+
+    // When: the owner creates a reporting token.
+    let create_response = server
+        .post(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "name": "finance export",
+            "expires_at": (Utc::now() + Duration::days(30)).to_rfc3339(),
+        }))
+        .await;
+
+    // Then: the create response exposes the raw token exactly once and no hash.
+    assert_eq!(
+        create_response.status_code(),
+        201,
+        "{}",
+        create_response.text()
+    );
+    let created = create_response.json::<Value>();
+    let raw_token = created
+        .get("token")
+        .and_then(Value::as_str)
+        .expect("create response should include raw reporting token once");
+    assert!(
+        raw_token.starts_with("rpt-"),
+        "raw reporting token should use rpt- prefix"
+    );
+    assert_eq!(
+        created.to_string().matches(raw_token).count(),
+        1,
+        "raw reporting token should appear exactly once in create response"
+    );
+    assert!(
+        !created.to_string().contains("token_hash"),
+        "create response must not expose token_hash"
+    );
+    println!(
+        "manual POST /reporting-tokens 201 {}",
+        redact_create_response(&created)
+    );
+    let token_id = created
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("create response should include token id")
+        .to_string();
+
+    // When: the owner lists reporting tokens.
+    let list_response = server
+        .get(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: list includes metadata only and never includes raw token material.
+    assert_eq!(list_response.status_code(), 200, "{}", list_response.text());
+    let listed = list_response.json::<Value>();
+    assert_json_has_no_secret_fields(&listed);
+    println!("manual GET /reporting-tokens 200 {listed}");
+    let tokens = listed
+        .get("reporting_tokens")
+        .and_then(Value::as_array)
+        .expect("list response should include reporting_tokens array");
+    assert_eq!(
+        tokens.len(),
+        1,
+        "created token should be listed while active"
+    );
+    assert_eq!(tokens[0]["id"], token_id);
+    assert_eq!(tokens[0]["name"], "finance export");
+
+    // When: the owner revokes the reporting token.
+    let revoke_response = server
+        .delete(format!("{url}/{token_id}").as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: the token is revoked and absent from active listings.
+    assert_eq!(
+        revoke_response.status_code(),
+        204,
+        "{}",
+        revoke_response.text()
+    );
+    println!("manual DELETE /reporting-tokens/{{token_id}} 204");
+    let after_revoke_response = server
+        .get(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(
+        after_revoke_response.status_code(),
+        200,
+        "{}",
+        after_revoke_response.text()
+    );
+    let after_revoke = after_revoke_response.json::<Value>();
+    assert_json_has_no_secret_fields(&after_revoke);
+    println!("manual GET /reporting-tokens after revoke 200 {after_revoke}");
+    assert_eq!(
+        after_revoke["reporting_tokens"]
+            .as_array()
+            .expect("reporting_tokens should be an array")
+            .len(),
+        0,
+        "revoked token should not appear in active token list"
+    );
+}
+
+#[tokio::test]
+async fn reporting_token_management_forbidden_for_non_member() {
+    // Given: an organization owned by the default test session and a second user
+    // who is not a member of that organization.
+    let (server, database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let (other_session, _email) = setup_unique_test_session(&database).await;
+
+    // When: the non-member attempts to create a reporting token.
+    let response = server
+        .post(format!("/v1/organizations/{}/reporting-tokens", org.id).as_str())
+        .add_header("Authorization", bearer(&other_session))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "unauthorized export" }))
+        .await;
+
+    // Then: the management route denies cross-org access.
+    assert_eq!(response.status_code(), 403, "{}", response.text());
+}
+
+#[tokio::test]
+async fn reporting_token_management_rejects_malformed_input() {
+    // Given: an organization owned by the authenticated session user.
+    let (server, _database) = setup_reporting_usage_server().await;
+    let org = create_org(&server).await;
+    let url = format!("/v1/organizations/{}/reporting-tokens", org.id);
+
+    // When/Then: empty names are rejected.
+    let empty_name = server
+        .post(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({ "name": "" }))
+        .await;
+    assert_eq!(empty_name.status_code(), 400, "{}", empty_name.text());
+
+    // When/Then: invalid organization ids are rejected at the HTTP boundary.
+    let invalid_org = server
+        .get("/v1/organizations/not-a-uuid/reporting-tokens")
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(invalid_org.status_code(), 400, "{}", invalid_org.text());
+
+    // When/Then: invalid token ids are rejected at the HTTP boundary.
+    let invalid_token = server
+        .delete(format!("{url}/not-a-uuid").as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(invalid_token.status_code(), 400, "{}", invalid_token.text());
+
+    // When/Then: already-expired reporting tokens are rejected.
+    let past_expiry = server
+        .post(&url)
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .json(&serde_json::json!({
+            "name": "already expired",
+            "expires_at": (Utc::now() - Duration::minutes(1)).to_rfc3339(),
+        }))
+        .await;
+    assert_eq!(past_expiry.status_code(), 400, "{}", past_expiry.text());
+}

--- a/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
@@ -1,0 +1,233 @@
+use super::usage_export_fixture::{
+    assert_no_private_export_fields, redacted_export, seed_export_fixture, url_ts, ExportFixture,
+};
+use super::{bearer, setup_reporting_usage_server};
+use crate::common::{create_org, get_session_id, MOCK_USER_AGENT};
+use serde_json::Value;
+
+#[tokio::test]
+async fn usage_export() {
+    // Given: one organization with inference and service usage sharing a timestamp.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let base = format!(
+        "/v1/organizations/{}/usage/export?start_time={}&end_time={}&workspace_id={}&api_key_id={}",
+        fixture.org_id,
+        url_ts(2026, 7, 1),
+        url_ts(2026, 7, 4),
+        fixture.workspace_id,
+        fixture.api_key_id
+    );
+
+    // When: the mixed export is fetched with a small page size.
+    let first = server
+        .get(format!("{base}&source=all&limit=2").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: rows are merged by created_at, source, id and return a cursor.
+    assert_eq!(first.status_code(), 200, "{}", first.text());
+    let first_body = first.json::<Value>();
+    assert_no_private_export_fields(&first_body);
+    let first_rows = first_body["data"]
+        .as_array()
+        .expect("data should be an array");
+    assert_eq!(first_rows.len(), 2);
+    assert_eq!(first_rows[0]["source"], "service");
+    assert_eq!(first_rows[1]["source"], "service");
+    let cursor = first_body["next_cursor"]
+        .as_str()
+        .expect("first page should include next_cursor");
+    println!(
+        "manual GET /usage/export source=all limit=2 200 {}",
+        redacted_export(&first_body)
+    );
+
+    // When: the next cursor is used.
+    let second = server
+        .get(format!("{base}&source=all&limit=2&cursor={cursor}").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    // Then: continuation returns the tied inference row without duplicate/skip.
+    assert_eq!(second.status_code(), 200, "{}", second.text());
+    let second_body = second.json::<Value>();
+    assert_no_private_export_fields(&second_body);
+    let second_rows = second_body["data"]
+        .as_array()
+        .expect("data should be an array");
+    assert_eq!(second_rows.len(), 2);
+    assert_eq!(second_rows[0]["source"], "inference");
+    assert_eq!(second_rows[1]["source"], "inference");
+    assert!(second_body.get("next_cursor").is_none());
+
+    // When/Then: source-specific filters return only applicable rows.
+    let inference = get_export(
+        &server,
+        &fixture,
+        format!("{base}&source=inference&model={}", fixture.model),
+    )
+    .await;
+    assert_eq!(inference["data"].as_array().expect("array").len(), 2);
+    assert!(inference["data"].as_array().expect("array")[0]["service"].is_null());
+
+    let service = get_export(
+        &server,
+        &fixture,
+        format!(
+            "{base}&source=service&service_name={}",
+            fixture.service_name
+        ),
+    )
+    .await;
+    assert_eq!(service["data"].as_array().expect("array").len(), 2);
+    assert!(service["data"].as_array().expect("array")[0]["inference"].is_null());
+
+    let empty = get_export(
+        &server,
+        &fixture,
+        format!("{base}&source=inference&model=none"),
+    )
+    .await;
+    assert!(empty["data"].as_array().expect("array").is_empty());
+    assert!(empty.get("next_cursor").is_none());
+}
+
+#[tokio::test]
+async fn usage_export_omits_cache_read_cost_when_not_separately_persisted() {
+    // Given: persisted inference usage includes cached tokens but no separate cache-read cost column.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let url = format!(
+        "/v1/organizations/{}/usage/export?start_time={}&end_time={}&source=inference&workspace_id={}&api_key_id={}&model={}",
+        fixture.org_id,
+        url_ts(2026, 7, 1),
+        url_ts(2026, 7, 4),
+        fixture.workspace_id,
+        fixture.api_key_id,
+        fixture.model
+    );
+
+    // When: inference usage is exported.
+    let body = get_export(&server, &fixture, url).await;
+
+    // Then: the cache token count is reported, but no cache-read cost is invented.
+    let rows = body["data"].as_array().expect("data should be an array");
+    assert_eq!(rows.len(), 2);
+    let inference = &rows[0]["inference"];
+    assert_eq!(inference["cache_read_tokens"].as_i64(), Some(1));
+    assert_eq!(inference["input_cost_nano_usd"].as_i64(), Some(400));
+    assert_eq!(inference["output_cost_nano_usd"].as_i64(), Some(300));
+    assert_eq!(inference["total_cost_nano_usd"].as_i64(), Some(700));
+    assert!(
+        inference.get("cache_read_cost_nano_usd").is_none(),
+        "cache-read cost split should be omitted when unavailable: {inference}"
+    );
+    println!(
+        "manual GET /usage/export source=inference cache_read_cost_nano_usd omitted contract 200 {}",
+        redacted_export(&body)
+    );
+}
+
+#[tokio::test]
+async fn usage_export_rejects_bad_input_and_bad_auth_scope() {
+    // Given: two organizations and one active reporting token.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let other_org = create_org(&server).await;
+
+    // When/Then: malformed input is rejected by the shared validators.
+    let invalid_range = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?start_time={}&end_time={}",
+                fixture.org_id,
+                url_ts(2026, 7, 4),
+                url_ts(2026, 7, 1)
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(invalid_range.status_code(), 400, "{}", invalid_range.text());
+
+    let invalid_cursor = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?cursor=bad",
+                fixture.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(
+        invalid_cursor.status_code(),
+        400,
+        "{}",
+        invalid_cursor.text()
+    );
+
+    // When: a token from one org calls another org export.
+    let mismatch = server
+        .get(format!("/v1/organizations/{}/usage/export", other_org.id).as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+
+    // Then: org mismatch uses the established forbidden envelope.
+    assert_eq!(mismatch.status_code(), 403, "{}", mismatch.text());
+    println!(
+        "manual GET /usage/export org mismatch 403 {}",
+        mismatch.text()
+    );
+
+    // When/Then: revoked reporting tokens cannot export usage.
+    revoke_reporting_token(&server, &fixture).await;
+    let revoked = server
+        .get(format!("/v1/organizations/{}/usage/export", fixture.org_id).as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(revoked.status_code(), 401, "{}", revoked.text());
+}
+
+async fn get_export(server: &axum_test::TestServer, fixture: &ExportFixture, url: String) -> Value {
+    let response = server
+        .get(&url)
+        .add_header("Authorization", bearer(&fixture.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body = response.json::<Value>();
+    assert_no_private_export_fields(&body);
+    body
+}
+
+async fn revoke_reporting_token(server: &axum_test::TestServer, fixture: &ExportFixture) {
+    let list = server
+        .get(format!("/v1/organizations/{}/reporting-tokens", fixture.org_id).as_str())
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await
+        .json::<Value>();
+    let token_id = list["reporting_tokens"]
+        .as_array()
+        .expect("tokens array")
+        .iter()
+        .find(|token| token["token_prefix"] == fixture.token[..12])
+        .and_then(|token| token["id"].as_str())
+        .expect("token id");
+    let response = server
+        .delete(
+            format!(
+                "/v1/organizations/{}/reporting-tokens/{token_id}",
+                fixture.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&get_session_id()))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(response.status_code(), 204, "{}", response.text());
+}

--- a/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
@@ -203,6 +203,11 @@ async fn usage_export_database_timeout_returns_504_and_stops_query() {
         .batch_execute("LOCK TABLE organization_usage_log IN ACCESS EXCLUSIVE MODE")
         .await
         .expect("exclusive test lock");
+    let application_name: String = transaction
+        .query_one("SHOW application_name", &[])
+        .await
+        .expect("test pool application name")
+        .get(0);
 
     let response = server
         .get(format!("/v1/organizations/{}/usage/export?source=inference", org.id).as_str())
@@ -222,10 +227,11 @@ async fn usage_export_database_timeout_returns_504_and_stops_query() {
             FROM pg_stat_activity
             WHERE datname = current_database()
               AND pid <> pg_backend_pid()
+              AND application_name = $1
               AND state = 'active'
               AND query LIKE '%FROM organization_usage_log%'
             "#,
-            &[],
+            &[&application_name],
         )
         .await
         .expect("active query check")

--- a/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_export.rs
@@ -2,7 +2,9 @@ use super::usage_export_fixture::{
     assert_no_private_export_fields, redacted_export, seed_export_fixture, url_ts, ExportFixture,
 };
 use super::{bearer, setup_reporting_usage_server};
-use crate::common::{create_org, get_session_id, MOCK_USER_AGENT};
+use crate::common::{
+    create_org, get_session_id, setup_test_server_with_config_and_database, MOCK_USER_AGENT,
+};
 use serde_json::Value;
 
 #[tokio::test]
@@ -96,6 +98,143 @@ async fn usage_export() {
 }
 
 #[tokio::test]
+async fn usage_export_cursor_restores_filters_and_excludes_consumed_tied_service_rows() {
+    // Given: a mixed export whose third row is inference usage tied with a service row.
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let first_url = format!(
+        "/v1/organizations/{}/usage/export?start_time={}&end_time={}&source=all&workspace_id={}&api_key_id={}&limit=3",
+        fixture.org_id,
+        url_ts(2026, 7, 1),
+        url_ts(2026, 7, 4),
+        fixture.workspace_id,
+        fixture.api_key_id
+    );
+    let first = get_export(&server, &fixture, first_url).await;
+    let first_rows = first["data"].as_array().expect("data should be an array");
+    assert_eq!(first_rows.len(), 3);
+    assert_eq!(first_rows[1]["source"], "service");
+    assert_eq!(first_rows[2]["source"], "inference");
+    assert_eq!(first_rows[1]["created_at"], first_rows[2]["created_at"]);
+    let cursor = first["next_cursor"]
+        .as_str()
+        .expect("first page should include next_cursor");
+
+    // When: page two supplies only the cursor, omitting the original window and filters.
+    let second = get_export(
+        &server,
+        &fixture,
+        format!(
+            "/v1/organizations/{}/usage/export?cursor={cursor}",
+            fixture.org_id
+        ),
+    )
+    .await;
+
+    // Then: context is restored and the already-consumed tied service row is not duplicated.
+    let second_rows = second["data"].as_array().expect("data should be an array");
+    assert_eq!(second_rows.len(), 1, "{second}");
+    assert_eq!(second_rows[0]["source"], "inference");
+    assert_eq!(second_rows[0]["created_at"], "2026-07-01T00:00:00Z");
+    assert!(second.get("next_cursor").is_none());
+}
+
+#[tokio::test]
+async fn usage_export_rejects_cursor_from_another_organization() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let first_org = seed_export_fixture(&server, &database).await;
+    let second_org = seed_export_fixture(&server, &database).await;
+
+    let first_page = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?start_time={}&end_time={}&limit=1",
+                first_org.org_id,
+                url_ts(2026, 7, 1),
+                url_ts(2026, 7, 4)
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&first_org.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+    assert_eq!(first_page.status_code(), 200, "{}", first_page.text());
+    let cursor = first_page
+        .json::<Value>()
+        .get("next_cursor")
+        .and_then(Value::as_str)
+        .expect("first organization should return a continuation cursor")
+        .to_string();
+
+    let replay = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?cursor={cursor}",
+                second_org.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&second_org.token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    assert_eq!(replay.status_code(), 400, "{}", replay.text());
+    assert_eq!(
+        replay.json::<Value>()["error"]["type"],
+        "invalid_reporting_usage_query"
+    );
+}
+
+#[tokio::test]
+async fn usage_export_database_timeout_returns_504_and_stops_query() {
+    let (server, database) = setup_test_server_with_config_and_database(|config| {
+        config.usage_reporting.request_timeout_seconds = 1;
+    })
+    .await;
+    let org = create_org(&server).await;
+    let token = super::create_reporting_token(&server, &org.id).await;
+    let mut blocker = database
+        .pool()
+        .get()
+        .await
+        .expect("blocking database connection");
+    let transaction = blocker.transaction().await.expect("blocking transaction");
+    transaction
+        .batch_execute("LOCK TABLE organization_usage_log IN ACCESS EXCLUSIVE MODE")
+        .await
+        .expect("exclusive test lock");
+
+    let response = server
+        .get(format!("/v1/organizations/{}/usage/export?source=inference", org.id).as_str())
+        .add_header("Authorization", bearer(&token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    assert_eq!(response.status_code(), 504, "{}", response.text());
+    assert_eq!(
+        response.json::<Value>()["error"]["type"],
+        "reporting_request_timeout"
+    );
+    let active_query_count: i64 = transaction
+        .query_one(
+            r#"
+            SELECT COUNT(*)::BIGINT
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND pid <> pg_backend_pid()
+              AND state = 'active'
+              AND query LIKE '%FROM organization_usage_log%'
+            "#,
+            &[],
+        )
+        .await
+        .expect("active query check")
+        .get(0);
+    assert_eq!(active_query_count, 0, "timed-out export query must stop");
+    transaction.rollback().await.expect("release test lock");
+}
+
+#[tokio::test]
 async fn usage_export_omits_cache_read_cost_when_not_separately_persisted() {
     // Given: persisted inference usage includes cached tokens but no separate cache-read cost column.
     let (server, database) = setup_reporting_usage_server().await;
@@ -168,6 +307,39 @@ async fn usage_export_rejects_bad_input_and_bad_auth_scope() {
         400,
         "{}",
         invalid_cursor.text()
+    );
+
+    let first_page = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?start_time={}&end_time={}&source=all&limit=1",
+                fixture.org_id,
+                url_ts(2026, 7, 1),
+                url_ts(2026, 7, 4)
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await
+        .json::<Value>();
+    let bound_cursor = first_page["next_cursor"]
+        .as_str()
+        .expect("first page should include next_cursor");
+    let conflicting_filter = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/export?cursor={bound_cursor}&source=service",
+                fixture.org_id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(
+        conflicting_filter.status_code(),
+        400,
+        "{}",
+        conflicting_filter.text()
     );
 
     // When: a token from one org calls another org export.

--- a/crates/api/tests/e2e_all/reporting_usage/usage_export_fixture.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_export_fixture.rs
@@ -1,0 +1,174 @@
+use super::create_reporting_token;
+use crate::common::{
+    create_api_key_in_workspace, create_org, get_or_create_web_search_service, list_workspaces,
+    setup_qwen_model,
+};
+use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+use database::Database;
+use serde_json::Value;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub struct ExportFixture {
+    pub org_id: String,
+    pub token: String,
+    pub workspace_id: String,
+    pub api_key_id: String,
+    pub model: String,
+    pub service_name: String,
+}
+
+pub async fn seed_export_fixture(
+    server: &axum_test::TestServer,
+    database: &Arc<Database>,
+) -> ExportFixture {
+    let org = create_org(server).await;
+    let workspaces = list_workspaces(server, org.id.clone()).await;
+    let workspace_id = workspaces
+        .first()
+        .expect("workspace should exist")
+        .id
+        .clone();
+    let api_key = create_api_key_in_workspace(
+        server,
+        workspace_id.clone(),
+        "reporting export key".to_string(),
+    )
+    .await;
+    let model = setup_qwen_model(server).await;
+    let service = get_or_create_web_search_service(server).await;
+    let token = create_reporting_token(server, &org.id).await;
+
+    insert_inference_usage(database, &org.id, &workspace_id, &api_key.id, &model).await;
+    insert_service_usage(database, &org.id, &workspace_id, &api_key.id, service.id).await;
+
+    ExportFixture {
+        org_id: org.id,
+        token,
+        workspace_id,
+        api_key_id: api_key.id,
+        model,
+        service_name: service.service_name,
+    }
+}
+
+pub fn assert_no_private_export_fields(value: &Value) {
+    let text = value.to_string();
+    for private in [
+        "provider_request_id",
+        "prompt",
+        "response_body",
+        "file",
+        "token_hash",
+        "Authorization",
+        "Bearer",
+        "rpt-",
+    ] {
+        assert!(
+            !text.contains(private),
+            "private field leaked: {private}: {text}"
+        );
+    }
+}
+
+pub fn redacted_export(value: &Value) -> Value {
+    let mut redacted = value.clone();
+    if let Some(cursor) = redacted.get_mut("next_cursor") {
+        *cursor = Value::String("<redacted-cursor>".to_string());
+    }
+    redacted
+}
+
+pub fn ts(year: i32, month: u32, day: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, 0, 0, 0)
+        .single()
+        .expect("fixture timestamp")
+}
+
+pub fn url_ts(year: i32, month: u32, day: u32) -> String {
+    ts(year, month, day).to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+async fn insert_inference_usage(
+    database: &Arc<Database>,
+    org_id: &str,
+    workspace_id: &str,
+    api_key_id: &str,
+    model: &str,
+) {
+    let client = database.pool().get().await.expect("db connection");
+    let model_id: Uuid = client
+        .query_one("SELECT id FROM models WHERE model_name = $1", &[&model])
+        .await
+        .expect("model id")
+        .get("id");
+    for (created_at, input_tokens, total_cost) in
+        [(ts(2026, 7, 2), 7, 700_i64), (ts(2026, 7, 1), 5, 500_i64)]
+    {
+        client
+            .execute(
+                r#"
+                INSERT INTO organization_usage_log (
+                    id, organization_id, workspace_id, api_key_id, model_id, model_name,
+                    input_tokens, output_tokens, cache_read_tokens, total_tokens,
+                    input_cost, output_cost, total_cost, request_type, inference_type,
+                    created_at, inference_id, stop_reason
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, 3, 1, $8, $9, 300, $10,
+                    NULL, 'chat_completion', $11, $12, 'completed')
+                "#,
+                &[
+                    &Uuid::new_v4(),
+                    &Uuid::parse_str(org_id).expect("org uuid"),
+                    &Uuid::parse_str(workspace_id).expect("workspace uuid"),
+                    &Uuid::parse_str(api_key_id).expect("api key uuid"),
+                    &model_id,
+                    &model,
+                    &input_tokens,
+                    &(input_tokens + 3),
+                    &(total_cost - 300),
+                    &total_cost,
+                    &created_at,
+                    &Some(Uuid::new_v4()),
+                ],
+            )
+            .await
+            .expect("insert inference usage");
+    }
+}
+
+async fn insert_service_usage(
+    database: &Arc<Database>,
+    org_id: &str,
+    workspace_id: &str,
+    api_key_id: &str,
+    service_id: Uuid,
+) {
+    let client = database.pool().get().await.expect("db connection");
+    for (created_at, quantity, total_cost) in
+        [(ts(2026, 7, 3), 1, 100_i64), (ts(2026, 7, 2), 2, 200_i64)]
+    {
+        client
+            .execute(
+                r#"
+                INSERT INTO organization_service_usage_log (
+                    id, organization_id, workspace_id, api_key_id, service_id,
+                    quantity, total_cost, inference_id, created_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, $8)
+                "#,
+                &[
+                    &Uuid::new_v4(),
+                    &Uuid::parse_str(org_id).expect("org uuid"),
+                    &Uuid::parse_str(workspace_id).expect("workspace uuid"),
+                    &Uuid::parse_str(api_key_id).expect("api key uuid"),
+                    &service_id,
+                    &quantity,
+                    &total_cost,
+                    &created_at,
+                ],
+            )
+            .await
+            .expect("insert service usage");
+    }
+}

--- a/crates/api/tests/e2e_all/reporting_usage/usage_export_fixture.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_export_fixture.rs
@@ -112,10 +112,10 @@ async fn insert_inference_usage(
                     id, organization_id, workspace_id, api_key_id, model_id, model_name,
                     input_tokens, output_tokens, cache_read_tokens, total_tokens,
                     input_cost, output_cost, total_cost, request_type, inference_type,
-                    created_at, inference_id, stop_reason
+                    created_at, inference_id, provider_request_id, stop_reason
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7, 3, 1, $8, $9, 300, $10,
-                    NULL, 'chat_completion', $11, $12, 'completed')
+                    NULL, 'chat_completion', $11, $12, $13, 'completed')
                 "#,
                 &[
                     &Uuid::new_v4(),
@@ -130,6 +130,7 @@ async fn insert_inference_usage(
                     &total_cost,
                     &created_at,
                     &Some(Uuid::new_v4()),
+                    &Some(format!("private-provider-request-{total_cost}")),
                 ],
             )
             .await

--- a/crates/api/tests/e2e_all/reporting_usage/usage_summary.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_summary.rs
@@ -1,0 +1,246 @@
+use super::{
+    bearer, create_reporting_token, setup_reporting_usage_server,
+    usage_export_fixture::{
+        assert_no_private_export_fields, seed_export_fixture, url_ts, ExportFixture,
+    },
+};
+use crate::common::create_org;
+use chrono::{DateTime, Duration, Utc};
+use serde_json::Value;
+
+#[tokio::test]
+async fn usage_summary_returns_all_source_breakdowns_and_reconciles_cost() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+
+    let response = server
+        .get(default_summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let json = response.json::<Value>();
+    assert_no_private_export_fields(&json);
+    assert_totals(&json, 2, 2, 12, 6, 2, 18, 1_200, 300);
+    assert_eq!(json["totals"]["total_cost_nano_usd"], 1_500);
+    assert_eq!(json["by_workspace"][0]["request_count"], 2);
+    assert_eq!(json["by_workspace"][0]["service_usage_count"], 2);
+    assert_eq!(json["by_workspace"][0]["total_cost_nano_usd"], 1_500);
+    assert_eq!(json["by_api_key"][0]["request_count"], 2);
+    assert_eq!(json["by_api_key"][0]["service_usage_count"], 2);
+    assert_eq!(json["by_model"][0]["model"], fixture.model);
+    assert_eq!(json["by_model"][0]["total_cost_nano_usd"], 1_200);
+    assert_eq!(json["by_service"][0]["service_name"], fixture.service_name);
+    assert_eq!(json["by_service"][0]["usage_count"], 2);
+    assert_eq!(json["by_service"][0]["quantity"], 3);
+    assert_eq!(json["by_service"][0]["total_cost_nano_usd"], 300);
+    assert_day(&json, "2026-07-01", 1, 0, 500, 0);
+    assert_day(&json, "2026-07-02", 1, 1, 700, 200);
+    assert_day(&json, "2026-07-03", 0, 1, 0, 100);
+    println!(
+        "manual GET /usage/summary source=all 200 {}",
+        redacted_summary(&json)
+    );
+}
+
+#[tokio::test]
+async fn usage_summary_applies_source_specific_zero_and_empty_contracts() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+
+    let inference = get_default_summary(&server, &fixture, "source=inference").await;
+    assert_totals(&inference, 2, 0, 12, 6, 2, 18, 1_200, 0);
+    assert!(inference["by_service"]
+        .as_array()
+        .expect("by_service")
+        .is_empty());
+    assert_eq!(inference["by_model"][0]["total_cost_nano_usd"], 1_200);
+
+    let service = get_default_summary(&server, &fixture, "source=service").await;
+    assert_totals(&service, 0, 2, 0, 0, 0, 0, 0, 300);
+    assert!(service["by_model"].as_array().expect("by_model").is_empty());
+    assert_eq!(service["by_service"][0]["total_cost_nano_usd"], 300);
+}
+
+#[tokio::test]
+async fn usage_summary_honors_date_boundaries_and_filters() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let query = format!(
+        "source=all&start_time={}&end_time={}&workspace_id={}&api_key_id={}",
+        url_ts(2026, 7, 2),
+        url_ts(2026, 7, 2),
+        fixture.workspace_id,
+        fixture.api_key_id
+    );
+
+    let json = get_summary(&server, &fixture, &query).await;
+
+    assert_totals(&json, 1, 1, 7, 3, 1, 10, 700, 200);
+    assert_eq!(json["by_day"].as_array().expect("by_day").len(), 1);
+    assert_day(&json, "2026-07-02", 1, 1, 700, 200);
+}
+
+#[tokio::test]
+async fn usage_summary_normalizes_open_ended_range_defaults() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+    let before_request = Utc::now();
+
+    let response = server
+        .get(summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    let after_request = Utc::now();
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let json = response.json::<Value>();
+    let start_time = json_timestamp(&json, "start_time");
+    let end_time = json_timestamp(&json, "end_time");
+    assert!(end_time >= before_request);
+    assert!(end_time <= after_request);
+    assert_eq!(end_time - start_time, Duration::days(366));
+    assert_totals(&json, 2, 2, 12, 6, 2, 18, 1_200, 300);
+    println!(
+        "manual GET /usage/summary source=all open-ended 200 {}",
+        redacted_summary(&json)
+    );
+}
+
+#[tokio::test]
+async fn usage_summary_rejects_invalid_range_org_mismatch_and_revoked_token() {
+    let (server, database) = setup_reporting_usage_server().await;
+    let fixture = seed_export_fixture(&server, &database).await;
+
+    let invalid = server
+        .get(
+            summary_url(
+                &fixture,
+                format!(
+                    "start_time={}&end_time={}",
+                    url_ts(2026, 7, 4),
+                    url_ts(2026, 7, 1)
+                )
+                .as_str(),
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(invalid.status_code(), 400, "{}", invalid.text());
+    println!(
+        "manual GET /usage/summary invalid range 400 {}",
+        invalid.text()
+    );
+
+    let other_org = create_org(&server).await;
+    let other_token = create_reporting_token(&server, &other_org.id).await;
+    let mismatch = server
+        .get(default_summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer(&other_token))
+        .await;
+    assert_eq!(mismatch.status_code(), 403, "{}", mismatch.text());
+
+    let revoked = server
+        .get(default_summary_url(&fixture, "source=all").as_str())
+        .add_header("Authorization", bearer("rpt-revoked-or-malformed"))
+        .await;
+    assert_eq!(revoked.status_code(), 401, "{}", revoked.text());
+}
+
+async fn get_default_summary(
+    server: &axum_test::TestServer,
+    fixture: &ExportFixture,
+    query: &str,
+) -> Value {
+    get_summary(server, fixture, default_summary_query(query).as_str()).await
+}
+
+async fn get_summary(
+    server: &axum_test::TestServer,
+    fixture: &ExportFixture,
+    query: &str,
+) -> Value {
+    let response = server
+        .get(summary_url(fixture, query).as_str())
+        .add_header("Authorization", bearer(&fixture.token))
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    response.json::<Value>()
+}
+
+fn summary_url(fixture: &ExportFixture, query: &str) -> String {
+    format!(
+        "/v1/organizations/{}/usage/summary?{}",
+        fixture.org_id, query
+    )
+}
+
+fn default_summary_url(fixture: &ExportFixture, query: &str) -> String {
+    summary_url(fixture, default_summary_query(query).as_str())
+}
+
+fn default_summary_query(query: &str) -> String {
+    format!(
+        "start_time={}&end_time={}&{}",
+        url_ts(2026, 7, 1),
+        url_ts(2026, 7, 3),
+        query
+    )
+}
+
+fn assert_totals(
+    json: &Value,
+    request_count: i64,
+    service_usage_count: i64,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    total_tokens: i64,
+    inference_cost: i64,
+    service_cost: i64,
+) {
+    let totals = &json["totals"];
+    assert_eq!(totals["request_count"], request_count);
+    assert_eq!(totals["service_usage_count"], service_usage_count);
+    assert_eq!(totals["input_tokens"], input_tokens);
+    assert_eq!(totals["output_tokens"], output_tokens);
+    assert_eq!(totals["cache_read_tokens"], cache_read_tokens);
+    assert_eq!(totals["total_tokens"], total_tokens);
+    assert_eq!(totals["inference_cost_nano_usd"], inference_cost);
+    assert_eq!(totals["service_cost_nano_usd"], service_cost);
+    assert_eq!(totals["total_cost_nano_usd"], inference_cost + service_cost);
+}
+
+fn assert_day(
+    json: &Value,
+    day: &str,
+    request_count: i64,
+    service_usage_count: i64,
+    inference_cost: i64,
+    service_cost: i64,
+) {
+    let days = json["by_day"].as_array().expect("by_day array");
+    let day_row = days
+        .iter()
+        .find(|row| row["day"] == day)
+        .unwrap_or_else(|| panic!("missing day {day}: {days:?}"));
+    assert_eq!(day_row["request_count"], request_count);
+    assert_eq!(day_row["service_usage_count"], service_usage_count);
+    assert_eq!(day_row["inference_cost_nano_usd"], inference_cost);
+    assert_eq!(day_row["service_cost_nano_usd"], service_cost);
+    assert_eq!(
+        day_row["total_cost_nano_usd"],
+        inference_cost + service_cost
+    );
+}
+
+fn json_timestamp(json: &Value, field: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(json[field].as_str().expect(field))
+        .expect(field)
+        .with_timezone(&Utc)
+}
+
+fn redacted_summary(value: &Value) -> Value {
+    value.clone()
+}

--- a/crates/api/tests/e2e_all/reporting_usage/usage_summary.rs
+++ b/crates/api/tests/e2e_all/reporting_usage/usage_summary.rs
@@ -4,7 +4,7 @@ use super::{
         assert_no_private_export_fields, seed_export_fixture, url_ts, ExportFixture,
     },
 };
-use crate::common::create_org;
+use crate::common::{create_org, setup_test_server_with_config_and_database, MOCK_USER_AGENT};
 use chrono::{DateTime, Duration, Utc};
 use serde_json::Value;
 
@@ -21,7 +21,19 @@ async fn usage_summary_returns_all_source_breakdowns_and_reconciles_cost() {
     assert_eq!(response.status_code(), 200, "{}", response.text());
     let json = response.json::<Value>();
     assert_no_private_export_fields(&json);
-    assert_totals(&json, 2, 2, 12, 6, 2, 18, 1_200, 300);
+    assert_totals(
+        &json,
+        ExpectedTotals {
+            request_count: 2,
+            service_usage_count: 2,
+            input_tokens: 12,
+            output_tokens: 6,
+            cache_read_tokens: 2,
+            total_tokens: 18,
+            inference_cost: 1_200,
+            service_cost: 300,
+        },
+    );
     assert_eq!(json["totals"]["total_cost_nano_usd"], 1_500);
     assert_eq!(json["by_workspace"][0]["request_count"], 2);
     assert_eq!(json["by_workspace"][0]["service_usage_count"], 2);
@@ -44,12 +56,63 @@ async fn usage_summary_returns_all_source_breakdowns_and_reconciles_cost() {
 }
 
 #[tokio::test]
+async fn usage_summary_database_timeout_returns_504() {
+    let (server, database) = setup_test_server_with_config_and_database(|config| {
+        config.usage_reporting.request_timeout_seconds = 1;
+    })
+    .await;
+    let org = create_org(&server).await;
+    let token = create_reporting_token(&server, &org.id).await;
+    let mut blocker = database
+        .pool()
+        .get()
+        .await
+        .expect("blocking database connection");
+    let transaction = blocker.transaction().await.expect("blocking transaction");
+    transaction
+        .batch_execute("LOCK TABLE organization_usage_log IN ACCESS EXCLUSIVE MODE")
+        .await
+        .expect("exclusive test lock");
+
+    let response = server
+        .get(
+            format!(
+                "/v1/organizations/{}/usage/summary?source=inference",
+                org.id
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", bearer(&token))
+        .add_header("User-Agent", MOCK_USER_AGENT)
+        .await;
+
+    assert_eq!(response.status_code(), 504, "{}", response.text());
+    assert_eq!(
+        response.json::<Value>()["error"]["type"],
+        "reporting_request_timeout"
+    );
+    transaction.rollback().await.expect("release test lock");
+}
+
+#[tokio::test]
 async fn usage_summary_applies_source_specific_zero_and_empty_contracts() {
     let (server, database) = setup_reporting_usage_server().await;
     let fixture = seed_export_fixture(&server, &database).await;
 
     let inference = get_default_summary(&server, &fixture, "source=inference").await;
-    assert_totals(&inference, 2, 0, 12, 6, 2, 18, 1_200, 0);
+    assert_totals(
+        &inference,
+        ExpectedTotals {
+            request_count: 2,
+            service_usage_count: 0,
+            input_tokens: 12,
+            output_tokens: 6,
+            cache_read_tokens: 2,
+            total_tokens: 18,
+            inference_cost: 1_200,
+            service_cost: 0,
+        },
+    );
     assert!(inference["by_service"]
         .as_array()
         .expect("by_service")
@@ -57,7 +120,19 @@ async fn usage_summary_applies_source_specific_zero_and_empty_contracts() {
     assert_eq!(inference["by_model"][0]["total_cost_nano_usd"], 1_200);
 
     let service = get_default_summary(&server, &fixture, "source=service").await;
-    assert_totals(&service, 0, 2, 0, 0, 0, 0, 0, 300);
+    assert_totals(
+        &service,
+        ExpectedTotals {
+            request_count: 0,
+            service_usage_count: 2,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            total_tokens: 0,
+            inference_cost: 0,
+            service_cost: 300,
+        },
+    );
     assert!(service["by_model"].as_array().expect("by_model").is_empty());
     assert_eq!(service["by_service"][0]["total_cost_nano_usd"], 300);
 }
@@ -76,7 +151,19 @@ async fn usage_summary_honors_date_boundaries_and_filters() {
 
     let json = get_summary(&server, &fixture, &query).await;
 
-    assert_totals(&json, 1, 1, 7, 3, 1, 10, 700, 200);
+    assert_totals(
+        &json,
+        ExpectedTotals {
+            request_count: 1,
+            service_usage_count: 1,
+            input_tokens: 7,
+            output_tokens: 3,
+            cache_read_tokens: 1,
+            total_tokens: 10,
+            inference_cost: 700,
+            service_cost: 200,
+        },
+    );
     assert_eq!(json["by_day"].as_array().expect("by_day").len(), 1);
     assert_day(&json, "2026-07-02", 1, 1, 700, 200);
 }
@@ -100,7 +187,19 @@ async fn usage_summary_normalizes_open_ended_range_defaults() {
     assert!(end_time >= before_request);
     assert!(end_time <= after_request);
     assert_eq!(end_time - start_time, Duration::days(366));
-    assert_totals(&json, 2, 2, 12, 6, 2, 18, 1_200, 300);
+    assert_totals(
+        &json,
+        ExpectedTotals {
+            request_count: 2,
+            service_usage_count: 2,
+            input_tokens: 12,
+            output_tokens: 6,
+            cache_read_tokens: 2,
+            total_tokens: 18,
+            inference_cost: 1_200,
+            service_cost: 300,
+        },
+    );
     println!(
         "manual GET /usage/summary source=all open-ended 200 {}",
         redacted_summary(&json)
@@ -189,8 +288,7 @@ fn default_summary_query(query: &str) -> String {
     )
 }
 
-fn assert_totals(
-    json: &Value,
+struct ExpectedTotals {
     request_count: i64,
     service_usage_count: i64,
     input_tokens: i64,
@@ -199,17 +297,22 @@ fn assert_totals(
     total_tokens: i64,
     inference_cost: i64,
     service_cost: i64,
-) {
+}
+
+fn assert_totals(json: &Value, expected: ExpectedTotals) {
     let totals = &json["totals"];
-    assert_eq!(totals["request_count"], request_count);
-    assert_eq!(totals["service_usage_count"], service_usage_count);
-    assert_eq!(totals["input_tokens"], input_tokens);
-    assert_eq!(totals["output_tokens"], output_tokens);
-    assert_eq!(totals["cache_read_tokens"], cache_read_tokens);
-    assert_eq!(totals["total_tokens"], total_tokens);
-    assert_eq!(totals["inference_cost_nano_usd"], inference_cost);
-    assert_eq!(totals["service_cost_nano_usd"], service_cost);
-    assert_eq!(totals["total_cost_nano_usd"], inference_cost + service_cost);
+    assert_eq!(totals["request_count"], expected.request_count);
+    assert_eq!(totals["service_usage_count"], expected.service_usage_count);
+    assert_eq!(totals["input_tokens"], expected.input_tokens);
+    assert_eq!(totals["output_tokens"], expected.output_tokens);
+    assert_eq!(totals["cache_read_tokens"], expected.cache_read_tokens);
+    assert_eq!(totals["total_tokens"], expected.total_tokens);
+    assert_eq!(totals["inference_cost_nano_usd"], expected.inference_cost);
+    assert_eq!(totals["service_cost_nano_usd"], expected.service_cost);
+    assert_eq!(
+        totals["total_cost_nano_usd"],
+        expected.inference_cost + expected.service_cost
+    );
 }
 
 fn assert_day(

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -25,6 +25,7 @@ pub struct ApiConfig {
     pub github_dispatch: GitHubDispatchConfig,
     pub infra: InfraConfig,
     pub staking_farm: StakingFarmConfig,
+    pub usage_reporting: UsageReportingConfig,
     pub ita: ItaAttestationConfig,
 }
 
@@ -57,7 +58,89 @@ impl ApiConfig {
             github_dispatch: GitHubDispatchConfig::from_env()?,
             infra: InfraConfig::from_env(),
             ita: ItaAttestationConfig::from_env()?,
+            usage_reporting: UsageReportingConfig::from_env()?,
         })
+    }
+}
+
+/// Operational limits for the programmatic usage-reporting API.
+///
+/// Reporting is disabled by default because its production indexes are built
+/// concurrently outside refinery. Operators enable it only after completing
+/// the rollout checklist in `docs/usage-reporting-rollout.md`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UsageReportingConfig {
+    pub enabled: bool,
+    pub global_requests_per_minute: u32,
+    pub token_requests_per_minute: u32,
+    pub max_concurrent_requests: usize,
+    pub token_max_concurrent_requests: usize,
+    pub request_timeout_seconds: u64,
+}
+
+impl Default for UsageReportingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            global_requests_per_minute: 600,
+            token_requests_per_minute: 60,
+            max_concurrent_requests: 4,
+            token_max_concurrent_requests: 2,
+            request_timeout_seconds: 15,
+        }
+    }
+}
+
+impl UsageReportingConfig {
+    pub fn database_statement_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(self.request_timeout_seconds.saturating_mul(800).max(1))
+    }
+
+    pub fn from_env() -> Result<Self, String> {
+        let defaults = Self::default();
+        let config = Self {
+            enabled: parse_bool_env("USAGE_REPORTING_ENABLED", defaults.enabled)?,
+            global_requests_per_minute: parse_u32_env(
+                "USAGE_REPORTING_GLOBAL_REQUESTS_PER_MINUTE",
+                defaults.global_requests_per_minute,
+            )?,
+            token_requests_per_minute: parse_u32_env(
+                "USAGE_REPORTING_TOKEN_REQUESTS_PER_MINUTE",
+                defaults.token_requests_per_minute,
+            )?,
+            max_concurrent_requests: usize::try_from(parse_u32_env(
+                "USAGE_REPORTING_MAX_CONCURRENT_REQUESTS",
+                u32::try_from(defaults.max_concurrent_requests)
+                    .map_err(|_| "default reporting concurrency exceeds u32".to_string())?,
+            )?)
+            .map_err(|_| "USAGE_REPORTING_MAX_CONCURRENT_REQUESTS is too large".to_string())?,
+            token_max_concurrent_requests: usize::try_from(parse_u32_env(
+                "USAGE_REPORTING_TOKEN_MAX_CONCURRENT_REQUESTS",
+                u32::try_from(defaults.token_max_concurrent_requests)
+                    .map_err(|_| "default token reporting concurrency exceeds u32".to_string())?,
+            )?)
+            .map_err(|_| {
+                "USAGE_REPORTING_TOKEN_MAX_CONCURRENT_REQUESTS is too large".to_string()
+            })?,
+            request_timeout_seconds: parse_u64_env(
+                "USAGE_REPORTING_REQUEST_TIMEOUT_SECONDS",
+                defaults.request_timeout_seconds,
+            )?,
+        };
+
+        if config.global_requests_per_minute == 0
+            || config.token_requests_per_minute == 0
+            || config.max_concurrent_requests == 0
+            || config.token_max_concurrent_requests == 0
+            || config.request_timeout_seconds == 0
+        {
+            return Err("usage reporting limits must be greater than zero".to_string());
+        }
+        if config.request_timeout_seconds > 3_600 {
+            return Err("USAGE_REPORTING_REQUEST_TIMEOUT_SECONDS must not exceed 3600".to_string());
+        }
+
+        Ok(config)
     }
 }
 
@@ -764,6 +847,23 @@ pub(crate) fn read_optional_secret_env_absent_empty(
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    fn reporting_database_timeout_leaves_headroom_for_http_response() {
+        let config = UsageReportingConfig {
+            request_timeout_seconds: 15,
+            ..UsageReportingConfig::default()
+        };
+
+        assert_eq!(
+            config.database_statement_timeout(),
+            std::time::Duration::from_secs(12)
+        );
+        assert!(
+            config.database_statement_timeout()
+                < std::time::Duration::from_secs(config.request_timeout_seconds)
+        );
+    }
 
     #[test]
     fn test_is_admin_email() {

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -12,10 +12,10 @@ pub use constants::*;
 pub use models::*;
 pub use pool::DbPool;
 pub use repositories::{
-    ApiKeyRepository, McpConnectorRepository, OAuthStateRepository, PgAttestationRepository,
-    PgConversationRepository, PgOrganizationInvitationRepository, PgOrganizationRepository,
-    PgResponseItemsRepository, PgResponseRepository, PostgresNearNonceRepository,
-    SessionRepository, UserRepository,
+    ApiKeyRepository, McpConnectorRepository, OAuthStateRepository,
+    OrganizationReportingTokenRepository, PgAttestationRepository, PgConversationRepository,
+    PgOrganizationInvitationRepository, PgOrganizationRepository, PgResponseItemsRepository,
+    PgResponseRepository, PostgresNearNonceRepository, SessionRepository, UserRepository,
 };
 pub use shutdown_coordinator::{ShutdownCoordinator, ShutdownStage, ShutdownStageResult};
 
@@ -35,6 +35,7 @@ pub struct Database {
     pub organizations: PgOrganizationRepository,
     pub users: UserRepository,
     pub api_keys: ApiKeyRepository,
+    pub organization_reporting_tokens: OrganizationReportingTokenRepository,
     pub sessions: SessionRepository,
     pub mcp_connectors: McpConnectorRepository,
     pub conversations: PgConversationRepository,
@@ -52,6 +53,7 @@ impl Database {
             organizations: PgOrganizationRepository::new(pool.clone()),
             users: UserRepository::new(pool.clone()),
             api_keys: ApiKeyRepository::new(pool.clone()),
+            organization_reporting_tokens: OrganizationReportingTokenRepository::new(pool.clone()),
             sessions: SessionRepository::new(pool.clone()),
             mcp_connectors: McpConnectorRepository::new(pool.clone()),
             conversations: PgConversationRepository::new(pool.clone()),

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -7,6 +7,7 @@ pub mod patroni_discovery;
 pub mod pool;
 pub mod repositories;
 pub mod shutdown_coordinator;
+mod usage_reporting_indexes;
 
 pub use constants::*;
 pub use models::*;
@@ -15,9 +16,11 @@ pub use repositories::{
     ApiKeyRepository, McpConnectorRepository, OAuthStateRepository,
     OrganizationReportingTokenRepository, PgAttestationRepository, PgConversationRepository,
     PgOrganizationInvitationRepository, PgOrganizationRepository, PgResponseItemsRepository,
-    PgResponseRepository, PostgresNearNonceRepository, SessionRepository, UserRepository,
+    PgResponseRepository, PostgresNearNonceRepository, PostgresReportingUsageSummaryRepository,
+    SessionRepository, UserRepository,
 };
 pub use shutdown_coordinator::{ShutdownCoordinator, ShutdownStage, ShutdownStageResult};
+pub use usage_reporting_indexes::ensure_usage_reporting_indexes;
 
 use anyhow::Result;
 use cluster_manager::{ClusterManager, DatabaseConfig as ClusterDbConfig, ReadPreference};

--- a/crates/database/src/migrations/out_of_band/usage_reporting_indexes.sql
+++ b/crates/database/src/migrations/out_of_band/usage_reporting_indexes.sql
@@ -1,0 +1,24 @@
+-- Usage reporting production indexes.
+--
+-- Run this script manually with psql outside refinery and outside an explicit
+-- transaction block before enabling high-volume reporting queries in production.
+-- These indexes target append-heavy usage tables, so they use CONCURRENTLY to
+-- avoid blocking writes during index builds.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_reporting_org_created_id
+    ON organization_usage_log (organization_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_reporting_org_workspace_created_id
+    ON organization_usage_log (organization_id, workspace_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_usage_reporting_org_api_key_created_id
+    ON organization_usage_log (organization_id, api_key_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_service_usage_reporting_org_created_id
+    ON organization_service_usage_log (organization_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_service_usage_reporting_org_workspace_created_id
+    ON organization_service_usage_log (organization_id, workspace_id, created_at DESC, id DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_org_service_usage_reporting_org_api_key_created_id
+    ON organization_service_usage_log (organization_id, api_key_id, created_at DESC, id DESC);

--- a/crates/database/src/migrations/sql/V0070__add_organization_reporting_tokens.sql
+++ b/crates/database/src/migrations/sql/V0070__add_organization_reporting_tokens.sql
@@ -1,0 +1,24 @@
+CREATE TABLE organization_reporting_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL CHECK (length(trim(name)) > 0),
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    token_prefix VARCHAR(16) NOT NULL,
+    created_by_user_id UUID NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+    revoked_by_user_id UUID REFERENCES users(id)
+);
+
+CREATE INDEX idx_org_reporting_tokens_hash
+    ON organization_reporting_tokens(token_hash);
+
+CREATE INDEX idx_org_reporting_tokens_active_org
+    ON organization_reporting_tokens(organization_id, created_at DESC, id DESC)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX idx_org_reporting_tokens_expiry
+    ON organization_reporting_tokens(expires_at)
+    WHERE revoked_at IS NULL AND expires_at IS NOT NULL;

--- a/crates/database/src/repositories/mod.rs
+++ b/crates/database/src/repositories/mod.rs
@@ -16,9 +16,14 @@ pub mod organization;
 pub mod organization_invitation;
 pub mod organization_limits;
 pub mod organization_limits_repository_impl;
+pub mod organization_reporting_token;
+mod organization_reporting_token_row;
 pub mod organization_service_usage;
+mod organization_service_usage_reporting_summary;
 pub mod organization_staking_farm_sources;
 pub mod organization_usage;
+mod organization_usage_reporting;
+mod organization_usage_reporting_summary;
 pub mod response;
 pub mod response_item;
 pub mod retry;
@@ -49,6 +54,7 @@ pub use oauth_state::{OAuthStateRepository, OAuthStateRow};
 pub use organization::PgOrganizationRepository;
 pub use organization_invitation::PgOrganizationInvitationRepository;
 pub use organization_limits::OrganizationLimitsRepository;
+pub use organization_reporting_token::OrganizationReportingTokenRepository;
 pub use organization_service_usage::{
     OrganizationServiceUsageRepository, RecordServiceUsageRequest,
 };

--- a/crates/database/src/repositories/mod.rs
+++ b/crates/database/src/repositories/mod.rs
@@ -24,6 +24,8 @@ pub mod organization_staking_farm_sources;
 pub mod organization_usage;
 mod organization_usage_reporting;
 mod organization_usage_reporting_summary;
+mod reporting_query;
+pub mod reporting_usage_summary;
 pub mod response;
 pub mod response_item;
 pub mod retry;
@@ -60,6 +62,7 @@ pub use organization_service_usage::{
 };
 pub use organization_staking_farm_sources::OrganizationStakingFarmSourcesRepository;
 pub use organization_usage::{OrganizationUsageRepository, UsageStats};
+pub use reporting_usage_summary::PostgresReportingUsageSummaryRepository;
 pub use response::PgResponseRepository;
 pub use response_item::PgResponseItemsRepository;
 pub use service::ServiceRepository;

--- a/crates/database/src/repositories/organization_reporting_token.rs
+++ b/crates/database/src/repositories/organization_reporting_token.rs
@@ -1,0 +1,263 @@
+use crate::pool::DbPool;
+use crate::repositories::organization_reporting_token_row::OrganizationReportingTokenRow;
+use crate::repositories::utils::map_db_error;
+use crate::retry_db;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use services::common::{
+    extract_reporting_token_prefix, generate_reporting_token, hash_reporting_token,
+    is_valid_reporting_token_format, RepositoryError,
+};
+use services::reporting_tokens::ports::{
+    CreateOrganizationReportingTokenRequest, CreatedOrganizationReportingToken,
+    OrganizationReportingToken, ValidatedOrganizationReportingToken,
+};
+use uuid::Uuid;
+
+pub struct OrganizationReportingTokenRepository {
+    pool: DbPool,
+}
+
+impl OrganizationReportingTokenRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    async fn create_token(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError> {
+        let name = request.name.trim().to_string();
+        if name.is_empty() {
+            return Err(RepositoryError::ValidationFailed(
+                "reporting token name cannot be empty".to_string(),
+            ));
+        }
+
+        let id = Uuid::new_v4();
+        let raw_token = generate_reporting_token();
+        let token_hash = hash_reporting_token(&raw_token);
+        let token_prefix = extract_reporting_token_prefix(&raw_token);
+
+        let row = retry_db!("create_organization_reporting_token", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_one(
+                    r#"
+                    INSERT INTO organization_reporting_tokens (
+                        id, organization_id, name, token_hash, token_prefix,
+                        created_by_user_id, expires_at
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    RETURNING *
+                    "#,
+                    &[
+                        &id,
+                        &request.organization_id,
+                        &name,
+                        &token_hash,
+                        &token_prefix,
+                        &request.created_by_user_id,
+                        &request.expires_at,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        let db_token = OrganizationReportingTokenRow::from_row(row)
+            .map_err(RepositoryError::DataConversionError)?;
+        Ok(CreatedOrganizationReportingToken {
+            token: db_token.into_service_token(),
+            raw_token,
+        })
+    }
+
+    async fn validate_token(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError> {
+        if !is_valid_reporting_token_format(raw_token) {
+            return Ok(None);
+        }
+
+        let token_hash = hash_reporting_token(raw_token);
+        let row = retry_db!("validate_organization_reporting_token", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_opt(
+                    r#"
+                    UPDATE organization_reporting_tokens
+                    SET last_used_at = NOW()
+                    WHERE token_hash = $1
+                      AND revoked_at IS NULL
+                      AND (expires_at IS NULL OR expires_at > NOW())
+                    RETURNING *
+                    "#,
+                    &[&token_hash],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        match row {
+            Some(row) => {
+                let db_token = OrganizationReportingTokenRow::from_row(row)
+                    .map_err(RepositoryError::DataConversionError)?;
+                Ok(Some(db_token.into_validated_token()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn get_token_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError> {
+        let row = retry_db!("get_organization_reporting_token_by_id", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query_opt(
+                    "SELECT * FROM organization_reporting_tokens WHERE id = $1",
+                    &[&token_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        match row {
+            Some(row) => {
+                let db_token = OrganizationReportingTokenRow::from_row(row)
+                    .map_err(RepositoryError::DataConversionError)?;
+                Ok(Some(db_token.into_service_token()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn list_active_tokens_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError> {
+        let rows = retry_db!("list_active_organization_reporting_tokens", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT *
+                    FROM organization_reporting_tokens
+                    WHERE organization_id = $1
+                      AND revoked_at IS NULL
+                      AND (expires_at IS NULL OR expires_at > NOW())
+                    ORDER BY created_at DESC, id DESC
+                    "#,
+                    &[&organization_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        rows.into_iter()
+            .map(|row| {
+                let db_token = OrganizationReportingTokenRow::from_row(row)?;
+                Ok(db_token.into_service_token())
+            })
+            .collect::<Result<Vec<_>>>()
+            .map_err(RepositoryError::DataConversionError)
+    }
+
+    async fn revoke_token(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError> {
+        let rows_affected = retry_db!("revoke_organization_reporting_token", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .execute(
+                    r#"
+                    UPDATE organization_reporting_tokens
+                    SET revoked_at = NOW(), revoked_by_user_id = $2
+                    WHERE id = $1 AND revoked_at IS NULL
+                    "#,
+                    &[&token_id, &revoked_by_user_id],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows_affected > 0)
+    }
+}
+
+#[async_trait]
+impl services::reporting_tokens::ports::OrganizationReportingTokenRepository
+    for OrganizationReportingTokenRepository
+{
+    async fn create(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError> {
+        self.create_token(request).await
+    }
+
+    async fn validate(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError> {
+        self.validate_token(raw_token).await
+    }
+
+    async fn get_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError> {
+        self.get_token_by_id(token_id).await
+    }
+
+    async fn list_active_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError> {
+        self.list_active_tokens_by_organization(organization_id)
+            .await
+    }
+
+    async fn revoke(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError> {
+        self.revoke_token(token_id, revoked_by_user_id).await
+    }
+}

--- a/crates/database/src/repositories/organization_reporting_token.rs
+++ b/crates/database/src/repositories/organization_reporting_token.rs
@@ -87,6 +87,18 @@ impl OrganizationReportingTokenRepository {
             return Ok(None);
         }
 
+        const SELECT_VALID_TOKEN: &str = r#"
+            SELECT *,
+                   COALESCE(
+                       last_used_at >= NOW() - INTERVAL '15 minutes',
+                       FALSE
+                   ) AS last_used_at_is_fresh
+            FROM organization_reporting_tokens
+            WHERE token_hash = $1
+              AND revoked_at IS NULL
+              AND (expires_at IS NULL OR expires_at > NOW())
+        "#;
+
         let token_hash = hash_reporting_token(raw_token);
         let row = retry_db!("validate_organization_reporting_token", {
             let client = self
@@ -96,20 +108,40 @@ impl OrganizationReportingTokenRepository {
                 .context("Failed to get database connection")
                 .map_err(RepositoryError::PoolError)?;
 
-            client
-                .query_opt(
-                    r#"
+            let selected = client
+                .query_opt(SELECT_VALID_TOKEN, &[&token_hash])
+                .await
+                .map_err(map_db_error)?;
+
+            match selected {
+                Some(row) if row.get("last_used_at_is_fresh") => Ok(Some(row)),
+                Some(_) => match client
+                    .query_opt(
+                        r#"
                     UPDATE organization_reporting_tokens
                     SET last_used_at = NOW()
                     WHERE token_hash = $1
                       AND revoked_at IS NULL
                       AND (expires_at IS NULL OR expires_at > NOW())
+                      AND (
+                          last_used_at IS NULL
+                          OR last_used_at < NOW() - INTERVAL '15 minutes'
+                      )
                     RETURNING *
                     "#,
-                    &[&token_hash],
-                )
-                .await
-                .map_err(map_db_error)
+                        &[&token_hash],
+                    )
+                    .await
+                    .map_err(map_db_error)?
+                {
+                    Some(row) => Ok(Some(row)),
+                    None => client
+                        .query_opt(SELECT_VALID_TOKEN, &[&token_hash])
+                        .await
+                        .map_err(map_db_error),
+                },
+                None => Ok(None),
+            }
         })?;
 
         match row {

--- a/crates/database/src/repositories/organization_reporting_token_row.rs
+++ b/crates/database/src/repositories/organization_reporting_token_row.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use services::reporting_tokens::ports::{
+    OrganizationReportingToken, ValidatedOrganizationReportingToken,
+    REPORTING_TOKEN_SCOPE_USAGE_READ,
+};
+use uuid::Uuid;
+
+pub struct OrganizationReportingTokenRow {
+    id: Uuid,
+    organization_id: Uuid,
+    name: String,
+    token_prefix: String,
+    created_by_user_id: Uuid,
+    created_at: DateTime<Utc>,
+    expires_at: Option<DateTime<Utc>>,
+    last_used_at: Option<DateTime<Utc>>,
+    revoked_at: Option<DateTime<Utc>>,
+    revoked_by_user_id: Option<Uuid>,
+}
+
+impl OrganizationReportingTokenRow {
+    pub fn from_row(row: tokio_postgres::Row) -> Result<Self> {
+        Ok(Self {
+            id: row.get("id"),
+            organization_id: row.get("organization_id"),
+            name: row.get("name"),
+            token_prefix: row.get("token_prefix"),
+            created_by_user_id: row.get("created_by_user_id"),
+            created_at: row.get("created_at"),
+            expires_at: row.get("expires_at"),
+            last_used_at: row.get("last_used_at"),
+            revoked_at: row.get("revoked_at"),
+            revoked_by_user_id: row.get("revoked_by_user_id"),
+        })
+    }
+
+    pub fn into_service_token(self) -> OrganizationReportingToken {
+        OrganizationReportingToken {
+            id: self.id,
+            organization_id: self.organization_id,
+            name: self.name,
+            token_prefix: self.token_prefix,
+            created_by_user_id: self.created_by_user_id,
+            created_at: self.created_at,
+            expires_at: self.expires_at,
+            last_used_at: self.last_used_at,
+            revoked_at: self.revoked_at,
+            revoked_by_user_id: self.revoked_by_user_id,
+            scope: REPORTING_TOKEN_SCOPE_USAGE_READ,
+        }
+    }
+
+    pub fn into_validated_token(self) -> ValidatedOrganizationReportingToken {
+        ValidatedOrganizationReportingToken {
+            id: self.id,
+            organization_id: self.organization_id,
+            token_prefix: self.token_prefix,
+            last_used_at: self.last_used_at,
+            scope: REPORTING_TOKEN_SCOPE_USAGE_READ,
+        }
+    }
+}

--- a/crates/database/src/repositories/organization_service_usage.rs
+++ b/crates/database/src/repositories/organization_service_usage.rs
@@ -5,6 +5,7 @@ use crate::retry_db;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use services::common::RepositoryError;
+use services::service_usage::ports::{ServiceUsageReportEntry, ServiceUsageReportFilters};
 use tokio_postgres::Row;
 use uuid::Uuid;
 
@@ -21,7 +22,7 @@ pub struct RecordServiceUsageRequest {
 
 #[derive(Debug, Clone)]
 pub struct OrganizationServiceUsageRepository {
-    pool: DbPool,
+    pub(crate) pool: DbPool,
 }
 
 impl OrganizationServiceUsageRepository {
@@ -89,6 +90,64 @@ impl OrganizationServiceUsageRepository {
 
         let logs = rows.iter().map(|row| self.row_to_log(row)).collect();
         Ok((logs, total))
+    }
+
+    pub async fn list_reporting_usage(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> Result<Vec<ServiceUsageReportEntry>> {
+        if let (Some(start_time), Some(end_time)) = (filters.start_time, filters.end_time) {
+            anyhow::ensure!(end_time >= start_time, "invalid reporting date range");
+        }
+
+        let cursor_created_at = filters.cursor.map(|cursor| cursor.created_at);
+        let cursor_id = filters.cursor.map(|cursor| cursor.id);
+        let rows = retry_db!("list_service_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT
+                        usage_log.id, usage_log.organization_id, usage_log.workspace_id,
+                        usage_log.api_key_id, usage_log.service_id, services.service_name,
+                        usage_log.quantity, usage_log.total_cost, usage_log.inference_id,
+                        usage_log.created_at
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TEXT IS NULL OR services.service_name = $2)
+                      AND ($3::UUID IS NULL OR usage_log.workspace_id = $3)
+                      AND ($4::UUID IS NULL OR usage_log.api_key_id = $4)
+                      AND ($5::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $5)
+                      AND ($6::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $6)
+                      AND ($7::TIMESTAMPTZ IS NULL OR $8::UUID IS NULL
+                           OR (usage_log.created_at, usage_log.id) < ($7, $8))
+                    ORDER BY usage_log.created_at DESC, usage_log.id DESC
+                    LIMIT $9
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.service_name,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &cursor_created_at,
+                        &cursor_id,
+                        &filters.limit,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows.iter().map(Self::row_to_report_entry).collect())
     }
 
     /// Record service usage and update organization_balance. Idempotent when inference_id is set:
@@ -198,6 +257,21 @@ impl OrganizationServiceUsageRepository {
             workspace_id: row.get("workspace_id"),
             api_key_id: row.get("api_key_id"),
             service_id: row.get("service_id"),
+            quantity: row.get("quantity"),
+            total_cost: row.get("total_cost"),
+            inference_id: row.get("inference_id"),
+            created_at: row.get("created_at"),
+        }
+    }
+
+    fn row_to_report_entry(row: &Row) -> ServiceUsageReportEntry {
+        ServiceUsageReportEntry {
+            id: row.get("id"),
+            organization_id: row.get("organization_id"),
+            workspace_id: row.get("workspace_id"),
+            api_key_id: row.get("api_key_id"),
+            service_id: row.get("service_id"),
+            service_name: row.get("service_name"),
             quantity: row.get("quantity"),
             total_cost: row.get("total_cost"),
             inference_id: row.get("inference_id"),

--- a/crates/database/src/repositories/organization_service_usage.rs
+++ b/crates/database/src/repositories/organization_service_usage.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use services::common::RepositoryError;
 use services::service_usage::ports::{ServiceUsageReportEntry, ServiceUsageReportFilters};
+use std::time::Duration;
 use tokio_postgres::Row;
 use uuid::Uuid;
 
@@ -23,11 +24,23 @@ pub struct RecordServiceUsageRequest {
 #[derive(Debug, Clone)]
 pub struct OrganizationServiceUsageRepository {
     pub(crate) pool: DbPool,
+    reporting_statement_timeout: Duration,
 }
 
 impl OrganizationServiceUsageRepository {
     pub fn new(pool: DbPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            reporting_statement_timeout:
+                crate::repositories::reporting_query::DEFAULT_REPORTING_STATEMENT_TIMEOUT,
+        }
+    }
+
+    pub fn with_reporting_statement_timeout(pool: DbPool, statement_timeout: Duration) -> Self {
+        Self {
+            pool,
+            reporting_statement_timeout: statement_timeout,
+        }
     }
 
     /// List service usage rows for an organization, optionally filtered by service_id.
@@ -102,15 +115,30 @@ impl OrganizationServiceUsageRepository {
 
         let cursor_created_at = filters.cursor.map(|cursor| cursor.created_at);
         let cursor_id = filters.cursor.map(|cursor| cursor.id);
+        let deadline = crate::repositories::reporting_query::reporting_deadline(
+            self.reporting_statement_timeout,
+            filters.deadline,
+        )?;
         let rows = retry_db!("list_service_usage_report", {
-            let client = self
+            let mut client = self
                 .pool
                 .get()
                 .await
                 .context("Failed to get database connection")
                 .map_err(RepositoryError::PoolError)?;
 
-            client
+            let transaction = client
+                .build_transaction()
+                .read_only(true)
+                .start()
+                .await
+                .map_err(map_db_error)?;
+            crate::repositories::reporting_query::configure_reporting_transaction(
+                &transaction,
+                crate::repositories::reporting_query::remaining_statement_timeout(deadline)?,
+            )
+            .await?;
+            let rows = transaction
                 .query(
                     r#"
                     SELECT
@@ -144,7 +172,9 @@ impl OrganizationServiceUsageRepository {
                     ],
                 )
                 .await
-                .map_err(map_db_error)
+                .map_err(map_db_error)?;
+            transaction.commit().await.map_err(map_db_error)?;
+            Ok::<_, RepositoryError>(rows)
         })?;
 
         Ok(rows.iter().map(Self::row_to_report_entry).collect())

--- a/crates/database/src/repositories/organization_service_usage_reporting_summary.rs
+++ b/crates/database/src/repositories/organization_service_usage_reporting_summary.rs
@@ -1,0 +1,224 @@
+use crate::repositories::{utils::map_db_error, OrganizationServiceUsageRepository};
+use crate::retry_db;
+use anyhow::{Context, Result};
+use services::{
+    common::RepositoryError,
+    reporting_usage::{
+        ReportingUsageSummaryFilters, ServiceApiKeySummary, ServiceDaySummary, ServiceNameSummary,
+        ServiceUsageSummary, ServiceUsageSummaryRepository, ServiceUsageTotals,
+        ServiceWorkspaceSummary,
+    },
+};
+use tokio_postgres::Row;
+
+impl OrganizationServiceUsageRepository {
+    pub async fn summarize_service_usage_report(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<ServiceUsageSummary> {
+        let summary = retry_db!("summarize_service_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let totals = client
+                .query_one(
+                    r#"
+                    SELECT COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_workspace = client
+                .query(
+                    r#"
+                    SELECT usage_log.workspace_id, COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY usage_log.workspace_id
+                    ORDER BY 3 DESC, usage_log.workspace_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_api_key = client
+                .query(
+                    r#"
+                    SELECT usage_log.api_key_id, COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY usage_log.api_key_id
+                    ORDER BY 3 DESC, usage_log.api_key_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_service = client
+                .query(
+                    r#"
+                    SELECT services.service_name, COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.quantity), 0)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY services.service_name
+                    ORDER BY 4 DESC, services.service_name ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_day = client
+                .query(
+                    r#"
+                    SELECT TO_CHAR(DATE_TRUNC('day', usage_log.created_at), 'YYYY-MM-DD'),
+                           COUNT(*)::bigint,
+                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
+                    FROM organization_service_usage_log AS usage_log
+                    INNER JOIN services ON services.id = usage_log.service_id
+                    WHERE usage_log.organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR services.service_name = $6)
+                    GROUP BY DATE_TRUNC('day', usage_log.created_at)
+                    ORDER BY 1 ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.service_name,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok::<_, RepositoryError>(ServiceUsageSummary {
+                totals: ServiceUsageTotals {
+                    usage_count: totals.get(0),
+                    total_cost_nano_usd: totals.get(1),
+                },
+                by_workspace: by_workspace.iter().map(workspace_from_row).collect(),
+                by_api_key: by_api_key.iter().map(api_key_from_row).collect(),
+                by_service: by_service.iter().map(service_from_row).collect(),
+                by_day: by_day.iter().map(day_from_row).collect(),
+            })
+        })?;
+
+        Ok(summary)
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceUsageSummaryRepository for OrganizationServiceUsageRepository {
+    async fn summarize_service_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<ServiceUsageSummary> {
+        self.summarize_service_usage_report(filters).await
+    }
+}
+
+fn workspace_from_row(row: &Row) -> ServiceWorkspaceSummary {
+    ServiceWorkspaceSummary {
+        workspace_id: row.get(0),
+        usage_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn api_key_from_row(row: &Row) -> ServiceApiKeySummary {
+    ServiceApiKeySummary {
+        api_key_id: row.get(0),
+        usage_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn service_from_row(row: &Row) -> ServiceNameSummary {
+    ServiceNameSummary {
+        service_name: row.get(0),
+        usage_count: row.get(1),
+        quantity: row.get(2),
+        total_cost_nano_usd: row.get(3),
+    }
+}
+
+fn day_from_row(row: &Row) -> ServiceDaySummary {
+    ServiceDaySummary {
+        day: row.get(0),
+        usage_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}

--- a/crates/database/src/repositories/organization_service_usage_reporting_summary.rs
+++ b/crates/database/src/repositories/organization_service_usage_reporting_summary.rs
@@ -1,224 +1,149 @@
-use crate::repositories::{utils::map_db_error, OrganizationServiceUsageRepository};
-use crate::retry_db;
-use anyhow::{Context, Result};
+use crate::repositories::utils::map_db_error;
 use services::{
     common::RepositoryError,
     reporting_usage::{
         ReportingUsageSummaryFilters, ServiceApiKeySummary, ServiceDaySummary, ServiceNameSummary,
-        ServiceUsageSummary, ServiceUsageSummaryRepository, ServiceUsageTotals,
-        ServiceWorkspaceSummary,
+        ServiceUsageSummary, ServiceUsageTotals, ServiceWorkspaceSummary,
     },
 };
-use tokio_postgres::Row;
+use tokio_postgres::{GenericClient, Row};
+use uuid::Uuid;
 
-impl OrganizationServiceUsageRepository {
-    pub async fn summarize_service_usage_report(
-        &self,
-        filters: &ReportingUsageSummaryFilters,
-    ) -> Result<ServiceUsageSummary> {
-        let summary = retry_db!("summarize_service_usage_report", {
-            let client = self
-                .pool
-                .get()
-                .await
-                .context("Failed to get database connection")
-                .map_err(RepositoryError::PoolError)?;
+pub(super) async fn summarize_service_usage<C>(
+    client: &C,
+    filters: &ReportingUsageSummaryFilters,
+) -> Result<ServiceUsageSummary, RepositoryError>
+where
+    C: GenericClient + Sync,
+{
+    let rows = client
+        .query(
+            r#"
+            WITH filtered AS MATERIALIZED (
+                SELECT usage_log.workspace_id, usage_log.api_key_id,
+                       services.service_name,
+                       DATE_TRUNC('day', usage_log.created_at) AS day,
+                       usage_log.quantity, usage_log.total_cost
+                FROM organization_service_usage_log AS usage_log
+                INNER JOIN services ON services.id = usage_log.service_id
+                WHERE usage_log.organization_id = $1
+                  AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
+                  AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
+                  AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
+                  AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
+                  AND ($6::TEXT IS NULL OR services.service_name = $6)
+            )
+            SELECT
+                CASE
+                    WHEN GROUPING(workspace_id) = 0 THEN 'workspace'
+                    WHEN GROUPING(api_key_id) = 0 THEN 'api_key'
+                    WHEN GROUPING(service_name) = 0 THEN 'service'
+                    WHEN GROUPING(day) = 0 THEN 'day'
+                    ELSE 'totals'
+                END AS dimension,
+                workspace_id,
+                api_key_id,
+                service_name,
+                TO_CHAR(day, 'YYYY-MM-DD') AS day,
+                COUNT(*)::BIGINT AS usage_count,
+                COALESCE(SUM(quantity), 0)::BIGINT AS quantity,
+                COALESCE(SUM(total_cost), 0)::BIGINT AS total_cost
+            FROM filtered
+            GROUP BY GROUPING SETS (
+                (), (workspace_id), (api_key_id), (service_name), (day)
+            )
+            "#,
+            &[
+                &filters.organization_id,
+                &filters.start_time,
+                &filters.end_time,
+                &filters.workspace_id,
+                &filters.api_key_id,
+                &filters.service_name,
+            ],
+        )
+        .await
+        .map_err(map_db_error)?;
 
-            let totals = client
-                .query_one(
-                    r#"
-                    SELECT COUNT(*)::bigint,
-                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
-                    FROM organization_service_usage_log AS usage_log
-                    INNER JOIN services ON services.id = usage_log.service_id
-                    WHERE usage_log.organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
-                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
-                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR services.service_name = $6)
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.service_name,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_workspace = client
-                .query(
-                    r#"
-                    SELECT usage_log.workspace_id, COUNT(*)::bigint,
-                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
-                    FROM organization_service_usage_log AS usage_log
-                    INNER JOIN services ON services.id = usage_log.service_id
-                    WHERE usage_log.organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
-                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
-                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR services.service_name = $6)
-                    GROUP BY usage_log.workspace_id
-                    ORDER BY 3 DESC, usage_log.workspace_id ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.service_name,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_api_key = client
-                .query(
-                    r#"
-                    SELECT usage_log.api_key_id, COUNT(*)::bigint,
-                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
-                    FROM organization_service_usage_log AS usage_log
-                    INNER JOIN services ON services.id = usage_log.service_id
-                    WHERE usage_log.organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
-                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
-                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR services.service_name = $6)
-                    GROUP BY usage_log.api_key_id
-                    ORDER BY 3 DESC, usage_log.api_key_id ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.service_name,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_service = client
-                .query(
-                    r#"
-                    SELECT services.service_name, COUNT(*)::bigint,
-                           COALESCE(SUM(usage_log.quantity), 0)::bigint,
-                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
-                    FROM organization_service_usage_log AS usage_log
-                    INNER JOIN services ON services.id = usage_log.service_id
-                    WHERE usage_log.organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
-                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
-                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR services.service_name = $6)
-                    GROUP BY services.service_name
-                    ORDER BY 4 DESC, services.service_name ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.service_name,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_day = client
-                .query(
-                    r#"
-                    SELECT TO_CHAR(DATE_TRUNC('day', usage_log.created_at), 'YYYY-MM-DD'),
-                           COUNT(*)::bigint,
-                           COALESCE(SUM(usage_log.total_cost), 0)::bigint
-                    FROM organization_service_usage_log AS usage_log
-                    INNER JOIN services ON services.id = usage_log.service_id
-                    WHERE usage_log.organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR usage_log.created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR usage_log.created_at <= $3)
-                      AND ($4::UUID IS NULL OR usage_log.workspace_id = $4)
-                      AND ($5::UUID IS NULL OR usage_log.api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR services.service_name = $6)
-                    GROUP BY DATE_TRUNC('day', usage_log.created_at)
-                    ORDER BY 1 ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.service_name,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            Ok::<_, RepositoryError>(ServiceUsageSummary {
-                totals: ServiceUsageTotals {
-                    usage_count: totals.get(0),
-                    total_cost_nano_usd: totals.get(1),
-                },
-                by_workspace: by_workspace.iter().map(workspace_from_row).collect(),
-                by_api_key: by_api_key.iter().map(api_key_from_row).collect(),
-                by_service: by_service.iter().map(service_from_row).collect(),
-                by_day: by_day.iter().map(day_from_row).collect(),
-            })
-        })?;
-
-        Ok(summary)
+    let mut summary = ServiceUsageSummary::default();
+    for row in &rows {
+        let dimension: String = value(row, "dimension")?;
+        let usage_count = value(row, "usage_count")?;
+        let total_cost_nano_usd = value(row, "total_cost")?;
+        match dimension.as_str() {
+            "totals" => {
+                summary.totals = ServiceUsageTotals {
+                    usage_count,
+                    total_cost_nano_usd,
+                };
+            }
+            "workspace" => summary.by_workspace.push(ServiceWorkspaceSummary {
+                workspace_id: required_uuid(row, "workspace_id")?,
+                usage_count,
+                total_cost_nano_usd,
+            }),
+            "api_key" => summary.by_api_key.push(ServiceApiKeySummary {
+                api_key_id: required_uuid(row, "api_key_id")?,
+                usage_count,
+                total_cost_nano_usd,
+            }),
+            "service" => summary.by_service.push(ServiceNameSummary {
+                service_name: required_string(row, "service_name")?,
+                usage_count,
+                quantity: value(row, "quantity")?,
+                total_cost_nano_usd,
+            }),
+            "day" => summary.by_day.push(ServiceDaySummary {
+                day: required_string(row, "day")?,
+                usage_count,
+                total_cost_nano_usd,
+            }),
+            other => {
+                return Err(RepositoryError::DataConversionError(anyhow::anyhow!(
+                    "unknown service summary dimension: {other}"
+                )));
+            }
+        }
     }
+
+    summary.by_workspace.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+    });
+    summary.by_api_key.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.api_key_id.cmp(&right.api_key_id))
+    });
+    summary.by_service.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.service_name.cmp(&right.service_name))
+    });
+    summary
+        .by_day
+        .sort_by(|left, right| left.day.cmp(&right.day));
+    Ok(summary)
 }
 
-#[async_trait::async_trait]
-impl ServiceUsageSummaryRepository for OrganizationServiceUsageRepository {
-    async fn summarize_service_usage(
-        &self,
-        filters: &ReportingUsageSummaryFilters,
-    ) -> Result<ServiceUsageSummary> {
-        self.summarize_service_usage_report(filters).await
-    }
+fn value<T>(row: &Row, column: &str) -> Result<T, RepositoryError>
+where
+    T: tokio_postgres::types::FromSqlOwned,
+{
+    row.try_get(column)
+        .map_err(|error| RepositoryError::DataConversionError(error.into()))
 }
 
-fn workspace_from_row(row: &Row) -> ServiceWorkspaceSummary {
-    ServiceWorkspaceSummary {
-        workspace_id: row.get(0),
-        usage_count: row.get(1),
-        total_cost_nano_usd: row.get(2),
-    }
+fn required_uuid(row: &Row, column: &str) -> Result<Uuid, RepositoryError> {
+    value::<Option<Uuid>>(row, column)?
+        .ok_or_else(|| RepositoryError::DataConversionError(anyhow::anyhow!("missing {column}")))
 }
 
-fn api_key_from_row(row: &Row) -> ServiceApiKeySummary {
-    ServiceApiKeySummary {
-        api_key_id: row.get(0),
-        usage_count: row.get(1),
-        total_cost_nano_usd: row.get(2),
-    }
-}
-
-fn service_from_row(row: &Row) -> ServiceNameSummary {
-    ServiceNameSummary {
-        service_name: row.get(0),
-        usage_count: row.get(1),
-        quantity: row.get(2),
-        total_cost_nano_usd: row.get(3),
-    }
-}
-
-fn day_from_row(row: &Row) -> ServiceDaySummary {
-    ServiceDaySummary {
-        day: row.get(0),
-        usage_count: row.get(1),
-        total_cost_nano_usd: row.get(2),
-    }
+fn required_string(row: &Row, column: &str) -> Result<String, RepositoryError> {
+    value::<Option<String>>(row, column)?
+        .ok_or_else(|| RepositoryError::DataConversionError(anyhow::anyhow!("missing {column}")))
 }

--- a/crates/database/src/repositories/organization_usage.rs
+++ b/crates/database/src/repositories/organization_usage.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct OrganizationUsageRepository {
-    pool: DbPool,
+    pub(crate) pool: DbPool,
 }
 
 impl OrganizationUsageRepository {

--- a/crates/database/src/repositories/organization_usage.rs
+++ b/crates/database/src/repositories/organization_usage.rs
@@ -10,17 +10,30 @@ use chrono::Utc;
 use services::common::RepositoryError;
 use services::responses::models::ResponseId;
 use std::collections::HashMap;
+use std::time::Duration;
 use tokio_postgres::Row;
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct OrganizationUsageRepository {
     pub(crate) pool: DbPool,
+    pub(crate) reporting_statement_timeout: Duration,
 }
 
 impl OrganizationUsageRepository {
     pub fn new(pool: DbPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            reporting_statement_timeout:
+                crate::repositories::reporting_query::DEFAULT_REPORTING_STATEMENT_TIMEOUT,
+        }
+    }
+
+    pub fn with_reporting_statement_timeout(pool: DbPool, statement_timeout: Duration) -> Self {
+        Self {
+            pool,
+            reporting_statement_timeout: statement_timeout,
+        }
     }
 
     /// Get total spend for a specific API key

--- a/crates/database/src/repositories/organization_usage_reporting.rs
+++ b/crates/database/src/repositories/organization_usage_reporting.rs
@@ -18,23 +18,39 @@ impl OrganizationUsageRepository {
         let cursor_created_at = cursor.map(|value| value.created_at);
         let cursor_id = cursor.map(|value| value.id);
         let limit = i64::from(query.limit);
+        let deadline = crate::repositories::reporting_query::reporting_deadline(
+            self.reporting_statement_timeout,
+            query.deadline,
+        )?;
 
         let rows = retry_db!("list_inference_usage_report", {
-            let client = self
+            let mut client = self
                 .pool
                 .get()
                 .await
                 .context("Failed to get database connection")
                 .map_err(RepositoryError::PoolError)?;
 
-            client
+            let transaction = client
+                .build_transaction()
+                .read_only(true)
+                .start()
+                .await
+                .map_err(map_db_error)?;
+            crate::repositories::reporting_query::configure_reporting_transaction(
+                &transaction,
+                crate::repositories::reporting_query::remaining_statement_timeout(deadline)?,
+            )
+            .await?;
+            let rows = transaction
                 .query(
                     r#"
                     SELECT
                         id, organization_id, workspace_id, api_key_id, created_at,
                         model_name, inference_type, input_tokens, output_tokens,
                         cache_read_tokens, total_tokens, input_cost, output_cost,
-                        total_cost, response_id, inference_id, stop_reason, image_count
+                        total_cost, response_id, provider_request_id, inference_id,
+                        stop_reason, image_count
                     FROM organization_usage_log
                     WHERE organization_id = $1
                       AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
@@ -65,7 +81,9 @@ impl OrganizationUsageRepository {
                     ],
                 )
                 .await
-                .map_err(map_db_error)
+                .map_err(map_db_error)?;
+            transaction.commit().await.map_err(map_db_error)?;
+            Ok::<_, RepositoryError>(rows)
         })?;
 
         Ok(rows.iter().map(row_to_report).collect())
@@ -92,7 +110,8 @@ impl OrganizationUsageRepository {
                         id, organization_id, workspace_id, api_key_id, created_at,
                         model_name, inference_type, input_tokens, output_tokens,
                         cache_read_tokens, total_tokens, input_cost, output_cost,
-                        total_cost, response_id, inference_id, stop_reason, image_count
+                        total_cost, response_id, provider_request_id, inference_id,
+                        stop_reason, image_count
                     FROM organization_usage_log
                     WHERE organization_id = $1
                       AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
@@ -197,6 +216,7 @@ fn row_to_report(row: &Row) -> InferenceUsageReportRow {
         cache_read_cost_nano_usd: None,
         total_cost_nano_usd: row.get("total_cost"),
         response_id: row.get("response_id"),
+        provider_request_id: row.get("provider_request_id"),
         inference_id: row.get("inference_id"),
         stop_reason: row.get("stop_reason"),
         image_count: row.get("image_count"),

--- a/crates/database/src/repositories/organization_usage_reporting.rs
+++ b/crates/database/src/repositories/organization_usage_reporting.rs
@@ -1,0 +1,204 @@
+use crate::repositories::{utils::map_db_error, OrganizationUsageRepository};
+use crate::retry_db;
+use anyhow::{Context, Result};
+use services::common::RepositoryError;
+use services::usage::{
+    InferenceUsageHistoryQuery, InferenceUsageReportQuery, InferenceUsageReportRow,
+};
+use tokio_postgres::Row;
+
+impl OrganizationUsageRepository {
+    pub async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>> {
+        validate_query(&query)?;
+
+        let cursor = query.cursor;
+        let cursor_created_at = cursor.map(|value| value.created_at);
+        let cursor_id = cursor.map(|value| value.id);
+        let limit = i64::from(query.limit);
+
+        let rows = retry_db!("list_inference_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            client
+                .query(
+                    r#"
+                    SELECT
+                        id, organization_id, workspace_id, api_key_id, created_at,
+                        model_name, inference_type, input_tokens, output_tokens,
+                        cache_read_tokens, total_tokens, input_cost, output_cost,
+                        total_cost, response_id, inference_id, stop_reason, image_count
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                      AND (
+                          $8::TIMESTAMPTZ IS NULL
+                          OR created_at < $8
+                          OR (created_at = $8 AND id < $9::UUID)
+                      )
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT $10
+                    "#,
+                    &[
+                        &query.organization_id,
+                        &query.start_time,
+                        &query.end_time,
+                        &query.workspace_id,
+                        &query.api_key_id,
+                        &query.model,
+                        &query.inference_type,
+                        &cursor_created_at,
+                        &cursor_id,
+                        &limit,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)
+        })?;
+
+        Ok(rows.iter().map(row_to_report).collect())
+    }
+
+    pub async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64)> {
+        validate_history_query(&query)?;
+
+        let (rows, total) = retry_db!("list_inference_usage_history", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let rows = client
+                .query(
+                    r#"
+                    SELECT
+                        id, organization_id, workspace_id, api_key_id, created_at,
+                        model_name, inference_type, input_tokens, output_tokens,
+                        cache_read_tokens, total_tokens, input_cost, output_cost,
+                        total_cost, response_id, inference_id, stop_reason, image_count
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT $6 OFFSET $7
+                    "#,
+                    &[
+                        &query.organization_id,
+                        &query.start_time,
+                        &query.end_time,
+                        &query.workspace_id,
+                        &query.api_key_id,
+                        &query.limit,
+                        &query.offset,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let count = client
+                .query_one(
+                    r#"
+                    SELECT COUNT(*)::BIGINT AS count
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                    "#,
+                    &[
+                        &query.organization_id,
+                        &query.start_time,
+                        &query.end_time,
+                        &query.workspace_id,
+                        &query.api_key_id,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok::<(Vec<Row>, i64), RepositoryError>((rows, count.get("count")))
+        })?;
+
+        Ok((rows.iter().map(row_to_report).collect(), total))
+    }
+}
+
+fn validate_query(query: &InferenceUsageReportQuery) -> Result<()> {
+    if query.limit == 0 {
+        return Err(RepositoryError::ValidationFailed("limit must be positive".to_string()).into());
+    }
+    if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
+        if end < start {
+            return Err(RepositoryError::ValidationFailed(
+                "end_time must be greater than or equal to start_time".to_string(),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_history_query(query: &InferenceUsageHistoryQuery) -> Result<()> {
+    if query.limit <= 0 {
+        return Err(RepositoryError::ValidationFailed("limit must be positive".to_string()).into());
+    }
+    if query.offset < 0 {
+        return Err(
+            RepositoryError::ValidationFailed("offset must be non-negative".to_string()).into(),
+        );
+    }
+    if let (Some(start), Some(end)) = (query.start_time, query.end_time) {
+        if end < start {
+            return Err(RepositoryError::ValidationFailed(
+                "end_time must be greater than or equal to start_time".to_string(),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn row_to_report(row: &Row) -> InferenceUsageReportRow {
+    InferenceUsageReportRow {
+        id: row.get("id"),
+        organization_id: row.get("organization_id"),
+        workspace_id: row.get("workspace_id"),
+        api_key_id: row.get("api_key_id"),
+        created_at: row.get("created_at"),
+        model: row.get("model_name"),
+        inference_type: row.get("inference_type"),
+        input_tokens: i64::from(row.get::<_, i32>("input_tokens")),
+        output_tokens: i64::from(row.get::<_, i32>("output_tokens")),
+        cache_read_tokens: i64::from(row.get::<_, i32>("cache_read_tokens")),
+        total_tokens: i64::from(row.get::<_, i32>("total_tokens")),
+        input_cost_nano_usd: row.get("input_cost"),
+        output_cost_nano_usd: row.get("output_cost"),
+        cache_read_cost_nano_usd: None,
+        total_cost_nano_usd: row.get("total_cost"),
+        response_id: row.get("response_id"),
+        inference_id: row.get("inference_id"),
+        stop_reason: row.get("stop_reason"),
+        image_count: row.get("image_count"),
+    }
+}

--- a/crates/database/src/repositories/organization_usage_reporting_summary.rs
+++ b/crates/database/src/repositories/organization_usage_reporting_summary.rs
@@ -1,0 +1,255 @@
+use crate::repositories::{utils::map_db_error, OrganizationUsageRepository};
+use crate::retry_db;
+use anyhow::{Context, Result};
+use services::{
+    common::RepositoryError,
+    reporting_usage::{
+        InferenceApiKeySummary, InferenceDaySummary, InferenceModelSummary, InferenceUsageSummary,
+        InferenceUsageSummaryRepository, InferenceUsageTotals, InferenceWorkspaceSummary,
+        ReportingUsageSummaryFilters,
+    },
+};
+use tokio_postgres::Row;
+
+impl OrganizationUsageRepository {
+    pub async fn summarize_inference_usage_report(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<InferenceUsageSummary> {
+        let summary = retry_db!("summarize_inference_usage_report", {
+            let client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+
+            let totals = client
+                .query_one(
+                    r#"
+                    SELECT COUNT(*)::bigint,
+                           COALESCE(SUM(input_tokens), 0)::bigint,
+                           COALESCE(SUM(output_tokens), 0)::bigint,
+                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
+                           COALESCE(SUM(total_tokens), 0)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_workspace = client
+                .query(
+                    r#"
+                    SELECT workspace_id, COUNT(*)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY workspace_id
+                    ORDER BY 3 DESC, workspace_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_api_key = client
+                .query(
+                    r#"
+                    SELECT api_key_id, COUNT(*)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY api_key_id
+                    ORDER BY 3 DESC, api_key_id ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_model = client
+                .query(
+                    r#"
+                    SELECT model_name, COUNT(*)::bigint,
+                           COALESCE(SUM(input_tokens), 0)::bigint,
+                           COALESCE(SUM(output_tokens), 0)::bigint,
+                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
+                           COALESCE(SUM(total_tokens), 0)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY model_name
+                    ORDER BY 7 DESC, model_name ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            let by_day = client
+                .query(
+                    r#"
+                    SELECT TO_CHAR(DATE_TRUNC('day', created_at), 'YYYY-MM-DD'),
+                           COUNT(*)::bigint,
+                           COALESCE(SUM(input_tokens), 0)::bigint,
+                           COALESCE(SUM(output_tokens), 0)::bigint,
+                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
+                           COALESCE(SUM(total_tokens), 0)::bigint,
+                           COALESCE(SUM(total_cost), 0)::bigint
+                    FROM organization_usage_log
+                    WHERE organization_id = $1
+                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                      AND ($4::UUID IS NULL OR workspace_id = $4)
+                      AND ($5::UUID IS NULL OR api_key_id = $5)
+                      AND ($6::TEXT IS NULL OR model_name = $6)
+                      AND ($7::TEXT IS NULL OR inference_type = $7)
+                    GROUP BY DATE_TRUNC('day', created_at)
+                    ORDER BY 1 ASC
+                    "#,
+                    &[
+                        &filters.organization_id,
+                        &filters.start_time,
+                        &filters.end_time,
+                        &filters.workspace_id,
+                        &filters.api_key_id,
+                        &filters.model,
+                        &filters.inference_type,
+                    ],
+                )
+                .await
+                .map_err(map_db_error)?;
+
+            Ok::<_, RepositoryError>(InferenceUsageSummary {
+                totals: totals_from_row(&totals),
+                by_workspace: by_workspace.iter().map(workspace_from_row).collect(),
+                by_api_key: by_api_key.iter().map(api_key_from_row).collect(),
+                by_model: by_model.iter().map(model_from_row).collect(),
+                by_day: by_day.iter().map(day_from_row).collect(),
+            })
+        })?;
+
+        Ok(summary)
+    }
+}
+
+#[async_trait::async_trait]
+impl InferenceUsageSummaryRepository for OrganizationUsageRepository {
+    async fn summarize_inference_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<InferenceUsageSummary> {
+        self.summarize_inference_usage_report(filters).await
+    }
+}
+
+fn totals_from_row(row: &Row) -> InferenceUsageTotals {
+    InferenceUsageTotals {
+        request_count: row.get(0),
+        input_tokens: row.get(1),
+        output_tokens: row.get(2),
+        cache_read_tokens: row.get(3),
+        total_tokens: row.get(4),
+        total_cost_nano_usd: row.get(5),
+    }
+}
+
+fn workspace_from_row(row: &Row) -> InferenceWorkspaceSummary {
+    InferenceWorkspaceSummary {
+        workspace_id: row.get(0),
+        request_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn api_key_from_row(row: &Row) -> InferenceApiKeySummary {
+    InferenceApiKeySummary {
+        api_key_id: row.get(0),
+        request_count: row.get(1),
+        total_cost_nano_usd: row.get(2),
+    }
+}
+
+fn model_from_row(row: &Row) -> InferenceModelSummary {
+    InferenceModelSummary {
+        model: row.get(0),
+        request_count: row.get(1),
+        input_tokens: row.get(2),
+        output_tokens: row.get(3),
+        cache_read_tokens: row.get(4),
+        total_tokens: row.get(5),
+        total_cost_nano_usd: row.get(6),
+    }
+}
+
+fn day_from_row(row: &Row) -> InferenceDaySummary {
+    InferenceDaySummary {
+        day: row.get(0),
+        request_count: row.get(1),
+        input_tokens: row.get(2),
+        output_tokens: row.get(3),
+        cache_read_tokens: row.get(4),
+        total_tokens: row.get(5),
+        total_cost_nano_usd: row.get(6),
+    }
+}

--- a/crates/database/src/repositories/organization_usage_reporting_summary.rs
+++ b/crates/database/src/repositories/organization_usage_reporting_summary.rs
@@ -1,255 +1,164 @@
-use crate::repositories::{utils::map_db_error, OrganizationUsageRepository};
-use crate::retry_db;
-use anyhow::{Context, Result};
+use crate::repositories::utils::map_db_error;
 use services::{
     common::RepositoryError,
     reporting_usage::{
         InferenceApiKeySummary, InferenceDaySummary, InferenceModelSummary, InferenceUsageSummary,
-        InferenceUsageSummaryRepository, InferenceUsageTotals, InferenceWorkspaceSummary,
-        ReportingUsageSummaryFilters,
+        InferenceUsageTotals, InferenceWorkspaceSummary, ReportingUsageSummaryFilters,
     },
 };
-use tokio_postgres::Row;
+use tokio_postgres::{GenericClient, Row};
+use uuid::Uuid;
 
-impl OrganizationUsageRepository {
-    pub async fn summarize_inference_usage_report(
-        &self,
-        filters: &ReportingUsageSummaryFilters,
-    ) -> Result<InferenceUsageSummary> {
-        let summary = retry_db!("summarize_inference_usage_report", {
-            let client = self
-                .pool
-                .get()
-                .await
-                .context("Failed to get database connection")
-                .map_err(RepositoryError::PoolError)?;
+pub(super) async fn summarize_inference_usage<C>(
+    client: &C,
+    filters: &ReportingUsageSummaryFilters,
+) -> Result<InferenceUsageSummary, RepositoryError>
+where
+    C: GenericClient + Sync,
+{
+    let rows = client
+        .query(
+            r#"
+            WITH filtered AS MATERIALIZED (
+                SELECT workspace_id, api_key_id, model_name,
+                       DATE_TRUNC('day', created_at) AS day,
+                       input_tokens, output_tokens, cache_read_tokens,
+                       total_tokens, total_cost
+                FROM organization_usage_log
+                WHERE organization_id = $1
+                  AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
+                  AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
+                  AND ($4::UUID IS NULL OR workspace_id = $4)
+                  AND ($5::UUID IS NULL OR api_key_id = $5)
+                  AND ($6::TEXT IS NULL OR model_name = $6)
+                  AND ($7::TEXT IS NULL OR inference_type = $7)
+            )
+            SELECT
+                CASE
+                    WHEN GROUPING(workspace_id) = 0 THEN 'workspace'
+                    WHEN GROUPING(api_key_id) = 0 THEN 'api_key'
+                    WHEN GROUPING(model_name) = 0 THEN 'model'
+                    WHEN GROUPING(day) = 0 THEN 'day'
+                    ELSE 'totals'
+                END AS dimension,
+                workspace_id,
+                api_key_id,
+                model_name,
+                TO_CHAR(day, 'YYYY-MM-DD') AS day,
+                COUNT(*)::BIGINT AS request_count,
+                COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
+                COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens,
+                COALESCE(SUM(cache_read_tokens), 0)::BIGINT AS cache_read_tokens,
+                COALESCE(SUM(total_tokens), 0)::BIGINT AS total_tokens,
+                COALESCE(SUM(total_cost), 0)::BIGINT AS total_cost
+            FROM filtered
+            GROUP BY GROUPING SETS (
+                (), (workspace_id), (api_key_id), (model_name), (day)
+            )
+            "#,
+            &[
+                &filters.organization_id,
+                &filters.start_time,
+                &filters.end_time,
+                &filters.workspace_id,
+                &filters.api_key_id,
+                &filters.model,
+                &filters.inference_type,
+            ],
+        )
+        .await
+        .map_err(map_db_error)?;
 
-            let totals = client
-                .query_one(
-                    r#"
-                    SELECT COUNT(*)::bigint,
-                           COALESCE(SUM(input_tokens), 0)::bigint,
-                           COALESCE(SUM(output_tokens), 0)::bigint,
-                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
-                           COALESCE(SUM(total_tokens), 0)::bigint,
-                           COALESCE(SUM(total_cost), 0)::bigint
-                    FROM organization_usage_log
-                    WHERE organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
-                      AND ($4::UUID IS NULL OR workspace_id = $4)
-                      AND ($5::UUID IS NULL OR api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR model_name = $6)
-                      AND ($7::TEXT IS NULL OR inference_type = $7)
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.model,
-                        &filters.inference_type,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_workspace = client
-                .query(
-                    r#"
-                    SELECT workspace_id, COUNT(*)::bigint,
-                           COALESCE(SUM(total_cost), 0)::bigint
-                    FROM organization_usage_log
-                    WHERE organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
-                      AND ($4::UUID IS NULL OR workspace_id = $4)
-                      AND ($5::UUID IS NULL OR api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR model_name = $6)
-                      AND ($7::TEXT IS NULL OR inference_type = $7)
-                    GROUP BY workspace_id
-                    ORDER BY 3 DESC, workspace_id ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.model,
-                        &filters.inference_type,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_api_key = client
-                .query(
-                    r#"
-                    SELECT api_key_id, COUNT(*)::bigint,
-                           COALESCE(SUM(total_cost), 0)::bigint
-                    FROM organization_usage_log
-                    WHERE organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
-                      AND ($4::UUID IS NULL OR workspace_id = $4)
-                      AND ($5::UUID IS NULL OR api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR model_name = $6)
-                      AND ($7::TEXT IS NULL OR inference_type = $7)
-                    GROUP BY api_key_id
-                    ORDER BY 3 DESC, api_key_id ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.model,
-                        &filters.inference_type,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_model = client
-                .query(
-                    r#"
-                    SELECT model_name, COUNT(*)::bigint,
-                           COALESCE(SUM(input_tokens), 0)::bigint,
-                           COALESCE(SUM(output_tokens), 0)::bigint,
-                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
-                           COALESCE(SUM(total_tokens), 0)::bigint,
-                           COALESCE(SUM(total_cost), 0)::bigint
-                    FROM organization_usage_log
-                    WHERE organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
-                      AND ($4::UUID IS NULL OR workspace_id = $4)
-                      AND ($5::UUID IS NULL OR api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR model_name = $6)
-                      AND ($7::TEXT IS NULL OR inference_type = $7)
-                    GROUP BY model_name
-                    ORDER BY 7 DESC, model_name ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.model,
-                        &filters.inference_type,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            let by_day = client
-                .query(
-                    r#"
-                    SELECT TO_CHAR(DATE_TRUNC('day', created_at), 'YYYY-MM-DD'),
-                           COUNT(*)::bigint,
-                           COALESCE(SUM(input_tokens), 0)::bigint,
-                           COALESCE(SUM(output_tokens), 0)::bigint,
-                           COALESCE(SUM(cache_read_tokens), 0)::bigint,
-                           COALESCE(SUM(total_tokens), 0)::bigint,
-                           COALESCE(SUM(total_cost), 0)::bigint
-                    FROM organization_usage_log
-                    WHERE organization_id = $1
-                      AND ($2::TIMESTAMPTZ IS NULL OR created_at >= $2)
-                      AND ($3::TIMESTAMPTZ IS NULL OR created_at <= $3)
-                      AND ($4::UUID IS NULL OR workspace_id = $4)
-                      AND ($5::UUID IS NULL OR api_key_id = $5)
-                      AND ($6::TEXT IS NULL OR model_name = $6)
-                      AND ($7::TEXT IS NULL OR inference_type = $7)
-                    GROUP BY DATE_TRUNC('day', created_at)
-                    ORDER BY 1 ASC
-                    "#,
-                    &[
-                        &filters.organization_id,
-                        &filters.start_time,
-                        &filters.end_time,
-                        &filters.workspace_id,
-                        &filters.api_key_id,
-                        &filters.model,
-                        &filters.inference_type,
-                    ],
-                )
-                .await
-                .map_err(map_db_error)?;
-
-            Ok::<_, RepositoryError>(InferenceUsageSummary {
-                totals: totals_from_row(&totals),
-                by_workspace: by_workspace.iter().map(workspace_from_row).collect(),
-                by_api_key: by_api_key.iter().map(api_key_from_row).collect(),
-                by_model: by_model.iter().map(model_from_row).collect(),
-                by_day: by_day.iter().map(day_from_row).collect(),
-            })
-        })?;
-
-        Ok(summary)
+    let mut summary = InferenceUsageSummary::default();
+    for row in &rows {
+        let dimension: String = value(row, "dimension")?;
+        let request_count = value(row, "request_count")?;
+        let total_cost_nano_usd = value(row, "total_cost")?;
+        match dimension.as_str() {
+            "totals" => {
+                summary.totals = InferenceUsageTotals {
+                    request_count,
+                    input_tokens: value(row, "input_tokens")?,
+                    output_tokens: value(row, "output_tokens")?,
+                    cache_read_tokens: value(row, "cache_read_tokens")?,
+                    total_tokens: value(row, "total_tokens")?,
+                    total_cost_nano_usd,
+                };
+            }
+            "workspace" => summary.by_workspace.push(InferenceWorkspaceSummary {
+                workspace_id: required_uuid(row, "workspace_id")?,
+                request_count,
+                total_cost_nano_usd,
+            }),
+            "api_key" => summary.by_api_key.push(InferenceApiKeySummary {
+                api_key_id: required_uuid(row, "api_key_id")?,
+                request_count,
+                total_cost_nano_usd,
+            }),
+            "model" => summary.by_model.push(InferenceModelSummary {
+                model: required_string(row, "model_name")?,
+                request_count,
+                input_tokens: value(row, "input_tokens")?,
+                output_tokens: value(row, "output_tokens")?,
+                cache_read_tokens: value(row, "cache_read_tokens")?,
+                total_tokens: value(row, "total_tokens")?,
+                total_cost_nano_usd,
+            }),
+            "day" => summary.by_day.push(InferenceDaySummary {
+                day: required_string(row, "day")?,
+                request_count,
+                input_tokens: value(row, "input_tokens")?,
+                output_tokens: value(row, "output_tokens")?,
+                cache_read_tokens: value(row, "cache_read_tokens")?,
+                total_tokens: value(row, "total_tokens")?,
+                total_cost_nano_usd,
+            }),
+            other => {
+                return Err(RepositoryError::DataConversionError(anyhow::anyhow!(
+                    "unknown inference summary dimension: {other}"
+                )));
+            }
+        }
     }
+
+    summary.by_workspace.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.workspace_id.cmp(&right.workspace_id))
+    });
+    summary.by_api_key.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.api_key_id.cmp(&right.api_key_id))
+    });
+    summary.by_model.sort_by(|left, right| {
+        right
+            .total_cost_nano_usd
+            .cmp(&left.total_cost_nano_usd)
+            .then_with(|| left.model.cmp(&right.model))
+    });
+    summary
+        .by_day
+        .sort_by(|left, right| left.day.cmp(&right.day));
+    Ok(summary)
 }
 
-#[async_trait::async_trait]
-impl InferenceUsageSummaryRepository for OrganizationUsageRepository {
-    async fn summarize_inference_usage(
-        &self,
-        filters: &ReportingUsageSummaryFilters,
-    ) -> Result<InferenceUsageSummary> {
-        self.summarize_inference_usage_report(filters).await
-    }
+fn value<T>(row: &Row, column: &str) -> Result<T, RepositoryError>
+where
+    T: tokio_postgres::types::FromSqlOwned,
+{
+    row.try_get(column)
+        .map_err(|error| RepositoryError::DataConversionError(error.into()))
 }
 
-fn totals_from_row(row: &Row) -> InferenceUsageTotals {
-    InferenceUsageTotals {
-        request_count: row.get(0),
-        input_tokens: row.get(1),
-        output_tokens: row.get(2),
-        cache_read_tokens: row.get(3),
-        total_tokens: row.get(4),
-        total_cost_nano_usd: row.get(5),
-    }
+fn required_uuid(row: &Row, column: &str) -> Result<Uuid, RepositoryError> {
+    value::<Option<Uuid>>(row, column)?
+        .ok_or_else(|| RepositoryError::DataConversionError(anyhow::anyhow!("missing {column}")))
 }
 
-fn workspace_from_row(row: &Row) -> InferenceWorkspaceSummary {
-    InferenceWorkspaceSummary {
-        workspace_id: row.get(0),
-        request_count: row.get(1),
-        total_cost_nano_usd: row.get(2),
-    }
-}
-
-fn api_key_from_row(row: &Row) -> InferenceApiKeySummary {
-    InferenceApiKeySummary {
-        api_key_id: row.get(0),
-        request_count: row.get(1),
-        total_cost_nano_usd: row.get(2),
-    }
-}
-
-fn model_from_row(row: &Row) -> InferenceModelSummary {
-    InferenceModelSummary {
-        model: row.get(0),
-        request_count: row.get(1),
-        input_tokens: row.get(2),
-        output_tokens: row.get(3),
-        cache_read_tokens: row.get(4),
-        total_tokens: row.get(5),
-        total_cost_nano_usd: row.get(6),
-    }
-}
-
-fn day_from_row(row: &Row) -> InferenceDaySummary {
-    InferenceDaySummary {
-        day: row.get(0),
-        request_count: row.get(1),
-        input_tokens: row.get(2),
-        output_tokens: row.get(3),
-        cache_read_tokens: row.get(4),
-        total_tokens: row.get(5),
-        total_cost_nano_usd: row.get(6),
-    }
+fn required_string(row: &Row, column: &str) -> Result<String, RepositoryError> {
+    value::<Option<String>>(row, column)?
+        .ok_or_else(|| RepositoryError::DataConversionError(anyhow::anyhow!("missing {column}")))
 }

--- a/crates/database/src/repositories/reporting_query.rs
+++ b/crates/database/src/repositories/reporting_query.rs
@@ -1,0 +1,74 @@
+use super::utils::map_db_error;
+use services::common::RepositoryError;
+use std::time::{Duration, Instant};
+use tokio_postgres::Transaction;
+
+pub const DEFAULT_REPORTING_STATEMENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn reporting_deadline(
+    maximum_duration: Duration,
+    request_deadline: Option<Instant>,
+) -> Result<Instant, RepositoryError> {
+    let local_deadline = Instant::now()
+        .checked_add(maximum_duration)
+        .ok_or(RepositoryError::QueryTimeout)?;
+    Ok(request_deadline
+        .map(|deadline| deadline.min(local_deadline))
+        .unwrap_or(local_deadline))
+}
+
+pub fn remaining_statement_timeout(deadline: Instant) -> Result<Duration, RepositoryError> {
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .filter(|duration| !duration.is_zero())
+        .ok_or(RepositoryError::QueryTimeout)?;
+    let cancellation_headroom = (remaining / 10).min(Duration::from_millis(50));
+    let statement_timeout = remaining.saturating_sub(cancellation_headroom);
+    if statement_timeout.is_zero() {
+        Err(RepositoryError::QueryTimeout)
+    } else {
+        Ok(statement_timeout)
+    }
+}
+
+pub async fn configure_reporting_transaction(
+    transaction: &Transaction<'_>,
+    statement_timeout: Duration,
+) -> Result<(), RepositoryError> {
+    let timeout_millis = statement_timeout.as_millis().max(1);
+    let timeout = format!("{timeout_millis}ms");
+    transaction
+        .query_one(
+            "SELECT set_config('statement_timeout', $1, true), set_config('timezone', 'UTC', true)",
+            &[&timeout],
+        )
+        .await
+        .map_err(map_db_error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_deadline_caps_repository_budget() {
+        let request_deadline = Instant::now() + Duration::from_millis(200);
+        let deadline = reporting_deadline(Duration::from_secs(10), Some(request_deadline)).unwrap();
+
+        assert_eq!(deadline, request_deadline);
+        let remaining = remaining_statement_timeout(deadline).unwrap();
+        assert!(remaining < Duration::from_millis(200));
+        assert!(remaining > Duration::from_millis(100));
+    }
+
+    #[test]
+    fn expired_deadline_fails_before_query_execution() {
+        let deadline = Instant::now() - Duration::from_millis(1);
+
+        assert!(matches!(
+            remaining_statement_timeout(deadline),
+            Err(RepositoryError::QueryTimeout)
+        ));
+    }
+}

--- a/crates/database/src/repositories/reporting_usage_summary.rs
+++ b/crates/database/src/repositories/reporting_usage_summary.rs
@@ -1,0 +1,95 @@
+use super::{
+    organization_service_usage_reporting_summary::summarize_service_usage,
+    organization_usage_reporting_summary::summarize_inference_usage, utils::map_db_error,
+};
+use crate::{pool::DbPool, retry_db};
+use anyhow::{Context, Result};
+use services::{
+    common::RepositoryError,
+    reporting_usage::{
+        ReportingUsageSummary, ReportingUsageSummaryFilters, ReportingUsageSummaryRepository,
+        ReportingUsageSummarySource,
+    },
+};
+use std::time::Duration;
+use tokio_postgres::IsolationLevel;
+
+pub struct PostgresReportingUsageSummaryRepository {
+    pool: DbPool,
+    statement_timeout: Duration,
+}
+
+impl PostgresReportingUsageSummaryRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self {
+            pool,
+            statement_timeout: super::reporting_query::DEFAULT_REPORTING_STATEMENT_TIMEOUT,
+        }
+    }
+
+    pub fn with_statement_timeout(pool: DbPool, statement_timeout: Duration) -> Self {
+        Self {
+            pool,
+            statement_timeout,
+        }
+    }
+
+    async fn summarize_report(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<ReportingUsageSummary> {
+        let deadline =
+            super::reporting_query::reporting_deadline(self.statement_timeout, filters.deadline)?;
+        let summary = retry_db!("summarize_reporting_usage", {
+            let mut client = self
+                .pool
+                .get()
+                .await
+                .context("Failed to get database connection")
+                .map_err(RepositoryError::PoolError)?;
+            let transaction = client
+                .build_transaction()
+                .isolation_level(IsolationLevel::RepeatableRead)
+                .read_only(true)
+                .start()
+                .await
+                .map_err(map_db_error)?;
+            let inference = match filters.source {
+                ReportingUsageSummarySource::All | ReportingUsageSummarySource::Inference => {
+                    super::reporting_query::configure_reporting_transaction(
+                        &transaction,
+                        super::reporting_query::remaining_statement_timeout(deadline)?,
+                    )
+                    .await?;
+                    summarize_inference_usage(&*transaction, filters).await?
+                }
+                ReportingUsageSummarySource::Service => Default::default(),
+            };
+            let service = match filters.source {
+                ReportingUsageSummarySource::All | ReportingUsageSummarySource::Service => {
+                    super::reporting_query::configure_reporting_transaction(
+                        &transaction,
+                        super::reporting_query::remaining_statement_timeout(deadline)?,
+                    )
+                    .await?;
+                    summarize_service_usage(&*transaction, filters).await?
+                }
+                ReportingUsageSummarySource::Inference => Default::default(),
+            };
+
+            transaction.commit().await.map_err(map_db_error)?;
+            Ok::<_, RepositoryError>(ReportingUsageSummary { inference, service })
+        })?;
+        Ok(summary)
+    }
+}
+
+#[async_trait::async_trait]
+impl ReportingUsageSummaryRepository for PostgresReportingUsageSummaryRepository {
+    async fn summarize_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<ReportingUsageSummary> {
+        self.summarize_report(filters).await
+    }
+}

--- a/crates/database/src/repositories/service_usage_repository_impl.rs
+++ b/crates/database/src/repositories/service_usage_repository_impl.rs
@@ -4,7 +4,8 @@ use crate::repositories::{
 };
 use async_trait::async_trait;
 use services::service_usage::ports::{
-    RecordServiceUsageParams, ServiceUsageLogEntry, ServiceUsageRepositoryTrait,
+    RecordServiceUsageParams, ServiceUsageLogEntry, ServiceUsageReportEntry,
+    ServiceUsageReportFilters, ServiceUsageRepositoryTrait,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -93,5 +94,12 @@ impl ServiceUsageRepositoryTrait for ServiceUsageRepositoryImpl {
             .collect();
 
         Ok((entries, total))
+    }
+
+    async fn list_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> anyhow::Result<Vec<ServiceUsageReportEntry>> {
+        self.usage_repo.list_reporting_usage(filters).await
     }
 }

--- a/crates/database/src/repositories/usage_repository_impl.rs
+++ b/crates/database/src/repositories/usage_repository_impl.rs
@@ -2,7 +2,8 @@ use crate::models::RecordUsageRequest;
 use crate::repositories::OrganizationUsageRepository;
 use chrono::{DateTime, Utc};
 use services::usage::ports::{
-    InferenceCost, OrganizationBalanceInfo, UsageByModelEntry, UsageLogEntry,
+    InferenceCost, InferenceUsageHistoryQuery, InferenceUsageReportQuery, InferenceUsageReportRow,
+    OrganizationBalanceInfo, UsageByModelEntry, UsageLogEntry,
 };
 use uuid::Uuid;
 
@@ -243,5 +244,19 @@ impl services::usage::ports::UsageRepository for OrganizationUsageRepository {
                 request_count: r.request_count,
             })
             .collect())
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> anyhow::Result<Vec<InferenceUsageReportRow>> {
+        self.list_inference_usage_report(query).await
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> anyhow::Result<(Vec<InferenceUsageReportRow>, i64)> {
+        self.list_inference_usage_history(query).await
     }
 }

--- a/crates/database/src/repositories/utils.rs
+++ b/crates/database/src/repositories/utils.rs
@@ -39,6 +39,8 @@ pub fn map_db_error(err: tokio_postgres::Error) -> RepositoryError {
                 RepositoryError::ConnectionFailed(message.to_string())
             }
 
+            &SqlState::QUERY_CANCELED => RepositoryError::QueryTimeout,
+
             // Default case - wrap in generic database error
             _ => RepositoryError::DatabaseError(anyhow::anyhow!(
                 "Database error ({}): {}",

--- a/crates/database/src/usage_reporting_indexes.rs
+++ b/crates/database/src/usage_reporting_indexes.rs
@@ -1,0 +1,117 @@
+use crate::DbPool;
+use anyhow::{bail, Context, Result};
+
+const REQUIRED_USAGE_REPORTING_INDEXES: [(&str, &str); 6] = [
+    (
+        "idx_org_usage_reporting_org_created_id",
+        "organization_usage_log",
+    ),
+    (
+        "idx_org_usage_reporting_org_workspace_created_id",
+        "organization_usage_log",
+    ),
+    (
+        "idx_org_usage_reporting_org_api_key_created_id",
+        "organization_usage_log",
+    ),
+    (
+        "idx_org_service_usage_reporting_org_created_id",
+        "organization_service_usage_log",
+    ),
+    (
+        "idx_org_service_usage_reporting_org_workspace_created_id",
+        "organization_service_usage_log",
+    ),
+    (
+        "idx_org_service_usage_reporting_org_api_key_created_id",
+        "organization_service_usage_log",
+    ),
+];
+
+pub async fn ensure_usage_reporting_indexes(pool: &DbPool) -> Result<()> {
+    let client = pool
+        .get()
+        .await
+        .context("Failed to get database connection for reporting index check")?;
+    let required_names: Vec<&str> = REQUIRED_USAGE_REPORTING_INDEXES
+        .iter()
+        .map(|(index_name, _)| *index_name)
+        .collect();
+    let required_tables: Vec<&str> = REQUIRED_USAGE_REPORTING_INDEXES
+        .iter()
+        .map(|(_, table_name)| *table_name)
+        .collect();
+    let rows = client
+        .query(
+            r#"
+            WITH required AS (
+                SELECT *
+                FROM UNNEST($1::TEXT[], $2::TEXT[]) AS item(index_name, table_name)
+            )
+            SELECT required.index_name
+            FROM required
+            LEFT JOIN pg_namespace AS namespace
+              ON namespace.nspname = current_schema()
+            LEFT JOIN pg_class AS table_class
+              ON table_class.relnamespace = namespace.oid
+             AND table_class.relname = required.table_name
+             AND table_class.relkind IN ('r', 'p')
+            LEFT JOIN pg_class AS index_class
+              ON index_class.relnamespace = namespace.oid
+             AND index_class.relname = required.index_name
+             AND index_class.relkind = 'i'
+            LEFT JOIN pg_index
+              ON pg_index.indexrelid = index_class.oid
+             AND pg_index.indrelid = table_class.oid
+            WHERE index_class.oid IS NULL
+               OR pg_index.indexrelid IS NULL
+               OR NOT pg_index.indisvalid
+               OR NOT pg_index.indisready
+            ORDER BY required.index_name
+            "#,
+            &[&required_names, &required_tables],
+        )
+        .await
+        .context("Failed to verify usage reporting indexes")?;
+    let missing: Vec<String> = rows.into_iter().map(|row| row.get(0)).collect();
+    if !missing.is_empty() {
+        bail!(
+            "usage reporting cannot be enabled; missing, invalid, or unready indexes: {}",
+            missing.join(", ")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn reporting_index_prerequisites_cover_both_usage_tables() {
+        assert_eq!(REQUIRED_USAGE_REPORTING_INDEXES.len(), 6);
+        assert_eq!(
+            REQUIRED_USAGE_REPORTING_INDEXES
+                .iter()
+                .map(|(index_name, _)| *index_name)
+                .collect::<HashSet<_>>()
+                .len(),
+            6
+        );
+        assert_eq!(
+            REQUIRED_USAGE_REPORTING_INDEXES
+                .iter()
+                .filter(|(_, table)| *table == "organization_usage_log")
+                .count(),
+            3
+        );
+        assert_eq!(
+            REQUIRED_USAGE_REPORTING_INDEXES
+                .iter()
+                .filter(|(_, table)| *table == "organization_service_usage_log")
+                .count(),
+            3
+        );
+    }
+}

--- a/crates/database/tests/organization_reporting_token.rs
+++ b/crates/database/tests/organization_reporting_token.rs
@@ -1,0 +1,196 @@
+use chrono::{Duration, Utc};
+use database::{migrations, DbPool};
+use deadpool::Runtime;
+use deadpool_postgres::Config;
+use services::common::REPORTING_TOKEN_PREFIX;
+use services::reporting_tokens::ports::{
+    CreateOrganizationReportingTokenRequest, OrganizationReportingTokenRepository as _,
+    REPORTING_TOKEN_SCOPE_USAGE_READ,
+};
+use tokio::sync::OnceCell;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+static MIGRATED: OnceCell<()> = OnceCell::const_new();
+
+fn pool_config() -> Config {
+    let mut config = Config::new();
+    config.host = Some(std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string()));
+    config.port = Some(
+        std::env::var("PGPORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())
+            .unwrap_or(5432),
+    );
+    config.dbname =
+        Some(std::env::var("PGDATABASE").unwrap_or_else(|_| "platform_api".to_string()));
+    config.user = Some(std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string()));
+    config.password = Some(std::env::var("PGPASSWORD").unwrap_or_else(|_| "postgres".to_string()));
+    config
+}
+
+async fn test_pool() -> anyhow::Result<DbPool> {
+    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    MIGRATED
+        .get_or_try_init(|| async { migrations::run(&pool).await })
+        .await?;
+    Ok(pool)
+}
+
+async fn insert_org_and_user(pool: &DbPool) -> anyhow::Result<(Uuid, Uuid)> {
+    let client = pool.get().await?;
+    let org_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let suffix = Uuid::new_v4().simple().to_string();
+    let now = Utc::now();
+
+    client
+        .execute(
+            r#"
+            INSERT INTO users (
+                id, email, username, display_name, avatar_url, created_at, updated_at,
+                last_login_at, is_active, auth_provider, provider_user_id
+            )
+            VALUES ($1, $2, $3, NULL, NULL, $4, $4, NULL, true, 'test', $5)
+            "#,
+            &[
+                &user_id,
+                &format!("reporting-{suffix}@example.test"),
+                &format!("reporting-{suffix}"),
+                &now,
+                &format!("provider-{suffix}"),
+            ],
+        )
+        .await?;
+
+    client
+        .execute(
+            r#"
+            INSERT INTO organizations (id, name, description, created_at, updated_at, is_active)
+            VALUES ($1, $2, NULL, $3, $3, true)
+            "#,
+            &[&org_id, &format!("reporting-org-{suffix}"), &now],
+        )
+        .await?;
+
+    Ok((org_id, user_id))
+}
+
+#[tokio::test]
+async fn organization_reporting_token_create_validate_active() -> anyhow::Result<()> {
+    // Given: an organization and creator exist.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+    let expires_at = Utc::now() + Duration::days(1);
+
+    // When: a reporting token is created and then validated by its raw secret.
+    let created = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "warehouse sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: Some(expires_at),
+        })
+        .await?;
+    let validated = repository.validate(&created.raw_token).await?;
+
+    // Then: the raw token is returned once, only its hash/prefix is persisted, and validation
+    // returns org-scoped usage-read context without exposing a raw token or hash.
+    assert!(created.raw_token.starts_with(REPORTING_TOKEN_PREFIX));
+    assert!(created
+        .token
+        .token_prefix
+        .starts_with(REPORTING_TOKEN_PREFIX));
+    assert_ne!(created.token.token_prefix, created.raw_token);
+    assert_eq!(created.token.scope, REPORTING_TOKEN_SCOPE_USAGE_READ);
+
+    let row = pool
+        .get()
+        .await?
+        .query_one(
+            r#"
+            SELECT token_hash, token_prefix
+            FROM organization_reporting_tokens
+            WHERE id = $1
+            "#,
+            &[&created.token.id],
+        )
+        .await?;
+    let token_hash: String = row.get("token_hash");
+    let token_prefix: String = row.get("token_prefix");
+    assert_ne!(token_hash, created.raw_token);
+    assert_eq!(token_prefix, created.token.token_prefix);
+
+    let validated = validated.expect("active reporting token should validate");
+    assert_eq!(validated.id, created.token.id);
+    assert_eq!(validated.organization_id, organization_id);
+    assert_eq!(validated.token_prefix, created.token.token_prefix);
+    assert_eq!(validated.scope, REPORTING_TOKEN_SCOPE_USAGE_READ);
+    assert!(validated.last_used_at.is_some());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_reporting_token_rejects_revoked_and_expired() -> anyhow::Result<()> {
+    // Given: one expired reporting token and one active reporting token.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+
+    let expired = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "expired sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: Some(Utc::now() - Duration::minutes(1)),
+        })
+        .await?;
+    let revoked = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "revoked sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: Some(Utc::now() + Duration::days(1)),
+        })
+        .await?;
+
+    // When: the active token is revoked and both secrets are validated.
+    assert!(repository.revoke(revoked.token.id, user_id).await?);
+
+    // Then: expired and revoked reporting tokens are rejected.
+    assert!(repository.validate(&expired.raw_token).await?.is_none());
+    assert!(repository.validate(&revoked.raw_token).await?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_reporting_token_rejects_malformed_inputs_and_empty_name() -> anyhow::Result<()>
+{
+    // Given: an organization and creator exist.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+
+    // When: malformed token material and an empty token name are submitted.
+    let malformed = repository.validate("sk-not-a-reporting-token").await?;
+    let empty_name = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "   ".to_string(),
+            created_by_user_id: user_id,
+            expires_at: None,
+        })
+        .await;
+
+    // Then: malformed tokens do not validate and empty names fail validation.
+    assert!(malformed.is_none());
+    assert!(empty_name.is_err());
+
+    Ok(())
+}

--- a/crates/database/tests/organization_reporting_token.rs
+++ b/crates/database/tests/organization_reporting_token.rs
@@ -194,3 +194,124 @@ async fn organization_reporting_token_rejects_malformed_inputs_and_empty_name() 
 
     Ok(())
 }
+
+#[tokio::test]
+async fn organization_reporting_token_validation_preserves_recent_last_used_at(
+) -> anyhow::Result<()> {
+    // Given: an active token whose audit timestamp was refreshed less than 15 minutes ago.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+    let created = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "recent sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: None,
+        })
+        .await?;
+    let client = pool.get().await?;
+    client
+        .execute(
+            r#"
+            UPDATE organization_reporting_tokens
+            SET last_used_at = NOW() - INTERVAL '5 minutes'
+            WHERE id = $1
+            "#,
+            &[&created.token.id],
+        )
+        .await?;
+    let row_before = client
+        .query_one(
+            r#"
+            SELECT last_used_at, xmin::text::bigint AS row_version
+            FROM organization_reporting_tokens
+            WHERE id = $1
+            "#,
+            &[&created.token.id],
+        )
+        .await?;
+    let persisted_before: chrono::DateTime<Utc> = row_before.get("last_used_at");
+    let row_version_before: i64 = row_before.get("row_version");
+
+    // When: the token is validated again inside the debounce interval.
+    let validated = repository
+        .validate(&created.raw_token)
+        .await?
+        .expect("active token should validate");
+
+    // Then: validation returns the token without issuing another audit-timestamp write.
+    let row_after = client
+        .query_one(
+            r#"
+            SELECT last_used_at, xmin::text::bigint AS row_version
+            FROM organization_reporting_tokens
+            WHERE id = $1
+            "#,
+            &[&created.token.id],
+        )
+        .await?;
+    let persisted_after: chrono::DateTime<Utc> = row_after.get("last_used_at");
+    let row_version_after: i64 = row_after.get("row_version");
+    assert_eq!(validated.last_used_at, Some(persisted_before));
+    assert_eq!(persisted_after, persisted_before);
+    assert_eq!(row_version_after, row_version_before);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_reporting_token_validation_refreshes_stale_last_used_at() -> anyhow::Result<()>
+{
+    // Given: an active token whose audit timestamp is older than 15 minutes.
+    let pool = test_pool().await?;
+    let repository =
+        database::repositories::OrganizationReportingTokenRepository::new(pool.clone());
+    let (organization_id, user_id) = insert_org_and_user(&pool).await?;
+    let created = repository
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id,
+            name: "stale sync".to_string(),
+            created_by_user_id: user_id,
+            expires_at: None,
+        })
+        .await?;
+    let client = pool.get().await?;
+    client
+        .execute(
+            r#"
+            UPDATE organization_reporting_tokens
+            SET last_used_at = NOW() - INTERVAL '16 minutes'
+            WHERE id = $1
+            "#,
+            &[&created.token.id],
+        )
+        .await?;
+    let persisted_before: chrono::DateTime<Utc> = client
+        .query_one(
+            "SELECT last_used_at FROM organization_reporting_tokens WHERE id = $1",
+            &[&created.token.id],
+        )
+        .await?
+        .get("last_used_at");
+
+    // When: the stale token is validated.
+    let validated = repository
+        .validate(&created.raw_token)
+        .await?
+        .expect("active token should validate");
+
+    // Then: its audit timestamp is refreshed and returned.
+    let persisted_after: chrono::DateTime<Utc> = client
+        .query_one(
+            "SELECT last_used_at FROM organization_reporting_tokens WHERE id = $1",
+            &[&created.token.id],
+        )
+        .await?
+        .get("last_used_at");
+    assert_eq!(validated.last_used_at, Some(persisted_after));
+    assert!(persisted_after > persisted_before);
+
+    Ok(())
+}

--- a/crates/database/tests/organization_service_usage_reporting.rs
+++ b/crates/database/tests/organization_service_usage_reporting.rs
@@ -1,0 +1,145 @@
+use services::service_usage::ports::{ServiceUsageReportCursor, ServiceUsageReportFilters};
+use uuid::Uuid;
+
+#[path = "support/service_usage_reporting_pool.rs"]
+mod service_usage_reporting_pool;
+#[path = "support/service_usage_reporting_rows.rs"]
+mod service_usage_reporting_rows;
+#[path = "support/service_usage_reporting_support.rs"]
+mod service_usage_reporting_support;
+
+use service_usage_reporting_support::{seed_usage_fixture, test_pool, ts};
+
+#[tokio::test]
+async fn organization_service_usage_reporting_filters_and_cursor() -> anyhow::Result<()> {
+    // Given: service usage rows for multiple services, workspaces, API keys, and timestamps.
+    let pool = test_pool().await?;
+    let fixture = seed_usage_fixture(&pool).await?;
+    let repository = database::repositories::OrganizationServiceUsageRepository::new(pool);
+
+    // When: the reporting query is narrowed to one service/workspace/API-key/date window.
+    let filtered = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some(fixture.web_search_name.clone()),
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            start_time: Some(ts("2026-07-02T00:00:00Z")),
+            end_time: Some(ts("2026-07-02T00:00:00Z")),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+
+    // Then: only rows matching every reporting filter are returned in stable tuple order.
+    let ids: Vec<Uuid> = filtered.iter().map(|row| row.id).collect();
+    assert_eq!(
+        ids,
+        vec![fixture.same_time_high_id, fixture.same_time_low_id]
+    );
+    assert!(filtered
+        .iter()
+        .all(|row| row.service_id == fixture.web_search_id));
+    assert!(filtered
+        .iter()
+        .all(|row| row.workspace_id == fixture.workspace_id));
+    assert!(filtered
+        .iter()
+        .all(|row| row.api_key_id == fixture.api_key_id));
+    assert!(filtered
+        .iter()
+        .all(|row| row.service_name == fixture.web_search_name.as_str()));
+
+    let first_page = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some(fixture.web_search_name.clone()),
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            limit: 2,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+    let cursor_row = first_page
+        .last()
+        .expect("first reporting page should contain cursor row");
+    let second_page = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some(fixture.web_search_name.clone()),
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            cursor: Some(ServiceUsageReportCursor {
+                created_at: cursor_row.created_at,
+                id: cursor_row.id,
+            }),
+            limit: 2,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+    let second_page_ids: Vec<Uuid> = second_page.iter().map(|row| row.id).collect();
+    assert_eq!(
+        second_page_ids,
+        vec![fixture.same_time_low_id, fixture.older_id]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_service_usage_reporting_excludes_other_orgs() -> anyhow::Result<()> {
+    // Given: another organization has a matching service usage row.
+    let pool = test_pool().await?;
+    let fixture = seed_usage_fixture(&pool).await?;
+    let repository = database::repositories::OrganizationServiceUsageRepository::new(pool);
+
+    // When: reporting usage is requested for the other organization with this org's filters.
+    let rows = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.other_org_id,
+            workspace_id: Some(fixture.workspace_id),
+            api_key_id: Some(fixture.api_key_id),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+
+    // Then: no cross-organization rows are returned.
+    assert!(rows.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_service_usage_reporting_rejects_invalid_range_and_unknown_service_is_empty(
+) -> anyhow::Result<()> {
+    // Given: service usage exists for one organization.
+    let pool = test_pool().await?;
+    let fixture = seed_usage_fixture(&pool).await?;
+    let repository = database::repositories::OrganizationServiceUsageRepository::new(pool);
+
+    // When: an invalid date range and an unknown service name are queried.
+    let invalid_range = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            start_time: Some(ts("2026-07-04T00:00:00Z")),
+            end_time: Some(ts("2026-07-03T00:00:00Z")),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await;
+    let unknown_service = repository
+        .list_reporting_usage(&ServiceUsageReportFilters {
+            organization_id: fixture.org_id,
+            service_name: Some("unknown_service".to_string()),
+            limit: 10,
+            ..ServiceUsageReportFilters::default()
+        })
+        .await?;
+
+    // Then: invalid ranges fail closed and unknown service names do not leak other data.
+    assert!(invalid_range.is_err());
+    assert!(unknown_service.is_empty());
+
+    Ok(())
+}

--- a/crates/database/tests/organization_usage_reporting.rs
+++ b/crates/database/tests/organization_usage_reporting.rs
@@ -115,6 +115,7 @@ async fn organization_usage_reporting_filters_and_cursor() -> anyhow::Result<()>
             inference_type: Some("chat_completion".to_string()),
             limit: 1,
             cursor: None,
+            deadline: None,
         })
         .await?;
 
@@ -148,6 +149,7 @@ async fn organization_usage_reporting_filters_and_cursor() -> anyhow::Result<()>
                 created_at: first_page[0].created_at,
                 id: first_page[0].id,
             }),
+            deadline: None,
         })
         .await?;
 

--- a/crates/database/tests/organization_usage_reporting.rs
+++ b/crates/database/tests/organization_usage_reporting.rs
@@ -1,0 +1,268 @@
+mod support;
+
+use database::repositories::OrganizationUsageRepository;
+use services::usage::ports::{InferenceUsageReportCursor, InferenceUsageReportQuery};
+use support::{
+    cleanup_usage_fixtures, insert_model, insert_org_fixture, insert_usage, test_pool, ts,
+    UsageSeed,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn organization_usage_reporting_filters_and_cursor() -> anyhow::Result<()> {
+    // Given: two org-scoped rows sharing a timestamp plus rows excluded by filters.
+    let pool = test_pool().await?;
+    let repository = OrganizationUsageRepository::new(pool.clone());
+    let org = insert_org_fixture(&pool).await?;
+    let other_org = insert_org_fixture(&pool).await?;
+    let model = insert_model(&pool, "report-model-a").await?;
+    let other_model = insert_model(&pool, "report-model-b").await?;
+    let model_id = model.id;
+    let other_model_id = other_model.id;
+    let response_id = Uuid::new_v4();
+    let shared_time = ts(2026, 1, 2, 0);
+    let mut tied_ids = [Uuid::new_v4(), Uuid::new_v4()];
+    tied_ids.sort();
+    let second_id = tied_ids[0];
+    let first_id = tied_ids[1];
+
+    for seed in [
+        UsageSeed {
+            id: first_id,
+            org_id: org.org_id,
+            workspace_id: org.workspace_a_id,
+            api_key_id: org.api_key_a_id,
+            model: model.clone(),
+            created_at: shared_time,
+            inference_type: "chat_completion",
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_tokens: 2,
+            input_cost: 100,
+            output_cost: 200,
+            total_cost: 300,
+            response_id: Some(response_id),
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-secret-first",
+        },
+        UsageSeed {
+            id: second_id,
+            org_id: org.org_id,
+            workspace_id: org.workspace_a_id,
+            api_key_id: org.api_key_a_id,
+            model: model.clone(),
+            created_at: shared_time,
+            inference_type: "chat_completion",
+            input_tokens: 11,
+            output_tokens: 6,
+            cache_read_tokens: 3,
+            input_cost: 110,
+            output_cost: 220,
+            total_cost: 330,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-secret-second",
+        },
+        UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: org.org_id,
+            workspace_id: org.workspace_b_id,
+            api_key_id: org.api_key_b_id,
+            model: other_model,
+            created_at: shared_time,
+            inference_type: "embedding",
+            input_tokens: 9,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            input_cost: 90,
+            output_cost: 0,
+            total_cost: 90,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-filtered",
+        },
+        UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: other_org.org_id,
+            workspace_id: other_org.workspace_a_id,
+            api_key_id: other_org.api_key_a_id,
+            model: model.clone(),
+            created_at: shared_time,
+            inference_type: "chat_completion",
+            input_tokens: 99,
+            output_tokens: 99,
+            cache_read_tokens: 0,
+            input_cost: 990,
+            output_cost: 990,
+            total_cost: 1980,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-other-org",
+        },
+    ] {
+        insert_usage(&pool, &seed).await?;
+    }
+
+    // When: a filtered report is fetched with a one-row keyset page.
+    let first_page = repository
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            organization_id: org.org_id,
+            start_time: Some(ts(2026, 1, 1, 0)),
+            end_time: Some(ts(2026, 1, 3, 0)),
+            workspace_id: Some(org.workspace_a_id),
+            api_key_id: Some(org.api_key_a_id),
+            model: Some(model.name.clone()),
+            inference_type: Some("chat_completion".to_string()),
+            limit: 1,
+            cursor: None,
+        })
+        .await?;
+
+    // Then: ordering uses created_at DESC, id DESC and exposes reporting-safe fields only.
+    assert_eq!(first_page.len(), 1);
+    assert_eq!(first_page[0].id, first_id);
+    assert_eq!(first_page[0].response_id, Some(response_id));
+    assert_eq!(first_page[0].input_tokens, 10);
+    assert_eq!(first_page[0].output_tokens, 5);
+    assert_eq!(first_page[0].cache_read_tokens, 2);
+    assert_eq!(first_page[0].total_tokens, 15);
+    assert_eq!(first_page[0].input_cost_nano_usd, 100);
+    assert_eq!(first_page[0].output_cost_nano_usd, 200);
+    assert_eq!(first_page[0].total_cost_nano_usd, 300);
+    let first_page_json = serde_json::to_string(&first_page)?;
+    assert!(!first_page_json.contains("provider_request_id"));
+    println!("first_page_json={first_page_json}");
+
+    // When: the next page starts after the first row's cursor tuple.
+    let second_page = repository
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            organization_id: org.org_id,
+            start_time: Some(ts(2026, 1, 1, 0)),
+            end_time: Some(ts(2026, 1, 3, 0)),
+            workspace_id: Some(org.workspace_a_id),
+            api_key_id: Some(org.api_key_a_id),
+            model: Some(model.name.clone()),
+            inference_type: Some("chat_completion".to_string()),
+            limit: 1,
+            cursor: Some(InferenceUsageReportCursor {
+                created_at: first_page[0].created_at,
+                id: first_page[0].id,
+            }),
+        })
+        .await?;
+
+    // Then: cursor continuation returns the tied row with the lower id.
+    assert_eq!(second_page.len(), 1);
+    assert_eq!(second_page[0].id, second_id);
+    assert_eq!(second_page[0].organization_id, org.org_id);
+    assert_eq!(second_page[0].workspace_id, org.workspace_a_id);
+    assert_eq!(second_page[0].api_key_id, org.api_key_a_id);
+    println!(
+        "cursor_continuation={} -> {}",
+        first_page[0].id, second_page[0].id
+    );
+    cleanup_usage_fixtures(
+        &pool,
+        &[org.org_id, other_org.org_id],
+        &[model_id, other_model_id],
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_usage_reporting_excludes_other_orgs() -> anyhow::Result<()> {
+    // Given: one row in each of two organizations.
+    let pool = test_pool().await?;
+    let repository = OrganizationUsageRepository::new(pool.clone());
+    let org = insert_org_fixture(&pool).await?;
+    let other_org = insert_org_fixture(&pool).await?;
+    let model = insert_model(&pool, "report-isolation-model").await?;
+    let model_id = model.id;
+    insert_usage(
+        &pool,
+        &UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: org.org_id,
+            workspace_id: org.workspace_a_id,
+            api_key_id: org.api_key_a_id,
+            model: model.clone(),
+            created_at: ts(2026, 2, 1, 0),
+            inference_type: "chat_completion",
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_tokens: 0,
+            input_cost: 10,
+            output_cost: 20,
+            total_cost: 30,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-owned",
+        },
+    )
+    .await?;
+    insert_usage(
+        &pool,
+        &UsageSeed {
+            id: Uuid::new_v4(),
+            org_id: other_org.org_id,
+            workspace_id: other_org.workspace_a_id,
+            api_key_id: other_org.api_key_a_id,
+            model,
+            created_at: ts(2026, 2, 1, 1),
+            inference_type: "chat_completion",
+            input_tokens: 2,
+            output_tokens: 2,
+            cache_read_tokens: 0,
+            input_cost: 20,
+            output_cost: 40,
+            total_cost: 60,
+            response_id: None,
+            inference_id: Uuid::new_v4(),
+            provider_request_id: "provider-other",
+        },
+    )
+    .await?;
+
+    // When: the first organization fetches reporting rows, including impossible filters.
+    let rows = repository
+        .list_inference_usage_report(InferenceUsageReportQuery::for_organization(org.org_id))
+        .await?;
+    let bad_workspace_rows = repository
+        .list_inference_usage_report(InferenceUsageReportQuery {
+            workspace_id: Some(other_org.workspace_a_id),
+            ..InferenceUsageReportQuery::for_organization(org.org_id)
+        })
+        .await?;
+
+    // Then: only rows belonging to the requested organization are returned.
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].organization_id, org.org_id);
+    assert!(bad_workspace_rows.is_empty());
+    println!("org_rows_json={}", serde_json::to_string(&rows)?);
+    println!("bad_workspace_rows={}", bad_workspace_rows.len());
+    cleanup_usage_fixtures(&pool, &[org.org_id, other_org.org_id], &[model_id]).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn organization_usage_reporting_rejects_invalid_date_range() -> anyhow::Result<()> {
+    // Given: a repository query with end_time before start_time.
+    let pool = test_pool().await?;
+    let repository = OrganizationUsageRepository::new(pool);
+    let query = InferenceUsageReportQuery {
+        start_time: Some(ts(2026, 3, 2, 0)),
+        end_time: Some(ts(2026, 3, 1, 0)),
+        ..InferenceUsageReportQuery::for_organization(Uuid::new_v4())
+    };
+
+    // When: the malformed range is submitted.
+    let result = repository.list_inference_usage_report(query).await;
+
+    // Then: repository validation rejects it before SQL execution.
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/crates/database/tests/support/mod.rs
+++ b/crates/database/tests/support/mod.rs
@@ -1,0 +1,238 @@
+use chrono::{DateTime, TimeZone, Utc};
+use database::{migrations, DbPool};
+use deadpool::Runtime;
+use deadpool_postgres::Config;
+use tokio::sync::OnceCell;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+static MIGRATED: OnceCell<()> = OnceCell::const_new();
+
+pub struct OrgFixture {
+    pub org_id: Uuid,
+    pub workspace_a_id: Uuid,
+    pub workspace_b_id: Uuid,
+    pub api_key_a_id: Uuid,
+    pub api_key_b_id: Uuid,
+}
+
+#[derive(Clone)]
+pub struct ModelFixture {
+    pub id: Uuid,
+    pub name: String,
+}
+
+pub struct UsageSeed {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub model: ModelFixture,
+    pub created_at: DateTime<Utc>,
+    pub inference_type: &'static str,
+    pub input_tokens: i32,
+    pub output_tokens: i32,
+    pub cache_read_tokens: i32,
+    pub input_cost: i64,
+    pub output_cost: i64,
+    pub total_cost: i64,
+    pub response_id: Option<Uuid>,
+    pub inference_id: Uuid,
+    pub provider_request_id: &'static str,
+}
+
+pub fn ts(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, hour, 0, 0).unwrap()
+}
+
+pub async fn test_pool() -> anyhow::Result<DbPool> {
+    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    MIGRATED
+        .get_or_try_init(|| async { migrations::run(&pool).await })
+        .await?;
+    Ok(pool)
+}
+
+pub async fn insert_org_fixture(pool: &DbPool) -> anyhow::Result<OrgFixture> {
+    let client = pool.get().await?;
+    let org_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let workspace_a_id = Uuid::new_v4();
+    let workspace_b_id = Uuid::new_v4();
+    let api_key_a_id = Uuid::new_v4();
+    let api_key_b_id = Uuid::new_v4();
+    let suffix = org_id.simple().to_string();
+    let now = Utc::now();
+
+    client
+        .execute(
+            "INSERT INTO users (id, email, username, created_at, updated_at, is_active, auth_provider, provider_user_id)
+             VALUES ($1, $2, $3, $4, $4, true, 'test', $5)",
+            &[
+                &user_id,
+                &format!("usage-report-{suffix}@example.test"),
+                &format!("usage-report-{suffix}"),
+                &now,
+                &format!("provider-{suffix}"),
+            ],
+        )
+        .await?;
+    client
+        .execute(
+            "INSERT INTO organizations (id, name, description, created_at, updated_at, is_active)
+             VALUES ($1, $2, NULL, $3, $3, true)",
+            &[&org_id, &format!("usage-report-org-{suffix}"), &now],
+        )
+        .await?;
+
+    for (workspace_id, name) in [
+        (workspace_a_id, "usage-report-a"),
+        (workspace_b_id, "usage-report-b"),
+    ] {
+        client
+            .execute(
+                "INSERT INTO workspaces (id, name, description, organization_id, created_by_user_id, created_at, updated_at, is_active, settings)
+                 VALUES ($1, $2, NULL, $3, $4, $5, $5, true, '{}'::jsonb)",
+                &[
+                    &workspace_id,
+                    &format!("{name}-{suffix}"),
+                    &org_id,
+                    &user_id,
+                    &now,
+                ],
+            )
+            .await?;
+    }
+
+    for (api_key_id, workspace_id, name) in [
+        (api_key_a_id, workspace_a_id, "usage-report-key-a"),
+        (api_key_b_id, workspace_b_id, "usage-report-key-b"),
+    ] {
+        client
+            .execute(
+                "INSERT INTO api_keys (id, key_hash, name, workspace_id, created_by_user_id, created_at, is_active, key_prefix)
+                 VALUES ($1, $2, $3, $4, $5, $6, true, $7)",
+                &[
+                    &api_key_id,
+                    &format!("hash-{api_key_id}"),
+                    &format!("{name}-{suffix}"),
+                    &workspace_id,
+                    &user_id,
+                    &now,
+                    &format!("sk-{}", &suffix[..8]),
+                ],
+            )
+            .await?;
+    }
+
+    Ok(OrgFixture {
+        org_id,
+        workspace_a_id,
+        workspace_b_id,
+        api_key_a_id,
+        api_key_b_id,
+    })
+}
+
+pub async fn insert_model(pool: &DbPool, name: &str) -> anyhow::Result<ModelFixture> {
+    let client = pool.get().await?;
+    let id = Uuid::new_v4();
+    let now = Utc::now();
+    client
+        .execute(
+            "INSERT INTO models (id, model_name, model_display_name, model_description, input_cost_per_token, output_cost_per_token, context_length, verifiable, is_active, created_at, updated_at)
+             VALUES ($1, $2, $2, 'reporting test model', 10, 20, 4096, true, true, $3, $3)",
+            &[&id, &format!("{name}-{id}"), &now],
+        )
+        .await?;
+    let row = client
+        .query_one("SELECT model_name FROM models WHERE id = $1", &[&id])
+        .await?;
+    Ok(ModelFixture {
+        id,
+        name: row.get("model_name"),
+    })
+}
+
+pub async fn insert_usage(pool: &DbPool, seed: &UsageSeed) -> anyhow::Result<()> {
+    let client = pool.get().await?;
+    if let Some(response_id) = seed.response_id {
+        client
+            .execute(
+                "INSERT INTO responses (id, model, status, instructions, conversation_id, previous_response_id, usage, metadata, created_at, updated_at, workspace_id, api_key_id)
+                 VALUES ($1, $2, 'completed', NULL, NULL, NULL, '{}'::jsonb, '{}'::jsonb, $3, $3, $4, $5)",
+                &[
+                    &response_id,
+                    &seed.model.name,
+                    &seed.created_at,
+                    &seed.workspace_id,
+                    &seed.api_key_id,
+                ],
+            )
+            .await?;
+    }
+    client
+        .execute(
+            "INSERT INTO organization_usage_log (
+                id, organization_id, workspace_id, api_key_id, response_id, model_id, model_name,
+                input_tokens, output_tokens, cache_read_tokens, total_tokens,
+                input_cost, output_cost, total_cost, request_type, inference_type, created_at,
+                inference_id, provider_request_id, stop_reason
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULL, $15, $16, $17, $18, 'completed')",
+            &[
+                &seed.id,
+                &seed.org_id,
+                &seed.workspace_id,
+                &seed.api_key_id,
+                &seed.response_id,
+                &seed.model.id,
+                &seed.model.name,
+                &seed.input_tokens,
+                &seed.output_tokens,
+                &seed.cache_read_tokens,
+                &(seed.input_tokens + seed.output_tokens),
+                &seed.input_cost,
+                &seed.output_cost,
+                &seed.total_cost,
+                &seed.inference_type,
+                &seed.created_at,
+                &Some(seed.inference_id),
+                &Some(seed.provider_request_id),
+            ],
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn cleanup_usage_fixtures(
+    pool: &DbPool,
+    org_ids: &[Uuid],
+    model_ids: &[Uuid],
+) -> anyhow::Result<()> {
+    let client = pool.get().await?;
+    let org_ids = org_ids.to_vec();
+    let model_ids = model_ids.to_vec();
+    client
+        .execute("DELETE FROM organizations WHERE id = ANY($1)", &[&org_ids])
+        .await?;
+    client
+        .execute("DELETE FROM models WHERE id = ANY($1)", &[&model_ids])
+        .await?;
+    Ok(())
+}
+
+fn pool_config() -> Config {
+    let mut config = Config::new();
+    config.host = Some(std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string()));
+    config.port = Some(
+        std::env::var("PGPORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())
+            .unwrap_or(5432),
+    );
+    config.dbname =
+        Some(std::env::var("PGDATABASE").unwrap_or_else(|_| "platform_api".to_string()));
+    config.user = Some(std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string()));
+    config.password = Some(std::env::var("PGPASSWORD").unwrap_or_else(|_| "postgres".to_string()));
+    config
+}

--- a/crates/database/tests/support/service_usage_reporting_pool.rs
+++ b/crates/database/tests/support/service_usage_reporting_pool.rs
@@ -1,0 +1,31 @@
+use database::{migrations, DbPool};
+use deadpool::Runtime;
+use deadpool_postgres::Config;
+use tokio::sync::OnceCell;
+use tokio_postgres::NoTls;
+
+static MIGRATED: OnceCell<()> = OnceCell::const_new();
+
+pub async fn test_pool() -> anyhow::Result<DbPool> {
+    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    MIGRATED
+        .get_or_try_init(|| async { migrations::run(&pool).await })
+        .await?;
+    Ok(pool)
+}
+
+fn pool_config() -> Config {
+    let mut config = Config::new();
+    config.host = Some(std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string()));
+    config.port = Some(
+        std::env::var("PGPORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())
+            .unwrap_or(5432),
+    );
+    config.dbname =
+        Some(std::env::var("PGDATABASE").unwrap_or_else(|_| "platform_api".to_string()));
+    config.user = Some(std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string()));
+    config.password = Some(std::env::var("PGPASSWORD").unwrap_or_else(|_| "postgres".to_string()));
+    config
+}

--- a/crates/database/tests/support/service_usage_reporting_rows.rs
+++ b/crates/database/tests/support/service_usage_reporting_rows.rs
@@ -1,0 +1,138 @@
+use chrono::{DateTime, Utc};
+use database::DbPool;
+use uuid::Uuid;
+
+pub struct ServiceUsageRowIds {
+    pub latest_id: Uuid,
+    pub same_time_high_id: Uuid,
+    pub same_time_low_id: Uuid,
+    pub older_id: Uuid,
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub web_search_id: Uuid,
+    pub other_workspace_id: Uuid,
+    pub other_api_key_id: Uuid,
+    pub file_search_id: Uuid,
+    pub other_org_id: Uuid,
+    pub other_org_workspace_id: Uuid,
+    pub other_org_api_key_id: Uuid,
+}
+
+pub struct UsageRow {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub service_id: Uuid,
+    pub quantity: i32,
+    pub total_cost: i64,
+    pub created_at: DateTime<Utc>,
+}
+
+pub fn ts(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("fixture timestamp is valid RFC3339")
+        .with_timezone(&Utc)
+}
+
+pub fn service_usage_rows(ids: ServiceUsageRowIds) -> [UsageRow; 7] {
+    [
+        UsageRow {
+            id: ids.latest_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 1,
+            total_cost: 100,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+        UsageRow {
+            id: ids.same_time_high_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 2,
+            total_cost: 200,
+            created_at: ts("2026-07-02T00:00:00Z"),
+        },
+        UsageRow {
+            id: ids.same_time_low_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 3,
+            total_cost: 300,
+            created_at: ts("2026-07-02T00:00:00Z"),
+        },
+        UsageRow {
+            id: ids.older_id,
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 4,
+            total_cost: 400,
+            created_at: ts("2026-06-30T00:00:00Z"),
+        },
+        UsageRow {
+            id: Uuid::new_v4(),
+            org_id: ids.org_id,
+            workspace_id: ids.other_workspace_id,
+            api_key_id: ids.other_api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 5,
+            total_cost: 500,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+        UsageRow {
+            id: Uuid::new_v4(),
+            org_id: ids.org_id,
+            workspace_id: ids.workspace_id,
+            api_key_id: ids.api_key_id,
+            service_id: ids.file_search_id,
+            quantity: 6,
+            total_cost: 600,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+        UsageRow {
+            id: Uuid::new_v4(),
+            org_id: ids.other_org_id,
+            workspace_id: ids.other_org_workspace_id,
+            api_key_id: ids.other_org_api_key_id,
+            service_id: ids.web_search_id,
+            quantity: 7,
+            total_cost: 700,
+            created_at: ts("2026-07-03T00:00:00Z"),
+        },
+    ]
+}
+
+pub async fn insert_usage(pool: &DbPool, row: &UsageRow) -> anyhow::Result<()> {
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO organization_service_usage_log (
+                id, organization_id, workspace_id, api_key_id, service_id,
+                quantity, total_cost, inference_id, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, $8)
+            "#,
+            &[
+                &row.id,
+                &row.org_id,
+                &row.workspace_id,
+                &row.api_key_id,
+                &row.service_id,
+                &row.quantity,
+                &row.total_cost,
+                &row.created_at,
+            ],
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/database/tests/support/service_usage_reporting_support.rs
+++ b/crates/database/tests/support/service_usage_reporting_support.rs
@@ -1,0 +1,245 @@
+use chrono::Utc;
+use database::DbPool;
+use uuid::Uuid;
+
+pub use crate::service_usage_reporting_pool::test_pool;
+pub use crate::service_usage_reporting_rows::ts;
+use crate::service_usage_reporting_rows::{insert_usage, service_usage_rows, ServiceUsageRowIds};
+
+pub struct UsageFixture {
+    pub org_id: Uuid,
+    pub other_org_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub web_search_id: Uuid,
+    pub web_search_name: String,
+    pub same_time_high_id: Uuid,
+    pub same_time_low_id: Uuid,
+    pub older_id: Uuid,
+}
+
+struct WorkspaceSeed<'a> {
+    org_id: Uuid,
+    user_id: Uuid,
+    suffix: &'a str,
+}
+
+struct ApiKeySeed<'a> {
+    workspace_id: Uuid,
+    user_id: Uuid,
+    suffix: &'a str,
+}
+
+pub async fn seed_usage_fixture(pool: &DbPool) -> anyhow::Result<UsageFixture> {
+    let suffix = Uuid::new_v4().simple().to_string();
+    let user_id = insert_user(pool, &suffix).await?;
+    let org_id = insert_org(pool, &suffix).await?;
+    let other_org_id = insert_org(pool, &format!("{suffix}-other")).await?;
+    let workspace_id = insert_workspace(
+        pool,
+        WorkspaceSeed {
+            org_id,
+            user_id,
+            suffix: &suffix,
+        },
+    )
+    .await?;
+    let other_workspace_id = insert_workspace(
+        pool,
+        WorkspaceSeed {
+            org_id,
+            user_id,
+            suffix: &format!("{suffix}-ws"),
+        },
+    )
+    .await?;
+    let other_org_workspace_id = insert_workspace(
+        pool,
+        WorkspaceSeed {
+            org_id: other_org_id,
+            user_id,
+            suffix: &format!("{suffix}-other-ws"),
+        },
+    )
+    .await?;
+    let api_key_id = insert_api_key(
+        pool,
+        ApiKeySeed {
+            workspace_id,
+            user_id,
+            suffix: &suffix,
+        },
+    )
+    .await?;
+    let other_api_key_id = insert_api_key(
+        pool,
+        ApiKeySeed {
+            workspace_id: other_workspace_id,
+            user_id,
+            suffix: &format!("{suffix}-key"),
+        },
+    )
+    .await?;
+    let other_org_api_key_id = insert_api_key(
+        pool,
+        ApiKeySeed {
+            workspace_id: other_org_workspace_id,
+            user_id,
+            suffix: &format!("{suffix}-other-key"),
+        },
+    )
+    .await?;
+    let web_search_name = format!("web_search_{suffix}");
+    let web_search_id = insert_service(pool, &web_search_name).await?;
+    let file_search_id = insert_service(pool, &format!("file_search_{suffix}")).await?;
+    let latest_id = Uuid::new_v4();
+    let first_same_time_id = Uuid::new_v4();
+    let second_same_time_id = Uuid::new_v4();
+    let same_time_high_id = first_same_time_id.max(second_same_time_id);
+    let same_time_low_id = first_same_time_id.min(second_same_time_id);
+    let older_id = Uuid::new_v4();
+
+    for row in service_usage_rows(ServiceUsageRowIds {
+        latest_id,
+        same_time_high_id,
+        same_time_low_id,
+        older_id,
+        org_id,
+        workspace_id,
+        api_key_id,
+        web_search_id,
+        other_workspace_id,
+        other_api_key_id,
+        file_search_id,
+        other_org_id,
+        other_org_workspace_id,
+        other_org_api_key_id,
+    }) {
+        insert_usage(pool, &row).await?;
+    }
+
+    Ok(UsageFixture {
+        org_id,
+        other_org_id,
+        workspace_id,
+        api_key_id,
+        web_search_id,
+        web_search_name,
+        same_time_high_id,
+        same_time_low_id,
+        older_id,
+    })
+}
+
+async fn insert_user(pool: &DbPool, suffix: &str) -> anyhow::Result<Uuid> {
+    let user_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO users (
+                id, email, username, display_name, avatar_url, created_at, updated_at,
+                last_login_at, is_active, auth_provider, provider_user_id
+            )
+            VALUES ($1, $2, $3, NULL, NULL, $4, $4, NULL, true, 'test', $5)
+            "#,
+            &[
+                &user_id,
+                &format!("service-report-{suffix}@example.test"),
+                &format!("service-report-{suffix}"),
+                &now,
+                &format!("provider-{suffix}"),
+            ],
+        )
+        .await?;
+    Ok(user_id)
+}
+
+async fn insert_org(pool: &DbPool, suffix: &str) -> anyhow::Result<Uuid> {
+    let org_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO organizations (id, name, description, created_at, updated_at, is_active)
+            VALUES ($1, $2, NULL, $3, $3, true)
+            "#,
+            &[&org_id, &format!("service-report-org-{suffix}"), &now],
+        )
+        .await?;
+    Ok(org_id)
+}
+
+async fn insert_workspace(pool: &DbPool, seed: WorkspaceSeed<'_>) -> anyhow::Result<Uuid> {
+    let workspace_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO workspaces (
+                id, name, description, organization_id, created_by_user_id,
+                created_at, updated_at, is_active, settings
+            )
+            VALUES ($1, $2, NULL, $3, $4, $5, $5, true, '{}'::jsonb)
+            "#,
+            &[
+                &workspace_id,
+                &format!("service-report-workspace-{}", seed.suffix),
+                &seed.org_id,
+                &seed.user_id,
+                &now,
+            ],
+        )
+        .await?;
+    Ok(workspace_id)
+}
+
+async fn insert_api_key(pool: &DbPool, seed: ApiKeySeed<'_>) -> anyhow::Result<Uuid> {
+    let api_key_id = Uuid::new_v4();
+    let now = Utc::now();
+    let key_prefix = format!("sk-{}", &seed.suffix[..8]);
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO api_keys (
+                id, key_hash, key_prefix, name, workspace_id, created_by_user_id,
+                created_at, expires_at, last_used_at, is_active, deleted_at, spend_limit
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NULL, true, NULL, NULL)
+            "#,
+            &[
+                &api_key_id,
+                &format!("service-report-hash-{}", seed.suffix),
+                &key_prefix,
+                &format!("service-report-key-{}", seed.suffix),
+                &seed.workspace_id,
+                &seed.user_id,
+                &now,
+            ],
+        )
+        .await?;
+    Ok(api_key_id)
+}
+
+async fn insert_service(pool: &DbPool, service_name: &str) -> anyhow::Result<Uuid> {
+    let service_id = Uuid::new_v4();
+    let now = Utc::now();
+    pool.get()
+        .await?
+        .execute(
+            r#"
+            INSERT INTO services (
+                id, service_name, display_name, description, unit, cost_per_unit,
+                is_active, created_at, updated_at
+            )
+            VALUES ($1, $2, $3, NULL, 'request', 100, true, $4, $4)
+            "#,
+            &[&service_id, &service_name, &service_name, &now],
+        )
+        .await?;
+    Ok(service_id)
+}

--- a/crates/database/tests/usage_reporting_indexes.rs
+++ b/crates/database/tests/usage_reporting_indexes.rs
@@ -1,0 +1,90 @@
+use database::{ensure_usage_reporting_indexes, DbPool};
+use deadpool::Runtime;
+use deadpool_postgres::Config;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn pool_config() -> Config {
+    let mut config = Config::new();
+    config.host = Some(std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string()));
+    config.port = Some(
+        std::env::var("PGPORT")
+            .ok()
+            .and_then(|value| value.parse::<u16>().ok())
+            .unwrap_or(5432),
+    );
+    config.dbname =
+        Some(std::env::var("PGDATABASE").unwrap_or_else(|_| "platform_api".to_string()));
+    config.user = Some(std::env::var("PGUSER").unwrap_or_else(|_| "postgres".to_string()));
+    config.password = Some(std::env::var("PGPASSWORD").unwrap_or_else(|_| "postgres".to_string()));
+    config
+}
+
+fn create_pool(config: &Config) -> anyhow::Result<DbPool> {
+    Ok(config.create_pool(Some(Runtime::Tokio1), NoTls)?)
+}
+
+#[tokio::test]
+async fn usage_reporting_startup_check_requires_valid_indexes_on_expected_tables(
+) -> anyhow::Result<()> {
+    let admin_pool = create_pool(&pool_config())?;
+    let admin = admin_pool.get().await?;
+    let schema = format!("reporting_indexes_{}", Uuid::new_v4().simple());
+    admin
+        .batch_execute(
+            format!(
+                r#"
+                CREATE SCHEMA {schema};
+                CREATE TABLE {schema}.organization_usage_log (
+                    id UUID, organization_id UUID, workspace_id UUID,
+                    api_key_id UUID, created_at TIMESTAMPTZ
+                );
+                CREATE TABLE {schema}.organization_service_usage_log (
+                    id UUID, organization_id UUID, workspace_id UUID,
+                    api_key_id UUID, created_at TIMESTAMPTZ
+                );
+                "#
+            )
+            .as_str(),
+        )
+        .await?;
+
+    let mut scoped_config = pool_config();
+    scoped_config.options = Some(format!("-c search_path={schema}"));
+    let scoped_pool = create_pool(&scoped_config)?;
+    let missing = ensure_usage_reporting_indexes(&scoped_pool)
+        .await
+        .expect_err("tables without reporting indexes must fail the startup gate");
+    assert!(missing
+        .to_string()
+        .contains("idx_org_usage_reporting_org_created_id"));
+
+    admin
+        .batch_execute(
+            format!(
+                r#"
+                CREATE INDEX idx_org_usage_reporting_org_created_id
+                    ON {schema}.organization_usage_log (organization_id, created_at DESC, id DESC);
+                CREATE INDEX idx_org_usage_reporting_org_workspace_created_id
+                    ON {schema}.organization_usage_log (organization_id, workspace_id, created_at DESC, id DESC);
+                CREATE INDEX idx_org_usage_reporting_org_api_key_created_id
+                    ON {schema}.organization_usage_log (organization_id, api_key_id, created_at DESC, id DESC);
+                CREATE INDEX idx_org_service_usage_reporting_org_created_id
+                    ON {schema}.organization_service_usage_log (organization_id, created_at DESC, id DESC);
+                CREATE INDEX idx_org_service_usage_reporting_org_workspace_created_id
+                    ON {schema}.organization_service_usage_log (organization_id, workspace_id, created_at DESC, id DESC);
+                CREATE INDEX idx_org_service_usage_reporting_org_api_key_created_id
+                    ON {schema}.organization_service_usage_log (organization_id, api_key_id, created_at DESC, id DESC);
+                "#
+            )
+            .as_str(),
+        )
+        .await?;
+
+    ensure_usage_reporting_indexes(&scoped_pool).await?;
+    drop(scoped_pool);
+    admin
+        .batch_execute(format!("DROP SCHEMA {schema} CASCADE").as_str())
+        .await?;
+    Ok(())
+}

--- a/crates/services/src/attestation/ita/service_test_support.rs
+++ b/crates/services/src/attestation/ita/service_test_support.rs
@@ -21,7 +21,8 @@ use crate::{
     metrics::MetricsServiceTrait,
     models::{ModelWithPricing, ModelsRepository},
     usage::{
-        InferenceCost, OrganizationBalanceInfo, RecordUsageDbRequest, StopReason,
+        InferenceCost, InferenceUsageHistoryQuery, InferenceUsageReportQuery,
+        InferenceUsageReportRow, OrganizationBalanceInfo, RecordUsageDbRequest, StopReason,
         UsageByModelEntry, UsageLogEntry, UsageRepository,
     },
 };
@@ -382,5 +383,19 @@ impl UsageRepository for NoopUsageRepository {
         _start_date: chrono::DateTime<chrono::Utc>,
     ) -> anyhow::Result<Vec<UsageByModelEntry>> {
         Ok(Vec::new())
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        _query: InferenceUsageReportQuery,
+    ) -> anyhow::Result<Vec<InferenceUsageReportRow>> {
+        Ok(Vec::new())
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        _query: InferenceUsageHistoryQuery,
+    ) -> anyhow::Result<(Vec<InferenceUsageReportRow>, i64)> {
+        Ok((Vec::new(), 0))
     }
 }

--- a/crates/services/src/common.rs
+++ b/crates/services/src/common.rs
@@ -91,10 +91,19 @@ pub enum RepositoryError {
     ConnectionFailed(String),
     #[error("Database authentication failed")]
     AuthenticationFailed,
+    #[error("Database query timed out")]
+    QueryTimeout,
     #[error("Database connection pool error: {0}")]
     PoolError(#[source] anyhow::Error),
     #[error("Database operation error: {0}")]
     DatabaseError(#[source] anyhow::Error),
     #[error("Data conversion error: {0}")]
     DataConversionError(#[source] anyhow::Error),
+}
+
+pub fn is_query_timeout(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<RepositoryError>())
+        .any(|error| matches!(error, RepositoryError::QueryTimeout))
 }

--- a/crates/services/src/common.rs
+++ b/crates/services/src/common.rs
@@ -3,6 +3,8 @@ use uuid::Uuid;
 
 pub const API_KEY_PREFIX: &str = "sk-";
 pub const API_KEY_LENGTH: usize = 35;
+pub const REPORTING_TOKEN_PREFIX: &str = "rpt-";
+pub const REPORTING_TOKEN_LENGTH: usize = 36;
 
 /// Maximum serialized size for metadata blobs (e.g. conversation metadata, response metadata)
 pub const MAX_METADATA_SIZE_BYTES: usize = 16 * 1024;
@@ -44,6 +46,26 @@ pub fn extract_api_key_prefix(key: &str) -> String {
 
 pub fn is_valid_api_key_format(key: &str) -> bool {
     key.starts_with(API_KEY_PREFIX) && key.len() == API_KEY_LENGTH
+}
+
+pub fn generate_reporting_token() -> String {
+    format!(
+        "{}{}",
+        REPORTING_TOKEN_PREFIX,
+        Uuid::new_v4().to_string().replace("-", "")
+    )
+}
+
+pub fn hash_reporting_token(token: &str) -> String {
+    hash_api_key(token)
+}
+
+pub fn extract_reporting_token_prefix(token: &str) -> String {
+    token[..12.min(token.len())].to_string()
+}
+
+pub fn is_valid_reporting_token_format(token: &str) -> bool {
+    token.starts_with(REPORTING_TOKEN_PREFIX) && token.len() == REPORTING_TOKEN_LENGTH
 }
 
 /// Shared error types for repository operations across all domains.

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -14,6 +14,8 @@ pub mod mcp;
 pub mod metrics;
 pub mod models;
 pub mod organization;
+pub mod reporting_tokens;
+pub mod reporting_usage;
 pub mod responses;
 pub mod service_usage;
 pub mod staking_farm;

--- a/crates/services/src/organization/mod.rs
+++ b/crates/services/src/organization/mod.rs
@@ -87,6 +87,9 @@ impl OrganizationServiceImpl {
             RepositoryError::AuthenticationFailed => {
                 OrganizationError::InternalError("Database authentication failed".to_string())
             }
+            RepositoryError::QueryTimeout => {
+                OrganizationError::InternalError("Database query timed out".to_string())
+            }
             RepositoryError::PoolError(err) => {
                 OrganizationError::InternalError(format!("Database connection pool error: {err}"))
             }

--- a/crates/services/src/reporting_tokens/mod.rs
+++ b/crates/services/src/reporting_tokens/mod.rs
@@ -1,0 +1,3 @@
+pub mod ports;
+
+pub use ports::*;

--- a/crates/services/src/reporting_tokens/mod.rs
+++ b/crates/services/src/reporting_tokens/mod.rs
@@ -1,3 +1,8 @@
 pub mod ports;
+mod service;
 
 pub use ports::*;
+pub use service::*;
+
+#[cfg(test)]
+mod service_tests;

--- a/crates/services/src/reporting_tokens/ports.rs
+++ b/crates/services/src/reporting_tokens/ports.rs
@@ -1,0 +1,82 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::common::RepositoryError;
+
+pub const REPORTING_TOKEN_SCOPE_USAGE_READ: ReportingTokenScope = ReportingTokenScope::UsageRead;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub enum ReportingTokenScope {
+    #[serde(rename = "usage:read")]
+    UsageRead,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrganizationReportingToken {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub name: String,
+    pub token_prefix: String,
+    pub created_by_user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub revoked_by_user_id: Option<Uuid>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreatedOrganizationReportingToken {
+    pub token: OrganizationReportingToken,
+    pub raw_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidatedOrganizationReportingToken {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub token_prefix: String,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub scope: ReportingTokenScope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateOrganizationReportingTokenRequest {
+    pub organization_id: Uuid,
+    pub name: String,
+    pub created_by_user_id: Uuid,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[async_trait]
+pub trait OrganizationReportingTokenRepository: Send + Sync {
+    async fn create(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError>;
+
+    async fn validate(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError>;
+
+    async fn get_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError>;
+
+    async fn list_active_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError>;
+
+    async fn revoke(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError>;
+}

--- a/crates/services/src/reporting_tokens/service.rs
+++ b/crates/services/src/reporting_tokens/service.rs
@@ -1,0 +1,112 @@
+use super::{
+    CreateOrganizationReportingTokenRequest, CreatedOrganizationReportingToken,
+    OrganizationReportingToken, OrganizationReportingTokenRepository,
+    ValidatedOrganizationReportingToken,
+};
+use crate::common::{is_valid_reporting_token_format, RepositoryError};
+use async_trait::async_trait;
+use chrono::Utc;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[async_trait]
+pub trait OrganizationReportingTokenService: Send + Sync {
+    async fn create(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError>;
+
+    async fn validate(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError>;
+
+    async fn get_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError>;
+
+    async fn list_active_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError>;
+
+    async fn revoke(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError>;
+}
+
+pub struct OrganizationReportingTokenServiceImpl {
+    repository: Arc<dyn OrganizationReportingTokenRepository>,
+}
+
+impl OrganizationReportingTokenServiceImpl {
+    pub fn new(repository: Arc<dyn OrganizationReportingTokenRepository>) -> Self {
+        Self { repository }
+    }
+}
+
+#[async_trait]
+impl OrganizationReportingTokenService for OrganizationReportingTokenServiceImpl {
+    async fn create(
+        &self,
+        mut request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError> {
+        request.name = request.name.trim().to_string();
+        if request.name.is_empty() {
+            return Err(RepositoryError::ValidationFailed(
+                "reporting token name cannot be empty".to_string(),
+            ));
+        }
+        if request.name.chars().count() > 255 {
+            return Err(RepositoryError::ValidationFailed(
+                "reporting token name must be at most 255 characters".to_string(),
+            ));
+        }
+        if request
+            .expires_at
+            .is_some_and(|expires_at| expires_at <= Utc::now())
+        {
+            return Err(RepositoryError::ValidationFailed(
+                "reporting token expiration must be in the future".to_string(),
+            ));
+        }
+        self.repository.create(request).await
+    }
+
+    async fn validate(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError> {
+        if !is_valid_reporting_token_format(raw_token) {
+            return Ok(None);
+        }
+        self.repository.validate(raw_token).await
+    }
+
+    async fn get_by_id(
+        &self,
+        token_id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError> {
+        self.repository.get_by_id(token_id).await
+    }
+
+    async fn list_active_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError> {
+        self.repository
+            .list_active_by_organization(organization_id)
+            .await
+    }
+
+    async fn revoke(
+        &self,
+        token_id: Uuid,
+        revoked_by_user_id: Uuid,
+    ) -> Result<bool, RepositoryError> {
+        self.repository.revoke(token_id, revoked_by_user_id).await
+    }
+}

--- a/crates/services/src/reporting_tokens/service_tests.rs
+++ b/crates/services/src/reporting_tokens/service_tests.rs
@@ -1,0 +1,227 @@
+use super::{
+    CreateOrganizationReportingTokenRequest, CreatedOrganizationReportingToken,
+    OrganizationReportingToken, OrganizationReportingTokenRepository,
+    OrganizationReportingTokenService as _, OrganizationReportingTokenServiceImpl,
+    ValidatedOrganizationReportingToken, REPORTING_TOKEN_SCOPE_USAGE_READ,
+};
+use crate::common::RepositoryError;
+use async_trait::async_trait;
+use chrono::{TimeZone as _, Utc};
+use std::sync::Arc;
+use uuid::Uuid;
+
+const RAW_TOKEN: &str = "rpt-0123456789abcdef0123456789abcdef";
+
+struct StubReportingTokenRepository;
+
+fn token_id() -> Uuid {
+    Uuid::parse_str("00000000-0000-0000-0000-000000000001").expect("valid token UUID")
+}
+
+fn organization_id() -> Uuid {
+    Uuid::parse_str("00000000-0000-0000-0000-000000000002").expect("valid organization UUID")
+}
+
+fn user_id() -> Uuid {
+    Uuid::parse_str("00000000-0000-0000-0000-000000000003").expect("valid user UUID")
+}
+
+fn service_token(id: Uuid, organization_id: Uuid) -> OrganizationReportingToken {
+    OrganizationReportingToken {
+        id,
+        organization_id,
+        name: "warehouse sync".to_string(),
+        token_prefix: "rpt-test".to_string(),
+        created_by_user_id: user_id(),
+        created_at: Utc
+            .with_ymd_and_hms(2026, 7, 10, 12, 0, 0)
+            .single()
+            .expect("valid fixture timestamp"),
+        expires_at: None,
+        last_used_at: None,
+        revoked_at: None,
+        revoked_by_user_id: None,
+        scope: REPORTING_TOKEN_SCOPE_USAGE_READ,
+    }
+}
+
+#[async_trait]
+impl OrganizationReportingTokenRepository for StubReportingTokenRepository {
+    async fn create(
+        &self,
+        request: CreateOrganizationReportingTokenRequest,
+    ) -> Result<CreatedOrganizationReportingToken, RepositoryError> {
+        Ok(CreatedOrganizationReportingToken {
+            token: OrganizationReportingToken {
+                name: request.name,
+                created_by_user_id: request.created_by_user_id,
+                expires_at: request.expires_at,
+                ..service_token(token_id(), request.organization_id)
+            },
+            raw_token: RAW_TOKEN.to_string(),
+        })
+    }
+
+    async fn validate(
+        &self,
+        raw_token: &str,
+    ) -> Result<Option<ValidatedOrganizationReportingToken>, RepositoryError> {
+        Ok(
+            (raw_token == RAW_TOKEN).then(|| ValidatedOrganizationReportingToken {
+                id: token_id(),
+                organization_id: organization_id(),
+                token_prefix: "rpt-test".to_string(),
+                last_used_at: None,
+                scope: REPORTING_TOKEN_SCOPE_USAGE_READ,
+            }),
+        )
+    }
+
+    async fn get_by_id(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<OrganizationReportingToken>, RepositoryError> {
+        Ok((id == token_id()).then(|| service_token(id, organization_id())))
+    }
+
+    async fn list_active_by_organization(
+        &self,
+        organization_id: Uuid,
+    ) -> Result<Vec<OrganizationReportingToken>, RepositoryError> {
+        Ok(vec![service_token(token_id(), organization_id)])
+    }
+
+    async fn revoke(&self, id: Uuid, revoked_by_user_id: Uuid) -> Result<bool, RepositoryError> {
+        Ok(id == token_id() && revoked_by_user_id == user_id())
+    }
+}
+
+fn service() -> OrganizationReportingTokenServiceImpl {
+    OrganizationReportingTokenServiceImpl::new(Arc::new(StubReportingTokenRepository))
+}
+
+#[tokio::test]
+async fn create_forwards_request_to_repository() {
+    // Given: a reporting-token service backed by a repository adapter.
+    let service = service();
+    let expires_at = Utc
+        .with_ymd_and_hms(2026, 8, 1, 0, 0, 0)
+        .single()
+        .expect("valid fixture timestamp");
+
+    // When: a reporting token is created.
+    let created = service
+        .create(CreateOrganizationReportingTokenRequest {
+            organization_id: organization_id(),
+            name: "  finance export  ".to_string(),
+            created_by_user_id: user_id(),
+            expires_at: Some(expires_at),
+        })
+        .await
+        .expect("service call should succeed");
+
+    // Then: the repository receives every request field.
+    assert_eq!(created.token.organization_id, organization_id());
+    assert_eq!(created.token.name, "finance export");
+    assert_eq!(created.token.created_by_user_id, user_id());
+    assert_eq!(created.token.expires_at, Some(expires_at));
+}
+
+#[tokio::test]
+async fn create_rejects_invalid_domain_values_before_persistence() {
+    let service = service();
+    let expired = Utc
+        .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+        .single()
+        .expect("valid fixture timestamp");
+
+    for request in [
+        CreateOrganizationReportingTokenRequest {
+            organization_id: organization_id(),
+            name: "   ".to_string(),
+            created_by_user_id: user_id(),
+            expires_at: None,
+        },
+        CreateOrganizationReportingTokenRequest {
+            organization_id: organization_id(),
+            name: "finance export".to_string(),
+            created_by_user_id: user_id(),
+            expires_at: Some(expired),
+        },
+    ] {
+        assert!(matches!(
+            service.create(request).await,
+            Err(RepositoryError::ValidationFailed(_))
+        ));
+    }
+}
+
+#[tokio::test]
+async fn validate_rejects_malformed_token_without_hash_lookup() {
+    assert!(service()
+        .validate("rpt-not-a-token")
+        .await
+        .expect("invalid format is not a repository failure")
+        .is_none());
+}
+
+#[tokio::test]
+async fn validate_forwards_raw_token_to_repository() {
+    // Given: a reporting-token service backed by a repository adapter.
+    let service = service();
+
+    // When: valid raw token material is validated.
+    let validated = service
+        .validate(RAW_TOKEN)
+        .await
+        .expect("service call should succeed");
+
+    // Then: the repository result is returned unchanged.
+    assert_eq!(validated.map(|token| token.id), Some(token_id()));
+}
+
+#[tokio::test]
+async fn get_forwards_token_id_to_repository() {
+    // Given: a reporting-token service backed by a repository adapter.
+    let service = service();
+
+    // When: a token is loaded by ID.
+    let token = service
+        .get_by_id(token_id())
+        .await
+        .expect("service call should succeed");
+
+    // Then: the matching repository token is returned.
+    assert_eq!(token.map(|token| token.id), Some(token_id()));
+}
+
+#[tokio::test]
+async fn list_forwards_organization_id_to_repository() {
+    // Given: a reporting-token service backed by a repository adapter.
+    let service = service();
+
+    // When: active organization tokens are listed.
+    let tokens = service
+        .list_active_by_organization(organization_id())
+        .await
+        .expect("service call should succeed");
+
+    // Then: the repository result is scoped to that organization.
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].organization_id, organization_id());
+}
+
+#[tokio::test]
+async fn revoke_forwards_token_and_actor_ids_to_repository() {
+    // Given: a reporting-token service backed by a repository adapter.
+    let service = service();
+
+    // When: a token is revoked by its actor.
+    let revoked = service
+        .revoke(token_id(), user_id())
+        .await
+        .expect("service call should succeed");
+
+    // Then: the repository confirms the matching IDs were received.
+    assert!(revoked);
+}

--- a/crates/services/src/reporting_usage.rs
+++ b/crates/services/src/reporting_usage.rs
@@ -1,0 +1,129 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportingUsageSummaryFilters {
+    pub organization_id: Uuid,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<String>,
+    pub service_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InferenceUsageSummary {
+    pub totals: InferenceUsageTotals,
+    pub by_workspace: Vec<InferenceWorkspaceSummary>,
+    pub by_api_key: Vec<InferenceApiKeySummary>,
+    pub by_model: Vec<InferenceModelSummary>,
+    pub by_day: Vec<InferenceDaySummary>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InferenceUsageTotals {
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InferenceWorkspaceSummary {
+    pub workspace_id: Uuid,
+    pub request_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InferenceApiKeySummary {
+    pub api_key_id: Uuid,
+    pub request_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceModelSummary {
+    pub model: String,
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceDaySummary {
+    pub day: String,
+    pub request_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ServiceUsageSummary {
+    pub totals: ServiceUsageTotals,
+    pub by_workspace: Vec<ServiceWorkspaceSummary>,
+    pub by_api_key: Vec<ServiceApiKeySummary>,
+    pub by_service: Vec<ServiceNameSummary>,
+    pub by_day: Vec<ServiceDaySummary>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ServiceUsageTotals {
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServiceWorkspaceSummary {
+    pub workspace_id: Uuid,
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServiceApiKeySummary {
+    pub api_key_id: Uuid,
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceNameSummary {
+    pub service_name: String,
+    pub usage_count: i64,
+    pub quantity: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceDaySummary {
+    pub day: String,
+    pub usage_count: i64,
+    pub total_cost_nano_usd: i64,
+}
+
+#[async_trait::async_trait]
+pub trait InferenceUsageSummaryRepository: Send + Sync {
+    async fn summarize_inference_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> anyhow::Result<InferenceUsageSummary>;
+}
+
+#[async_trait::async_trait]
+pub trait ServiceUsageSummaryRepository: Send + Sync {
+    async fn summarize_service_usage(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> anyhow::Result<ServiceUsageSummary>;
+}

--- a/crates/services/src/reporting_usage.rs
+++ b/crates/services/src/reporting_usage.rs
@@ -1,5 +1,14 @@
 use chrono::{DateTime, Utc};
+use std::{sync::Arc, time::Instant};
+use thiserror::Error;
 use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportingUsageSummarySource {
+    All,
+    Inference,
+    Service,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReportingUsageSummaryFilters {
@@ -11,6 +20,8 @@ pub struct ReportingUsageSummaryFilters {
     pub model: Option<String>,
     pub inference_type: Option<String>,
     pub service_name: Option<String>,
+    pub source: ReportingUsageSummarySource,
+    pub deadline: Option<Instant>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -112,18 +123,100 @@ pub struct ServiceDaySummary {
     pub total_cost_nano_usd: i64,
 }
 
-#[async_trait::async_trait]
-pub trait InferenceUsageSummaryRepository: Send + Sync {
-    async fn summarize_inference_usage(
-        &self,
-        filters: &ReportingUsageSummaryFilters,
-    ) -> anyhow::Result<InferenceUsageSummary>;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReportingUsageSummary {
+    pub inference: InferenceUsageSummary,
+    pub service: ServiceUsageSummary,
+}
+
+#[derive(Debug, Error)]
+pub enum ReportingUsageError {
+    #[error("Usage reporting query timed out")]
+    Timeout,
+    #[error("Failed to summarize usage: {0}")]
+    Internal(String),
 }
 
 #[async_trait::async_trait]
-pub trait ServiceUsageSummaryRepository: Send + Sync {
-    async fn summarize_service_usage(
+pub trait ReportingUsageSummaryRepository: Send + Sync {
+    async fn summarize_usage(
         &self,
         filters: &ReportingUsageSummaryFilters,
-    ) -> anyhow::Result<ServiceUsageSummary>;
+    ) -> anyhow::Result<ReportingUsageSummary>;
+}
+
+pub struct ReportingUsageService {
+    repository: Arc<dyn ReportingUsageSummaryRepository>,
+}
+
+impl ReportingUsageService {
+    pub fn new(repository: Arc<dyn ReportingUsageSummaryRepository>) -> Self {
+        Self { repository }
+    }
+
+    pub async fn summarize(
+        &self,
+        filters: &ReportingUsageSummaryFilters,
+    ) -> Result<ReportingUsageSummary, ReportingUsageError> {
+        self.repository
+            .summarize_usage(filters)
+            .await
+            .map_err(|error| {
+                if crate::common::is_query_timeout(&error) {
+                    ReportingUsageError::Timeout
+                } else {
+                    ReportingUsageError::Internal(error.to_string())
+                }
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    struct RecordingSummaryRepository {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl ReportingUsageSummaryRepository for RecordingSummaryRepository {
+        async fn summarize_usage(
+            &self,
+            filters: &ReportingUsageSummaryFilters,
+        ) -> anyhow::Result<ReportingUsageSummary> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(filters.source, ReportingUsageSummarySource::All);
+            Ok(ReportingUsageSummary::default())
+        }
+    }
+
+    #[tokio::test]
+    async fn reporting_usage_service_uses_one_composite_repository_call() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let service = ReportingUsageService::new(Arc::new(RecordingSummaryRepository {
+            calls: calls.clone(),
+        }));
+        let filters = ReportingUsageSummaryFilters {
+            organization_id: Uuid::new_v4(),
+            start_time: None,
+            end_time: None,
+            workspace_id: None,
+            api_key_id: None,
+            model: None,
+            inference_type: None,
+            service_name: None,
+            source: ReportingUsageSummarySource::All,
+            deadline: None,
+        };
+
+        let summary = service.summarize(&filters).await.unwrap();
+
+        assert_eq!(summary, ReportingUsageSummary::default());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
 }

--- a/crates/services/src/service_usage/mod.rs
+++ b/crates/services/src/service_usage/mod.rs
@@ -2,7 +2,8 @@ pub mod ports;
 
 pub use ports::ServiceUsageServiceTrait;
 use ports::{
-    RecordServiceUsageParams, RecordServiceUsageWithPricingParams, ServiceUsageRepositoryTrait,
+    RecordServiceUsageParams, RecordServiceUsageWithPricingParams, ServiceUsageReportEntry,
+    ServiceUsageReportFilters, ServiceUsageRepositoryTrait,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -74,6 +75,16 @@ impl ServiceUsageServiceTrait for ServiceUsageService {
     ) -> Result<(Vec<ports::ServiceUsageLogEntry>, i64), ServiceUsageError> {
         self.repo
             .list_usage_logs(organization_id, service_name, limit, offset)
+            .await
+            .map_err(|e| ServiceUsageError::InternalError(e.to_string()))
+    }
+
+    async fn get_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> Result<Vec<ServiceUsageReportEntry>, ServiceUsageError> {
+        self.repo
+            .list_usage_report(filters)
             .await
             .map_err(|e| ServiceUsageError::InternalError(e.to_string()))
     }

--- a/crates/services/src/service_usage/mod.rs
+++ b/crates/services/src/service_usage/mod.rs
@@ -16,6 +16,8 @@ pub enum ServiceUsageError {
     CostOverflow,
     #[error("Internal error: {0}")]
     InternalError(String),
+    #[error("Usage reporting query timed out")]
+    ReportingTimeout,
 }
 
 /// Records platform-level service usage (e.g. web_search) and updates org balance.
@@ -83,9 +85,12 @@ impl ServiceUsageServiceTrait for ServiceUsageService {
         &self,
         filters: &ServiceUsageReportFilters,
     ) -> Result<Vec<ServiceUsageReportEntry>, ServiceUsageError> {
-        self.repo
-            .list_usage_report(filters)
-            .await
-            .map_err(|e| ServiceUsageError::InternalError(e.to_string()))
+        self.repo.list_usage_report(filters).await.map_err(|error| {
+            if crate::common::is_query_timeout(&error) {
+                ServiceUsageError::ReportingTimeout
+            } else {
+                ServiceUsageError::InternalError(error.to_string())
+            }
+        })
     }
 }

--- a/crates/services/src/service_usage/ports.rs
+++ b/crates/services/src/service_usage/ports.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -69,6 +70,53 @@ pub struct ServiceUsageLogEntry {
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServiceUsageReportCursor {
+    pub created_at: DateTime<Utc>,
+    pub id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceUsageReportFilters {
+    pub organization_id: Uuid,
+    pub service_name: Option<String>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub cursor: Option<ServiceUsageReportCursor>,
+    pub limit: i64,
+}
+
+impl Default for ServiceUsageReportFilters {
+    fn default() -> Self {
+        Self {
+            organization_id: Uuid::default(),
+            service_name: None,
+            workspace_id: None,
+            api_key_id: None,
+            start_time: None,
+            end_time: None,
+            cursor: None,
+            limit: 100,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceUsageReportEntry {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub service_id: Uuid,
+    pub service_name: String,
+    pub quantity: i32,
+    pub total_cost: i64,
+    pub inference_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
 /// Port for the service usage service. Implemented by ServiceUsageService.
 #[async_trait]
 pub trait ServiceUsageServiceTrait: Send + Sync {
@@ -93,6 +141,11 @@ pub trait ServiceUsageServiceTrait: Send + Sync {
         limit: i64,
         offset: i64,
     ) -> Result<(Vec<ServiceUsageLogEntry>, i64), super::ServiceUsageError>;
+
+    async fn get_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> Result<Vec<ServiceUsageReportEntry>, super::ServiceUsageError>;
 }
 
 /// Port for recording platform service usage (e.g. web_search).
@@ -116,4 +169,9 @@ pub trait ServiceUsageRepositoryTrait: Send + Sync {
         limit: i64,
         offset: i64,
     ) -> anyhow::Result<(Vec<ServiceUsageLogEntry>, i64)>;
+
+    async fn list_usage_report(
+        &self,
+        filters: &ServiceUsageReportFilters,
+    ) -> anyhow::Result<Vec<ServiceUsageReportEntry>>;
 }

--- a/crates/services/src/service_usage/ports.rs
+++ b/crates/services/src/service_usage/ports.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::time::Instant;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -86,6 +87,7 @@ pub struct ServiceUsageReportFilters {
     pub end_time: Option<DateTime<Utc>>,
     pub cursor: Option<ServiceUsageReportCursor>,
     pub limit: i64,
+    pub deadline: Option<Instant>,
 }
 
 impl Default for ServiceUsageReportFilters {
@@ -99,6 +101,7 @@ impl Default for ServiceUsageReportFilters {
             end_time: None,
             cursor: None,
             limit: 100,
+            deadline: None,
         }
     }
 }

--- a/crates/services/src/test_utils.rs
+++ b/crates/services/src/test_utils.rs
@@ -7,7 +7,8 @@ use crate::{
         AttestationError,
     },
     usage::{
-        CostBreakdown, InferenceType, OrganizationBalanceInfo, OrganizationCreditLimit,
+        CostBreakdown, InferenceType, InferenceUsageHistoryQuery, InferenceUsageReportQuery,
+        InferenceUsageReportRow, OrganizationBalanceInfo, OrganizationCreditLimit,
         OrganizationLimit, ProviderAttribution, RecordUsageApiRequest, RecordUsageServiceRequest,
         UsageCheckResult, UsageError, UsageLogEntry, UsageServiceTrait,
     },
@@ -316,6 +317,20 @@ impl UsageServiceTrait for MockUsageService {
     ) -> Result<Vec<crate::usage::UsageByModelEntry>, UsageError> {
         Ok(vec![])
     }
+
+    async fn list_inference_usage_report(
+        &self,
+        _query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError> {
+        Ok(vec![])
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        _query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError> {
+        Ok((vec![], 0))
+    }
 }
 
 /// A usage service that captures requests for testing
@@ -563,5 +578,19 @@ impl UsageServiceTrait for CapturingUsageService {
         _start_date: chrono::DateTime<chrono::Utc>,
     ) -> Result<Vec<crate::usage::UsageByModelEntry>, UsageError> {
         Ok(vec![])
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        _query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError> {
+        Ok(vec![])
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        _query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError> {
+        Ok((vec![], 0))
     }
 }

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -1,5 +1,6 @@
 pub mod ports;
 pub mod provider_attribution;
+pub mod reporting;
 
 use crate::metrics::{
     consts::{
@@ -11,6 +12,7 @@ use crate::metrics::{
 };
 pub use ports::*;
 pub use provider_attribution::*;
+pub use reporting::*;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -779,6 +781,30 @@ impl UsageServiceTrait for UsageServiceImpl {
             .get_usage_by_model(organization_id, start_date)
             .await
             .map_err(|e| UsageError::InternalError(format!("Failed to get usage by model: {e}")))
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError> {
+        self.usage_repository
+            .list_inference_usage_report(query)
+            .await
+            .map_err(|e| {
+                UsageError::InternalError(format!("Failed to list inference usage report: {e}"))
+            })
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError> {
+        self.usage_repository
+            .list_inference_usage_history(query)
+            .await
+            .map_err(|e| {
+                UsageError::InternalError(format!("Failed to list inference usage history: {e}"))
+            })
     }
 }
 

--- a/crates/services/src/usage/mod.rs
+++ b/crates/services/src/usage/mod.rs
@@ -790,8 +790,14 @@ impl UsageServiceTrait for UsageServiceImpl {
         self.usage_repository
             .list_inference_usage_report(query)
             .await
-            .map_err(|e| {
-                UsageError::InternalError(format!("Failed to list inference usage report: {e}"))
+            .map_err(|error| {
+                if crate::common::is_query_timeout(&error) {
+                    UsageError::ReportingTimeout
+                } else {
+                    UsageError::InternalError(format!(
+                        "Failed to list inference usage report: {error}"
+                    ))
+                }
             })
     }
 

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -1,5 +1,9 @@
 use super::provider_attribution::ProviderAttribution;
 use crate::responses::models::ResponseId;
+pub use crate::usage::reporting::{
+    InferenceUsageHistoryQuery, InferenceUsageReportCursor, InferenceUsageReportQuery,
+    InferenceUsageReportRow,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -295,6 +299,16 @@ pub trait UsageServiceTrait: Send + Sync {
         organization_id: Uuid,
         start_date: DateTime<Utc>,
     ) -> Result<Vec<UsageByModelEntry>, UsageError>;
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> Result<Vec<InferenceUsageReportRow>, UsageError>;
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> Result<(Vec<InferenceUsageReportRow>, i64), UsageError>;
 }
 
 // ============================================
@@ -361,6 +375,16 @@ pub trait UsageRepository: Send + Sync {
         organization_id: Uuid,
         start_date: DateTime<Utc>,
     ) -> anyhow::Result<Vec<UsageByModelEntry>>;
+
+    async fn list_inference_usage_report(
+        &self,
+        query: InferenceUsageReportQuery,
+    ) -> anyhow::Result<Vec<InferenceUsageReportRow>>;
+
+    async fn list_inference_usage_history(
+        &self,
+        query: InferenceUsageHistoryQuery,
+    ) -> anyhow::Result<(Vec<InferenceUsageReportRow>, i64)>;
 }
 
 #[async_trait::async_trait]

--- a/crates/services/src/usage/ports.rs
+++ b/crates/services/src/usage/ports.rs
@@ -698,6 +698,7 @@ pub enum UsageError {
     NotFound(String),
     CostCalculationOverflow(String),
     ValidationError(String),
+    ReportingTimeout,
 }
 
 impl std::fmt::Display for UsageError {
@@ -712,6 +713,7 @@ impl std::fmt::Display for UsageError {
                 write!(f, "Cost calculation overflow: {msg}")
             }
             UsageError::ValidationError(msg) => write!(f, "Validation error: {msg}"),
+            UsageError::ReportingTimeout => write!(f, "Usage reporting query timed out"),
         }
     }
 }

--- a/crates/services/src/usage/reporting.rs
+++ b/crates/services/src/usage/reporting.rs
@@ -1,0 +1,72 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceUsageReportCursor {
+    pub created_at: DateTime<Utc>,
+    pub id: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceUsageReportQuery {
+    pub organization_id: Uuid,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub inference_type: Option<String>,
+    pub limit: u16,
+    pub cursor: Option<InferenceUsageReportCursor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceUsageHistoryQuery {
+    pub organization_id: Uuid,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub workspace_id: Option<Uuid>,
+    pub api_key_id: Option<Uuid>,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+impl InferenceUsageReportQuery {
+    pub const fn for_organization(organization_id: Uuid) -> Self {
+        Self {
+            organization_id,
+            start_time: None,
+            end_time: None,
+            workspace_id: None,
+            api_key_id: None,
+            model: None,
+            inference_type: None,
+            limit: 100,
+            cursor: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceUsageReportRow {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub workspace_id: Uuid,
+    pub api_key_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub model: String,
+    pub inference_type: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub total_tokens: i64,
+    pub input_cost_nano_usd: i64,
+    pub output_cost_nano_usd: i64,
+    pub cache_read_cost_nano_usd: Option<i64>,
+    pub total_cost_nano_usd: i64,
+    pub response_id: Option<Uuid>,
+    pub inference_id: Option<Uuid>,
+    pub stop_reason: Option<String>,
+    pub image_count: Option<i32>,
+}

--- a/crates/services/src/usage/reporting.rs
+++ b/crates/services/src/usage/reporting.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::time::Instant;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -19,6 +20,7 @@ pub struct InferenceUsageReportQuery {
     pub inference_type: Option<String>,
     pub limit: u16,
     pub cursor: Option<InferenceUsageReportCursor>,
+    pub deadline: Option<Instant>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +46,7 @@ impl InferenceUsageReportQuery {
             inference_type: None,
             limit: 100,
             cursor: None,
+            deadline: None,
         }
     }
 }
@@ -66,6 +69,8 @@ pub struct InferenceUsageReportRow {
     pub cache_read_cost_nano_usd: Option<i64>,
     pub total_cost_nano_usd: i64,
     pub response_id: Option<Uuid>,
+    #[serde(skip)]
+    pub provider_request_id: Option<String>,
     pub inference_id: Option<Uuid>,
     pub stop_reason: Option<String>,
     pub image_count: Option<i32>,

--- a/crates/services/src/web_search/mod.rs
+++ b/crates/services/src/web_search/mod.rs
@@ -166,7 +166,9 @@ impl WebSearchService {
             })
             .await
             .map_err(|err| match err {
-                ServiceUsageError::InternalError(_) => WebSearchServiceError::Internal,
+                ServiceUsageError::InternalError(_) | ServiceUsageError::ReportingTimeout => {
+                    WebSearchServiceError::Internal
+                }
                 ServiceUsageError::ServiceNotFound(_) | ServiceUsageError::CostOverflow => {
                     WebSearchServiceError::UsageRecordingFailed
                 }

--- a/crates/services/src/workspace/mod.rs
+++ b/crates/services/src/workspace/mod.rs
@@ -56,6 +56,9 @@ impl WorkspaceServiceImpl {
             RepositoryError::AuthenticationFailed => {
                 WorkspaceError::InternalError("Database authentication failed".to_string())
             }
+            RepositoryError::QueryTimeout => {
+                WorkspaceError::InternalError("Database query timed out".to_string())
+            }
             RepositoryError::PoolError(err) => {
                 WorkspaceError::InternalError(format!("Database connection pool error: {err}"))
             }

--- a/docs/usage-reporting-rollout.md
+++ b/docs/usage-reporting-rollout.md
@@ -1,0 +1,118 @@
+# Programmatic usage reporting rollout
+
+Programmatic usage reporting is disabled unless `USAGE_REPORTING_ENABLED=true`. Keep it disabled until all six concurrent indexes below are valid and ready on the database used by each Cloud API deployment. When the flag is enabled, Cloud API repeats this check at startup and refuses to start if a prerequisite is missing.
+
+Reporting-token management and the OpenAPI description remain available while reporting is disabled. Export and summary routes return 404 until the flag is enabled, so tokens can be provisioned before a staged rollout without exposing the query workload.
+
+## 1. Build the indexes
+
+Run the out-of-band script outside a transaction during a low-traffic window:
+
+```bash
+psql "$DATABASE_URL" \
+  --set ON_ERROR_STOP=1 \
+  --file crates/database/src/migrations/out_of_band/usage_reporting_indexes.sql
+```
+
+`CREATE INDEX CONCURRENTLY` can leave an invalid index after interruption. Re-run the script only after checking and removing any invalid index with the same name.
+
+## 2. Verify the prerequisite
+
+This query must return six rows with both booleans set to `t`:
+
+```sql
+WITH required(index_name, table_name) AS (
+    VALUES
+        ('idx_org_usage_reporting_org_created_id', 'organization_usage_log'),
+        ('idx_org_usage_reporting_org_workspace_created_id', 'organization_usage_log'),
+        ('idx_org_usage_reporting_org_api_key_created_id', 'organization_usage_log'),
+        ('idx_org_service_usage_reporting_org_created_id', 'organization_service_usage_log'),
+        ('idx_org_service_usage_reporting_org_workspace_created_id', 'organization_service_usage_log'),
+        ('idx_org_service_usage_reporting_org_api_key_created_id', 'organization_service_usage_log')
+)
+SELECT required.index_name,
+       COALESCE(pg_index.indisvalid, false) AS is_valid,
+       COALESCE(pg_index.indisready, false) AS is_ready
+FROM required
+LEFT JOIN pg_namespace
+  ON pg_namespace.nspname = current_schema()
+LEFT JOIN pg_class AS table_class
+  ON table_class.relnamespace = pg_namespace.oid
+ AND table_class.relname = required.table_name
+ AND table_class.relkind IN ('r', 'p')
+LEFT JOIN pg_class AS index_class
+  ON index_class.relnamespace = pg_namespace.oid
+ AND index_class.relname = required.index_name
+ AND index_class.relkind = 'i'
+LEFT JOIN pg_index
+  ON pg_index.indexrelid = index_class.oid
+ AND pg_index.indrelid = table_class.oid
+ORDER BY required.index_name;
+```
+
+Do not enable reporting if a row is missing or either value is `f`.
+
+## 3. Check representative query plans
+
+Run `EXPLAIN (ANALYZE, BUFFERS)` with a high-volume organization and a 366-day window for the default, workspace, API-key, and model-filtered export shapes. Replace the values below with non-sensitive production identifiers:
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT id, created_at
+FROM organization_usage_log
+WHERE organization_id = '<organization-uuid>'
+  AND created_at >= NOW() - INTERVAL '366 days'
+  AND created_at <= NOW()
+ORDER BY created_at DESC, id DESC
+LIMIT 1001;
+
+-- Repeat with each additional predicate separately:
+-- AND workspace_id = '<workspace-uuid>'
+-- AND api_key_id = '<api-key-uuid>'
+-- AND model_name = '<model-name>'
+```
+
+Repeat the default, workspace, and API-key shapes for `organization_service_usage_log`. The default/workspace/API-key plans should use the corresponding reporting index. Model filtering should still use the organization/time index before applying the model predicate. Do not enable the feature if a high-volume organization unexpectedly uses an unbounded sequential scan or if representative execution approaches the database deadline (12 seconds with the default 15-second request timeout).
+
+## 4. Enable with bounded limits
+
+Set the feature flag and restart Cloud API instances gradually:
+
+```dotenv
+USAGE_REPORTING_ENABLED=true
+USAGE_REPORTING_GLOBAL_REQUESTS_PER_MINUTE=600
+USAGE_REPORTING_TOKEN_REQUESTS_PER_MINUTE=60
+USAGE_REPORTING_MAX_CONCURRENT_REQUESTS=4
+USAGE_REPORTING_TOKEN_MAX_CONCURRENT_REQUESTS=2
+USAGE_REPORTING_REQUEST_TIMEOUT_SECONDS=15
+```
+
+The values shown are the application defaults. PostgreSQL statements are cancelled at 80% of the request deadline, leaving time to return a structured HTTP 504. Limits are enforced per Cloud API process; ingress-level client/IP throttling remains required for fleet-wide protection.
+
+## 5. Smoke test
+
+An invalid reporting token must be rejected before a reporting query runs:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --header 'Authorization: Bearer rpt-00000000000000000000000000000000' \
+  "$CLOUD_API_URL/v1/organizations/$ORGANIZATION_ID/usage/summary"
+```
+
+Expect HTTP 401. Then use a short-lived token created for the test organization and verify export and summary return HTTP 200:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --header "Authorization: Bearer $REPORTING_TOKEN" \
+  "$CLOUD_API_URL/v1/organizations/$ORGANIZATION_ID/usage/export?limit=1"
+
+curl --fail-with-body --silent --show-error \
+  --header "Authorization: Bearer $REPORTING_TOKEN" \
+  "$CLOUD_API_URL/v1/organizations/$ORGANIZATION_ID/usage/summary"
+```
+
+Revoke the smoke-test token immediately afterward.
+
+## 6. Monitor and roll back
+
+Watch database pool saturation, PostgreSQL query latency/timeouts, lock waits, API 429/504 rates, CPU, and replica lag. If reporting causes pressure, set `USAGE_REPORTING_ENABLED=false` and restart the affected instances. Disabling the routes does not remove reporting tokens or indexes, so they can be re-enabled after the cause is addressed.

--- a/env.example
+++ b/env.example
@@ -119,6 +119,19 @@ DATABASE_TLS_ENABLED=false
 # DATABASE_MIGRATIONS_PATH=path/to/migrations/sql/directory
 
 # =============================================================================
+# Programmatic Usage Reporting
+# =============================================================================
+# Keep disabled until the six out-of-band indexes pass the rollout checks in
+# docs/usage-reporting-rollout.md. Startup refuses to enable reporting if any
+# required index is missing, invalid, or not ready.
+USAGE_REPORTING_ENABLED=false
+USAGE_REPORTING_GLOBAL_REQUESTS_PER_MINUTE=600
+USAGE_REPORTING_TOKEN_REQUESTS_PER_MINUTE=60
+USAGE_REPORTING_MAX_CONCURRENT_REQUESTS=4
+USAGE_REPORTING_TOKEN_MAX_CONCURRENT_REQUESTS=2
+USAGE_REPORTING_REQUEST_TIMEOUT_SECONDS=15
+
+# =============================================================================
 # AWS S3 Configuration (for file uploads)
 # =============================================================================
 # S3 bucket name for file storage


### PR DESCRIPTION
## Summary

Adds a customer-facing, read-only programmatic usage reporting surface for organizations:

- scoped `rpt-` tokens with session-authenticated owner/admin management
- cursor-paginated `GET /v1/organizations/{org_id}/usage/export`
- aggregate `GET /v1/organizations/{org_id}/usage/summary`
- inference and service usage with `source=inference|service|all`
- OpenAPI coverage, rollout controls, and focused database/E2E coverage

## Safety and operability

- Reporting is disabled by default and query routes return 404 while disabled.
- Enabling reporting fails startup closed unless all six reporting indexes are attached to the expected tables and are valid/ready.
- Run `crates/database/src/migrations/out_of_band/usage_reporting_indexes.sql` outside a transaction before enabling; follow `docs/usage-reporting-rollout.md` for verification and rollback.
- Global and per-token request/concurrency limits protect the routes. These limits are process-local, so production should also enforce aggregate ingress limits.
- One absolute request deadline covers admission, authentication, pool acquisition, and SQL. PostgreSQL queries receive a shorter `statement_timeout` and cancellation is returned as structured 504.
- Token `last_used_at` writes are debounced to at most once per 15 minutes.
- Cursor v3 binds the organization, effective time range, source, and all filters.
- Summary reads use a repeatable-read snapshot and grouped queries.

## Contract and privacy

- Integer nano-USD fields are the cost source of truth.
- `cache_read_cost_nano_usd` is omitted when Cloud API does not persist a separate cache-read split.
- Provider request IDs, provider attribution fields, token hashes/raw tokens, prompts, outputs, uploaded content, and payment data are excluded.
- The API returns JSON; CSV requires client-side conversion.
- Workspace/API-key attribution is not per-human attribution, and usage rows do not expose TTFT/ITL performance telemetry.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features -- --test-threads=1`
  - API units: 240 passed, 2 ignored
  - HTTP E2E: 661 passed, 10 ignored
  - Config: 39 passed
  - Database units: 18 passed
  - Services units: 507 passed, 1 ignored
  - Attestation integration: 6 passed
- Reporting E2E: 23 passed, including database timeout/cancellation, cross-organization cursor rejection, and tied mixed-source pagination in both directions.
- Startup-index integration verifies the missing-index failure and the six-index success path.
- Live binary smoke: create token, export, summary, invalid token, revoke, revoked-token rejection, graceful shutdown.
- `git diff --check`

## Related PR

- Docs: https://github.com/nearai/docs/pull/39
