### PR TITLE
fix(api): return generic JSON envelope for unmatched routes

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1389,6 +1389,11 @@ pub fn build_app_with_config(
         .merge(openapi_routes)
         .merge(mcp_routes)
         .merge(ohttp_root_routes)
+        // Requests matching no route (or no method on a matched route) get a
+        // stable generic JSON envelope instead of Axum's default empty-body
+        // 404/405 (nearai/infra#192).
+        .fallback(routes::unsupported::unknown_route)
+        .method_not_allowed_fallback(routes::unsupported::method_not_allowed)
         .layer(cors)
         // Add HTTP metrics middleware to track all requests
         .layer(from_fn_with_state(

--- a/crates/api/src/routes/unsupported.rs
+++ b/crates/api/src/routes/unsupported.rs
@@ -26,6 +26,44 @@ pub fn openai_compat_routes() -> Router {
         .route("/models/{*model_id}", any(openai_endpoint_not_implemented))
 }
 
+/// Global router fallback for requests that match no route.
+///
+/// Returns a stable generic OpenAI-style error envelope instead of Axum's
+/// default empty-body 404, so unmapped paths never surface framework or
+/// infrastructure detail (nearai/infra#192). The body is intentionally
+/// static: no method/path echo, no version, no implementation hints.
+pub async fn unknown_route() -> (
+    StatusCode,
+    [(&'static str, &'static str); 1],
+    Json<ErrorResponse>,
+) {
+    (
+        StatusCode::NOT_FOUND,
+        [(HEADER_SHOULD_RETRY, SHOULD_RETRY_FALSE)],
+        Json(ErrorResponse::new(
+            "Not found".to_string(),
+            "invalid_request_error".to_string(),
+        )),
+    )
+}
+
+/// Fallback for requests that match a route path but not the HTTP method:
+/// the same stable generic envelope as [`unknown_route`], with 405.
+pub async fn method_not_allowed() -> (
+    StatusCode,
+    [(&'static str, &'static str); 1],
+    Json<ErrorResponse>,
+) {
+    (
+        StatusCode::METHOD_NOT_ALLOWED,
+        [(HEADER_SHOULD_RETRY, SHOULD_RETRY_FALSE)],
+        Json(ErrorResponse::new(
+            "Method not allowed".to_string(),
+            "invalid_request_error".to_string(),
+        )),
+    )
+}
+
 pub async fn openai_endpoint_not_implemented(
     method: Method,
     OriginalUri(uri): OriginalUri,
@@ -125,6 +163,101 @@ mod tests {
                 "message should mention {method} {path}, got {message:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn unknown_route_fallback_returns_generic_json_envelope() {
+        async fn ok() -> &'static str {
+            "ok"
+        }
+
+        for (method, path) in [
+            (Method::GET, "/nonexistent"),
+            (Method::GET, "/test.html"),
+            (Method::POST, "/v1/nonexistent"),
+            (Method::DELETE, "/.env"),
+        ] {
+            let app: Router = Router::new()
+                .route("/v1/health", get(ok))
+                .fallback(unknown_route);
+            let response = app
+                .oneshot(
+                    HttpRequest::builder()
+                        .method(method.clone())
+                        .uri(path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{method} {path}");
+            assert_eq!(
+                response
+                    .headers()
+                    .get(CONTENT_TYPE)
+                    .map(|value| value.to_str().unwrap()),
+                Some("application/json"),
+                "{method} {path}"
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get(HEADER_SHOULD_RETRY)
+                    .map(|value| value.to_str().unwrap()),
+                Some(SHOULD_RETRY_FALSE),
+                "{method} {path}"
+            );
+
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+            // The body must stay static and generic: no path echo, no
+            // implementation detail.
+            assert_eq!(body["error"]["message"], "Not found", "{method} {path}");
+            assert_eq!(
+                body["error"]["type"], "invalid_request_error",
+                "{method} {path}"
+            );
+            assert_eq!(body["error"]["param"], serde_json::Value::Null);
+            assert_eq!(body["error"]["code"], serde_json::Value::Null);
+        }
+    }
+
+    #[tokio::test]
+    async fn method_not_allowed_fallback_returns_generic_json_envelope() {
+        async fn ok() -> &'static str {
+            "ok"
+        }
+
+        let app: Router = Router::new()
+            .route("/only-get", get(ok))
+            .fallback(unknown_route)
+            .method_not_allowed_fallback(method_not_allowed);
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method(Method::POST)
+                    .uri("/only-get")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .map(|value| value.to_str().unwrap()),
+            Some("application/json")
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["message"], "Method not allowed");
+        assert_eq!(body["error"]["type"], "invalid_request_error");
     }
 
     #[test]


### PR DESCRIPTION
Requests that match no route currently hit Axum's default fallback and return a `404` with an empty body (verified against the live API on 2026-07-22: `GET https://cloud-api.near.ai/nonexistent` → `404`, `content-length: 0`). Method mismatches on existing routes likewise return an empty-body `405`. This adds explicit fallbacks so those cases return the same stable OpenAI-style error envelope the rest of the API uses, instead of a framework default.

## Changes

- `crates/api/src/routes/unsupported.rs`: two new handlers.
  - `unknown_route` — global fallback: `404` + `{"error":{"message":"Not found","type":"invalid_request_error","param":null,"code":null}}` with `x-should-retry: false`. The body is intentionally static: no method/path echo, no version, no implementation detail.
  - `method_not_allowed` — same envelope with `405` for matched-path/wrong-method requests.
- `crates/api/src/lib.rs`: wires them via `.fallback(...)` and `.method_not_allowed_fallback(...)` on the outermost router, after all merges (so they cover `/v1/*`, root-level, and OHTTP/MCP surfaces) and before the middleware layers (so CORS/metrics/correlation apply to fallback responses too).

No behavior change for any existing route: documented error envelopes, the `501 not_implemented` placeholders, and streaming responses are untouched.

## Test plan

- New unit tests in `routes/unsupported.rs`: unknown paths (`/nonexistent`, `/test.html`, `/v1/nonexistent`, `/.env`) return `404` `application/json` with the static generic envelope and `x-should-retry: false`; wrong method on an existing route returns `405` with the same envelope shape.
- `cargo test -p api --lib`: 250 passed, 0 failed (includes the existing OpenAI-compatible error envelope tests).
- `cargo fmt --check`: clean. `cargo clippy -p api --lib --tests`: clean.

## Rollout

- Ships with the normal cloud-api release train: staging deploy + external scan of unmapped-path behavior on `cloud-stg-api.near.ai`, then production rollout.
- Edge-level counterparts (port 80 contract, ingress error bodies) are separate changes; server version-banner suppression is tracked separately as well.

Part of nearai/infra#192
