### PR TITLE
fix(database): follow the Patroni leader across failovers

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -61,6 +61,7 @@ tokio-util = { version = "0.7", features = ["compat", "io"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 
 [dev-dependencies]
+database = { path = "../database", features = ["test-support"] }
 axum-test = "20"
 wiremock = "0.6"
 serde_json = "1.0"

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -134,13 +134,16 @@ pub async fn init_database(db_config: &config::DatabaseConfig) -> Arc<Database> 
         use std::time::Duration;
         loop {
             tokio::time::sleep(Duration::from_secs(60)).await;
-            tracing::info!(
-                pool = "database",
-                size = pool.status().size,
-                available = pool.status().available,
-                waiting = pool.status().waiting,
-                "Pool status"
-            );
+            match pool.status() {
+                Some(status) => tracing::info!(
+                    pool = "database",
+                    size = status.size,
+                    available = status.available,
+                    waiting = status.waiting,
+                    "Pool status"
+                ),
+                None => tracing::warn!(pool = "database", "Pool status: no pool installed"),
+            }
         }
     });
 

--- a/crates/api/tests/common/db_setup.rs
+++ b/crates/api/tests/common/db_setup.rs
@@ -142,4 +142,5 @@ pub async fn create_test_pool() -> database::pool::DbPool {
             tokio_postgres::NoTls,
         )
         .expect("Failed to create test connection pool")
+        .into()
 }

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -55,6 +55,7 @@ mod oauth_frontend_callback;
 mod openrouter_params;
 mod org_system_prompt;
 mod pagination_validation;
+mod patroni_failover;
 mod privacy_classify;
 mod privacy_redact;
 mod provider_errors;

--- a/crates/api/tests/e2e_all/patroni_failover.rs
+++ b/crates/api/tests/e2e_all/patroni_failover.rs
@@ -1,13 +1,19 @@
-// Regression test for the 2026-07-12 outage root cause: pool handles cloned at
-// startup (as `Database::new` hands to every repository) must observe the pool
-// the ClusterManager installs for a new leader. Previously the manager swapped
-// a pool nothing re-read, so repositories kept dialing the host captured at
-// startup until the process was redeployed.
+// Regression tests for the 2026-07-12 outage root cause: pool handles cloned
+// at startup (as `Database::new` hands to every repository) must observe the
+// pool the ClusterManager installs for a new leader. Previously the manager
+// swapped a pool nothing re-read, so repositories kept dialing the host
+// captured at startup until the process was redeployed.
+//
+// Both "leaders" are TCP proxies in front of the CI Postgres, so the tests can
+// tell which path a connection takes and can kill the old leader's path
+// outright.
 
 use database::cluster_manager::{ClusterManager, DatabaseConfig, ReadPreference};
 use database::patroni_discovery::{ClusterMember, PatroniDiscovery};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::net::TcpListener;
+use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
 
 fn leader_member(name: &str, host: &str, port: u16) -> ClusterMember {
     ClusterMember {
@@ -21,79 +27,196 @@ fn leader_member(name: &str, host: &str, port: u16) -> ClusterMember {
     }
 }
 
-/// Listener that accepts TCP connections and immediately closes them, standing
-/// in for a failed leader that is still reachable at the TCP level.
-async fn dead_postgres_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move {
-        loop {
-            if let Ok((socket, _)) = listener.accept().await {
-                drop(socket);
-            }
-        }
-    });
-    port
+fn test_db_config() -> DatabaseConfig {
+    DatabaseConfig {
+        database: std::env::var("DATABASE_NAME").unwrap_or_else(|_| "postgres".to_string()),
+        username: std::env::var("DATABASE_USERNAME").unwrap_or_else(|_| "postgres".to_string()),
+        password: std::env::var("DATABASE_PASSWORD").unwrap_or_else(|_| "postgres".to_string()),
+        max_write_connections: 2,
+        max_read_connections: 2,
+        tls_enabled: false,
+        tls_ca_cert_path: None,
+    }
 }
 
-#[tokio::test]
-async fn reconcile_repoints_startup_pool_clones_to_new_leader() {
-    let pg_host = std::env::var("DATABASE_HOST").unwrap_or_else(|_| "localhost".to_string());
-    let pg_port: u16 = std::env::var("DATABASE_PORT")
-        .unwrap_or_else(|_| "5432".to_string())
-        .parse()
-        .unwrap();
-
-    // "Old leader": up at the TCP level but unusable, like a failed member.
-    let dead_port = dead_postgres_port().await;
-    // Refresh interval long enough that the injected state never goes stale.
-    let discovery = Arc::new(PatroniDiscovery::new(
+/// Discovery whose refresh interval is long enough that injected state never
+/// counts as stale during a test.
+fn test_discovery() -> Arc<PatroniDiscovery> {
+    Arc::new(PatroniDiscovery::new(
         "test-app".to_string(),
         "gateway.invalid".to_string(),
         3600,
-    ));
+    ))
+}
+
+fn postgres_upstream() -> String {
+    let host = std::env::var("DATABASE_HOST").unwrap_or_else(|_| "localhost".to_string());
+    let port = std::env::var("DATABASE_PORT").unwrap_or_else(|_| "5432".to_string());
+    format!("{host}:{port}")
+}
+
+/// TCP proxy in front of Postgres standing in for one cluster member. Counts
+/// accepted connections, optionally delays each connection before it reaches
+/// Postgres (to widen verification windows), and can be shut down hard —
+/// killing established connections — like a leader going down.
+struct TcpProxy {
+    port: u16,
+    connections: Arc<AtomicUsize>,
+    tasks: Arc<std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+}
+
+impl TcpProxy {
+    async fn start(upstream: String, pre_connect_delay: Duration) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let tasks: Arc<std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>> = Arc::default();
+
+        let accept_task = {
+            let connections = connections.clone();
+            let tasks = tasks.clone();
+            tokio::spawn(async move {
+                loop {
+                    if let Ok((mut client, _)) = listener.accept().await {
+                        connections.fetch_add(1, Ordering::SeqCst);
+                        let upstream = upstream.clone();
+                        let conn_task = tokio::spawn(async move {
+                            tokio::time::sleep(pre_connect_delay).await;
+                            if let Ok(mut server) = TcpStream::connect(&upstream).await {
+                                let _ =
+                                    tokio::io::copy_bidirectional(&mut client, &mut server).await;
+                            }
+                        });
+                        tasks.lock().unwrap().push(conn_task);
+                    }
+                }
+            })
+        };
+        tasks.lock().unwrap().push(accept_task);
+
+        Self {
+            port,
+            connections,
+            tasks,
+        }
+    }
+
+    fn target(&self) -> ClusterMember {
+        leader_member(&format!("member-{}", self.port), "127.0.0.1", self.port)
+    }
+
+    /// Stop accepting and kill every established connection — the member is
+    /// hard-down.
+    fn shutdown(&self) {
+        for task in self.tasks.lock().unwrap().drain(..) {
+            task.abort();
+        }
+    }
+}
+
+/// The outage invariant: a handle clone already serving traffic through the
+/// old leader's pool must observe the failover install and route subsequent
+/// acquisitions through the new leader — even once the old leader is gone.
+#[tokio::test]
+async fn startup_pool_clones_follow_leader_across_failover() {
+    let upstream = postgres_upstream();
+    let leader_a = TcpProxy::start(upstream.clone(), Duration::ZERO).await;
+    let leader_b = TcpProxy::start(upstream, Duration::ZERO).await;
+
+    let discovery = test_discovery();
     discovery
-        .set_cluster_state_for_test(
-            Some(leader_member("old-leader", "127.0.0.1", dead_port)),
-            vec![],
-        )
+        .set_cluster_state_for_test(Some(leader_a.target()), vec![])
         .await;
 
     let manager = ClusterManager::new(
         discovery.clone(),
-        DatabaseConfig {
-            database: std::env::var("DATABASE_NAME").unwrap_or_else(|_| "postgres".to_string()),
-            username: std::env::var("DATABASE_USERNAME").unwrap_or_else(|_| "postgres".to_string()),
-            password: std::env::var("DATABASE_PASSWORD").unwrap_or_else(|_| "postgres".to_string()),
-            max_write_connections: 2,
-            max_read_connections: 2,
-            tls_enabled: false,
-            tls_ca_cert_path: None,
-        },
+        test_db_config(),
         ReadPreference::LeaderOnly,
         None,
     );
-
-    // What Database::new does at startup: take a handle and clone it into the
-    // repositories.
-    let repository_handle = manager.write_pool();
-
     manager.reconcile().await;
+
+    // What Database::new does at startup: clone the handle into repositories.
+    let repository_handle = manager.write_pool();
+    let conn = repository_handle
+        .get()
+        .await
+        .expect("must serve through leader A before the failover");
+    let row = conn.query_one("SELECT 1", &[]).await.unwrap();
+    assert_eq!(row.get::<_, i32>(0), 1);
+    drop(conn);
     assert!(
-        repository_handle.get().await.is_err(),
-        "no pool must be installed while the leader is unusable"
+        leader_a.connections.load(Ordering::SeqCst) >= 1,
+        "pre-failover traffic must flow through leader A"
     );
 
-    // Failover: discovery now reports a reachable leader.
+    // Failover: discovery reports B as leader; reconcile installs it, then A
+    // goes hard-down. With the outage bug, the clone stayed pinned to A and
+    // wedged right here.
     discovery
-        .set_cluster_state_for_test(Some(leader_member("new-leader", &pg_host, pg_port)), vec![])
+        .set_cluster_state_for_test(Some(leader_b.target()), vec![])
         .await;
     manager.reconcile().await;
+    leader_a.shutdown();
 
     let conn = repository_handle
         .get()
         .await
-        .expect("startup handle must serve connections to the new leader");
+        .expect("startup clone must route through leader B after the failover");
     let row = conn.query_one("SELECT 1", &[]).await.unwrap();
     assert_eq!(row.get::<_, i32>(0), 1);
+    assert!(
+        leader_b.connections.load(Ordering::SeqCst) >= 1,
+        "post-failover traffic must flow through leader B"
+    );
+}
+
+/// If discovery advances to a new leader while a candidate is still being
+/// verified, the stale candidate must be discarded, not installed.
+#[tokio::test]
+async fn stale_candidate_is_discarded_when_leader_changes_during_verification() {
+    let upstream = postgres_upstream();
+    // Candidate A delays every connection, holding reconcile inside
+    // verification long enough to flip the leader underneath it.
+    let leader_a = TcpProxy::start(upstream.clone(), Duration::from_millis(750)).await;
+    let leader_b = TcpProxy::start(upstream, Duration::ZERO).await;
+
+    let discovery = test_discovery();
+    discovery
+        .set_cluster_state_for_test(Some(leader_a.target()), vec![])
+        .await;
+
+    let manager = Arc::new(ClusterManager::new(
+        discovery.clone(),
+        test_db_config(),
+        ReadPreference::LeaderOnly,
+        None,
+    ));
+    let repository_handle = manager.write_pool();
+
+    let reconcile_task = tokio::spawn({
+        let manager = manager.clone();
+        async move { manager.reconcile().await }
+    });
+    // Wait until reconcile is inside A's delayed verification, then fail over.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    discovery
+        .set_cluster_state_for_test(Some(leader_b.target()), vec![])
+        .await;
+    reconcile_task.await.unwrap();
+
+    assert!(
+        repository_handle.get().await.is_err(),
+        "the stale candidate must not be installed as the write pool"
+    );
+
+    // The next tick converges on the current leader.
+    manager.reconcile().await;
+    let conn = repository_handle
+        .get()
+        .await
+        .expect("reconcile must install the current leader");
+    let row = conn.query_one("SELECT 1", &[]).await.unwrap();
+    assert_eq!(row.get::<_, i32>(0), 1);
+    assert!(leader_b.connections.load(Ordering::SeqCst) >= 1);
 }

--- a/crates/api/tests/e2e_all/patroni_failover.rs
+++ b/crates/api/tests/e2e_all/patroni_failover.rs
@@ -1,0 +1,99 @@
+// Regression test for the 2026-07-12 outage root cause: pool handles cloned at
+// startup (as `Database::new` hands to every repository) must observe the pool
+// the ClusterManager installs for a new leader. Previously the manager swapped
+// a pool nothing re-read, so repositories kept dialing the host captured at
+// startup until the process was redeployed.
+
+use database::cluster_manager::{ClusterManager, DatabaseConfig, ReadPreference};
+use database::patroni_discovery::{ClusterMember, PatroniDiscovery};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+
+fn leader_member(name: &str, host: &str, port: u16) -> ClusterMember {
+    ClusterMember {
+        name: name.to_string(),
+        host: host.to_string(),
+        port,
+        role: "leader".to_string(),
+        state: "running".to_string(),
+        lag: None,
+        timeline: None,
+    }
+}
+
+/// Listener that accepts TCP connections and immediately closes them, standing
+/// in for a failed leader that is still reachable at the TCP level.
+async fn dead_postgres_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            if let Ok((socket, _)) = listener.accept().await {
+                drop(socket);
+            }
+        }
+    });
+    port
+}
+
+#[tokio::test]
+async fn reconcile_repoints_startup_pool_clones_to_new_leader() {
+    let pg_host = std::env::var("DATABASE_HOST").unwrap_or_else(|_| "localhost".to_string());
+    let pg_port: u16 = std::env::var("DATABASE_PORT")
+        .unwrap_or_else(|_| "5432".to_string())
+        .parse()
+        .unwrap();
+
+    // "Old leader": up at the TCP level but unusable, like a failed member.
+    let dead_port = dead_postgres_port().await;
+    // Refresh interval long enough that the injected state never goes stale.
+    let discovery = Arc::new(PatroniDiscovery::new(
+        "test-app".to_string(),
+        "gateway.invalid".to_string(),
+        3600,
+    ));
+    discovery
+        .set_cluster_state_for_test(
+            Some(leader_member("old-leader", "127.0.0.1", dead_port)),
+            vec![],
+        )
+        .await;
+
+    let manager = ClusterManager::new(
+        discovery.clone(),
+        DatabaseConfig {
+            database: std::env::var("DATABASE_NAME").unwrap_or_else(|_| "postgres".to_string()),
+            username: std::env::var("DATABASE_USERNAME").unwrap_or_else(|_| "postgres".to_string()),
+            password: std::env::var("DATABASE_PASSWORD").unwrap_or_else(|_| "postgres".to_string()),
+            max_write_connections: 2,
+            max_read_connections: 2,
+            tls_enabled: false,
+            tls_ca_cert_path: None,
+        },
+        ReadPreference::LeaderOnly,
+        None,
+    );
+
+    // What Database::new does at startup: take a handle and clone it into the
+    // repositories.
+    let repository_handle = manager.write_pool();
+
+    manager.reconcile().await;
+    assert!(
+        repository_handle.get().await.is_err(),
+        "no pool must be installed while the leader is unusable"
+    );
+
+    // Failover: discovery now reports a reachable leader.
+    discovery
+        .set_cluster_state_for_test(Some(leader_member("new-leader", &pg_host, pg_port)), vec![])
+        .await;
+    manager.reconcile().await;
+
+    let conn = repository_handle
+        .get()
+        .await
+        .expect("startup handle must serve connections to the new leader");
+    let row = conn.query_one("SELECT 1", &[]).await.unwrap();
+    assert_eq!(row.get::<_, i32>(0), 1);
+}

--- a/crates/api/tests/e2e_all/patroni_failover.rs
+++ b/crates/api/tests/e2e_all/patroni_failover.rs
@@ -178,7 +178,7 @@ async fn stale_candidate_is_discarded_when_leader_changes_during_verification() 
     let upstream = postgres_upstream();
     // Candidate A delays every connection, holding reconcile inside
     // verification long enough to flip the leader underneath it.
-    let leader_a = TcpProxy::start(upstream.clone(), Duration::from_millis(750)).await;
+    let leader_a = TcpProxy::start(upstream.clone(), Duration::from_secs(2)).await;
     let leader_b = TcpProxy::start(upstream, Duration::ZERO).await;
 
     let discovery = test_discovery();
@@ -198,8 +198,17 @@ async fn stale_candidate_is_discarded_when_leader_changes_during_verification() 
         let manager = manager.clone();
         async move { manager.reconcile().await }
     });
-    // Wait until reconcile is inside A's delayed verification, then fail over.
-    tokio::time::sleep(Duration::from_millis(250)).await;
+    // Wait until reconcile has snapshotted A and is inside its delayed
+    // verification — observable as A's proxy accepting the first connection —
+    // then fail over. The 2s pre-connect delay keeps verification pending far
+    // longer than the flip takes.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while leader_a.connections.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("reconcile must attempt a connection to leader A");
     discovery
         .set_cluster_state_for_test(Some(leader_b.target()), vec![])
         .await;

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -62,3 +62,8 @@ reqwest = { version = "0.12", features = ["json"] }
 # For TLS connections to PostgreSQL
 postgres-native-tls = "0.5"
 native-tls = "0.2"
+
+[features]
+# Exposes test-only helpers (e.g. Patroni cluster-state injection) to
+# dependent crates' test suites. Never enable in production builds.
+test-support = []

--- a/crates/database/src/cluster_manager.rs
+++ b/crates/database/src/cluster_manager.rs
@@ -1,5 +1,5 @@
 use crate::patroni_discovery::{ClusterMember, PatroniDiscovery};
-use crate::pool::create_pool_with_native_tls;
+use crate::pool::{create_pool_with_native_tls, DbPool};
 use anyhow::{anyhow, Result};
 use deadpool::managed::QueueMode;
 use deadpool_postgres::{Config, Object as PooledConnection, Pool, Runtime};
@@ -10,6 +10,12 @@ use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time;
 use tracing::{debug, error, info, warn};
+
+/// Upper bound on verifying a candidate leader before installing its pool.
+/// Generous next to the 5s pool create/wait timeouts it wraps, but bounded so
+/// a member that accepts connections and then hangs cannot stall the
+/// reconcile loop.
+const WRITE_POOL_VERIFY_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Read preference strategy
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,7 +41,13 @@ impl From<&str> for ReadPreference {
 
 pub struct ClusterManager {
     discovery: Arc<PatroniDiscovery>,
-    write_pool: Arc<RwLock<Option<Pool>>>,
+    /// Shared handle the repositories clone at startup. Installing a new pool
+    /// here repoints every clone; see [`DbPool`].
+    write_pool: DbPool,
+    /// `host:port` the write pool currently targets. Recorded only after a
+    /// pool was successfully built and verified against that member, so a
+    /// failed rebuild leaves it unchanged and the next reconcile tick retries.
+    write_pool_target: Arc<RwLock<Option<String>>>,
     read_pools: Arc<RwLock<HashMap<String, Pool>>>,
     database_config: DatabaseConfig,
     read_preference: ReadPreference,
@@ -64,7 +76,8 @@ impl ClusterManager {
     ) -> Self {
         Self {
             discovery,
-            write_pool: Arc::new(RwLock::new(None)),
+            write_pool: DbPool::uninitialized(),
+            write_pool_target: Arc::new(RwLock::new(None)),
             read_pools: Arc::new(RwLock::new(HashMap::new())),
             database_config,
             read_preference,
@@ -72,6 +85,11 @@ impl ClusterManager {
             round_robin_counter: AtomicUsize::new(0),
             background_task_handle: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// `host:port` connection target for a cluster member.
+    fn member_target(member: &ClusterMember) -> String {
+        format!("{}:{}", member.host, member.port)
     }
 
     /// Initialize the cluster manager and create initial pools
@@ -108,24 +126,47 @@ impl ClusterManager {
             self.database_config.max_write_connections,
         )?;
 
-        // Test the connection
-        let conn = pool.get().await?;
-        conn.simple_query("SELECT 1").await?;
+        // The deadpool timeouts only bound connection establishment; a member
+        // that accepts connections but then hangs would otherwise block the
+        // reconcile loop indefinitely and freeze all failover handling, so the
+        // whole verification is bounded.
+        let verification = async {
+            // Test the connection
+            let conn = pool.get().await?;
+            conn.simple_query("SELECT 1").await?;
 
-        // Verify this is actually the leader
-        let rows = conn.query("SELECT pg_is_in_recovery()", &[]).await?;
-        let is_replica: bool = rows[0].get(0);
-        if is_replica {
-            warn!(
-                "Node {} claims to be leader but is in recovery mode",
-                leader.name
-            );
-        }
+            // Verify this is actually the leader. Patroni can report a member
+            // as leader while Postgres is still completing promotion;
+            // installing it would pin every write to a read-only node with no
+            // retry, so fail and let the next reconcile tick try again.
+            let rows = conn.query("SELECT pg_is_in_recovery()", &[]).await?;
+            let is_replica: bool = rows
+                .first()
+                .ok_or_else(|| anyhow!("Empty response to pg_is_in_recovery()"))?
+                .try_get(0)?;
+            if is_replica {
+                return Err(anyhow!(
+                    "Node {} claims to be leader but is still in recovery",
+                    leader.name
+                ));
+            }
+            Ok(())
+        };
+        time::timeout(WRITE_POOL_VERIFY_TIMEOUT, verification)
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "Timed out verifying leader {} after {:?}",
+                    leader.name,
+                    WRITE_POOL_VERIFY_TIMEOUT
+                )
+            })??;
 
-        let mut write_pool = self.write_pool.write().await;
-        *write_pool = Some(pool);
+        self.write_pool.replace(pool);
+        let target = Self::member_target(leader);
+        *self.write_pool_target.write().await = Some(target.clone());
 
-        debug!("Write pool created successfully for leader {}", leader.name);
+        info!("Write pool now targets leader {} ({})", leader.name, target);
         Ok(())
     }
 
@@ -199,12 +240,8 @@ impl ClusterManager {
 
     /// Get a connection for write operations (always uses leader)
     pub async fn get_write_connection(&self) -> Result<PooledConnection> {
-        let write_pool = self.write_pool.read().await;
-        let pool = write_pool
-            .as_ref()
-            .ok_or_else(|| anyhow!("No write pool available"))?;
-
-        pool.get()
+        self.write_pool
+            .get()
             .await
             .map_err(|e| anyhow!("Failed to get write connection: {e}"))
     }
@@ -220,18 +257,18 @@ impl ClusterManager {
 
     /// Get read connection using round-robin selection
     async fn get_read_connection_round_robin(&self) -> Result<PooledConnection> {
-        let read_pools = self.read_pools.read().await;
-
-        if read_pools.is_empty() {
+        let replicas = self.discovery.get_replicas().await;
+        if replicas.is_empty() {
             debug!("No read replicas available, falling back to leader");
             return self.get_write_connection().await;
         }
 
         let index = self.round_robin_counter.fetch_add(1, Ordering::Relaxed);
-        let replicas = self.discovery.get_replicas().await;
-
         if let Some(replica) = replicas.get(index % replicas.len()) {
-            if let Some(pool) = read_pools.get(&replica.host) {
+            // Clone the pool out of the map so the lock is not held across the
+            // acquisition await.
+            let pool = self.read_pools.read().await.get(&replica.host).cloned();
+            if let Some(pool) = pool {
                 match pool.get().await {
                     Ok(conn) => return Ok(conn),
                     Err(e) => {
@@ -251,20 +288,16 @@ impl ClusterManager {
 
     /// Get read connection from replica with least lag
     async fn get_read_connection_least_lag(&self) -> Result<PooledConnection> {
-        let read_pools = self.read_pools.read().await;
-
-        if read_pools.is_empty() {
-            debug!("No read replicas available, falling back to leader");
-            return self.get_write_connection().await;
-        }
-
         // Get replica with least lag
         if let Some(replica) = self
             .discovery
             .get_least_lag_replica(self.max_replica_lag_ms)
             .await
         {
-            if let Some(pool) = read_pools.get(&replica.host) {
+            // Clone the pool out of the map so the lock is not held across the
+            // acquisition await.
+            let pool = self.read_pools.read().await.get(&replica.host).cloned();
+            if let Some(pool) = pool {
                 match pool.get().await {
                     Ok(conn) => {
                         debug!(
@@ -288,25 +321,43 @@ impl ClusterManager {
         self.get_write_connection().await
     }
 
-    /// Handle leader change event
-    pub async fn handle_leader_change(&self) -> Result<()> {
-        warn!("Handling leader change");
+    /// Converge the pools on the current cluster topology: rebuild the write
+    /// pool whenever it does not target the discovered leader, and refresh the
+    /// read pools. Safe to call repeatedly — the installed target is only
+    /// recorded on a successful rebuild, so a failure (e.g. the new leader not
+    /// accepting connections yet) is retried on the next tick instead of being
+    /// dropped.
+    pub async fn reconcile(&self) {
+        if self.discovery.is_state_stale().await {
+            warn!(
+                "Patroni cluster state is stale (age: {:?}s); leader changes may go undetected",
+                self.discovery.get_state_age_secs().await
+            );
+        }
 
-        // Get new leader
-        let leader = self
-            .discovery
-            .get_leader()
-            .await
-            .ok_or_else(|| anyhow!("No leader available after failover"))?;
+        match self.discovery.get_leader().await {
+            Some(leader) => {
+                let target = Self::member_target(&leader);
+                let installed = self.write_pool_target.read().await.clone();
+                if installed.as_deref() != Some(target.as_str()) {
+                    warn!(
+                        "Write pool targets {installed:?} but cluster leader is {target}; rebuilding write pool"
+                    );
+                    if let Err(e) = self.create_write_pool(&leader).await {
+                        error!(
+                            "Failed to rebuild write pool for leader {target} (will retry): {e:#}"
+                        );
+                    }
+                }
+            }
+            None => {
+                warn!("No cluster leader known; keeping current write pool");
+            }
+        }
 
-        // Recreate write pool
-        self.create_write_pool(&leader).await?;
-
-        // Update read pools
-        self.update_read_pools().await?;
-
-        info!("Leader change handled successfully");
-        Ok(())
+        if let Err(e) = self.update_read_pools().await {
+            error!("Failed to update read pools: {e:#}");
+        }
     }
 
     /// Start background tasks for cluster management and store handle for lifecycle management
@@ -315,41 +366,24 @@ impl ClusterManager {
             let manager = self.clone();
             async move {
                 let mut interval = time::interval(Duration::from_secs(30));
-                let mut last_leader: Option<String> = None;
+                interval.tick().await; // skip the immediate first tick
 
                 loop {
                     interval.tick().await;
-
-                    // Check for leader changes
-                    if let Some(leader) = manager.discovery.get_leader().await {
-                        let current_leader = Some(leader.host.clone());
-                        if last_leader != current_leader {
-                            if last_leader.is_some() {
-                                // Leader changed
-                                info!("Leader change detected");
-                                if manager.handle_leader_change().await.is_err() {
-                                    error!("Failed to handle leader change");
-                                }
-                            }
-                            last_leader = current_leader;
-                        }
-                    }
-
-                    // Update read pools periodically
-                    if manager.update_read_pools().await.is_err() {
-                        error!("Failed to update read pools");
-                    }
+                    manager.reconcile().await;
                 }
             }
         });
 
         let mut task_handle = self.background_task_handle.lock().await;
-        *task_handle = Some(handle);
+        if let Some(previous) = task_handle.replace(handle) {
+            previous.abort();
+        }
     }
 
     /// Get statistics about the cluster
     pub async fn get_stats(&self) -> ClusterStats {
-        let write_available = self.write_pool.read().await.is_some();
+        let write_available = self.write_pool.current().is_some();
         let read_pool_count = self.read_pools.read().await.len();
         let leader = self.discovery.get_leader().await;
         let replicas = self.discovery.get_replicas().await;
@@ -363,13 +397,10 @@ impl ClusterManager {
         }
     }
 
-    /// Get a clone of the write pool for direct access
-    pub async fn get_write_pool(&self) -> Result<Pool> {
-        let pool_guard = self.write_pool.read().await;
-        pool_guard
-            .as_ref()
-            .ok_or_else(|| anyhow!("Write pool not initialized"))
-            .cloned()
+    /// Get the shared write-pool handle. Clones of this handle stay pointed at
+    /// the current leader across failovers.
+    pub fn write_pool(&self) -> DbPool {
+        self.write_pool.clone()
     }
 
     /// Shutdown the cluster manager and cancel background tasks
@@ -397,4 +428,101 @@ pub struct ClusterStats {
     pub leader_name: Option<String>,
     pub replica_count: usize,
     pub state_age_secs: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    fn leader_member(name: &str, host: &str, port: u16) -> ClusterMember {
+        ClusterMember {
+            name: name.to_string(),
+            host: host.to_string(),
+            port,
+            role: "leader".to_string(),
+            state: "running".to_string(),
+            lag: None,
+            timeline: None,
+        }
+    }
+
+    fn test_db_config() -> DatabaseConfig {
+        DatabaseConfig {
+            database: std::env::var("DATABASE_NAME").unwrap_or_else(|_| "postgres".to_string()),
+            username: std::env::var("DATABASE_USERNAME").unwrap_or_else(|_| "postgres".to_string()),
+            password: std::env::var("DATABASE_PASSWORD").unwrap_or_else(|_| "postgres".to_string()),
+            max_write_connections: 2,
+            max_read_connections: 2,
+            tls_enabled: false,
+            tls_ca_cert_path: None,
+        }
+    }
+
+    /// A discovery whose refresh interval is long enough that the injected
+    /// state never counts as stale during a test.
+    fn test_discovery() -> Arc<PatroniDiscovery> {
+        Arc::new(PatroniDiscovery::new(
+            "test-app".to_string(),
+            "gateway.invalid".to_string(),
+            3600,
+        ))
+    }
+
+    /// Listener that accepts TCP connections and immediately closes them, so
+    /// the Postgres handshake fails. Returns the port and an attempt counter.
+    async fn dead_postgres() -> (u16, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let counter = attempts.clone();
+        tokio::spawn(async move {
+            loop {
+                if let Ok((socket, _)) = listener.accept().await {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    drop(socket);
+                }
+            }
+        });
+        (port, attempts)
+    }
+
+    /// Regression test for the 2026-07-12 outage follow-up: a failed write-pool
+    /// rebuild (new leader not accepting connections yet) must be retried on
+    /// the next reconcile tick, not dropped. The old loop recorded the new
+    /// leader as handled even when the rebuild failed, wedging the write pool
+    /// on the previous leader until a redeploy.
+    #[tokio::test]
+    async fn failed_write_pool_rebuild_is_retried_on_next_reconcile() {
+        let (port, attempts) = dead_postgres().await;
+        let discovery = test_discovery();
+        discovery
+            .set_cluster_state_for_test(Some(leader_member("n1", "127.0.0.1", port)), vec![])
+            .await;
+
+        let manager = ClusterManager::new(
+            discovery.clone(),
+            test_db_config(),
+            ReadPreference::LeaderOnly,
+            None,
+        );
+
+        manager.reconcile().await;
+        let first_attempts = attempts.load(Ordering::SeqCst);
+        assert!(first_attempts >= 1, "reconcile must attempt a connection");
+        assert!(
+            manager.write_pool_target.read().await.is_none(),
+            "a failed rebuild must not record the leader as installed"
+        );
+
+        manager.reconcile().await;
+        assert!(
+            attempts.load(Ordering::SeqCst) > first_attempts,
+            "the next reconcile must retry the failed rebuild"
+        );
+    }
+
+    // The success-path regression test (a startup pool handle following a
+    // leader change to a live Postgres) needs a real database and lives in the
+    // e2e suite: crates/api/tests/e2e_all/patroni_failover.rs.
 }

--- a/crates/database/src/cluster_manager.rs
+++ b/crates/database/src/cluster_manager.rs
@@ -47,7 +47,10 @@ pub struct ClusterManager {
     /// `host:port` the write pool currently targets. Recorded only after a
     /// pool was successfully built and verified against that member, so a
     /// failed rebuild leaves it unchanged and the next reconcile tick retries.
-    write_pool_target: Arc<RwLock<Option<String>>>,
+    /// A std lock (never held across an await) so the compare-and-install in
+    /// `create_write_pool` can run synchronously under the discovery state
+    /// lock.
+    write_pool_target: Arc<std::sync::RwLock<Option<String>>>,
     /// Serializes reconciliation so concurrent callers cannot interleave
     /// verify/install sequences and roll the write pool back to an older
     /// leader (last-writer-wins).
@@ -81,7 +84,7 @@ impl ClusterManager {
         Self {
             discovery,
             write_pool: DbPool::uninitialized(),
-            write_pool_target: Arc::new(RwLock::new(None)),
+            write_pool_target: Arc::new(std::sync::RwLock::new(None)),
             reconcile_lock: Mutex::new(()),
             read_pools: Arc::new(RwLock::new(HashMap::new())),
             database_config,
@@ -167,18 +170,31 @@ impl ClusterManager {
         // Discovery may have advanced while this candidate was being verified
         // (up to WRITE_POOL_VERIFY_TIMEOUT). Installing a stale leader would
         // repoint every repository to a demoted node until the next reconcile
-        // tick, so confirm the candidate is still the current leader.
+        // tick, so compare-and-install under the discovery state lock:
+        // topology publication is excluded while the closure runs, so a
+        // leader change cannot slip in between the check and the install.
         let target = Self::member_target(leader);
-        let current = self.discovery.get_leader().await;
-        if current.as_ref().map(Self::member_target).as_deref() != Some(target.as_str()) {
+        let install_result = self
+            .discovery
+            .with_current_leader(|current| {
+                let current_target = current.map(Self::member_target);
+                if current_target.as_deref() == Some(target.as_str()) {
+                    self.write_pool.replace(pool);
+                    *self
+                        .write_pool_target
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner()) = Some(target.clone());
+                    Ok(())
+                } else {
+                    Err(current_target)
+                }
+            })
+            .await;
+        if let Err(current) = install_result {
             return Err(anyhow!(
-                "Cluster leader changed to {:?} while verifying {target}; discarding this pool",
-                current.map(|m| Self::member_target(&m))
+                "Cluster leader changed to {current:?} while verifying {target}; discarding this pool"
             ));
         }
-
-        self.write_pool.replace(pool);
-        *self.write_pool_target.write().await = Some(target.clone());
 
         info!("Write pool now targets leader {} ({})", leader.name, target);
         Ok(())
@@ -359,7 +375,11 @@ impl ClusterManager {
         match self.discovery.get_leader().await {
             Some(leader) => {
                 let target = Self::member_target(&leader);
-                let installed = self.write_pool_target.read().await.clone();
+                let installed = self
+                    .write_pool_target
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .clone();
                 if installed.as_deref() != Some(target.as_str()) {
                     warn!(
                         "Write pool targets {installed:?} but cluster leader is {target}; rebuilding write pool"
@@ -532,7 +552,7 @@ mod tests {
         let first_attempts = attempts.load(Ordering::SeqCst);
         assert!(first_attempts >= 1, "reconcile must attempt a connection");
         assert!(
-            manager.write_pool_target.read().await.is_none(),
+            manager.write_pool_target.read().unwrap().is_none(),
             "a failed rebuild must not record the leader as installed"
         );
 

--- a/crates/database/src/cluster_manager.rs
+++ b/crates/database/src/cluster_manager.rs
@@ -48,6 +48,10 @@ pub struct ClusterManager {
     /// pool was successfully built and verified against that member, so a
     /// failed rebuild leaves it unchanged and the next reconcile tick retries.
     write_pool_target: Arc<RwLock<Option<String>>>,
+    /// Serializes reconciliation so concurrent callers cannot interleave
+    /// verify/install sequences and roll the write pool back to an older
+    /// leader (last-writer-wins).
+    reconcile_lock: Mutex<()>,
     read_pools: Arc<RwLock<HashMap<String, Pool>>>,
     database_config: DatabaseConfig,
     read_preference: ReadPreference,
@@ -78,6 +82,7 @@ impl ClusterManager {
             discovery,
             write_pool: DbPool::uninitialized(),
             write_pool_target: Arc::new(RwLock::new(None)),
+            reconcile_lock: Mutex::new(()),
             read_pools: Arc::new(RwLock::new(HashMap::new())),
             database_config,
             read_preference,
@@ -159,8 +164,20 @@ impl ClusterManager {
                 )
             })??;
 
-        self.write_pool.replace(pool);
+        // Discovery may have advanced while this candidate was being verified
+        // (up to WRITE_POOL_VERIFY_TIMEOUT). Installing a stale leader would
+        // repoint every repository to a demoted node until the next reconcile
+        // tick, so confirm the candidate is still the current leader.
         let target = Self::member_target(leader);
+        let current = self.discovery.get_leader().await;
+        if current.as_ref().map(Self::member_target).as_deref() != Some(target.as_str()) {
+            return Err(anyhow!(
+                "Cluster leader changed to {:?} while verifying {target}; discarding this pool",
+                current.map(|m| Self::member_target(&m))
+            ));
+        }
+
+        self.write_pool.replace(pool);
         *self.write_pool_target.write().await = Some(target.clone());
 
         info!("Write pool now targets leader {} ({})", leader.name, target);
@@ -325,6 +342,10 @@ impl ClusterManager {
     /// accepting connections yet) is retried on the next tick instead of being
     /// dropped.
     pub async fn reconcile(&self) {
+        // One reconciliation at a time: interleaved verify/install sequences
+        // could install pools out of order and roll back to an older leader.
+        let _guard = self.reconcile_lock.lock().await;
+
         if self.discovery.is_state_stale().await {
             let age = self
                 .discovery

--- a/crates/database/src/cluster_manager.rs
+++ b/crates/database/src/cluster_manager.rs
@@ -139,11 +139,8 @@ impl ClusterManager {
             // as leader while Postgres is still completing promotion;
             // installing it would pin every write to a read-only node with no
             // retry, so fail and let the next reconcile tick try again.
-            let rows = conn.query("SELECT pg_is_in_recovery()", &[]).await?;
-            let is_replica: bool = rows
-                .first()
-                .ok_or_else(|| anyhow!("Empty response to pg_is_in_recovery()"))?
-                .try_get(0)?;
+            let row = conn.query_one("SELECT pg_is_in_recovery()", &[]).await?;
+            let is_replica: bool = row.try_get(0)?;
             if is_replica {
                 return Err(anyhow!(
                     "Node {} claims to be leader but is still in recovery",
@@ -329,10 +326,13 @@ impl ClusterManager {
     /// dropped.
     pub async fn reconcile(&self) {
         if self.discovery.is_state_stale().await {
-            warn!(
-                "Patroni cluster state is stale (age: {:?}s); leader changes may go undetected",
-                self.discovery.get_state_age_secs().await
-            );
+            let age = self
+                .discovery
+                .get_state_age_secs()
+                .await
+                .map(|secs| format!("{secs}s"))
+                .unwrap_or_else(|| "never loaded".to_string());
+            warn!("Patroni cluster state is stale (age: {age}); leader changes may go undetected");
         }
 
         match self.discovery.get_leader().await {

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -138,8 +138,10 @@ impl Database {
         info!("Starting cluster manager background tasks");
         cluster_manager.clone().start_background_tasks().await;
 
-        // Get write pool to use for repositories
-        let pool = cluster_manager.get_write_pool().await?;
+        // Shared write-pool handle for the repositories; clones of it follow
+        // the leader across failovers because ClusterManager installs new
+        // pools into this same handle.
+        let pool = cluster_manager.write_pool();
 
         info!("Database initialization with Patroni discovery complete");
 
@@ -235,6 +237,6 @@ impl Database {
             pg_config.create_pool(Some(Runtime::Tokio1), NoTls)?
         };
 
-        Ok(Self::new(pool))
+        Ok(Self::new(DbPool::new(pool)))
     }
 }

--- a/crates/database/src/mock.rs
+++ b/crates/database/src/mock.rs
@@ -1,3 +1,4 @@
+use crate::pool::DbPool;
 use crate::Database;
 use anyhow::Result;
 use std::env;
@@ -27,7 +28,7 @@ pub async fn create_mock_database() -> Result<Database> {
             deadpool_postgres::Manager::from_config(config, tokio_postgres::NoTls, mgr_config);
         let pool = deadpool_postgres::Pool::builder(mgr).max_size(1).build()?;
 
-        return Ok(Database::new(pool));
+        return Ok(Database::new(DbPool::new(pool)));
     }
 
     // Otherwise, create a dummy pool that will fail if actually used
@@ -49,5 +50,5 @@ pub async fn create_mock_database() -> Result<Database> {
     // Create a pool with max_size of 0 so it doesn't try to connect immediately
     let pool = deadpool_postgres::Pool::builder(mgr).max_size(1).build()?;
 
-    Ok(Database::new(pool))
+    Ok(Database::new(DbPool::new(pool)))
 }

--- a/crates/database/src/patroni_discovery.rs
+++ b/crates/database/src/patroni_discovery.rs
@@ -234,6 +234,16 @@ impl PatroniDiscovery {
         state.as_ref()?.leader.clone()
     }
 
+    /// Run `f` with the current leader while holding the cluster-state read
+    /// lock. Topology publication (`update_cluster_state`) takes the write
+    /// lock, so it is excluded for the duration — letting callers make a
+    /// leader comparison and a pool install atomic relative to discovery
+    /// updates. `f` must be synchronous and quick; it runs under the lock.
+    pub async fn with_current_leader<R>(&self, f: impl FnOnce(Option<&ClusterMember>) -> R) -> R {
+        let state = self.cluster_state.read().await;
+        f(state.as_ref().and_then(|s| s.leader.as_ref()))
+    }
+
     /// Get all replica information
     pub async fn get_replicas(&self) -> Vec<ClusterMember> {
         let state = self.cluster_state.read().await;

--- a/crates/database/src/patroni_discovery.rs
+++ b/crates/database/src/patroni_discovery.rs
@@ -278,9 +278,10 @@ impl PatroniDiscovery {
     }
 
     /// Test-only: inject a cluster state directly, bypassing HTTP discovery.
-    /// Not part of the public API; exposed so integration/e2e tests can drive
-    /// failover scenarios without a real Patroni endpoint.
-    #[doc(hidden)]
+    /// Compiled only for this crate's tests and for dependents that enable the
+    /// `test-support` feature (the e2e suite), so it does not ship in release
+    /// builds.
+    #[cfg(any(test, feature = "test-support"))]
     pub async fn set_cluster_state_for_test(
         &self,
         leader: Option<ClusterMember>,

--- a/crates/database/src/patroni_discovery.rs
+++ b/crates/database/src/patroni_discovery.rs
@@ -277,6 +277,23 @@ impl PatroniDiscovery {
         *task_handle = Some(handle);
     }
 
+    /// Test-only: inject a cluster state directly, bypassing HTTP discovery.
+    /// Not part of the public API; exposed so integration/e2e tests can drive
+    /// failover scenarios without a real Patroni endpoint.
+    #[doc(hidden)]
+    pub async fn set_cluster_state_for_test(
+        &self,
+        leader: Option<ClusterMember>,
+        replicas: Vec<ClusterMember>,
+    ) {
+        let mut state = self.cluster_state.write().await;
+        *state = Some(ClusterState {
+            leader,
+            replicas,
+            last_updated: std::time::Instant::now(),
+        });
+    }
+
     /// Get cluster state age in seconds
     pub async fn get_state_age_secs(&self) -> Option<u64> {
         let state = self.cluster_state.read().await;

--- a/crates/database/src/pool.rs
+++ b/crates/database/src/pool.rs
@@ -126,8 +126,9 @@ impl DbPool {
     }
 
     /// Install `pool` as the active pool for this handle and every clone of it.
-    /// The previous pool (if any) is dropped once its checked-out connections
-    /// are returned.
+    /// Connections already checked out of the previous pool are not
+    /// interrupted; the old pool is torn down once those connections are
+    /// returned and its last reference is gone.
     pub fn replace(&self, pool: Pool) {
         let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
         *guard = Some(pool);

--- a/crates/database/src/pool.rs
+++ b/crates/database/src/pool.rs
@@ -94,5 +94,124 @@ pub fn create_pool_with_native_tls(
         .map_err(|e| anyhow::anyhow!("Failed to create TLS pool: {e}"))
 }
 
-/// Connection pool type alias
-pub type DbPool = Pool;
+/// Shared, swappable handle to the active write pool.
+///
+/// Repositories hold clones of this handle and acquire connections through it
+/// per call. When the Patroni leader changes, `ClusterManager` installs the new
+/// leader's pool via [`DbPool::replace`] and every clone immediately routes new
+/// acquisitions to the new leader. A plain `deadpool::Pool` clone cannot do
+/// this — its target host is fixed at creation, so pools captured at startup
+/// keep dialing the old leader after a failover (the 2026-07-12 outage: the
+/// leader change was detected and a new pool was built, but no repository ever
+/// saw it).
+#[derive(Clone)]
+pub struct DbPool {
+    inner: std::sync::Arc<std::sync::RwLock<Option<Pool>>>,
+}
+
+impl DbPool {
+    /// Create a handle wrapping an already-built pool.
+    pub fn new(pool: Pool) -> Self {
+        Self {
+            inner: std::sync::Arc::new(std::sync::RwLock::new(Some(pool))),
+        }
+    }
+
+    /// Create a handle with no pool installed yet. [`DbPool::get`] fails with
+    /// `PoolError::Closed` until [`DbPool::replace`] installs one.
+    pub fn uninitialized() -> Self {
+        Self {
+            inner: std::sync::Arc::new(std::sync::RwLock::new(None)),
+        }
+    }
+
+    /// Install `pool` as the active pool for this handle and every clone of it.
+    /// The previous pool (if any) is dropped once its checked-out connections
+    /// are returned.
+    pub fn replace(&self, pool: Pool) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(pool);
+    }
+
+    /// The currently installed pool, if any.
+    pub fn current(&self) -> Option<Pool> {
+        self.inner.read().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    /// Acquire a connection from the currently installed pool.
+    pub async fn get(&self) -> Result<deadpool_postgres::Object, deadpool_postgres::PoolError> {
+        // Clone the pool out of the lock so it is not held across the await.
+        let pool = self.current().ok_or(deadpool_postgres::PoolError::Closed)?;
+        pool.get().await
+    }
+
+    /// Status of the currently installed pool, or `None` before initialization.
+    pub fn status(&self) -> Option<deadpool::Status> {
+        self.current().map(|pool| pool.status())
+    }
+}
+
+impl From<Pool> for DbPool {
+    fn from(pool: Pool) -> Self {
+        Self::new(pool)
+    }
+}
+
+// Manual impl: the inner pool's Debug output includes connection config, which
+// must never end up in logs.
+impl std::fmt::Debug for DbPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbPool")
+            .field("initialized", &self.current().is_some())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deadpool::managed::QueueMode;
+
+    fn lazy_pool(max_size: usize) -> Pool {
+        // deadpool creates connections lazily, so building a pool against an
+        // unreachable host is fine as long as no connection is acquired.
+        let mut cfg = Config::new();
+        cfg.host = Some("pool-test-host.invalid".to_string());
+        cfg.port = Some(5432);
+        cfg.dbname = Some("test".to_string());
+        cfg.user = Some("test".to_string());
+        cfg.password = Some("test".to_string());
+        cfg.pool = Some(deadpool_postgres::PoolConfig {
+            max_size,
+            timeouts: deadpool_postgres::Timeouts::default(),
+            queue_mode: QueueMode::Fifo,
+        });
+        cfg.create_pool(Some(Runtime::Tokio1), tokio_postgres::NoTls)
+            .expect("lazy pool must build without connecting")
+    }
+
+    #[tokio::test]
+    async fn replace_propagates_to_existing_clones() {
+        let handle = DbPool::new(lazy_pool(3));
+        // Simulates a repository holding a clone taken at startup.
+        let repository_clone = handle.clone();
+        assert_eq!(repository_clone.status().unwrap().max_size, 3);
+
+        handle.replace(lazy_pool(7));
+        assert_eq!(
+            repository_clone.status().unwrap().max_size,
+            7,
+            "clones taken before replace() must observe the new pool"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_on_uninitialized_handle_fails_closed() {
+        let handle = DbPool::uninitialized();
+        assert!(handle.status().is_none());
+        match handle.get().await {
+            Err(deadpool_postgres::PoolError::Closed) => {}
+            other => panic!("expected PoolError::Closed, got {other:?}"),
+        }
+    }
+}

--- a/crates/database/tests/organization_reporting_token.rs
+++ b/crates/database/tests/organization_reporting_token.rs
@@ -30,7 +30,7 @@ fn pool_config() -> Config {
 }
 
 async fn test_pool() -> anyhow::Result<DbPool> {
-    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    let pool = DbPool::new(pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?);
     MIGRATED
         .get_or_try_init(|| async { migrations::run(&pool).await })
         .await?;

--- a/crates/database/tests/support/mod.rs
+++ b/crates/database/tests/support/mod.rs
@@ -46,7 +46,7 @@ pub fn ts(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
 }
 
 pub async fn test_pool() -> anyhow::Result<DbPool> {
-    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    let pool = DbPool::new(pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?);
     MIGRATED
         .get_or_try_init(|| async { migrations::run(&pool).await })
         .await?;

--- a/crates/database/tests/support/service_usage_reporting_pool.rs
+++ b/crates/database/tests/support/service_usage_reporting_pool.rs
@@ -7,7 +7,7 @@ use tokio_postgres::NoTls;
 static MIGRATED: OnceCell<()> = OnceCell::const_new();
 
 pub async fn test_pool() -> anyhow::Result<DbPool> {
-    let pool = pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?;
+    let pool = DbPool::new(pool_config().create_pool(Some(Runtime::Tokio1), NoTls)?);
     MIGRATED
         .get_or_try_init(|| async { migrations::run(&pool).await })
         .await?;

--- a/crates/database/tests/usage_reporting_indexes.rs
+++ b/crates/database/tests/usage_reporting_indexes.rs
@@ -21,7 +21,7 @@ fn pool_config() -> Config {
 }
 
 fn create_pool(config: &Config) -> anyhow::Result<DbPool> {
-    Ok(config.create_pool(Some(Runtime::Tokio1), NoTls)?)
+    Ok(config.create_pool(Some(Runtime::Tokio1), NoTls)?.into())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

During the 2026-07-12 outage the Patroni leader failover was **detected** by cloud-api (`Leader change detected` logged on both prod hosts at 00:45 UTC, ~40s after the first DB errors) and a new write pool was built — but every repository holds a clone of the **startup** deadpool `Pool`, whose target host is fixed at creation. The ClusterManager swapped a pool object nothing re-reads, so 100% of traffic stayed pinned to the failed leader until a redeploy rebuilt the pools. Three secondary defects compounded this class of outage:

- a failed `handle_leader_change()` still advanced `last_leader`, so a single transient failure (new leader not accepting connections yet) permanently suppressed any retry, with the error cause discarded;
- a member reported as leader while `pg_is_in_recovery()` was still true was installed anyway (warn only), pinning writes to a read-only node;
- stale discovery state (unreachable Patroni `/cluster` endpoint) was invisible — `is_state_stale()` had no callers.

## Fix

- **`DbPool` is now a shared, swappable handle** (`Arc<RwLock<Option<Pool>>>`): the ClusterManager installs the new leader's pool into it and every repository clone immediately routes new acquisitions to the new leader. Repository code is unchanged (`.get().await` as before).
- **Reconcile loop replaces the one-shot leader tracking**: the manager records which `host:port` the write pool actually targets — only on a successful, verified build — and compares it against the discovered leader every 30s tick. Failed rebuilds are retried on the next tick and the error cause is logged.
- **Leader verification is bounded** (15s timeout): a candidate that accepts connections and then hangs cannot stall the reconcile loop.
- **In-recovery leaders are rejected** (retried next tick) instead of installed.
- Stale discovery state now logs a warning from the reconcile loop.
- Hardening: no lock held across pool acquisition in the read paths, no divide-by-zero when the replica list empties mid-failover, no `rows[0]` panic in the background task, double-start of the background task aborts the previous loop.

## Tests

- `failed_write_pool_rebuild_is_retried_on_next_reconcile` (unit): a failed rebuild must not record the leader as installed and must be retried.
- `reconcile_repoints_startup_pool_clones_to_new_leader` (e2e, runs against the CI Postgres): a pool handle cloned at startup — what every repository holds — must serve connections to the new leader after reconcile.
- `replace_propagates_to_existing_clones` / `get_on_uninitialized_handle_fails_closed` (unit).
- Full suite green locally: 240 unit + 34 database integration + 662 e2e.

With this, a leader failover self-heals within one discovery refresh + reconcile tick instead of requiring a redeploy. chat-api has a copy of the same code and gets a mirror PR.

Follow-ups (not in this PR): TCP keepalive/`tcp_user_timeout` tuning so already-checked-out connections to a hard-dead leader die faster; a `/v1/health` variant that exercises the DB; Datadog monitors for `Failed to refresh cluster state` (still firing intermittently in prod since 07-12) and chat-api error logs.