### PR TITLE
fix(attestation): omit unsupported dstack event log for ITA

### DIFF
--- a/crates/services/src/attestation/gateway_quote.rs
+++ b/crates/services/src/attestation/gateway_quote.rs
@@ -36,7 +36,7 @@ impl GatewayQuoteCollector for DstackGatewayQuoteCollector {
                     signing_address: input.signing_address,
                     signing_algo: input.signing_algo,
                     intel_quote: "0x1234567890abcdef".to_string(),
-                    event_log: "0x1234567890abcdef".to_string(),
+                    event_log: "[]".to_string(),
                     report_data: hex::encode(input.report_data),
                     request_nonce: input.request_nonce,
                     info: serde_json::json!({

--- a/crates/services/src/attestation/ita/evidence.rs
+++ b/crates/services/src/attestation/ita/evidence.rs
@@ -114,13 +114,11 @@ fn build_tdx_evidence(
     let quote = decode_required_hex("tdx.quote", &gateway.intel_quote)?;
     let runtime_data = runtime_data_bytes(gateway)?;
     verify_report_data(gateway, verifier_nonce, &runtime_data)?;
-    let event_log = gateway.event_log.trim();
-    let event_log =
-        (!event_log.is_empty() && event_log != "0x").then(|| STANDARD.encode(event_log.as_bytes()));
     Ok(ItaTdxEvidence {
         quote: STANDARD.encode(quote),
         runtime_data: STANDARD.encode(runtime_data),
-        event_log,
+        // Dstack's JSON event log is not the raw CCEL/NEL format accepted by ITA.
+        event_log: None,
         verifier_nonce: verifier_nonce.clone(),
     })
 }

--- a/crates/services/src/attestation/ita/evidence.rs
+++ b/crates/services/src/attestation/ita/evidence.rs
@@ -114,11 +114,12 @@ fn build_tdx_evidence(
     let quote = decode_required_hex("tdx.quote", &gateway.intel_quote)?;
     let runtime_data = runtime_data_bytes(gateway)?;
     verify_report_data(gateway, verifier_nonce, &runtime_data)?;
-    let event_log = decode_optional_hex("tdx.event_log", &gateway.event_log)?;
+    let event_log = (!gateway.event_log.trim().is_empty())
+        .then(|| STANDARD.encode(gateway.event_log.as_bytes()));
     Ok(ItaTdxEvidence {
         quote: STANDARD.encode(quote),
         runtime_data: STANDARD.encode(runtime_data),
-        event_log: event_log.map(|bytes| STANDARD.encode(bytes)),
+        event_log,
         verifier_nonce: verifier_nonce.clone(),
     })
 }
@@ -192,20 +193,6 @@ fn decode_required_hex(field: &'static str, raw: &str) -> Result<Vec<u8>, ItaEvi
         return Err(ItaEvidenceError::MissingField(field));
     }
     hex::decode(hex_value).map_err(|source| ItaEvidenceError::InvalidHex { field, source })
-}
-
-fn decode_optional_hex(
-    field: &'static str,
-    raw: &str,
-) -> Result<Option<Vec<u8>>, ItaEvidenceError> {
-    let trimmed = raw.trim();
-    let hex_value = trimmed.strip_prefix("0x").unwrap_or(trimmed);
-    if hex_value.is_empty() {
-        return Ok(None);
-    }
-    hex::decode(hex_value)
-        .map(Some)
-        .map_err(|source| ItaEvidenceError::InvalidHex { field, source })
 }
 
 #[cfg(test)]

--- a/crates/services/src/attestation/ita/evidence.rs
+++ b/crates/services/src/attestation/ita/evidence.rs
@@ -114,8 +114,9 @@ fn build_tdx_evidence(
     let quote = decode_required_hex("tdx.quote", &gateway.intel_quote)?;
     let runtime_data = runtime_data_bytes(gateway)?;
     verify_report_data(gateway, verifier_nonce, &runtime_data)?;
-    let event_log = (!gateway.event_log.trim().is_empty())
-        .then(|| STANDARD.encode(gateway.event_log.as_bytes()));
+    let event_log = gateway.event_log.trim();
+    let event_log =
+        (!event_log.is_empty() && event_log != "0x").then(|| STANDARD.encode(event_log.as_bytes()));
     Ok(ItaTdxEvidence {
         quote: STANDARD.encode(quote),
         runtime_data: STANDARD.encode(runtime_data),

--- a/crates/services/src/attestation/ita/evidence_tdx_tests.rs
+++ b/crates/services/src/attestation/ita/evidence_tdx_tests.rs
@@ -76,6 +76,9 @@ fn omits_unsupported_dstack_event_log() -> TestResult {
     let runtime_data = runtime_data();
     let gateway = gateway_quote(&runtime_data);
     assert!(!gateway.event_log.is_empty());
+    let parsed_event_log: Vec<dstack_sdk_types::dstack::EventLog> =
+        serde_json::from_str(&gateway.event_log)?;
+    assert_eq!(parsed_event_log.len(), 1);
 
     // When: the gateway evidence is mapped to the ITA wire request.
     let value = serde_json::to_value(gateway_request(&gateway)?)?;

--- a/crates/services/src/attestation/ita/evidence_tdx_tests.rs
+++ b/crates/services/src/attestation/ita/evidence_tdx_tests.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 
 use super::evidence_test_support::{
     effective_policy, gateway_quote, gateway_request, runtime_data, verifier_nonce, TestResult,
-    POLICY_A, POLICY_B,
+    DSTACK_EVENT_LOG, POLICY_A, POLICY_B,
 };
 use super::*;
 
@@ -12,7 +12,7 @@ pub(super) fn expected_tdx_json() -> Value {
     json!({
         "quote": "AQIDBA==",
         "runtime_data": STANDARD.encode(runtime_data()),
-        "event_log": "Cgs=",
+        "event_log": STANDARD.encode(DSTACK_EVENT_LOG.as_bytes()),
         "verifier_nonce": {
             "val": "dmVyaWZpZXItdmFsdWU=",
             "iat": "aWF0LWJ5dGVz",

--- a/crates/services/src/attestation/ita/evidence_tdx_tests.rs
+++ b/crates/services/src/attestation/ita/evidence_tdx_tests.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 
 use super::evidence_test_support::{
     effective_policy, gateway_quote, gateway_request, runtime_data, verifier_nonce, TestResult,
-    DSTACK_EVENT_LOG, POLICY_A, POLICY_B,
+    POLICY_A, POLICY_B,
 };
 use super::*;
 
@@ -12,7 +12,6 @@ pub(super) fn expected_tdx_json() -> Value {
     json!({
         "quote": "AQIDBA==",
         "runtime_data": STANDARD.encode(runtime_data()),
-        "event_log": STANDARD.encode(DSTACK_EVENT_LOG.as_bytes()),
         "verifier_nonce": {
             "val": "dmVyaWZpZXItdmFsdWU=",
             "iat": "aWF0LWJ5dGVz",
@@ -72,32 +71,17 @@ fn omits_empty_policy_ids_but_keeps_effective_policy_controls() -> TestResult {
 }
 
 #[test]
-fn trims_event_log_before_base64_encoding() -> TestResult {
+fn omits_unsupported_dstack_event_log() -> TestResult {
+    // Given: dstack supplies a non-empty JSON event log rather than raw CCEL/NEL bytes.
     let runtime_data = runtime_data();
-    let mut gateway = gateway_quote(&runtime_data);
-    gateway.event_log = format!(" \n{DSTACK_EVENT_LOG}\t");
+    let gateway = gateway_quote(&runtime_data);
+    assert!(!gateway.event_log.is_empty());
 
+    // When: the gateway evidence is mapped to the ITA wire request.
     let value = serde_json::to_value(gateway_request(&gateway)?)?;
 
-    assert_eq!(
-        value["tdx"]["event_log"],
-        "W3siaW1yIjozLCJldmVudF90eXBlIjoxLCJkaWdlc3QiOiIwMCJ9XQ=="
-    );
-    Ok(())
-}
-
-#[test]
-fn omits_empty_event_log_placeholders() -> TestResult {
-    let runtime_data = runtime_data();
-
-    for event_log in ["", " \n\t", "0x", " 0x \n"] {
-        let mut gateway = gateway_quote(&runtime_data);
-        gateway.event_log = event_log.to_string();
-
-        let value = serde_json::to_value(gateway_request(&gateway)?)?;
-
-        assert_eq!(value["tdx"].get("event_log"), None, "{event_log:?}");
-    }
+    // Then: the optional event_log field is omitted.
+    assert_eq!(value["tdx"].get("event_log"), None);
     Ok(())
 }
 

--- a/crates/services/src/attestation/ita/evidence_tdx_tests.rs
+++ b/crates/services/src/attestation/ita/evidence_tdx_tests.rs
@@ -72,6 +72,36 @@ fn omits_empty_policy_ids_but_keeps_effective_policy_controls() -> TestResult {
 }
 
 #[test]
+fn trims_event_log_before_base64_encoding() -> TestResult {
+    let runtime_data = runtime_data();
+    let mut gateway = gateway_quote(&runtime_data);
+    gateway.event_log = format!(" \n{DSTACK_EVENT_LOG}\t");
+
+    let value = serde_json::to_value(gateway_request(&gateway)?)?;
+
+    assert_eq!(
+        value["tdx"]["event_log"],
+        "W3siaW1yIjozLCJldmVudF90eXBlIjoxLCJkaWdlc3QiOiIwMCJ9XQ=="
+    );
+    Ok(())
+}
+
+#[test]
+fn omits_empty_event_log_placeholders() -> TestResult {
+    let runtime_data = runtime_data();
+
+    for event_log in ["", " \n\t", "0x", " 0x \n"] {
+        let mut gateway = gateway_quote(&runtime_data);
+        gateway.event_log = event_log.to_string();
+
+        let value = serde_json::to_value(gateway_request(&gateway)?)?;
+
+        assert_eq!(value["tdx"].get("event_log"), None, "{event_log:?}");
+    }
+    Ok(())
+}
+
+#[test]
 fn report_data_uses_decoded_nonce_bytes_not_base64_text() -> TestResult {
     // Given: gateway report_data was produced with decoded Val || Iat bytes.
     let runtime_data = runtime_data();

--- a/crates/services/src/attestation/ita/evidence_test_support.rs
+++ b/crates/services/src/attestation/ita/evidence_test_support.rs
@@ -10,7 +10,8 @@ pub(super) type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 pub(super) const POLICY_A: &str = "11111111-1111-4111-8111-111111111111";
 pub(super) const POLICY_B: &str = "22222222-2222-4222-8222-222222222222";
-pub(super) const DSTACK_EVENT_LOG: &str = r#"[{"imr":3,"event_type":1,"digest":"00"}]"#;
+pub(super) const DSTACK_EVENT_LOG: &str =
+    r#"[{"imr":3,"event_type":1,"digest":"00","event":"test","event_payload":"00"}]"#;
 
 pub(super) fn verifier_nonce() -> ItaVerifierNonce {
     ItaVerifierNonce {

--- a/crates/services/src/attestation/ita/evidence_test_support.rs
+++ b/crates/services/src/attestation/ita/evidence_test_support.rs
@@ -10,6 +10,7 @@ pub(super) type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 pub(super) const POLICY_A: &str = "11111111-1111-4111-8111-111111111111";
 pub(super) const POLICY_B: &str = "22222222-2222-4222-8222-222222222222";
+pub(super) const DSTACK_EVENT_LOG: &str = r#"[{"imr":3,"event_type":1,"digest":"00"}]"#;
 
 pub(super) fn verifier_nonce() -> ItaVerifierNonce {
     ItaVerifierNonce {
@@ -56,7 +57,7 @@ pub(super) fn gateway_quote(runtime_data: &[u8]) -> DstackCpuQuote {
         signing_address: "0xabc123".to_string(),
         signing_algo: "ed25519".to_string(),
         intel_quote: "0x01020304".to_string(),
-        event_log: "0x0a0b".to_string(),
+        event_log: DSTACK_EVENT_LOG.to_string(),
         report_data: report_data(runtime_data),
         request_nonce: "00".repeat(32),
         info: json!({}),

--- a/crates/services/src/attestation/ita/service_test_support.rs
+++ b/crates/services/src/attestation/ita/service_test_support.rs
@@ -144,7 +144,7 @@ impl GatewayQuoteCollector for RecordingGatewayQuoteCollector {
             signing_address: input.signing_address,
             signing_algo: input.signing_algo,
             intel_quote: "0x01020304".to_string(),
-            event_log: "0x0a0b".to_string(),
+            event_log: "[]".to_string(),
             report_data: hex::encode(input.report_data),
             request_nonce: input.request_nonce,
             info: json!({}),


### PR DESCRIPTION
## Summary

- omit dstack's event log from Intel Trust Authority TDX evidence because it is not an ITA-supported raw CCEL/NEL representation
- keep quote decoding, nonce-bound runtime data, and report_data verification unchanged
- add an exact wire-format regression proving a non-empty dstack JSON event log is not forwarded

## Root cause

The initial staging failure happened because Cloud API tried to hex-decode dstack's JSON event log. Directly base64-encoding that JSON removes the local decode error, but still sends an unsupported representation: Intel's TDX adapter populates `EventLog` from raw `GetCcel()` bytes, while dstack exposes a distinct simplified JSON schema.

Because `event_log` is optional in the ITA request, this PR now omits it until Cloud API can obtain raw CCEL/NEL bytes or implement a documented conversion. Quote and runtime-data attestation remain enabled.

## Validation

- exact request regression validates a complete non-empty fixture through `dstack_sdk_types::dstack::EventLog` and requires `tdx.event_log` to be absent
- red/green: the schema assertion failed on the partial fixture with `missing field event`, then passed after adding `event` and `event_payload`
- malformed/missing quote and report_data nonce-binding coverage remains unchanged
- `cargo test -p services attestation::ita`: 41 passed
- focused regression, rustfmt, strict services clippy, and `git diff --check`: passed
- remote lint, unit, integration, E2E, and aggregate Test Suite: passed on `20d63ee7`
- `cargo deny advisories`: passed

## Rollout

Once merged and promoted, redeploy Cloud API staging and verify the live ITA JWT signature against the returned JWKS without logging token material.