### PR TITLE
fix(api): add Retry-After header to all client-facing 429 responses

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -41,7 +41,7 @@ use axum::http::{header::CACHE_CONTROL, HeaderValue};
 use axum::response::Response;
 use axum::{
     extract::DefaultBodyLimit,
-    middleware::{from_fn, from_fn_with_state, Next},
+    middleware::{from_fn, from_fn_with_state, map_response, Next},
     response::Html,
     routing::{get, post},
     Router,
@@ -1403,6 +1403,11 @@ pub fn build_app_with_config(
         // so compression is safe for them as well.
         .layer(CompressionLayer::new())
         .layer(from_fn(middleware::request_correlation_middleware))
+        // Outermost response pass: every client-facing 429 gets a
+        // machine-readable Retry-After header (SDK backoff honors it).
+        // Sites that set their own value (per-key limiter window, upstream
+        // ITA propagation) are left untouched.
+        .layer(map_response(middleware::retry_after_middleware))
 }
 
 /// Build VPC authentication routes

--- a/crates/api/src/middleware/mod.rs
+++ b/crates/api/src/middleware/mod.rs
@@ -9,6 +9,7 @@ pub mod metrics;
 pub mod rate_limit;
 pub mod reporting_guard;
 pub mod request_correlation;
+pub mod retry_after;
 pub mod usage;
 
 // Re-export commonly used items
@@ -24,4 +25,5 @@ pub use reporting_guard::{
     ReportingRequestDeadline,
 };
 pub use request_correlation::{request_correlation_middleware, RequestCorrelation};
+pub use retry_after::retry_after_middleware;
 pub use usage::{usage_check_middleware, UsageState};

--- a/crates/api/src/middleware/rate_limit.rs
+++ b/crates/api/src/middleware/rate_limit.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Request, State},
-    http::StatusCode,
+    http::{header::RETRY_AFTER, HeaderName, HeaderValue, StatusCode},
     middleware::Next,
     response::Response,
 };
@@ -74,10 +74,32 @@ impl RateLimitState {
     }
 }
 
+/// 429 rejection from the per-key limiter: status, `Retry-After` header, body.
+/// The header value matches the fixed rate-limit window (and the "Try again in
+/// N seconds" prose in the message) so SDK backoff waits out the window.
+pub type RateLimitedResponse = (
+    StatusCode,
+    [(HeaderName, HeaderValue); 1],
+    axum::Json<ErrorResponse>,
+);
+
+fn rate_limited_response(count: u32, limit: u32) -> RateLimitedResponse {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [(RETRY_AFTER, HeaderValue::from(RATE_LIMIT_WINDOW_SECS))],
+        axum::Json(ErrorResponse::new(
+            format!(
+                "API rate limit exceeded ({count}/{limit} requests/min). Try again in {RATE_LIMIT_WINDOW_SECS} seconds."
+            ),
+            "rate_limit_exceeded".to_string(),
+        )),
+    )
+}
+
 pub async fn check_rate_limit_for_api_key(
     state: &RateLimitState,
     auth_key: &AuthenticatedApiKey,
-) -> Result<(), (StatusCode, axum::Json<ErrorResponse>)> {
+) -> Result<(), RateLimitedResponse> {
     let api_key_id = &auth_key.api_key.id.0;
     let (allowed, count, limit) = state.check_limit(api_key_id).await;
 
@@ -86,15 +108,7 @@ pub async fn check_rate_limit_for_api_key(
             "API key rate limit exceeded for key {}: {}/{} requests/min (org_id: {})",
             api_key_id, count, limit, auth_key.organization.id.0
         );
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            axum::Json(ErrorResponse::new(
-                format!(
-                    "API rate limit exceeded ({count}/{limit} requests/min). Try again in {RATE_LIMIT_WINDOW_SECS} seconds."
-                ),
-                "rate_limit_exceeded".to_string(),
-            )),
-        ));
+        return Err(rate_limited_response(count, limit));
     }
 
     debug!(
@@ -108,7 +122,7 @@ pub async fn api_key_rate_limit_middleware(
     State(state): State<RateLimitState>,
     request: Request,
     next: Next,
-) -> Result<Response, (StatusCode, axum::Json<ErrorResponse>)> {
+) -> Result<Response, RateLimitedResponse> {
     let auth_key = match request.extensions().get::<AuthenticatedApiKey>() {
         Some(key) => key.clone(),
         None => return Ok(next.run(request).await),
@@ -151,5 +165,23 @@ mod tests {
         assert!(allowed2);
         assert_eq!(count1, 1);
         assert_eq!(count2, 1);
+    }
+
+    #[test]
+    fn test_rate_limited_response_carries_retry_after() {
+        use axum::response::IntoResponse;
+
+        let response = rate_limited_response(1001, 1000).into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        // SDK backoff honors Retry-After; the value must match the fixed
+        // window advertised in the error message ("Try again in 60 seconds").
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some(RATE_LIMIT_WINDOW_SECS.to_string().as_str())
+        );
     }
 }

--- a/crates/api/src/middleware/rate_limit.rs
+++ b/crates/api/src/middleware/rate_limit.rs
@@ -176,12 +176,11 @@ mod tests {
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
         // SDK backoff honors Retry-After; the value must match the fixed
         // window advertised in the error message ("Try again in 60 seconds").
-        assert_eq!(
-            response
-                .headers()
-                .get(RETRY_AFTER)
-                .and_then(|v| v.to_str().ok()),
-            Some(RATE_LIMIT_WINDOW_SECS.to_string().as_str())
-        );
+        let retry_after = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+        assert_eq!(retry_after, Some(RATE_LIMIT_WINDOW_SECS));
     }
 }

--- a/crates/api/src/middleware/retry_after.rs
+++ b/crates/api/src/middleware/retry_after.rs
@@ -31,7 +31,7 @@ use axum::{
 /// value. A short seed: the error body already tells clients to back off
 /// exponentially, and the conditions behind these 429s (concurrency caps,
 /// transient overload) usually clear quickly.
-pub const DEFAULT_RETRY_AFTER_SECS: u64 = 2;
+const DEFAULT_RETRY_AFTER_SECS: u64 = 2;
 
 /// `map_response` layer: add a default `Retry-After` header to any 429 that
 /// does not already carry one. Never overrides a value set closer to the

--- a/crates/api/src/middleware/retry_after.rs
+++ b/crates/api/src/middleware/retry_after.rs
@@ -64,13 +64,12 @@ mod tests {
         let response =
             retry_after_middleware(response_with_status(StatusCode::TOO_MANY_REQUESTS)).await;
 
-        assert_eq!(
-            response
-                .headers()
-                .get(RETRY_AFTER)
-                .and_then(|v| v.to_str().ok()),
-            Some(DEFAULT_RETRY_AFTER_SECS.to_string().as_str())
-        );
+        let retry_after = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+        assert_eq!(retry_after, Some(DEFAULT_RETRY_AFTER_SECS));
     }
 
     #[tokio::test]

--- a/crates/api/src/middleware/retry_after.rs
+++ b/crates/api/src/middleware/retry_after.rs
@@ -1,0 +1,110 @@
+// Retry-After on 429 responses
+//
+// Guarantees every client-facing HTTP 429 carries a machine-readable
+// `Retry-After` header. Standard OpenAI/Anthropic SDK backoff honors
+// `Retry-After`; without it clients only get retry guidance as prose in the
+// JSON error body ("Please retry with exponential backoff") and fall back to
+// their own schedule.
+//
+// Sites that know a better value set the header themselves and win over this
+// default:
+// - the per-API-key fixed-window limiter sets the window length (60s), see
+//   `rate_limit.rs`;
+// - the ITA attestation path propagates the upstream `Retry-After` when Intel
+//   Trust Authority supplies one, see `routes/attestation/errors.rs`.
+//
+// Everything else — per-(org,model) concurrency-cap 429s, upstream provider
+// 429 passthrough, and `ServiceOverloaded` ("all backends exhausted") — is a
+// transient condition where a short retry hint is appropriate, so this layer
+// fills in `DEFAULT_RETRY_AFTER_SECS`. Upstream provider 429s cannot carry the
+// provider's own `Retry-After` today: `CompletionError::HttpError` only keeps
+// the status code and message, and the provider pool retries with its own
+// backoff ladder before surfacing the error, so any captured value would be
+// stale by the time it reached the client.
+
+use axum::{
+    http::{header::RETRY_AFTER, HeaderValue, StatusCode},
+    response::Response,
+};
+
+/// Default `Retry-After` seconds for 429 responses that did not set their own
+/// value. A short seed: the error body already tells clients to back off
+/// exponentially, and the conditions behind these 429s (concurrency caps,
+/// transient overload) usually clear quickly.
+pub const DEFAULT_RETRY_AFTER_SECS: u64 = 2;
+
+/// `map_response` layer: add a default `Retry-After` header to any 429 that
+/// does not already carry one. Never overrides a value set closer to the
+/// source (per-key limiter window, upstream ITA propagation).
+pub async fn retry_after_middleware(mut response: Response) -> Response {
+    if response.status() == StatusCode::TOO_MANY_REQUESTS
+        && !response.headers().contains_key(RETRY_AFTER)
+    {
+        response
+            .headers_mut()
+            .insert(RETRY_AFTER, HeaderValue::from(DEFAULT_RETRY_AFTER_SECS));
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+
+    fn response_with_status(status: StatusCode) -> Response {
+        Response::builder()
+            .status(status)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn adds_default_retry_after_to_429_without_header() {
+        let response =
+            retry_after_middleware(response_with_status(StatusCode::TOO_MANY_REQUESTS)).await;
+
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some(DEFAULT_RETRY_AFTER_SECS.to_string().as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_existing_retry_after_on_429() {
+        // e.g. the per-key limiter (60s window) or an upstream-propagated
+        // value (ITA) must not be clobbered by the default.
+        let mut response = response_with_status(StatusCode::TOO_MANY_REQUESTS);
+        response
+            .headers_mut()
+            .insert(RETRY_AFTER, HeaderValue::from_static("60"));
+
+        let response = retry_after_middleware(response).await;
+
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("60")
+        );
+    }
+
+    #[tokio::test]
+    async fn leaves_non_429_responses_untouched() {
+        for status in [
+            StatusCode::OK,
+            StatusCode::BAD_REQUEST,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            let response = retry_after_middleware(response_with_status(status)).await;
+            assert!(
+                response.headers().get(RETRY_AFTER).is_none(),
+                "{status} must not get a Retry-After header"
+            );
+        }
+    }
+}

--- a/crates/api/src/routes/mcp_server.rs
+++ b/crates/api/src/routes/mcp_server.rs
@@ -289,7 +289,10 @@ pub async fn handle_mcp_request(
             }),
         )),
         "tools/call" => {
-            if let Err((status, error)) =
+            // The Retry-After header from the limiter is dropped here on
+            // purpose: MCP errors travel inside the JSON-RPC body of a 200
+            // response, so there is no client-facing 429 to attach it to.
+            if let Err((status, _retry_after, error)) =
                 check_rate_limit_for_api_key(&state.rate_limit_state, &api_key).await
             {
                 return Ok(map_http_error_to_mcp_error(request_id, status, error.0));

--- a/crates/api/tests/common/fake_ita.rs
+++ b/crates/api/tests/common/fake_ita.rs
@@ -103,7 +103,9 @@ async fn fake_attest(State(state): State<Arc<FakeItaState>>, body: Bytes) -> Res
         FakeItaMode::Success => Json(json!({"token": "gateway.jwt"})).into_response(),
         FakeItaMode::RateLimited => (
             StatusCode::TOO_MANY_REQUESTS,
-            [(RETRY_AFTER, "2")],
+            // Deliberately distinct from the router's default Retry-After (2) so
+            // e2e tests prove the upstream value is preserved, not re-inserted.
+            [(RETRY_AFTER, "7")],
             Json(json!({})),
         )
             .into_response(),

--- a/crates/api/tests/e2e_all/ita_attestation.rs
+++ b/crates/api/tests/e2e_all/ita_attestation.rs
@@ -83,20 +83,21 @@ async fn ita_token_disabled_returns_service_unavailable_without_auth() {
 
 #[tokio::test]
 async fn ita_token_rate_limit_preserves_retry_after_header() {
-    // Given: ITA rate-limits appraisal and asks the caller to retry after two seconds.
+    // Given: ITA rate-limits appraisal and asks the caller to retry after seven seconds
+    // (a value distinct from the router's default of 2, so preservation is provable).
     let fake_ita = FakeIta::start(FakeItaMode::RateLimited).await;
     let server = setup_ita_server(&fake_ita, ItaServerMode::Enabled { max_retries: 0 }).await;
 
     // When: a caller requests an ITA token through the HTTP surface.
     let response = server.get(&format!("{ITA_TOKEN_PATH}?nonce={NONCE}")).await;
 
-    // Then: the endpoint returns 429 and preserves Retry-After.
+    // Then: the endpoint returns 429 and preserves the upstream Retry-After.
     assert_eq!(response.status_code(), 429, "{}", response.text());
     let retry_after = response
         .headers()
         .get(RETRY_AFTER)
         .and_then(|value| value.to_str().ok());
-    assert_eq!(retry_after, Some("2"));
+    assert_eq!(retry_after, Some("7"));
 }
 
 #[tokio::test]
@@ -188,7 +189,7 @@ async fn ita_token_manual_qa_curl_style_success_and_rate_limit() {
         .headers()
         .get(RETRY_AFTER)
         .and_then(|value| value.to_str().ok());
-    assert_eq!(retry_after, Some("2"));
+    assert_eq!(retry_after, Some("7"));
 }
 
 fn print_curl_style_response(path: &str, response: &axum_test::TestResponse) {

--- a/crates/api/tests/e2e_all/provider_errors.rs
+++ b/crates/api/tests/e2e_all/provider_errors.rs
@@ -3,6 +3,23 @@
 use crate::common::*;
 
 use api::models::BatchUpdateModelApiRequest;
+use axum::http::header::RETRY_AFTER;
+
+/// Assert a 429 response carries a machine-readable `Retry-After` header with
+/// a positive integer value — the signal SDK backoff (OpenAI/Anthropic
+/// clients) actually honors, unlike the prose in the error body.
+fn assert_retry_after_present(response: &axum_test::TestResponse) {
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    assert!(
+        retry_after.is_some_and(|secs| secs > 0),
+        "429 must carry a positive integer Retry-After header, got {:?}",
+        response.headers().get(RETRY_AFTER)
+    );
+}
 
 /// Helper to create a standard chat completion request body
 fn chat_request(model: &str, stream: bool) -> serde_json::Value {
@@ -74,6 +91,7 @@ async fn test_provider_error_503_propagated() {
         "Error message should indicate overloaded status. Got: {}",
         err.error.message
     );
+    assert_retry_after_present(&response);
 }
 
 /// Test that a 429 error from the provider is propagated as rate_limit_exceeded
@@ -108,6 +126,7 @@ async fn test_provider_error_429_propagated() {
 
     let err = response.json::<api::models::ErrorResponse>();
     assert_eq!(err.error.r#type, "rate_limit_exceeded");
+    assert_retry_after_present(&response);
 }
 
 /// Test that the non-streaming Responses API propagates provider 429s as HTTP 429
@@ -269,6 +288,7 @@ async fn test_responses_service_overloaded_returns_429() {
         "Responses API: overloaded error should carry type=service_overloaded, got {}",
         err.error.r#type
     );
+    assert_retry_after_present(&response);
 }
 
 /// Test that initial inference failures in non-streaming Responses API surface


### PR DESCRIPTION
## Problem

Live-verified 2026-07-20 on prod `/v1/chat/completions`: HTTP 429 responses (upstream rate-limit passthrough, captured on `z-ai/glm-5`) carry **no `Retry-After` and no `x-ratelimit-*` headers** — the only per-request header is `x-request-id`, and the sole retry guidance is prose in the JSON body ("Please retry with exponential backoff", type `rate_limit_exceeded`). Standard OpenAI/Anthropic SDK backoff honors `Retry-After`, so clients currently get no machine-readable retry signal. This was a parked follow-up from the 2026-07-08 customer-feedback triage.

## Changes

Two mechanisms:

1. **Catch-all layer** (`crates/api/src/middleware/retry_after.rs`, registered as the outermost `map_response` layer in `build_app_with_config`): inserts `Retry-After: 2` into any 429 response that does not already carry the header, and never overrides an existing value. Because every route (chat completions, `/v1/responses`, images, audio, embeddings, gateway, MCP HTTP surface) lives inside this one Router, this guarantees the header on the wire for every 429 construction site:
   - per-(org,model) concurrency cap (`CompletionError::RateLimitExceeded`)
   - upstream provider 429 passthrough
   - `ServiceOverloaded` → 429 on both `/v1/chat/completions` and `/v1/responses`
2. **Site-specific value where a better one is known**: the per-API-key fixed-window limiter (1000 req/min) now returns `Retry-After: 60` at the construction site, matching its 60s window and its existing "Try again in 60 seconds" message.

Notes:

- The existing ITA attestation path (which propagates the upstream `Retry-After`) is untouched — the layer only fills in when the header is absent. The fake ITA's upstream value in the e2e harness was changed from `2` to `7` so the preservation tests prove the upstream value survives rather than coinciding with the new default.
- Upstream provider `Retry-After` values are deliberately **not** propagated on 429 passthrough: `CompletionError::HttpError` carries only status + message, and the provider pool retries 429s through its own 1s→2s→4s→8s backoff ladder before surfacing, so any captured upstream value would be stale by the time the client saw it. The 2s default seeds SDK backoff instead; real propagation would need header plumbing through the provider crate (larger change, out of scope).
- OHTTP-encapsulated requests are covered too: the relay loops the inner request back through the full router, and the response-header copy includes `Retry-After`, so encapsulated 429s carry it as well.
- Mid-stream SSE failures still surface in-band with HTTP 200 (headers already sent) — `Retry-After` inherently applies only to pre-stream 429s. The mid-stream 429 frame already maps to `rate_limit_exceeded` on main.
- `mcp_server.rs` destructuring updated for the limiter's new return type; the header is deliberately dropped there because MCP errors ride in a 200 JSON-RPC body (no client-facing 429 exists on that surface).

## Validation

- `cargo test -p api --lib` — 247 passed, 0 failed (includes 4 new unit tests: layer inserts default on bare 429 / preserves existing value / leaves non-429 untouched; limiter response carries `Retry-After: 60` through `IntoResponse`).
- e2e (`--test e2e_all`, local test postgres, same env shape as CI): `provider_errors::` 12 passed with new on-the-wire `Retry-After` assertions on provider-429 passthrough (chat), `ServiceOverloaded`→429 (chat), and `/v1/responses` 429; `ita_attestation:: + provider_errors::` re-run after the fake-ITA value change — 19 passed, 0 failed, confirming the layer does not clobber the upstream-propagated value; `mcp_server::` passed with the tuple change.
- `cargo fmt --all -- --check` and `cargo clippy -p api --all-targets --all-features -- -D warnings` — clean.
