### PR TITLE
fix(api): strip stream usage on attested models when include_usage is unset

### DIFF
--- a/crates/api/src/routes/attestation/signature.rs
+++ b/crates/api/src/routes/attestation/signature.rs
@@ -19,10 +19,24 @@ pub struct SignatureQuery {
 /// Response for signature endpoint
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SignatureResponse {
+    /// The signed payload. Its format depends on `signature_kind`:
+    /// - `provider_tee`: `"{model_id}:{request_hash}:{response_hash}"` —
+    ///   signed inside the model-serving TEE over the bytes the model backend
+    ///   emitted.
+    /// - `gateway`: `"{request_hash}:{response_hash}"` — signed by the
+    ///   cloud-api gateway TEE over the exact bytes the client received.
     pub text: String,
     pub signature: String,
     pub signing_address: String,
     pub signing_algo: String,
+    /// Which key produced this signature: `"provider_tee"` (model-serving TEE)
+    /// or `"gateway"` (cloud-api gateway TEE, used when the gateway rewrites
+    /// the stream bytes — usage accounting/stripping, redaction — and for
+    /// attested fallback providers without per-response signatures). Omitted
+    /// for signatures stored before the kind was recorded, whose provenance is
+    /// unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature_kind: Option<String>,
 }
 
 impl From<services::attestation::ChatSignature> for SignatureResponse {
@@ -32,6 +46,7 @@ impl From<services::attestation::ChatSignature> for SignatureResponse {
             signature: sig.signature,
             signing_address: sig.signing_address,
             signing_algo: sig.signing_algo,
+            signature_kind: sig.signature_kind.map(|kind| kind.as_str().to_string()),
         }
     }
 }

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -417,24 +417,31 @@ fn chat_stream_usage_mode(
         && !chat_stream_has_non_text_modalities(request);
 
     // For default streaming (no include_usage or include_usage:false), strip populated
-    // usage from all chunks so intermediate ones carry `usage: null` per OpenAI spec.
+    // usage from all chunks so intermediate ones carry `usage: null` per OpenAI spec,
+    // and drop the upstream's trailing usage-only chunk entirely (OpenAI emits no
+    // final usage chunk when include_usage wasn't requested; forwarding it breaks
+    // strict SDK parsers — the same defect class as the Chutes husk fix, #870).
     //
-    // Only applied for non-attested (external) models. Attested models (e.g. nearai,
-    // chutes) sign the raw upstream bytes; stripping usage before forwarding to the
-    // client would break byte-exact TEE signature verification because the client
-    // would hash different bytes than what the inference proxy signed. For those
-    // models the provider-signed stream MUST be forwarded verbatim (the
-    // `rewrite_public_stream_usage` path handles `include_usage:true` via the
-    // separately-computed gateway signature).
+    // Applied for BOTH non-attested and attested models. Self-hosted upstreams
+    // always emit per-chunk usage because the nearai provider forces
+    // `stream_options: {include_usage: true, continuous_usage_stats: true}` for
+    // billing capture, so without this gate every chunk of an attested stream
+    // carries a populated `usage` object the client never asked for, plus a
+    // trailing `choices: []` usage-only chunk. Stripping re-serializes the chunks,
+    // so byte-exact provider-signature verification no longer applies; for attested
+    // models the gateway signature covers the rewritten client-facing bytes instead
+    // (`gateway_signature_enabled` below), exactly like the
+    // `rewrite_public_stream_usage` path does for `include_usage: true`. Internal
+    // usage capture is unaffected: InterceptStream records usage from the parsed
+    // chunks in the service layer, upstream of this route-level rewrite.
     //
-    // Also skipped when: the client requested continuous stats (explicit per-chunk
-    // usage), E2EE is active (chunks are opaque), non-text modalities are in use,
-    // `rewrite_public_stream_usage` already handles usage shaping, or the client
-    // explicitly requested `include_usage:true` (fall back to byte-exact passthrough
-    // so the client receives the usage it asked for even if model metadata is
-    // temporarily unavailable).
+    // Skipped when: model metadata is unavailable (`None` — fall back to byte-exact
+    // passthrough rather than guessing), the client requested continuous stats
+    // (explicit per-chunk usage), E2EE is active (chunks are opaque), non-text
+    // modalities are in use, `rewrite_public_stream_usage` already handles usage
+    // shaping, or the client explicitly requested `include_usage:true`.
     let strip_intermediate_usage = request.stream == Some(true)
-        && model_attestation_supported == Some(false)
+        && model_attestation_supported.is_some()
         && !rewrite_public_stream_usage
         && !chat_stream_include_usage_requested(request)
         && !chat_stream_continuous_usage_requested(request)
@@ -443,7 +450,11 @@ fn chat_stream_usage_mode(
 
     ChatStreamUsageMode {
         rewrite_public_stream_usage,
-        gateway_signature_enabled: rewrite_public_stream_usage
+        // Both rewrite modes re-serialize the client-facing bytes, so for attested
+        // models the provider's byte-exact signature can no longer match what the
+        // client received. Skip the provider signature fetch and sign the rewritten
+        // stream at the gateway instead.
+        gateway_signature_enabled: (rewrite_public_stream_usage || strip_intermediate_usage)
             && model_attestation_supported.unwrap_or(false),
         strip_intermediate_usage,
     }
@@ -1587,6 +1598,7 @@ async fn chat_completions_inner(
                 let public_signature_hasher_for_chain = public_signature_hasher.clone();
                 let public_signature_chat_id_for_chain = public_signature_chat_id.clone();
                 let attestation_service_for_chain = app_state.attestation_service.clone();
+                let provider_pool_for_chain = app_state.inference_provider_pool.clone();
 
                 // Re-attach any stashed leading control events, then convert
                 // to a raw bytes stream.
@@ -1948,6 +1960,26 @@ async fn chat_completions_inner(
                                             model = %model_name,
                                             "Cannot store public stream chat signature: no chat_id observed"
                                         );
+                                    }
+                                }
+
+                                if gateway_signature_enabled {
+                                    // The provider-signature fetch is skipped for
+                                    // gateway-signed streams
+                                    // (skip_provider_chat_signature), so its
+                                    // post-fetch unpin never runs. Drop the
+                                    // signature-fetch routing pin here so the
+                                    // provider's chat_id → backend map does not
+                                    // grow unboundedly.
+                                    if let Some(chat_id) =
+                                        public_signature_chat_id_for_chain.lock().await.clone()
+                                    {
+                                        if let Some(provider) = provider_pool_for_chain
+                                            .get_provider_by_chat_id(&chat_id)
+                                            .await
+                                        {
+                                            provider.unpin_chat_connection(&chat_id);
+                                        }
                                     }
                                 }
 
@@ -3155,32 +3187,40 @@ mod tests {
     }
 
     #[test]
-    fn default_attested_stream_preserves_passthrough_for_tee_verification() {
-        // Default streaming for ATTESTED models: byte-exact passthrough is preserved
-        // so the client can verify the inference TEE's provider signature.
-        // Stripping usage would change the bytes the client sees vs what the provider
-        // signed, breaking TEE signature verification.
+    fn default_attested_stream_strips_usage_and_signs_at_gateway() {
+        // Default streaming for ATTESTED models: the self-hosted upstream always
+        // emits per-chunk usage plus a trailing usage-only chunk (the nearai
+        // provider forces include_usage + continuous_usage_stats for billing), so
+        // the route must strip usage and drop the trailing chunk per OpenAI spec.
+        // Re-serializing breaks byte-exact provider-signature verification, so the
+        // gateway signature covers the rewritten client-facing bytes instead —
+        // same mechanism as the include_usage:true rewrite path.
         let request = chat_request_with_include_usage(None);
         let mode = chat_stream_usage_mode(&request, Some(true), false);
 
         assert!(!mode.rewrite_public_stream_usage);
-        assert!(!mode.gateway_signature_enabled);
         assert!(
-            !mode.strip_intermediate_usage,
-            "attested streams must preserve raw passthrough for TEE verification"
+            mode.strip_intermediate_usage,
+            "attested default streams must strip usage per OpenAI spec"
+        );
+        assert!(
+            mode.gateway_signature_enabled,
+            "stripped attested streams must be gateway-signed so the stored \
+             signature matches the bytes the client received"
         );
     }
 
     #[test]
-    fn include_usage_false_attested_stream_preserves_passthrough_for_tee_verification() {
-        // Explicit include_usage:false for ATTESTED model: same as default,
-        // preserve passthrough for TEE signature verification.
+    fn include_usage_false_attested_stream_strips_usage_and_signs_at_gateway() {
+        // Explicit include_usage:false for ATTESTED model: same as default —
+        // strip usage, drop the trailing usage-only chunk, gateway-sign the
+        // rewritten bytes.
         let request = chat_request_with_include_usage(Some(false));
         let mode = chat_stream_usage_mode(&request, Some(true), false);
 
         assert!(!mode.rewrite_public_stream_usage);
-        assert!(!mode.gateway_signature_enabled);
-        assert!(!mode.strip_intermediate_usage);
+        assert!(mode.strip_intermediate_usage);
+        assert!(mode.gateway_signature_enabled);
     }
 
     #[test]
@@ -3240,6 +3280,25 @@ mod tests {
         assert!(
             !mode.strip_intermediate_usage,
             "explicit include_usage:true must never strip usage, even on metadata lookup failure"
+        );
+    }
+
+    #[test]
+    fn default_stream_with_metadata_lookup_failure_preserves_passthrough() {
+        // Default streaming with model metadata unavailable
+        // (model_attestation_supported == None): fall back to byte-exact
+        // passthrough. Without metadata we cannot know whether the stream needs
+        // a gateway signature, so rewriting would either break provider-signature
+        // verification (attested) or be applied blindly; passthrough is the safe
+        // fallback, matching the include_usage:true metadata-failure behaviour.
+        let request = chat_request_with_include_usage(None);
+        let mode = chat_stream_usage_mode(&request, None, false);
+
+        assert!(!mode.rewrite_public_stream_usage);
+        assert!(!mode.gateway_signature_enabled);
+        assert!(
+            !mode.strip_intermediate_usage,
+            "metadata lookup failure must preserve raw passthrough"
         );
     }
 

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -1656,12 +1656,19 @@ async fn chat_completions_inner(
                                     // Anthropic) need normalization to OpenAI format.
                                     // Control lines carry no parsed payload; forward
                                     // them raw so keepalives/comments are preserved.
-                                    // Hold [DONE] back for rewritten streams so the
-                                    // tail can emit final usage, append [DONE], and
-                                    // store any gateway signature before completion.
+                                    // Hold [DONE] back for rewritten streams
+                                    // (redacted, usage-rewritten, or usage-stripped)
+                                    // so the tail can emit final usage, store any
+                                    // gateway signature, and only then append
+                                    // [DONE] — a client that fetches the signature
+                                    // the moment it sees [DONE] must not race the
+                                    // store.
                                     let Some(mut chunk) = event.chunk else {
                                         if event.is_done_marker() {
-                                            if auto_redact_enabled || rewrite_public_stream_usage {
+                                            if auto_redact_enabled
+                                                || rewrite_public_stream_usage
+                                                || strip_intermediate_usage
+                                            {
                                                 return None;
                                             }
                                             upstream_done.store(
@@ -1970,10 +1977,12 @@ async fn chat_completions_inner(
                                     // post-fetch unpin never runs. Drop the
                                     // signature-fetch routing pin here so the
                                     // provider's chat_id → backend map does not
-                                    // grow unboundedly.
-                                    if let Some(chat_id) =
-                                        public_signature_chat_id_for_chain.lock().await.clone()
-                                    {
+                                    // grow unboundedly. Clone the chat_id in its
+                                    // own statement so the mutex guard is not held
+                                    // across the pool lookup await.
+                                    let chat_id =
+                                        public_signature_chat_id_for_chain.lock().await.clone();
+                                    if let Some(chat_id) = chat_id {
                                         if let Some(provider) = provider_pool_for_chain
                                             .get_provider_by_chat_id(&chat_id)
                                             .await

--- a/crates/api/src/routes/completions.rs
+++ b/crates/api/src/routes/completions.rs
@@ -42,7 +42,6 @@ const USAGE_RECORDING_TIMEOUT_SECS: u64 = 5;
 // unbounded. Past the cap we proceed without an Inference-Id header and let
 // the remaining stream (including the buffered control events) flow through.
 const MAX_LEADING_CONTROL_EVENTS: usize = 32;
-const STREAM_SIGNATURE_STORE_TIMEOUT_SECS: u64 = 5;
 
 /// Insert validated E2EE headers into a provider `extra` HashMap.
 fn insert_encryption_headers(
@@ -1598,7 +1597,6 @@ async fn chat_completions_inner(
                 let public_signature_hasher_for_chain = public_signature_hasher.clone();
                 let public_signature_chat_id_for_chain = public_signature_chat_id.clone();
                 let attestation_service_for_chain = app_state.attestation_service.clone();
-                let provider_pool_for_chain = app_state.inference_provider_pool.clone();
 
                 // Re-attach any stashed leading control events, then convert
                 // to a raw bytes stream.
@@ -1921,31 +1919,38 @@ async fn chat_completions_inner(
                                     combined.extend_from_slice(b"data: [DONE]\n\n");
                                 }
 
-                                if gateway_signature_enabled && error_count_final == 0 {
-                                    let response_hash = {
-                                        let mut hasher =
-                                            public_signature_hasher_for_chain.lock().await;
-                                        hasher.update(&combined);
-                                        hex::encode(hasher.clone().finalize())
-                                    };
+                                if gateway_signature_enabled {
+                                    // The provider-signature fetch is skipped for
+                                    // gateway-signed streams
+                                    // (skip_provider_chat_signature), so its
+                                    // post-fetch unpin never runs. The attestation
+                                    // service owns the store+unpin lifecycle
+                                    // (mirroring store_chat_signature_from_provider):
+                                    // it releases the signature-fetch routing pin
+                                    // whether the store succeeds, fails, or times
+                                    // out, so the provider's chat_id → backend map
+                                    // does not grow unboundedly. Clone the chat_id
+                                    // in its own statement so the mutex guard is
+                                    // not held across the service awaits.
+                                    let chat_id =
+                                        public_signature_chat_id_for_chain.lock().await.clone();
+                                    if error_count_final == 0 {
+                                        let response_hash = {
+                                            let mut hasher =
+                                                public_signature_hasher_for_chain.lock().await;
+                                            hasher.update(&combined);
+                                            hex::encode(hasher.clone().finalize())
+                                        };
 
-                                    if let Some(chat_id) =
-                                        public_signature_chat_id_for_chain.lock().await.clone()
-                                    {
-                                        match tokio::time::timeout(
-                                            Duration::from_secs(
-                                                STREAM_SIGNATURE_STORE_TIMEOUT_SECS,
-                                            ),
-                                            attestation_service_for_chain.store_chat_signature(
-                                                &chat_id,
-                                                request_hash,
-                                                response_hash,
-                                            ),
-                                        )
-                                        .await
-                                        {
-                                            Ok(Ok(())) => {}
-                                            Ok(Err(e)) => {
+                                        if let Some(chat_id) = chat_id {
+                                            if let Err(e) = attestation_service_for_chain
+                                                .store_chat_signature_and_unpin(
+                                                    &chat_id,
+                                                    request_hash,
+                                                    response_hash,
+                                                )
+                                                .await
+                                            {
                                                 tracing::error!(
                                                     %organization_id,
                                                     model = %model_name,
@@ -1953,42 +1958,20 @@ async fn chat_completions_inner(
                                                     "Failed to store public stream chat signature"
                                                 );
                                             }
-                                            Err(_) => {
-                                                tracing::error!(
-                                                    %organization_id,
-                                                    model = %model_name,
-                                                    "Timeout storing public stream chat signature"
-                                                );
-                                            }
+                                        } else {
+                                            tracing::warn!(
+                                                %organization_id,
+                                                model = %model_name,
+                                                "Cannot store public stream chat signature: no chat_id observed"
+                                            );
                                         }
-                                    } else {
-                                        tracing::warn!(
-                                            %organization_id,
-                                            model = %model_name,
-                                            "Cannot store public stream chat signature: no chat_id observed"
-                                        );
-                                    }
-                                }
-
-                                if gateway_signature_enabled {
-                                    // The provider-signature fetch is skipped for
-                                    // gateway-signed streams
-                                    // (skip_provider_chat_signature), so its
-                                    // post-fetch unpin never runs. Drop the
-                                    // signature-fetch routing pin here so the
-                                    // provider's chat_id → backend map does not
-                                    // grow unboundedly. Clone the chat_id in its
-                                    // own statement so the mutex guard is not held
-                                    // across the pool lookup await.
-                                    let chat_id =
-                                        public_signature_chat_id_for_chain.lock().await.clone();
-                                    if let Some(chat_id) = chat_id {
-                                        if let Some(provider) = provider_pool_for_chain
-                                            .get_provider_by_chat_id(&chat_id)
-                                            .await
-                                        {
-                                            provider.unpin_chat_connection(&chat_id);
-                                        }
+                                    } else if let Some(chat_id) = chat_id {
+                                        // Errored stream: nothing to sign, but the
+                                        // signature-fetch routing pin still has to
+                                        // be dropped.
+                                        attestation_service_for_chain
+                                            .release_chat_signature_pin(&chat_id)
+                                            .await;
                                     }
                                 }
 

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -168,6 +168,7 @@ async fn build_test_server_components(
     axum_test::TestServer,
     Arc<services::inference_provider_pool::InferenceProviderPool>,
     Arc<inference_providers::mock::MockProvider>,
+    axum::Router,
 ) {
     // Create mock user in database for foreign key constraints
     assert_mock_user_in_db(&database).await;
@@ -193,9 +194,9 @@ async fn build_test_server_components(
         domain_services,
         Arc::new(config),
     );
-    let server = axum_test::TestServer::new(app);
+    let server = axum_test::TestServer::new(app.clone());
 
-    (server, inference_provider_pool, mock_provider)
+    (server, inference_provider_pool, mock_provider, app)
 }
 
 async fn build_test_server_components_with_real_providers(
@@ -411,7 +412,7 @@ where
 {
     let mut infra = setup_test_infrastructure().await;
     mutate(&mut infra.config);
-    let (server, _pool, _mock) =
+    let (server, _pool, _mock, _router) =
         build_test_server_components(infra.database.clone(), infra.config).await;
     server
 }
@@ -425,7 +426,8 @@ where
     let mut infra = setup_test_infrastructure().await;
     mutate(&mut infra.config);
     let database = infra.database.clone();
-    let (server, _pool, _mock) = build_test_server_components(database.clone(), infra.config).await;
+    let (server, _pool, _mock, _router) =
+        build_test_server_components(database.clone(), infra.config).await;
     (server, database)
 }
 
@@ -442,7 +444,7 @@ pub async fn setup_test_server_with_pool() -> (
 ) {
     let infra = setup_test_infrastructure().await;
 
-    let (server, inference_provider_pool, mock_provider) =
+    let (server, inference_provider_pool, mock_provider, _router) =
         build_test_server_components(infra.database.clone(), infra.config).await;
 
     (
@@ -451,6 +453,20 @@ pub async fn setup_test_server_with_pool() -> (
         mock_provider,
         infra.database,
     )
+}
+
+/// Like `setup_test_server`, but also returns the underlying `axum::Router`,
+/// so a test can drive it in-process (`tower::ServiceExt::oneshot`) and poll
+/// the response body frame-by-frame. `axum_test` buffers whole response
+/// bodies, which cannot observe mid-body ordering (e.g. "the signature is
+/// stored before `[DONE]` is emitted"). Both handles share the same
+/// state/database, so setup done through the `TestServer` is visible to
+/// requests driven through the `Router`.
+pub async fn setup_test_server_and_router() -> (axum_test::TestServer, axum::Router) {
+    let infra = setup_test_infrastructure().await;
+    let (server, _pool, _mock, router) =
+        build_test_server_components(infra.database.clone(), infra.config).await;
+    (server, router)
 }
 
 pub async fn setup_test_server_real_providers() -> (

--- a/crates/api/tests/e2e_all/signature_verification.rs
+++ b/crates/api/tests/e2e_all/signature_verification.rs
@@ -324,14 +324,25 @@ async fn test_streaming_chat_include_usage_signature_hashes_client_bytes() {
 }
 
 #[tokio::test]
-async fn test_streaming_chat_default_stream_signature_stored_before_stream_completes() {
+async fn test_streaming_chat_default_stream_signature_stored_before_done_emitted() {
     // Default streaming (no stream_options) on an attested model takes the
     // usage-strip gateway-signature path. The route must store the gateway
-    // signature BEFORE emitting [DONE]/ending the stream (the [DONE] marker is
-    // held back and appended by the end-of-stream tail after the store), so a
-    // client that fetches the signature as soon as the stream completes must
-    // never race the store. Deliberately no sleep before the signature query.
-    let server = setup_test_server().await;
+    // signature BEFORE emitting [DONE] (the marker is held back and appended
+    // by the end-of-stream tail after the store), so a client that fetches
+    // the signature the moment it sees [DONE] must never race the store.
+    //
+    // `axum_test` buffers the whole response body, which cannot discriminate
+    // here: by the time the buffered body is handed back, the tail (and the
+    // store) has already run regardless of ordering. Instead, drive the
+    // router in-process and poll the SSE body frame-by-frame, issuing the
+    // signature GET the instant the [DONE] line is decoded — before polling
+    // any further frames. Without the [DONE] holdback the marker arrives in
+    // an inline frame before the tail future (which stores the signature) has
+    // run, and the GET deterministically misses.
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    let (server, router) = setup_test_server_and_router().await;
     setup_qwen_model(&server).await;
     let org = setup_org_with_credits(&server, 10000000000i64).await;
     let api_key = get_api_key_for_org(&server, org.id).await;
@@ -348,33 +359,52 @@ async fn test_streaming_chat_default_stream_signature_stored_before_stream_compl
         "model": model_name,
         "nonce": 44
     });
-
     let request_json = serde_json::to_string(&request_body).expect("Failed to serialize request");
     let expected_request_hash = compute_sha256(&request_json);
 
-    let response = server
-        .post("/v1/chat/completions")
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .json(&request_body)
-        .await;
+    let request = axum::http::Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Content-Type", "application/json")
+        .body(axum::body::Body::from(request_json))
+        .expect("request should build");
+    let response = router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("router should serve the streaming request");
     assert_eq!(
-        response.status_code(),
-        200,
-        "Streaming request should succeed: {}",
-        response.text()
+        response.status(),
+        axum::http::StatusCode::OK,
+        "Streaming request should succeed"
     );
 
-    let response_text = response.text();
-    let expected_response_hash = compute_sha256(&response_text);
-    let mut chat_id = None::<String>;
+    // Poll the body frame-by-frame and stop the instant [DONE] is decoded.
+    let mut body = response.into_body();
+    let mut received: Vec<u8> = Vec::new();
     let mut saw_done = false;
+    while let Some(frame) = body.frame().await {
+        let frame = frame.expect("stream frame should not error");
+        let Some(data) = frame.data_ref() else {
+            continue;
+        };
+        received.extend_from_slice(data);
+        if String::from_utf8_lossy(&received).contains("data: [DONE]") {
+            saw_done = true;
+            break; // deliberately do NOT poll further frames before the GET
+        }
+    }
+    let response_text = String::from_utf8(received).expect("SSE body should be UTF-8");
+    assert!(saw_done, "stream should end with [DONE]: {response_text}");
+    let expected_response_hash = compute_sha256(&response_text);
 
+    let mut chat_id = None::<String>;
     for line in response_text.lines() {
         let Some(data) = line.strip_prefix("data: ") else {
             continue;
         };
         if data.trim() == "[DONE]" {
-            saw_done = true;
             break;
         }
         if let Ok(StreamChunk::Chat(chat_chunk)) = serde_json::from_str::<StreamChunk>(data) {
@@ -387,24 +417,40 @@ async fn test_streaming_chat_default_stream_signature_stored_before_stream_compl
             );
         }
     }
-
     let chat_id = chat_id.expect("Should have extracted chat_id from stream");
-    assert!(saw_done, "stream should end with [DONE]: {response_text}");
 
-    // No sleep: the signature must already be stored by the time the stream has
-    // ended, because the tail only emits the final [DONE] frame after the store.
-    let signature_response = server
-        .get(format!("/v1/signature/{chat_id}?model={model_name}&signing_algo=ecdsa").as_str())
-        .add_header("Authorization", format!("Bearer {api_key}"))
-        .await;
+    // The signature GET is issued NOW — after [DONE] was decoded but before
+    // the body stream is polled again — so nothing that runs after the
+    // [DONE]-bearing frame can have stored the signature yet.
+    let signature_request = axum::http::Request::builder()
+        .method("GET")
+        .uri(format!(
+            "/v1/signature/{chat_id}?model={model_name}&signing_algo=ecdsa"
+        ))
+        .header("Authorization", format!("Bearer {api_key}"))
+        .body(axum::body::Body::empty())
+        .expect("signature request should build");
+    let signature_response = router
+        .clone()
+        .oneshot(signature_request)
+        .await
+        .expect("router should serve the signature request");
+    let signature_status = signature_response.status();
+    let signature_bytes = signature_response
+        .into_body()
+        .collect()
+        .await
+        .expect("signature body should collect")
+        .to_bytes();
     assert_eq!(
-        signature_response.status_code(),
-        200,
-        "Signature must be retrievable immediately after the stream ends: {}",
-        signature_response.text()
+        signature_status,
+        axum::http::StatusCode::OK,
+        "Signature must be retrievable the instant [DONE] is decoded: {}",
+        String::from_utf8_lossy(&signature_bytes)
     );
 
-    let signature_json = signature_response.json::<serde_json::Value>();
+    let signature_json: serde_json::Value =
+        serde_json::from_slice(&signature_bytes).expect("signature response should be JSON");
     let signature_text = signature_json
         .get("text")
         .and_then(|v| v.as_str())
@@ -420,4 +466,23 @@ async fn test_streaming_chat_default_stream_signature_stored_before_stream_compl
         hash_parts[1], expected_response_hash,
         "stored response hash must match the exact stripped SSE body returned to the client"
     );
+    assert_eq!(
+        signature_json
+            .get("signature_kind")
+            .and_then(|v| v.as_str()),
+        Some("gateway"),
+        "stripped streams are gateway-signed and must say so"
+    );
+
+    // Nothing may follow the [DONE]-bearing frame.
+    while let Some(frame) = body.frame().await {
+        let frame = frame.expect("trailing frame should not error");
+        if let Some(data) = frame.data_ref() {
+            assert!(
+                data.is_empty(),
+                "no bytes may follow [DONE]: {:?}",
+                String::from_utf8_lossy(data)
+            );
+        }
+    }
 }

--- a/crates/api/tests/e2e_all/signature_verification.rs
+++ b/crates/api/tests/e2e_all/signature_verification.rs
@@ -322,3 +322,102 @@ async fn test_streaming_chat_include_usage_signature_hashes_client_bytes() {
         "stored response hash must match the exact include_usage SSE body returned to the client"
     );
 }
+
+#[tokio::test]
+async fn test_streaming_chat_default_stream_signature_stored_before_stream_completes() {
+    // Default streaming (no stream_options) on an attested model takes the
+    // usage-strip gateway-signature path. The route must store the gateway
+    // signature BEFORE emitting [DONE]/ending the stream (the [DONE] marker is
+    // held back and appended by the end-of-stream tail after the store), so a
+    // client that fetches the signature as soon as the stream completes must
+    // never race the store. Deliberately no sleep before the signature query.
+    let server = setup_test_server().await;
+    setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10000000000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id).await;
+    let model_name = "Qwen/Qwen3-30B-A3B-Instruct-2507";
+
+    let request_body = serde_json::json!({
+        "messages": [
+            {
+                "role": "user",
+                "content": "Respond with only two words."
+            }
+        ],
+        "stream": true,
+        "model": model_name,
+        "nonce": 44
+    });
+
+    let request_json = serde_json::to_string(&request_body).expect("Failed to serialize request");
+    let expected_request_hash = compute_sha256(&request_json);
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&request_body)
+        .await;
+    assert_eq!(
+        response.status_code(),
+        200,
+        "Streaming request should succeed: {}",
+        response.text()
+    );
+
+    let response_text = response.text();
+    let expected_response_hash = compute_sha256(&response_text);
+    let mut chat_id = None::<String>;
+    let mut saw_done = false;
+
+    for line in response_text.lines() {
+        let Some(data) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if data.trim() == "[DONE]" {
+            saw_done = true;
+            break;
+        }
+        if let Ok(StreamChunk::Chat(chat_chunk)) = serde_json::from_str::<StreamChunk>(data) {
+            if chat_id.is_none() {
+                chat_id = Some(chat_chunk.id.clone());
+            }
+            assert!(
+                chat_chunk.usage.is_none(),
+                "default stream must not forward populated usage: {data}"
+            );
+        }
+    }
+
+    let chat_id = chat_id.expect("Should have extracted chat_id from stream");
+    assert!(saw_done, "stream should end with [DONE]: {response_text}");
+
+    // No sleep: the signature must already be stored by the time the stream has
+    // ended, because the tail only emits the final [DONE] frame after the store.
+    let signature_response = server
+        .get(format!("/v1/signature/{chat_id}?model={model_name}&signing_algo=ecdsa").as_str())
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .await;
+    assert_eq!(
+        signature_response.status_code(),
+        200,
+        "Signature must be retrievable immediately after the stream ends: {}",
+        signature_response.text()
+    );
+
+    let signature_json = signature_response.json::<serde_json::Value>();
+    let signature_text = signature_json
+        .get("text")
+        .and_then(|v| v.as_str())
+        .expect("Signature response should have 'text' field");
+    let hash_parts: Vec<&str> = signature_text.split(':').collect();
+    assert_eq!(
+        hash_parts.len(),
+        2,
+        "Signature text should contain two hashes separated by ':'"
+    );
+    assert_eq!(hash_parts[0], expected_request_hash);
+    assert_eq!(
+        hash_parts[1], expected_response_hash,
+        "stored response hash must match the exact stripped SSE body returned to the client"
+    );
+}

--- a/crates/api/tests/e2e_all/usage_chat_completions.rs
+++ b/crates/api/tests/e2e_all/usage_chat_completions.rs
@@ -131,8 +131,9 @@ async fn test_chat_completions_records_usage_and_history() {
 }
 
 /// Call chat/completions with the default stream mode, consume the stream, then verify usage was
-/// still recorded in org usage history (limit=1). The public response may stay on raw passthrough
-/// for attested models to preserve provider signatures; billing capture must remain independent.
+/// still recorded in org usage history (limit=1). The attested model's public stream has usage
+/// stripped by the route-level rewrite; billing capture must remain independent (InterceptStream
+/// reads the parsed chunks in the service layer, upstream of the rewrite).
 #[tokio::test]
 async fn test_chat_completions_stream_records_usage_in_history() {
     ensure_usage_chat_completions_env();
@@ -215,8 +216,8 @@ async fn test_chat_completions_stream_records_usage_in_history() {
 }
 
 /// Register a non-attested (external) chat model in both the provider pool and the DB.
-/// For attested models, usage in intermediate chunks is preserved byte-exactly for TEE
-/// signature verification. Only non-attested models have usage stripped to `null`.
+/// Both attested and non-attested models have usage stripped to `null` when the client
+/// did not request `include_usage`; non-attested streams are simply not gateway-signed.
 async fn setup_non_attested_model(
     server: &axum_test::TestServer,
     pool: &std::sync::Arc<services::inference_provider_pool::InferenceProviderPool>,
@@ -256,8 +257,7 @@ async fn setup_non_attested_model(
 async fn test_chat_completions_stream_default_emits_usage_null_in_all_chunks() {
     // Default streaming (no stream_options): per OpenAI spec, `usage` must be
     // `null` in every chunk and no final usage-only chunk is emitted.
-    // Only verified for non-attested models; attested model streams are forwarded
-    // byte-exactly for TEE signature verification.
+    // Non-attested variant; see the *_attested_* tests below for the self-hosted path.
     let (server, pool, mock_provider, _db) = setup_test_server_with_pool().await;
     let model_name = setup_non_attested_model(&server, &pool, &mock_provider).await;
 
@@ -306,8 +306,7 @@ async fn test_chat_completions_stream_default_emits_usage_null_in_all_chunks() {
 async fn test_chat_completions_stream_include_usage_false_emits_usage_null_in_all_chunks() {
     // Explicit include_usage:false: same as default — all chunks must carry
     // `usage: null` and no final usage-only chunk is emitted.
-    // Only verified for non-attested models; attested model streams are forwarded
-    // byte-exactly for TEE signature verification.
+    // Non-attested variant; see the *_attested_* tests below for the self-hosted path.
     let (server, pool, mock_provider, _db) = setup_test_server_with_pool().await;
     let model_name = setup_non_attested_model(&server, &pool, &mock_provider).await;
 
@@ -353,8 +352,122 @@ async fn test_chat_completions_stream_include_usage_false_emits_usage_null_in_al
     assert!(saw_chunk, "stream should contain at least one chunk");
 }
 
+/// Assert the OpenAI streaming contract for a stream where `include_usage` was NOT
+/// requested: every chunk carries `usage: null`, no trailing usage-only
+/// (`choices: []`) chunk is emitted, and the stream ends with `[DONE]`.
+fn assert_stream_has_no_usage(response_text: &str, context: &str) {
+    let mut saw_chunk = false;
+    let mut saw_done = false;
+    for line in response_text.lines() {
+        let Some(data) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if data.trim() == "[DONE]" {
+            saw_done = true;
+            break;
+        }
+
+        saw_chunk = true;
+        let value: serde_json::Value =
+            serde_json::from_str(data).expect("stream data should be JSON");
+        assert!(
+            value.get("usage").is_some_and(serde_json::Value::is_null),
+            "{context}: all chunks must carry usage:null (got {value})"
+        );
+        // The upstream's trailing usage-only chunk (`choices: []`) must be
+        // suppressed entirely — forwarding it (with or without usage) breaks
+        // strict SDK parsers.
+        let choices_empty = value
+            .get("choices")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(Vec::is_empty);
+        assert!(
+            !choices_empty,
+            "{context}: no usage-only/empty-choices chunk may be forwarded (got {value})"
+        );
+    }
+    assert!(
+        saw_chunk,
+        "{context}: stream should contain at least one chunk"
+    );
+    assert!(saw_done, "{context}: stream should end with [DONE]");
+}
+
+#[tokio::test]
+async fn test_chat_completions_stream_default_attested_strips_usage_and_final_chunk() {
+    // Default streaming (no stream_options) on an ATTESTED (self-hosted) model.
+    // The upstream always emits per-chunk usage plus a trailing usage-only chunk
+    // (the nearai provider forces include_usage + continuous_usage_stats for
+    // billing; the mock provider mirrors that shape). Live-verified on prod
+    // 2026-07-20: 200 of 202 chunks carried populated usage and the stream ended
+    // with a `choices: []` usage husk. Per OpenAI spec, none of that may reach a
+    // client that did not request include_usage.
+    ensure_usage_chat_completions_env();
+    let server = setup_test_server().await;
+
+    let model_name = setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+
+    let stream_resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({
+            "model": model_name,
+            "messages": [{ "role": "user", "content": "hello" }],
+            "stream": true
+        }))
+        .await;
+
+    assert_eq!(
+        stream_resp.status_code(),
+        200,
+        "streaming chat/completions should succeed: {}",
+        stream_resp.text()
+    );
+
+    assert_stream_has_no_usage(&stream_resp.text(), "attested default streaming");
+}
+
+#[tokio::test]
+async fn test_chat_completions_stream_include_usage_false_attested_strips_usage_and_final_chunk() {
+    // Explicit include_usage:false on an ATTESTED model: same contract as the
+    // default case — usage:null everywhere, no trailing usage-only chunk.
+    ensure_usage_chat_completions_env();
+    let server = setup_test_server().await;
+
+    let model_name = setup_qwen_model(&server).await;
+    let org = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let api_key = get_api_key_for_org(&server, org.id.clone()).await;
+
+    let stream_resp = server
+        .post("/v1/chat/completions")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({
+            "model": model_name,
+            "messages": [{ "role": "user", "content": "hello" }],
+            "stream": true,
+            "stream_options": { "include_usage": false }
+        }))
+        .await;
+
+    assert_eq!(
+        stream_resp.status_code(),
+        200,
+        "streaming chat/completions should succeed: {}",
+        stream_resp.text()
+    );
+
+    assert_stream_has_no_usage(
+        &stream_resp.text(),
+        "attested include_usage:false streaming",
+    );
+}
+
 #[tokio::test]
 async fn test_chat_completions_stream_include_usage_true_emits_final_usage_only() {
+    // include_usage:true on the (attested) qwen model: intermediate chunks carry
+    // usage:null and exactly one final usage chunk is emitted (rewrite path).
     ensure_usage_chat_completions_env();
     let server = setup_test_server().await;
 

--- a/crates/database/src/migrations/sql/V0071__add_signature_kind_to_chat_signatures.sql
+++ b/crates/database/src/migrations/sql/V0071__add_signature_kind_to_chat_signatures.sql
@@ -1,0 +1,10 @@
+-- Record which key produced each stored chat signature:
+--   'provider_tee' — signed inside the model-serving TEE over the provider's
+--                    canonical text "{model_id}:{request_hash}:{response_hash}"
+--   'gateway'      — signed by the cloud-api gateway TEE over
+--                    "{request_hash}:{response_hash}" covering the exact bytes
+--                    returned to the client (stream rewrites, Chutes fallback)
+-- Nullable: rows written before this column existed have unknown provenance
+-- (both provider-TEE and gateway writes predate it) and stay NULL; readers
+-- surface NULL as "kind absent" rather than guessing.
+ALTER TABLE chat_signatures ADD COLUMN signature_kind VARCHAR(50);

--- a/crates/database/src/repositories/attestation.rs
+++ b/crates/database/src/repositories/attestation.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use services::attestation::{ports::AttestationRepository, AttestationError, ChatSignature};
+use services::attestation::{
+    ports::AttestationRepository, AttestationError, ChatSignature, SignatureKind,
+};
 
 use crate::DbPool;
 
@@ -28,11 +30,20 @@ impl PgAttestationRepository {
         let signing_algo: String = row
             .try_get("signing_algo")
             .map_err(|e| AttestationError::RepositoryError(e.to_string()))?;
+        // NULL (legacy rows) and unrecognized values both surface as `None`:
+        // the kind is unknown, not guessed.
+        let signature_kind: Option<String> = row
+            .try_get("signature_kind")
+            .map_err(|e| AttestationError::RepositoryError(e.to_string()))?;
+        let signature_kind = signature_kind
+            .as_deref()
+            .and_then(SignatureKind::from_db_str);
         Ok(ChatSignature {
             text,
             signature,
             signing_address,
             signing_algo,
+            signature_kind,
         })
     }
 }
@@ -49,10 +60,11 @@ impl AttestationRepository for PgAttestationRepository {
             .get()
             .await
             .map_err(|e| AttestationError::RepositoryError(e.to_string()))?;
+        let signature_kind = signature.signature_kind.map(|kind| kind.as_str());
         client
             .execute(
-                "INSERT INTO chat_signatures (chat_id, text, signature, signing_address, signing_algo) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (chat_id, signing_algo) DO UPDATE SET text = EXCLUDED.text, signature = EXCLUDED.signature, signing_address = EXCLUDED.signing_address, updated_at = NOW()",
-                &[&chat_id, &signature.text, &signature.signature, &signature.signing_address, &signature.signing_algo],
+                "INSERT INTO chat_signatures (chat_id, text, signature, signing_address, signing_algo, signature_kind) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (chat_id, signing_algo) DO UPDATE SET text = EXCLUDED.text, signature = EXCLUDED.signature, signing_address = EXCLUDED.signing_address, signature_kind = EXCLUDED.signature_kind, updated_at = NOW()",
+                &[&chat_id, &signature.text, &signature.signature, &signature.signing_address, &signature.signing_algo, &signature_kind],
             )
             .await
             .map_err(|e| AttestationError::RepositoryError(e.to_string()))?;

--- a/crates/inference_providers/src/mock.rs
+++ b/crates/inference_providers/src/mock.rs
@@ -636,6 +636,10 @@ pub struct MockProvider {
     /// `true`. Set via [`MockProvider::with_client_e2ee_support`] to exercise the
     /// client-E2EE-capability filter (e.g. a Chutes-like fallback that rejects it).
     supports_client_e2ee: bool,
+    /// Chat ids passed to [`InferenceProvider::unpin_chat_connection`], in call
+    /// order. Lets lifecycle tests assert the signature-fetch routing pin was
+    /// released. `std::sync::Mutex` because the trait method is synchronous.
+    unpinned_chat_ids: Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 impl MockProvider {
@@ -668,6 +672,7 @@ impl MockProvider {
             provider_source: crate::ProviderSource::External,
             supports_streaming: true,
             supports_client_e2ee: true,
+            unpinned_chat_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -692,6 +697,7 @@ impl MockProvider {
             provider_source: crate::ProviderSource::External,
             supports_streaming: true,
             supports_client_e2ee: true,
+            unpinned_chat_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -714,6 +720,7 @@ impl MockProvider {
             provider_source: crate::ProviderSource::External,
             supports_streaming: true,
             supports_client_e2ee: true,
+            unpinned_chat_ids: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -753,6 +760,16 @@ impl MockProvider {
     /// Get the last chat completion params received by the mock provider
     pub async fn last_chat_params(&self) -> Option<ChatCompletionParams> {
         self.last_chat_params.lock().await.clone()
+    }
+
+    /// Chat ids for which [`crate::InferenceProvider::unpin_chat_connection`]
+    /// was called, in call order. Used by lifecycle tests to assert the
+    /// signature-fetch routing pin was released.
+    pub fn unpinned_chat_ids(&self) -> Vec<String> {
+        self.unpinned_chat_ids
+            .lock()
+            .map(|ids| ids.clone())
+            .unwrap_or_default()
     }
 
     /// Register request and response hashes for a chat_id
@@ -947,6 +964,12 @@ impl crate::InferenceProvider for MockProvider {
 
     fn supports_client_e2ee(&self) -> bool {
         self.supports_client_e2ee
+    }
+
+    fn unpin_chat_connection(&self, chat_id: &str) {
+        if let Ok(mut ids) = self.unpinned_chat_ids.lock() {
+            ids.push(chat_id.to_string());
+        }
     }
 
     async fn models(&self) -> Result<ModelsResponse, ListModelsError> {

--- a/crates/services/src/attestation/chat_signature_lifecycle_tests.rs
+++ b/crates/services/src/attestation/chat_signature_lifecycle_tests.rs
@@ -1,0 +1,390 @@
+//! Lifecycle tests for the gateway signature store+unpin path.
+//!
+//! `store_chat_signature_and_unpin` owns the same lifecycle contract as
+//! `store_chat_signature_from_provider`: the provider-pool signature-fetch
+//! routing pin must be released whether the store succeeds, fails, or times
+//! out, and `release_chat_signature_pin` must release it without storing
+//! anything (errored-stream path). These tests construct the service directly
+//! (private-field struct literals are legal inside `crate::attestation`) with
+//! a real `InferenceProviderPool` seeded via `store_chat_id_mapping` and a
+//! `MockProvider` that records unpin calls.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use config::{ExternalProvidersConfig, ItaAttestationConfig};
+use inference_providers::mock::MockProvider;
+use uuid::Uuid;
+
+use super::{
+    chat_signatures::STREAM_SIGNATURE_STORE_TIMEOUT,
+    ita::ProviderPoolModelAttestationCollector,
+    models::{ChatSignature, SignatureKind},
+    ports::{AttestationRepository, AttestationServiceTrait},
+    AttestationError, AttestationService, DstackGatewayQuoteCollector,
+};
+use crate::{
+    inference_provider_pool::InferenceProviderPool,
+    metrics::MetricsServiceTrait,
+    models::{ModelWithPricing, ModelsRepository},
+    usage::{
+        InferenceCost, InferenceUsageHistoryQuery, InferenceUsageReportQuery,
+        InferenceUsageReportRow, OrganizationBalanceInfo, RecordUsageDbRequest, StopReason,
+        UsageByModelEntry, UsageLogEntry, UsageRepository,
+    },
+};
+
+/// Repository that records stored signatures and succeeds.
+#[derive(Clone, Default)]
+struct RecordingRepository {
+    stored: Arc<Mutex<Vec<(String, ChatSignature)>>>,
+}
+
+impl RecordingRepository {
+    fn stored(&self) -> Vec<(String, ChatSignature)> {
+        self.stored.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl AttestationRepository for RecordingRepository {
+    async fn add_chat_signature(
+        &self,
+        chat_id: &str,
+        signature: ChatSignature,
+    ) -> Result<(), AttestationError> {
+        self.stored
+            .lock()
+            .map_err(|_| AttestationError::InternalError("stored lock poisoned".to_string()))?
+            .push((chat_id.to_string(), signature));
+        Ok(())
+    }
+
+    async fn get_chat_signature(
+        &self,
+        chat_id: &str,
+        signing_algo: &str,
+    ) -> Result<ChatSignature, AttestationError> {
+        Err(AttestationError::SignatureNotFound(format!(
+            "{chat_id}:{signing_algo}"
+        )))
+    }
+}
+
+/// Repository whose store always fails.
+struct FailingRepository;
+
+#[async_trait]
+impl AttestationRepository for FailingRepository {
+    async fn add_chat_signature(
+        &self,
+        _chat_id: &str,
+        _signature: ChatSignature,
+    ) -> Result<(), AttestationError> {
+        Err(AttestationError::RepositoryError(
+            "simulated store failure".to_string(),
+        ))
+    }
+
+    async fn get_chat_signature(
+        &self,
+        chat_id: &str,
+        signing_algo: &str,
+    ) -> Result<ChatSignature, AttestationError> {
+        Err(AttestationError::SignatureNotFound(format!(
+            "{chat_id}:{signing_algo}"
+        )))
+    }
+}
+
+/// Repository whose store never completes (exercises the store timeout).
+struct HangingRepository;
+
+#[async_trait]
+impl AttestationRepository for HangingRepository {
+    async fn add_chat_signature(
+        &self,
+        _chat_id: &str,
+        _signature: ChatSignature,
+    ) -> Result<(), AttestationError> {
+        std::future::pending().await
+    }
+
+    async fn get_chat_signature(
+        &self,
+        chat_id: &str,
+        signing_algo: &str,
+    ) -> Result<ChatSignature, AttestationError> {
+        Err(AttestationError::SignatureNotFound(format!(
+            "{chat_id}:{signing_algo}"
+        )))
+    }
+}
+
+struct EmptyModelsRepository;
+
+#[async_trait]
+impl ModelsRepository for EmptyModelsRepository {
+    async fn get_all_active_models(&self) -> anyhow::Result<Vec<ModelWithPricing>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_model_by_name(
+        &self,
+        _model_name: &str,
+    ) -> anyhow::Result<Option<ModelWithPricing>> {
+        Ok(None)
+    }
+
+    async fn resolve_and_get_model(
+        &self,
+        _identifier: &str,
+    ) -> anyhow::Result<Option<ModelWithPricing>> {
+        Ok(None)
+    }
+
+    async fn get_configured_model_names(&self) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+}
+
+struct NoopMetricsService;
+
+impl MetricsServiceTrait for NoopMetricsService {
+    fn record_latency(&self, _name: &str, _duration: std::time::Duration, _tags: &[&str]) {}
+    fn record_count(&self, _name: &str, _value: i64, _tags: &[&str]) {}
+    fn record_histogram(&self, _name: &str, _value: f64, _tags: &[&str]) {}
+}
+
+struct NoopUsageRepository;
+
+#[async_trait]
+impl UsageRepository for NoopUsageRepository {
+    async fn record_usage(&self, _request: RecordUsageDbRequest) -> anyhow::Result<UsageLogEntry> {
+        anyhow::bail!("unused")
+    }
+
+    async fn get_balance(
+        &self,
+        _organization_id: Uuid,
+    ) -> anyhow::Result<Option<OrganizationBalanceInfo>> {
+        Ok(None)
+    }
+
+    async fn get_usage_history(
+        &self,
+        _organization_id: Uuid,
+        _limit: Option<i64>,
+        _offset: Option<i64>,
+    ) -> anyhow::Result<(Vec<UsageLogEntry>, i64)> {
+        Ok((Vec::new(), 0))
+    }
+
+    async fn get_usage_history_by_api_key(
+        &self,
+        _api_key_id: Uuid,
+        _limit: Option<i64>,
+        _offset: Option<i64>,
+    ) -> anyhow::Result<(Vec<UsageLogEntry>, i64)> {
+        Ok((Vec::new(), 0))
+    }
+
+    async fn get_api_key_spend(&self, _api_key_id: Uuid) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+
+    async fn get_costs_by_inference_ids(
+        &self,
+        _organization_id: Uuid,
+        _inference_ids: Vec<Uuid>,
+    ) -> anyhow::Result<Vec<InferenceCost>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_stop_reason_by_response_id(
+        &self,
+        _response_id: Uuid,
+    ) -> anyhow::Result<Option<StopReason>> {
+        Ok(None)
+    }
+
+    async fn get_stop_reason_by_provider_request_id(
+        &self,
+        _provider_request_id: &str,
+    ) -> anyhow::Result<Option<StopReason>> {
+        Ok(None)
+    }
+
+    async fn get_usage_by_model(
+        &self,
+        _organization_id: Uuid,
+        _start_date: chrono::DateTime<chrono::Utc>,
+    ) -> anyhow::Result<Vec<UsageByModelEntry>> {
+        Ok(Vec::new())
+    }
+
+    async fn list_inference_usage_report(
+        &self,
+        _query: InferenceUsageReportQuery,
+    ) -> anyhow::Result<Vec<InferenceUsageReportRow>> {
+        Ok(Vec::new())
+    }
+
+    async fn list_inference_usage_history(
+        &self,
+        _query: InferenceUsageHistoryQuery,
+    ) -> anyhow::Result<(Vec<InferenceUsageReportRow>, i64)> {
+        Ok((Vec::new(), 0))
+    }
+}
+
+/// Pool with a chat_id already pinned to a recording `MockProvider`, matching
+/// the state a gateway-signed stream is in when its end-of-stream tail runs.
+async fn pool_with_pinned_chat(chat_id: &str) -> (Arc<InferenceProviderPool>, Arc<MockProvider>) {
+    let pool = Arc::new(InferenceProviderPool::new(
+        None,
+        ExternalProvidersConfig::default(),
+    ));
+    let provider = Arc::new(MockProvider::new());
+    pool.store_chat_id_mapping(chat_id.to_string(), provider.clone())
+        .await;
+    (pool, provider)
+}
+
+fn lifecycle_service(
+    repository: Arc<dyn AttestationRepository + Send + Sync>,
+    pool: Arc<InferenceProviderPool>,
+) -> AttestationService {
+    let (ed25519_signing_key, ed25519_verifying_key, ecdsa_signing_key, ecdsa_verifying_key) =
+        AttestationService::generate_ephemeral_signing_keys();
+    AttestationService {
+        repository,
+        inference_provider_pool: pool.clone(),
+        models_repository: Arc::new(EmptyModelsRepository),
+        metrics_service: Arc::new(NoopMetricsService),
+        usage_repository: Arc::new(NoopUsageRepository),
+        vpc_info: None,
+        vpc_shared_secret: None,
+        tls_cert_fingerprint: None,
+        ed25519_signing_key: Arc::new(ed25519_signing_key),
+        ed25519_verifying_key: Arc::new(ed25519_verifying_key),
+        ecdsa_signing_key: Arc::new(ecdsa_signing_key),
+        ecdsa_verifying_key: Arc::new(ecdsa_verifying_key),
+        ita_config: ItaAttestationConfig::default(),
+        ita_client: None,
+        gateway_quote_collector: Arc::new(DstackGatewayQuoteCollector),
+        model_attestation_collector: Arc::new(ProviderPoolModelAttestationCollector::new(pool)),
+        report_cache: None,
+    }
+}
+
+#[tokio::test]
+async fn store_and_unpin_stores_gateway_signature_and_releases_pin_on_success() {
+    let chat_id = "chatcmpl-lifecycle-success";
+    let (pool, provider) = pool_with_pinned_chat(chat_id).await;
+    let repository = RecordingRepository::default();
+    let service = lifecycle_service(Arc::new(repository.clone()), pool);
+
+    let result = service
+        .store_chat_signature_and_unpin(chat_id, "req-hash".to_string(), "resp-hash".to_string())
+        .await;
+
+    assert!(result.is_ok(), "store should succeed: {result:?}");
+    let stored = repository.stored();
+    assert_eq!(stored.len(), 2, "one signature per signing algorithm");
+    for (stored_chat_id, signature) in &stored {
+        assert_eq!(stored_chat_id, chat_id);
+        assert_eq!(signature.text, "req-hash:resp-hash");
+        assert_eq!(signature.signature_kind, Some(SignatureKind::Gateway));
+    }
+    assert_eq!(
+        provider.unpinned_chat_ids(),
+        vec![chat_id.to_string()],
+        "the signature-fetch routing pin must be released exactly once"
+    );
+}
+
+#[tokio::test]
+async fn store_and_unpin_releases_pin_when_store_fails() {
+    let chat_id = "chatcmpl-lifecycle-store-error";
+    let (pool, provider) = pool_with_pinned_chat(chat_id).await;
+    let service = lifecycle_service(Arc::new(FailingRepository), pool);
+
+    let result = service
+        .store_chat_signature_and_unpin(chat_id, "req-hash".to_string(), "resp-hash".to_string())
+        .await;
+
+    assert!(result.is_err(), "store failure must propagate");
+    assert_eq!(
+        provider.unpinned_chat_ids(),
+        vec![chat_id.to_string()],
+        "the pin must be released even when the store fails"
+    );
+}
+
+// `start_paused` lets the 5s store timeout elapse instantly: tokio auto-
+// advances the paused clock once the hanging store is the only pending work.
+#[tokio::test(start_paused = true)]
+async fn store_and_unpin_releases_pin_when_store_times_out() {
+    let chat_id = "chatcmpl-lifecycle-timeout";
+    let (pool, provider) = pool_with_pinned_chat(chat_id).await;
+    let service = lifecycle_service(Arc::new(HangingRepository), pool);
+
+    let started = tokio::time::Instant::now();
+    let result = service
+        .store_chat_signature_and_unpin(chat_id, "req-hash".to_string(), "resp-hash".to_string())
+        .await;
+
+    assert!(
+        started.elapsed() >= STREAM_SIGNATURE_STORE_TIMEOUT,
+        "the hanging store must be cut off by the timeout, not complete"
+    );
+    match result {
+        Err(AttestationError::InternalError(message)) => {
+            assert!(
+                message.contains("Timed out"),
+                "timeout must surface as such: {message}"
+            );
+        }
+        other => panic!("expected timeout error, got {other:?}"),
+    }
+    assert_eq!(
+        provider.unpinned_chat_ids(),
+        vec![chat_id.to_string()],
+        "the pin must be released even when the store times out"
+    );
+}
+
+#[tokio::test]
+async fn release_chat_signature_pin_unpins_without_storing() {
+    let chat_id = "chatcmpl-lifecycle-errored-stream";
+    let (pool, provider) = pool_with_pinned_chat(chat_id).await;
+    let repository = RecordingRepository::default();
+    let service = lifecycle_service(Arc::new(repository.clone()), pool);
+
+    service.release_chat_signature_pin(chat_id).await;
+
+    assert!(
+        repository.stored().is_empty(),
+        "the errored-stream path must not store a signature"
+    );
+    assert_eq!(
+        provider.unpinned_chat_ids(),
+        vec![chat_id.to_string()],
+        "the pin must still be released for errored streams"
+    );
+}
+
+#[tokio::test]
+async fn release_chat_signature_pin_is_a_noop_without_a_mapping() {
+    let pool = Arc::new(InferenceProviderPool::new(
+        None,
+        ExternalProvidersConfig::default(),
+    ));
+    let repository = RecordingRepository::default();
+    let service = lifecycle_service(Arc::new(repository.clone()), pool);
+
+    // No mapping for this chat_id — must not panic or store anything.
+    service.release_chat_signature_pin("chatcmpl-unknown").await;
+    assert!(repository.stored().is_empty());
+}

--- a/crates/services/src/attestation/chat_signatures.rs
+++ b/crates/services/src/attestation/chat_signatures.rs
@@ -1,7 +1,17 @@
+use std::time::Duration;
+
 use uuid::Uuid;
 
-use super::{AttestationError, AttestationService, ChatSignature, SignatureLookupResult};
+use super::{
+    AttestationError, AttestationService, ChatSignature, SignatureKind, SignatureLookupResult,
+};
 use crate::{metrics::consts::*, usage::StopReason};
+
+/// Upper bound on the gateway signature store at end-of-stream. The client is
+/// still waiting for the held-back `[DONE]` while this runs, so it must be
+/// bounded; on timeout the routing pin is still released and the stream ends
+/// without a stored signature (logged by the caller).
+pub(in crate::attestation) const STREAM_SIGNATURE_STORE_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl AttestationService {
     pub(in crate::attestation) async fn get_chat_signature_impl(
@@ -93,6 +103,7 @@ impl AttestationService {
                     signature: provider_signature.signature,
                     signing_address: provider_signature.signing_address,
                     signing_algo: provider_signature.signing_algo,
+                    signature_kind: Some(SignatureKind::ProviderTee),
                 };
 
                 self.repository
@@ -142,6 +153,48 @@ impl AttestationService {
     ) -> Result<(), AttestationError> {
         self.store_gateway_signature(chat_id, "chat", request_hash, response_hash)
             .await
+    }
+
+    /// Store the gateway signature for a stream and then release the
+    /// provider-pool signature-fetch routing pin, mirroring the lifecycle
+    /// ownership of `store_chat_signature_from_provider_impl` (which unpins
+    /// after the provider fetch). The store is bounded by
+    /// [`STREAM_SIGNATURE_STORE_TIMEOUT`] *inside* this method so the unpin
+    /// runs even when the store hangs — an outer timeout would drop the
+    /// future and leak the pin.
+    pub(in crate::attestation) async fn store_chat_signature_and_unpin_impl(
+        &self,
+        chat_id: &str,
+        request_hash: String,
+        response_hash: String,
+    ) -> Result<(), AttestationError> {
+        let result = match tokio::time::timeout(
+            STREAM_SIGNATURE_STORE_TIMEOUT,
+            self.store_chat_signature_impl(chat_id, request_hash, response_hash),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(AttestationError::InternalError(format!(
+                "Timed out storing gateway chat signature for {chat_id}"
+            ))),
+        };
+        self.release_chat_signature_pin_impl(chat_id).await;
+        result
+    }
+
+    /// Release the provider-pool signature-fetch routing pin for `chat_id`.
+    /// Called on gateway-signed streams (where the provider signature fetch —
+    /// and its post-fetch unpin — is skipped) and on errored streams that
+    /// store nothing.
+    pub(in crate::attestation) async fn release_chat_signature_pin_impl(&self, chat_id: &str) {
+        if let Some(provider) = self
+            .inference_provider_pool
+            .get_provider_by_chat_id(chat_id)
+            .await
+        {
+            provider.unpin_chat_connection(chat_id);
+        }
     }
 
     pub(in crate::attestation) async fn store_response_signature_impl(

--- a/crates/services/src/attestation/gateway_signatures.rs
+++ b/crates/services/src/attestation/gateway_signatures.rs
@@ -2,7 +2,7 @@ use ed25519_dalek::Signer;
 use k256::ecdsa::{RecoveryId, Signature as EcdsaSignature};
 use sha3::{Digest, Keccak256};
 
-use super::{AttestationError, AttestationService, ChatSignature};
+use super::{AttestationError, AttestationService, ChatSignature, SignatureKind};
 use crate::metrics::consts::*;
 
 impl AttestationService {
@@ -35,6 +35,7 @@ impl AttestationService {
                         signature: signature_hex,
                         signing_address,
                         signing_algo: algo.to_string(),
+                        signature_kind: Some(SignatureKind::Gateway),
                     },
                 )
                 .await

--- a/crates/services/src/attestation/mod.rs
+++ b/crates/services/src/attestation/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod chat_signature_lifecycle_tests;
 mod chat_signatures;
 pub mod chutes;
 mod environment;
@@ -26,7 +28,7 @@ pub use environment::{
 pub use gateway_quote::{DstackGatewayQuoteCollector, GatewayQuoteCollector, GatewayQuoteInput};
 pub use ita::{ModelAttestationCollector, ModelAttestationInput};
 pub use measurement::MeasurementPolicy;
-pub use models::{AttestationError, ChatSignature, SignatureLookupResult};
+pub use models::{AttestationError, ChatSignature, SignatureKind, SignatureLookupResult};
 pub(in crate::attestation) use report::{decode_nonce_hex, generate_nonce_hex};
 pub use report_data::{ReportDataVerifier, StrictBoundReportDataVerifier};
 pub use verification::{AttestationVerificationError, AttestationVerifier, VerifiedAttestation};

--- a/crates/services/src/attestation/models.rs
+++ b/crates/services/src/attestation/models.rs
@@ -46,6 +46,47 @@ pub enum SignatureLookupResult {
     Unavailable { error_code: String, message: String },
 }
 
+/// Which key produced a stored chat signature.
+///
+/// The two kinds sign different payloads:
+/// - [`SignatureKind::ProviderTee`]: signed inside the model-serving TEE over
+///   `"{model_id}:{request_hash}:{response_hash}"` (the provider's canonical
+///   text), covering the exact bytes the model backend emitted.
+/// - [`SignatureKind::Gateway`]: signed by the cloud-api gateway TEE over
+///   `"{request_hash}:{response_hash}"`, covering the exact bytes the client
+///   received. Used when the gateway rewrites the stream (usage accounting or
+///   stripping, redaction), so the provider's byte-exact signature can no
+///   longer match, and for attested providers without per-response signatures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignatureKind {
+    /// Signed by the model-serving TEE (provider signature, stored verbatim).
+    ProviderTee,
+    /// Signed by the cloud-api gateway TEE over the client-visible bytes.
+    Gateway,
+}
+
+impl SignatureKind {
+    /// Database string representation (matches the serde snake_case form).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SignatureKind::ProviderTee => "provider_tee",
+            SignatureKind::Gateway => "gateway",
+        }
+    }
+
+    /// Parse the database string representation. Returns `None` for unknown
+    /// values so an unexpected row degrades to "kind unknown" instead of
+    /// failing the whole signature lookup.
+    pub fn from_db_str(s: &str) -> Option<Self> {
+        match s {
+            "provider_tee" => Some(SignatureKind::ProviderTee),
+            "gateway" => Some(SignatureKind::Gateway),
+            _ => None,
+        }
+    }
+}
+
 /// Chat signature for cryptographic verification
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatSignature {
@@ -57,6 +98,12 @@ pub struct ChatSignature {
     pub signing_address: String,
     /// The signing algorithm used (e.g., "ecdsa")
     pub signing_algo: String,
+    /// Which key produced this signature. `None` for rows stored before the
+    /// kind was recorded (their provenance is unknown — both provider-TEE and
+    /// gateway writes predate the column), so it is surfaced as absent rather
+    /// than guessed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_kind: Option<SignatureKind>,
 }
 
 /// VPC (Virtual Private Cloud) metadata included in attestation reports

--- a/crates/services/src/attestation/ports.rs
+++ b/crates/services/src/attestation/ports.rs
@@ -33,6 +33,32 @@ pub trait AttestationServiceTrait: Send + Sync {
         response_hash: String,
     ) -> Result<(), AttestationError>;
 
+    /// Store a gateway chat signature and then release the provider-pool
+    /// signature-fetch routing pin for `chat_id`, mirroring the lifecycle
+    /// ownership of [`Self::store_chat_signature_from_provider`]: the pin is
+    /// released whether the store succeeds, fails, or times out, so the
+    /// provider's chat_id → backend map cannot grow unboundedly on
+    /// gateway-signed streams (where the provider signature fetch — and its
+    /// post-fetch unpin — is skipped).
+    async fn store_chat_signature_and_unpin(
+        &self,
+        chat_id: &str,
+        request_hash: String,
+        response_hash: String,
+    ) -> Result<(), AttestationError> {
+        let result = self
+            .store_chat_signature(chat_id, request_hash, response_hash)
+            .await;
+        self.release_chat_signature_pin(chat_id).await;
+        result
+    }
+
+    /// Release the provider-pool signature-fetch routing pin for `chat_id`
+    /// without storing a signature — the errored-stream path, where there is
+    /// nothing to sign but the pin still has to be dropped. Default no-op for
+    /// implementations without a provider pool (mocks).
+    async fn release_chat_signature_pin(&self, _chat_id: &str) {}
+
     /// Store a response signature directly (for response streams)
     /// Creates a signature with text format "request_hash:response_hash"
     /// Stores both ECDSA and ED25519 signatures

--- a/crates/services/src/attestation/service_trait.rs
+++ b/crates/services/src/attestation/service_trait.rs
@@ -34,6 +34,20 @@ impl ports::AttestationServiceTrait for AttestationService {
             .await
     }
 
+    async fn store_chat_signature_and_unpin(
+        &self,
+        chat_id: &str,
+        request_hash: String,
+        response_hash: String,
+    ) -> Result<(), AttestationError> {
+        self.store_chat_signature_and_unpin_impl(chat_id, request_hash, response_hash)
+            .await
+    }
+
+    async fn release_chat_signature_pin(&self, chat_id: &str) {
+        self.release_chat_signature_pin_impl(chat_id).await
+    }
+
     async fn store_response_signature(
         &self,
         response_id: &str,

--- a/crates/services/src/inference_provider_pool/mod.rs
+++ b/crates/services/src/inference_provider_pool/mod.rs
@@ -1655,8 +1655,10 @@ impl InferenceProviderPool {
         mappings.model_to_providers.get(model_id).cloned()
     }
 
-    /// Store a mapping of chat_id to provider
-    async fn store_chat_id_mapping(
+    /// Store a mapping of chat_id to provider.
+    /// `pub(crate)` (not `pub`) so attestation lifecycle unit tests can seed a
+    /// chat_id → provider pin; production writes stay inside this module.
+    pub(crate) async fn store_chat_id_mapping(
         &self,
         chat_id: String,
         provider: Arc<dyn InferenceProvider + Send + Sync>,


### PR DESCRIPTION
## Problem

Live-verified on prod (2026-07-20): streaming `zai-org/GLM-5.1-FP8` (self-hosted/nearai path) **without** `stream_options`, 200 of 202 chunks carried a full non-null `usage` object and the stream ended with a trailing `{"choices":[],"usage":{...}}` usage-only chunk. Per the OpenAI streaming spec, when `include_usage` is not requested no chunk should carry `usage` and there must be no trailing usage-only chunk. This is the exact defect class that broke strict SDK parsers on the Chutes path (customer-reported; fixed there by #870, which explicitly left the nearai provider path untouched). Usage values themselves are correct — this is a spec-conformance/parser-robustness fix, not a billing fix.

Root cause: the nearai provider forces `stream_options {include_usage: true, continuous_usage_stats: true}` upstream for billing capture, and the route forwarded those bytes verbatim because `strip_intermediate_usage` (#801) was scoped to non-attested models only, to preserve byte-exact provider-signature verification.

## Fix

All in `chat_stream_usage_mode` (`crates/api/src/routes/completions.rs`):

- `strip_intermediate_usage` now activates for attested models too (`model_attestation_supported.is_some()` instead of `== Some(false)`): chunks are re-serialized with `usage: null` and the trailing usage-only chunk is dropped, identical to the non-attested behaviour from #801.
- `gateway_signature_enabled` now covers the strip path (`(rewrite_public_stream_usage || strip_intermediate_usage) && attested`): the provider signature fetch is skipped and the gateway signs the exact rewritten bytes the client received — the same verifiability-preserving mechanism the `include_usage: true` rewrite path already uses.
- The end-of-stream tail unpins the provider's signature-fetch routing entry for gateway-signed streams (the post-fetch unpin never runs when the fetch is skipped), preventing unbounded `chat_id -> backend` map growth. This also covers the pre-existing `include_usage: true` gateway path. Scope note: the unpin runs when the stream is polled to completion; the client-disconnect case is a pre-existing gap shared with main (as is pool-level `chat_id_mapping` growth) and is unchanged here.

Billing is untouched: `InterceptStream` records usage from the parsed chunks in the service layer, upstream of the route-level rewrite (same preservation property as #870), pinned by the existing stream-billing e2e which now exercises the strip path.

Unchanged paths: metadata-lookup failure (attestation unknown) falls back to byte-exact passthrough; `include_usage: true`, `continuous_usage_stats`, E2EE, and non-text-modality streams are byte-exact as before.

## Verifiability trade-off (needs owner sign-off)

Default attested (nearai) streams — the majority of self-hosted stream traffic — switch from byte-exact provider TEE signatures to **gateway signatures over the rewritten bytes**. This knowingly supersedes #801's deliberate attested-passthrough choice: re-serialization breaks byte-exact provider-signature verification, so gateway signing (the mechanism `include_usage: true` streams have used since #724/#801) is the only way to be spec-conformant while keeping the stored signature consistent with the bytes the client actually received. Clients verifying default streams now verify a cloud-api gateway signature rather than the inference TEE's signature.

Chutes side effect: chutes models are attested, so their default streams also move onto the strip+gateway path. The chutes module already sanitizes the parsed chunk (canonical model id, internal fields stripped, usage kept for billing) and has no provider chat signatures, so the skip flag is a no-op there. Two client-visible nuances: intermediate chutes chunks now carry an explicit `"usage": null` (instead of the key being removed by `gate_stream_usage` — same shape as every other non-passthrough stream since #801), and non-E2EE default chutes streams now store a gateway signature where the signature endpoint previously returned `SIGNATURE_UNSUPPORTED`, matching chutes' existing `include_usage: true` behaviour.

Known remaining gap (out of scope, same as #801/#870): the legacy `/v1/completions` text streaming path has the identical defect — `text_completion_stream` forces the same `stream_options` and the route's usage shaping never applies to text streams — and is untouched here; follow-up candidate.

Perf note: default attested streams no longer take the raw passthrough shortcut — per-chunk re-serialize plus gateway SHA-256 hashing, the same cost profile as the existing `include_usage: true` rewrite path.

## Testing

All run in a worktree based on `c46b2488`:

- `cargo test -p api --lib` — 244 passed (includes the 68 `routes::completions` tests covering the new mode matrix: attested default / `include_usage: false` -> strip + gateway signature; metadata-None -> passthrough regression; the two former attested-passthrough tests inverted to the new contract).
- `DEV=1 cargo test -p api --test e2e_all -- usage_chat_completions` — 10 passed, including two new attested e2e tests (default and `include_usage: false`) asserting `usage: null` on every chunk, no usage-only/empty-choices chunk, and `[DONE]` termination (mock provider mirrors vLLM's per-chunk-usage + trailing-husk shape), plus the stream-billing-through-strip regression. The attested `include_usage: true` spec shape was already pinned by `test_chat_completions_stream_include_usage_true_emits_final_usage_only`.
- `DEV=1 cargo test -p api --test e2e_all -- signature_verification` — 5 passed; `test_streaming_chat_completion_signature_verification` (default attested stream, now gateway-signed) verifies the stored signature hash matches sha256 of the exact client-received bytes.
- Broader e2e sweep (general, auto_redact, model_alias_transparency, serving_provider, client_disconnect, chat_encryption, reasoning, usage_recording, usage_responses) — 128 passed, 1 failed: `general::test_admin_list_users_with_organizations_no_spend_limit`, which fails identically on clean `origin/main` (pre-existing/ordering-dependent, unrelated).
- `cargo check -p api --tests`, `cargo fmt -p api --check`, `cargo clippy -p api --all-targets` — clean.
