### PR TITLE
Add cargo deny advisory policy

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   security_audit:
+    name: cargo audit
     runs-on: [self-hosted, infra]
     steps:
       - uses: actions/checkout@v7
@@ -21,3 +22,13 @@ jobs:
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  cargo_deny_advisories:
+    name: cargo deny advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+          arguments: --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,9 +500,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,15 @@
+[graph]
+all-features = true
+
+[advisories]
+db-urls = ["https://github.com/RustSec/advisory-db"]
+yanked = "warn"
+unmaintained = "workspace"
+unsound = "workspace"
+unused-ignored-advisory = "warn"
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing side channel does not affect cloud-api JWT handling because cloud-api uses HS256/HMAC rather than RSA algorithms." },
+    { id = "RUSTSEC-2024-0436", reason = "paste is an unmaintained transitive dependency from dstack-sdk/alloy; informational only and tracked for upstream migration." },
+    { id = "RUSTSEC-2024-0388", reason = "derivative is an unmaintained transitive dependency from dstack-sdk/alloy/ruint/ark-ff; informational only and tracked for upstream migration." },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is a build-time transitive dependency from dstack-sdk/alloy-sol-macro; informational only and tracked for upstream migration." },
+]

--- a/docs/security/rustsec-exception-register.md
+++ b/docs/security/rustsec-exception-register.md
@@ -1,0 +1,26 @@
+# RustSec Exception Register
+
+This register is the human review record for RustSec advisories intentionally ignored by `cargo audit` and `cargo deny`.
+
+Tracker: `nearai/infra#188`
+
+## Review Ownership
+
+- Owner: Inference team placeholder
+- Review cadence: TODO
+- Review trigger: dependency update, new affected code path, or RustSec advisory change
+
+## Active Exceptions
+
+| Advisory | Package | Type | Reason | Upstream/Tracking |
+| --- | --- | --- | --- | --- |
+| `RUSTSEC-2023-0071` | `rsa` | Vulnerability | The Marvin timing side-channel advisory does not affect current cloud-api JWT handling because cloud-api uses HS256/HMAC, not RSA algorithms. | Revisit before introducing RSA signing or verification. |
+| `RUSTSEC-2024-0436` | `paste` | Unmaintained | Transitive dependency from `dstack-sdk` through Alloy. This is informational and not a direct runtime security issue. | Waiting for upstream Alloy/dstack dependency migration. |
+| `RUSTSEC-2024-0388` | `derivative` | Unmaintained | Transitive dependency from `dstack-sdk` through Alloy/ruint/ark-ff. This is informational and not a direct runtime security issue. | Waiting for upstream Alloy/dstack dependency migration. |
+| `RUSTSEC-2026-0173` | `proc-macro-error2` | Unmaintained | Build-time transitive dependency from `dstack-sdk` through Alloy proc-macro dependencies. This is informational and not a runtime dependency. | Existing tracking reference: `nearai/cloud-api#732`. |
+
+## Maintenance Rules
+
+- Add a row before adding a new advisory ignore to `.cargo/audit.toml` or `deny.toml`.
+- Remove a row in the same PR that removes the corresponding ignore.
+- Keep the `Reason` field specific to cloud-api usage rather than copying the advisory summary.


### PR DESCRIPTION
## Problem
nearai/infra#188 tracks the SOC2 Inference/private-inference vulnerability-management rollout. `cloud-api` already ran `cargo audit`, but it did not have a repo-local `cargo-deny` policy or a human-readable RustSec exception register.

The new cargo-deny advisory check also surfaced `RUSTSEC-2026-0190` against `anyhow 1.0.102`.

## Changes
- Adds `deny.toml` with an advisory-focused cargo-deny policy.
- Mirrors the existing cargo-audit ignores into cargo-deny with cloud-api-specific reasons.
- Adds `docs/security/rustsec-exception-register.md` as the review record for advisory exceptions.
- Extends the security audit workflow with a `cargo deny advisories` job.
- Updates `anyhow` from `1.0.102` to `1.0.103` to remediate `RUSTSEC-2026-0190`.

## Validation
- Parsed `.github/workflows/security-audit.yml` locally with Ruby's YAML parser.
- Parsed `deny.toml` locally with Python `tomllib`.
- Ran `cargo metadata --locked --format-version 1` successfully after the lockfile update.
- `cargo-deny` is not installed locally, so the new GitHub Actions job is the execution validation for the deny policy.

## Rollout Notes
This is advisory-only cargo-deny coverage. Broader license, source, and duplicate-version policy can be added later once ownership and exception policy are explicitly agreed.

Tracker: nearai/infra#188
