### PR TITLE
fix(auth): revoke server-side session on logout and bind access tokens to sessions

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -201,6 +201,7 @@ pub fn init_auth_services(database: Arc<Database>, config: &ApiConfig) -> AuthCo
             organization_repo as Arc<dyn services::organization::ports::OrganizationRepository>,
             workspace_repository_for_auth,
             organization_service.clone(),
+            config.auth.require_session_bound_access_tokens,
         ))
     };
 
@@ -1476,7 +1477,17 @@ pub fn build_auth_routes(
                 auth_middleware,
             )),
         )
-        .route("/logout", post(logout))
+        // Logout authenticates with the refresh token (same middleware as
+        // token refresh) so the handler can revoke that exact server-side
+        // session, invalidating the refresh token and all access tokens
+        // bound to it.
+        .route(
+            "/logout",
+            post(logout).layer(from_fn_with_state(
+                auth_state_middleware.clone(),
+                crate::middleware::auth::refresh_middleware,
+            )),
+        )
         .merge(near_router)
         .with_state(auth_state)
 }
@@ -2535,6 +2546,7 @@ mod tests {
                 google: None,
                 near: config::NearConfig::default(),
                 admin_domains: vec![],
+                require_session_bound_access_tokens: false,
             },
             database: config::DatabaseConfig {
                 primary_app_id: "postgres-patroni-1".to_string(),
@@ -2642,6 +2654,7 @@ mod tests {
                 google: None,
                 near: config::NearConfig::default(),
                 admin_domains: vec![],
+                require_session_bound_access_tokens: false,
             },
             database: config::DatabaseConfig {
                 primary_app_id: "postgres-patroni-1".to_string(),

--- a/crates/api/src/routes/auth.rs
+++ b/crates/api/src/routes/auth.rs
@@ -578,8 +578,8 @@ pub async fn logout(
             )
                 .into_response()
         }
-        Err(_) => {
-            error!("Failed to revoke session on logout");
+        Err(e) => {
+            error!(error = %e, user_id = %user.0.id, "Failed to revoke session on logout");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({

--- a/crates/api/src/routes/auth.rs
+++ b/crates/api/src/routes/auth.rs
@@ -1,7 +1,7 @@
 use crate::middleware::AuthenticatedUser;
 use axum::{
     extract::{Query, Request, State},
-    http::{header::SET_COOKIE, HeaderMap, StatusCode},
+    http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect, Response},
     Extension, Json,
 };
@@ -547,21 +547,49 @@ pub async fn current_user(Extension(user): Extension<AuthenticatedUser>) -> Json
 }
 
 /// Logout endpoint
-pub async fn logout(Extension(user): Extension<AuthenticatedUser>) -> Response {
-    debug!("Logging out user_id={}", user.0.id);
+///
+/// Authenticated with the session's refresh token (via `refresh_middleware`,
+/// like token refresh). Revokes exactly the current server-side refresh-token
+/// session, which immediately invalidates that refresh token and every access
+/// token bound to it through its `sid` claim. Other sessions (devices) of the
+/// same user are not touched.
+///
+/// Idempotent from the caller's perspective: revoking a session that was
+/// already deleted between authentication and revocation still returns 200.
+/// A repeated call with the already-revoked refresh token fails middleware
+/// authentication with 401 and changes nothing.
+pub async fn logout(
+    State((_oauth, _state_store, auth_service, _config)): State<AuthState>,
+    Extension((session, user)): Extension<(services::auth::Session, AuthenticatedUser)>,
+) -> Response {
+    debug!(
+        "Logging out user_id={} session_id={}",
+        user.0.id, session.id
+    );
 
-    // This would need the session_id from cookie in real implementation
-    // For now, just clear the cookie
-    let cookie = "session_id=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0";
-
-    (
-        StatusCode::OK,
-        [(SET_COOKIE, cookie)],
-        Json(serde_json::json!({
-            "message": "Logged out successfully"
-        })),
-    )
-        .into_response()
+    match auth_service.logout(session.id).await {
+        Ok(revoked) => {
+            debug!(revoked, user_id = %user.0.id, "Logout completed");
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "message": "Logged out successfully"
+                })),
+            )
+                .into_response()
+        }
+        Err(_) => {
+            error!("Failed to revoke session on logout");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "internal_server_error",
+                    "error_description": "Failed to revoke session"
+                })),
+            )
+                .into_response()
+        }
+    }
 }
 
 /// NEAR wallet login endpoint

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -86,6 +86,7 @@ pub fn test_config() -> ApiConfig {
             google: None,
             near: config::NearConfig::default(),
             admin_domains: vec!["test.com".to_string()],
+            require_session_bound_access_tokens: false,
         },
         database: config::DatabaseConfig {
             primary_app_id: "postgres-test".to_string(),

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -68,6 +68,7 @@ mod rerank;
 mod response_signature_verification;
 mod score;
 mod serving_provider;
+mod session_logout;
 mod signature_verification;
 mod usage_chat_completions;
 mod usage_provider_attribution;

--- a/crates/api/tests/e2e_all/session_logout.rs
+++ b/crates/api/tests/e2e_all/session_logout.rs
@@ -14,9 +14,6 @@ use std::sync::Arc;
 /// numbers, so any consistent value works.
 const TEST_UA: &str = "Mozilla/5.0 (X11; Linux x86_64) TestBrowser/1.0";
 
-/// Matches the encoding key in `test_config()`.
-const TEST_ENCODING_KEY: &str = "mock_encoding_key";
-
 async fn real_auth_server() -> (axum_test::TestServer, Arc<database::Database>) {
     setup_test_server_with_config_and_database(|c| c.auth.mock = false).await
 }
@@ -105,6 +102,21 @@ async fn session_row_exists(database: &Arc<database::Database>, session_id: uuid
         .is_some()
 }
 
+/// Delete a test user (sessions cascade) so repeated runs don't accumulate
+/// rows in the shared e2e database. Deletes by id, so it cannot interfere
+/// with users created by concurrently running tests.
+async fn cleanup_user(database: &Arc<database::Database>, user_id: uuid::Uuid) {
+    let client = database
+        .pool()
+        .get()
+        .await
+        .expect("Failed to get database connection");
+    client
+        .execute("DELETE FROM users WHERE id = $1", &[&user_id])
+        .await
+        .expect("Failed to clean up test user");
+}
+
 #[tokio::test]
 async fn test_logout_invalidates_access_and_refresh_tokens() {
     let (server, database) = real_auth_server().await;
@@ -145,6 +157,8 @@ async fn test_logout_invalidates_access_and_refresh_tokens() {
         !session_row_exists(&database, session_id).await,
         "refresh-token session row must be gone after logout"
     );
+
+    cleanup_user(&database, user_id).await;
 }
 
 #[tokio::test]
@@ -170,6 +184,8 @@ async fn test_logout_revokes_only_the_current_session() {
     assert!(session_row_exists(&database, session_b_id).await);
     let rotated_b = mint_tokens(&server, &tokens_b.refresh_token).await;
     assert_eq!(me_status(&server, &rotated_b.access_token).await, 200);
+
+    cleanup_user(&database, user_id).await;
 }
 
 #[tokio::test]
@@ -194,6 +210,8 @@ async fn test_repeated_logout_is_safe() {
         remaining.is_empty(),
         "repeated logout must not create or restore sessions"
     );
+
+    cleanup_user(&database, user_id).await;
 }
 
 #[tokio::test]
@@ -216,6 +234,8 @@ async fn test_fresh_login_after_logout_creates_independent_session() {
     assert_eq!(logout_status(&server, &new_tokens.refresh_token).await, 200);
     assert_eq!(me_status(&server, &new_tokens.access_token).await, 401);
     assert!(!session_row_exists(&database, new_session_id).await);
+
+    cleanup_user(&database, user_id).await;
 }
 
 #[tokio::test]
@@ -231,8 +251,10 @@ async fn test_legacy_access_token_without_sid_follows_compat_flag() {
             database.pool().clone(),
         )),
     };
+    // Sign with the same key the test servers use.
+    let encoding_key = test_config().auth.encoding_key;
     let legacy_token = minter
-        .create_session_access_token(UserId(user_id), None, TEST_ENCODING_KEY.to_string(), 1)
+        .create_session_access_token(UserId(user_id), None, encoding_key, 1)
         .expect("Failed to mint legacy token");
 
     // Default (compat window): legacy tokens still validate.
@@ -255,6 +277,9 @@ async fn test_legacy_access_token_without_sid_follows_compat_flag() {
         me_status(&strict_server, &strict_tokens.access_token).await,
         200
     );
+
+    cleanup_user(&database, user_id).await;
+    cleanup_user(&strict_database, strict_user_id).await;
 }
 
 #[tokio::test]

--- a/crates/api/tests/e2e_all/session_logout.rs
+++ b/crates/api/tests/e2e_all/session_logout.rs
@@ -1,0 +1,276 @@
+//! End-to-end tests for server-side session revocation on logout
+//! (nearai/infra#191).
+//!
+//! These tests run against the real `AuthService` (`auth.mock = false`) and
+//! the real PostgreSQL-backed session repository, seeding users and sessions
+//! directly in the shared test database.
+
+use crate::common::*;
+use database::repositories::SessionRepository;
+use services::auth::{AuthServiceTrait, MockAuthService, UserId};
+use std::sync::Arc;
+
+/// Browser-like User-Agent; the session repository normalizes version
+/// numbers, so any consistent value works.
+const TEST_UA: &str = "Mozilla/5.0 (X11; Linux x86_64) TestBrowser/1.0";
+
+/// Matches the encoding key in `test_config()`.
+const TEST_ENCODING_KEY: &str = "mock_encoding_key";
+
+async fn real_auth_server() -> (axum_test::TestServer, Arc<database::Database>) {
+    setup_test_server_with_config_and_database(|c| c.auth.mock = false).await
+}
+
+/// Insert a unique user directly in the database and return its id.
+///
+/// `created_at` is backdated so these users sort below the shared mock user
+/// in `ORDER BY created_at DESC` admin listings — other e2e tests page
+/// through those with a fixed limit and expect the mock user on page one.
+async fn create_real_user(database: &Arc<database::Database>) -> uuid::Uuid {
+    let user_id = uuid::Uuid::new_v4();
+    let user_id_str = user_id.to_string();
+    let client = database
+        .pool()
+        .get()
+        .await
+        .expect("Failed to get database connection");
+    client.execute(
+        "INSERT INTO users (id, email, username, display_name, avatar_url, auth_provider, provider_user_id, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() - INTERVAL '30 days', NOW())",
+        &[
+            &user_id,
+            &format!("logout-test-{user_id_str}@test.com"),
+            &format!("logout-test-{user_id_str}"),
+            &Some("Logout Test User".to_string()),
+            &None::<String>,
+            &"mock",
+            &format!("logout-test-{user_id_str}"),
+        ],
+    ).await.expect("Failed to create test user");
+    user_id
+}
+
+/// Create a refresh-token session for the user directly via the repository.
+/// Returns (session_id, plaintext_refresh_token).
+async fn create_session(
+    database: &Arc<database::Database>,
+    user_id: uuid::Uuid,
+) -> (uuid::Uuid, String) {
+    let repo = SessionRepository::new(database.pool().clone());
+    let (session, refresh_token) = repo
+        .create(user_id, None, TEST_UA.to_string(), 24)
+        .await
+        .expect("Failed to create session");
+    (session.id, refresh_token)
+}
+
+/// Exchange a refresh token for an access token + rotated refresh token over HTTP.
+async fn mint_tokens(
+    server: &axum_test::TestServer,
+    refresh_token: &str,
+) -> api::models::AccessAndRefreshTokenResponse {
+    let response = server
+        .post("/v1/users/me/access-tokens")
+        .add_header("Authorization", format!("Bearer {refresh_token}"))
+        .add_header("User-Agent", TEST_UA)
+        .await;
+    assert_eq!(response.status_code(), 200, "token mint should succeed");
+    response.json::<api::models::AccessAndRefreshTokenResponse>()
+}
+
+async fn me_status(server: &axum_test::TestServer, access_token: &str) -> u16 {
+    server
+        .get("/v1/users/me")
+        .add_header("Authorization", format!("Bearer {access_token}"))
+        .await
+        .status_code()
+        .as_u16()
+}
+
+async fn logout_status(server: &axum_test::TestServer, refresh_token: &str) -> u16 {
+    server
+        .post("/v1/auth/logout")
+        .add_header("Authorization", format!("Bearer {refresh_token}"))
+        .add_header("User-Agent", TEST_UA)
+        .await
+        .status_code()
+        .as_u16()
+}
+
+async fn session_row_exists(database: &Arc<database::Database>, session_id: uuid::Uuid) -> bool {
+    let repo = SessionRepository::new(database.pool().clone());
+    repo.get_by_id(session_id)
+        .await
+        .expect("Failed to query session")
+        .is_some()
+}
+
+#[tokio::test]
+async fn test_logout_invalidates_access_and_refresh_tokens() {
+    let (server, database) = real_auth_server().await;
+    let user_id = create_real_user(&database).await;
+    let (session_id, refresh_token) = create_session(&database, user_id).await;
+
+    // Mint an access token; this rotates the refresh token but keeps the
+    // same session row.
+    let tokens = mint_tokens(&server, &refresh_token).await;
+
+    // Both credentials work before logout.
+    assert_eq!(me_status(&server, &tokens.access_token).await, 200);
+
+    // Logout with the current refresh token revokes the session.
+    assert_eq!(logout_status(&server, &tokens.refresh_token).await, 200);
+
+    // The still-unexpired access token is rejected immediately.
+    assert_eq!(
+        me_status(&server, &tokens.access_token).await,
+        401,
+        "access token must be invalid after logout"
+    );
+
+    // The refresh token is rejected as well.
+    let response = server
+        .post("/v1/users/me/access-tokens")
+        .add_header("Authorization", format!("Bearer {}", tokens.refresh_token))
+        .add_header("User-Agent", TEST_UA)
+        .await;
+    assert_eq!(
+        response.status_code(),
+        401,
+        "refresh token must be invalid after logout"
+    );
+
+    // The session row was removed.
+    assert!(
+        !session_row_exists(&database, session_id).await,
+        "refresh-token session row must be gone after logout"
+    );
+}
+
+#[tokio::test]
+async fn test_logout_revokes_only_the_current_session() {
+    let (server, database) = real_auth_server().await;
+    let user_id = create_real_user(&database).await;
+    let (session_a_id, refresh_a) = create_session(&database, user_id).await;
+    let (session_b_id, refresh_b) = create_session(&database, user_id).await;
+
+    let tokens_a = mint_tokens(&server, &refresh_a).await;
+    let tokens_b = mint_tokens(&server, &refresh_b).await;
+
+    // Log out session A only.
+    assert_eq!(logout_status(&server, &tokens_a.refresh_token).await, 200);
+
+    // Session A is invalidated immediately.
+    assert_eq!(me_status(&server, &tokens_a.access_token).await, 401);
+    assert!(!session_row_exists(&database, session_a_id).await);
+
+    // Session B stays fully valid: access token works and the refresh token
+    // can still mint new access tokens.
+    assert_eq!(me_status(&server, &tokens_b.access_token).await, 200);
+    assert!(session_row_exists(&database, session_b_id).await);
+    let rotated_b = mint_tokens(&server, &tokens_b.refresh_token).await;
+    assert_eq!(me_status(&server, &rotated_b.access_token).await, 200);
+}
+
+#[tokio::test]
+async fn test_repeated_logout_is_safe() {
+    let (server, database) = real_auth_server().await;
+    let user_id = create_real_user(&database).await;
+    let (session_id, refresh_token) = create_session(&database, user_id).await;
+
+    assert_eq!(logout_status(&server, &refresh_token).await, 200);
+
+    // A second logout with the same refresh token is rejected by the
+    // refresh-token middleware and neither restores nor rotates the session.
+    assert_eq!(logout_status(&server, &refresh_token).await, 401);
+    assert!(!session_row_exists(&database, session_id).await);
+
+    let repo = SessionRepository::new(database.pool().clone());
+    let remaining = repo
+        .list_by_user(user_id)
+        .await
+        .expect("Failed to list sessions");
+    assert!(
+        remaining.is_empty(),
+        "repeated logout must not create or restore sessions"
+    );
+}
+
+#[tokio::test]
+async fn test_fresh_login_after_logout_creates_independent_session() {
+    let (server, database) = real_auth_server().await;
+    let user_id = create_real_user(&database).await;
+    let (_, refresh_token) = create_session(&database, user_id).await;
+    let tokens = mint_tokens(&server, &refresh_token).await;
+
+    assert_eq!(logout_status(&server, &tokens.refresh_token).await, 200);
+    assert_eq!(me_status(&server, &tokens.access_token).await, 401);
+
+    // A fresh login (new session) works and is independently revocable.
+    let (new_session_id, new_refresh) = create_session(&database, user_id).await;
+    let new_tokens = mint_tokens(&server, &new_refresh).await;
+    assert_eq!(me_status(&server, &new_tokens.access_token).await, 200);
+
+    // The old access token stays dead; revoking the new session kills only it.
+    assert_eq!(me_status(&server, &tokens.access_token).await, 401);
+    assert_eq!(logout_status(&server, &new_tokens.refresh_token).await, 200);
+    assert_eq!(me_status(&server, &new_tokens.access_token).await, 401);
+    assert!(!session_row_exists(&database, new_session_id).await);
+}
+
+#[tokio::test]
+async fn test_legacy_access_token_without_sid_follows_compat_flag() {
+    // Legacy tokens carry no `sid` claim. Mint one with the same signing key
+    // the servers use (MockAuthService::create_session_access_token skips the
+    // claim entirely when the session id is None).
+    let (server, database) = real_auth_server().await;
+    let user_id = create_real_user(&database).await;
+
+    let minter = MockAuthService {
+        apikey_repository: Arc::new(database::repositories::ApiKeyRepository::new(
+            database.pool().clone(),
+        )),
+    };
+    let legacy_token = minter
+        .create_session_access_token(UserId(user_id), None, TEST_ENCODING_KEY.to_string(), 1)
+        .expect("Failed to mint legacy token");
+
+    // Default (compat window): legacy tokens still validate.
+    assert_eq!(me_status(&server, &legacy_token).await, 200);
+
+    // With the cutover flag on, tokens that cannot be tied to a live
+    // session are rejected...
+    let (strict_server, strict_database) = setup_test_server_with_config_and_database(|c| {
+        c.auth.mock = false;
+        c.auth.require_session_bound_access_tokens = true;
+    })
+    .await;
+    assert_eq!(me_status(&strict_server, &legacy_token).await, 401);
+
+    // ...while session-bound tokens keep working.
+    let strict_user_id = create_real_user(&strict_database).await;
+    let (_, strict_refresh) = create_session(&strict_database, strict_user_id).await;
+    let strict_tokens = mint_tokens(&strict_server, &strict_refresh).await;
+    assert_eq!(
+        me_status(&strict_server, &strict_tokens.access_token).await,
+        200
+    );
+}
+
+#[tokio::test]
+async fn test_logout_requires_refresh_token_auth() {
+    let (server, _database) = real_auth_server().await;
+
+    // No Authorization header.
+    let response = server
+        .post("/v1/auth/logout")
+        .add_header("User-Agent", TEST_UA)
+        .await;
+    assert_eq!(response.status_code(), 401);
+
+    // Invalid refresh token.
+    assert_eq!(
+        logout_status(&server, "rt_definitely_not_a_session").await,
+        401
+    );
+}

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -536,6 +536,18 @@ pub struct AuthConfig {
     /// Email domains that are granted platform admin access
     /// Users with emails from these domains will have admin privileges
     pub admin_domains: Vec<String>,
+    /// Reject session access tokens that carry no `sid` (session id) claim.
+    ///
+    /// Access tokens minted since session binding was introduced are tied to
+    /// their refresh-token session and die with it on logout. Tokens issued
+    /// before that carry no `sid` and cannot be tied to a live session.
+    ///
+    /// Default `false`: legacy tokens keep validating during the cutover
+    /// window (they age out naturally — access tokens live at most a few
+    /// hours). Set `AUTH_REQUIRE_SESSION_BOUND_ACCESS_TOKENS=true` once all
+    /// outstanding legacy tokens have expired to reject any token that cannot
+    /// be tied to a live session.
+    pub require_session_bound_access_tokens: bool,
 }
 
 impl AuthConfig {
@@ -593,6 +605,12 @@ impl AuthConfig {
             google,
             near,
             admin_domains,
+            require_session_bound_access_tokens: env::var(
+                "AUTH_REQUIRE_SESSION_BOUND_ACCESS_TOKENS",
+            )
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(false),
         })
     }
 
@@ -874,6 +892,7 @@ mod tests {
             google: None,
             near: NearConfig::default(),
             admin_domains: vec!["near.ai".to_string(), "near.org".to_string()],
+            require_session_bound_access_tokens: false,
         };
 
         // Test admin domains
@@ -897,6 +916,7 @@ mod tests {
             google: None,
             near: NearConfig::default(),
             admin_domains: vec![],
+            require_session_bound_access_tokens: false,
         };
 
         // Should return false when no admin domains configured

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -605,12 +605,10 @@ impl AuthConfig {
             google,
             near,
             admin_domains,
-            require_session_bound_access_tokens: env::var(
+            require_session_bound_access_tokens: parse_bool_env(
                 "AUTH_REQUIRE_SESSION_BOUND_ACCESS_TOKENS",
-            )
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(false),
+                false,
+            )?,
         })
     }
 

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -47,14 +47,26 @@ impl AuthServiceTrait for AuthService {
             return Err(AuthError::UserAgentTooLong(MAX_USER_AGENT_LEN));
         }
 
-        let access_token =
-            self.create_session_access_token(user_id.clone(), encoding_key, expires_in_hours)?;
-
+        // Create the refresh-token session first so the access token can be
+        // bound to it via the `sid` claim: revoking the session on logout then
+        // invalidates both credentials at once.
         let (refresh_session, refresh_token) = self
             .session_repository
-            .create(user_id, ip_address, user_agent, refresh_expires_in_hours)
+            .create(
+                user_id.clone(),
+                ip_address,
+                user_agent,
+                refresh_expires_in_hours,
+            )
             .await
             .map_err(|e| AuthError::InternalError(format!("Failed to create session: {e}")))?;
+
+        let access_token = self.create_session_access_token(
+            user_id,
+            Some(refresh_session.id.clone()),
+            encoding_key,
+            expires_in_hours,
+        )?;
 
         Ok((access_token, refresh_session, refresh_token))
     }
@@ -62,6 +74,7 @@ impl AuthServiceTrait for AuthService {
     fn create_session_access_token(
         &self,
         user_id: UserId,
+        session_id: Option<SessionId>,
         encoding_key: String,
         expires_in_hours: i64,
     ) -> Result<String, AuthError> {
@@ -71,6 +84,7 @@ impl AuthServiceTrait for AuthService {
             sub: user_id,
             exp: expiration.timestamp(),
             iat: chrono::Utc::now().timestamp(),
+            sid: session_id,
         };
 
         jsonwebtoken::encode(
@@ -114,7 +128,7 @@ impl AuthServiceTrait for AuthService {
         // Get the user
         let user = self
             .user_repository
-            .get_by_id(claims.sub)
+            .get_by_id(claims.sub.clone())
             .await
             .map_err(|e| AuthError::InternalError(format!("Failed to get user: {e}")))?
             .ok_or(AuthError::UserNotFound)?;
@@ -130,6 +144,37 @@ impl AuthServiceTrait for AuthService {
                     token_issued_at, revoked_at
                 );
                 return Err(AuthError::SessionNotFound);
+            }
+        }
+
+        // Bind the access token to its originating refresh-token session: a
+        // revoked (logged-out) or expired session invalidates the token
+        // immediately. This is a single primary-key lookup per request; it is
+        // deliberately uncached because any cache TTL would re-open the exact
+        // revocation window this check closes.
+        match claims.sid {
+            Some(session_id) => {
+                let session = self
+                    .session_repository
+                    .get_by_id(session_id)
+                    .await
+                    .map_err(|e| AuthError::InternalError(format!("Failed to get session: {e}")))?
+                    .ok_or(AuthError::SessionNotFound)?;
+
+                if session.user_id != claims.sub || session.expires_at < Utc::now() {
+                    debug!("Access token session is expired or bound to another user");
+                    return Err(AuthError::SessionNotFound);
+                }
+            }
+            None => {
+                // Legacy access token issued before session binding. During
+                // the compatibility window (flag off) these keep validating
+                // and age out naturally; once the flag is on, any token that
+                // cannot be tied to a live session is rejected.
+                if self.require_session_bound_access_tokens {
+                    debug!("Rejecting legacy access token without sid claim");
+                    return Err(AuthError::SessionNotFound);
+                }
             }
         }
 
@@ -206,14 +251,9 @@ impl AuthServiceTrait for AuthService {
         access_token_expires_in_hours: i64,
         refresh_token_expires_in_hours: i64,
     ) -> Result<(String, Session, String), AuthError> {
-        // Create a new access token
-        let access_token = self.create_session_access_token(
-            user_id.clone(),
-            encoding_key,
-            access_token_expires_in_hours,
-        )?;
-
-        // Rotate the refresh token
+        // Rotate the refresh token first; only mint an access token for a
+        // session that is confirmed live. Rotation keeps the session id, so
+        // the new access token stays bound to the same session.
         let (rotated_session, new_refresh_token) = self
             .session_repository
             .rotate(session_id, old_token_hash, refresh_token_expires_in_hours)
@@ -227,6 +267,14 @@ impl AuthServiceTrait for AuthService {
                     AuthError::InternalError(format!("Failed to rotate session: {e}"))
                 }
             })?;
+
+        // Create a new access token bound to the rotated session
+        let access_token = self.create_session_access_token(
+            user_id,
+            Some(rotated_session.id.clone()),
+            encoding_key,
+            access_token_expires_in_hours,
+        )?;
 
         Ok((access_token, rotated_session, new_refresh_token))
     }
@@ -428,6 +476,7 @@ impl AuthService {
         organization_repository: Arc<dyn OrganizationRepository>,
         workspace_repository: Arc<dyn WorkspaceRepository>,
         organization_service: Arc<dyn crate::organization::OrganizationServiceTrait>,
+        require_session_bound_access_tokens: bool,
     ) -> Self {
         let api_key_cache: ApiKeyCache = Cache::builder()
             .max_capacity(API_KEY_CACHE_MAX_CAPACITY)
@@ -455,6 +504,7 @@ impl AuthService {
             api_key_cache,
             api_key_bloom_filter,
             bloom_filter_ready,
+            require_session_bound_access_tokens,
         }
     }
 
@@ -636,8 +686,9 @@ mod tests {
         ) -> anyhow::Result<User> {
             unimplemented!()
         }
-        async fn get_by_id(&self, _: UserId) -> anyhow::Result<Option<User>> {
-            unimplemented!()
+        async fn get_by_id(&self, id: UserId) -> anyhow::Result<Option<User>> {
+            let user = self.user.lock().unwrap();
+            Ok(user.as_ref().filter(|u| u.id == id).cloned())
         }
         async fn get_by_email(&self, _: &str) -> anyhow::Result<Option<User>> {
             unimplemented!()
@@ -711,6 +762,87 @@ mod tests {
         }
         async fn revoke(&self, _: SessionId) -> anyhow::Result<bool> {
             unimplemented!()
+        }
+        async fn revoke_all_for_user(&self, _: UserId) -> anyhow::Result<usize> {
+            unimplemented!()
+        }
+        async fn cleanup_expired(&self) -> anyhow::Result<usize> {
+            unimplemented!()
+        }
+    }
+
+    /// In-memory session repository for exercising session binding/revocation.
+    struct InMemorySessionRepo {
+        sessions: Mutex<std::collections::HashMap<Uuid, Session>>,
+    }
+
+    impl InMemorySessionRepo {
+        fn new() -> Self {
+            Self {
+                sessions: Mutex::new(std::collections::HashMap::new()),
+            }
+        }
+
+        fn insert_session(&self, user_id: UserId, expires_at: chrono::DateTime<Utc>) -> Session {
+            let session = Session {
+                id: SessionId(Uuid::new_v4()),
+                user_id,
+                token_hash: "test_token_hash".to_string(),
+                created_at: Utc::now(),
+                expires_at,
+                ip_address: None,
+                user_agent: "Test Agent".to_string(),
+            };
+            self.sessions
+                .lock()
+                .unwrap()
+                .insert(session.id.0, session.clone());
+            session
+        }
+
+        fn contains(&self, session_id: &SessionId) -> bool {
+            self.sessions.lock().unwrap().contains_key(&session_id.0)
+        }
+    }
+
+    #[async_trait]
+    impl SessionRepository for InMemorySessionRepo {
+        async fn create(
+            &self,
+            user_id: UserId,
+            _: Option<String>,
+            _: String,
+            expires_in_hours: i64,
+        ) -> anyhow::Result<(Session, String)> {
+            let session = self.insert_session(
+                user_id,
+                Utc::now() + chrono::Duration::hours(expires_in_hours),
+            );
+            let token = format!("rt_{}", session.id.0.simple());
+            Ok((session, token))
+        }
+        async fn validate(&self, _: SessionToken, _: &str) -> anyhow::Result<Option<Session>> {
+            unimplemented!()
+        }
+        async fn get_by_id(&self, session_id: SessionId) -> anyhow::Result<Option<Session>> {
+            Ok(self.sessions.lock().unwrap().get(&session_id.0).cloned())
+        }
+        async fn list_by_user(&self, _: UserId) -> anyhow::Result<Vec<Session>> {
+            unimplemented!()
+        }
+        async fn extend(&self, _: SessionId, _: i64) -> anyhow::Result<bool> {
+            unimplemented!()
+        }
+        async fn rotate(&self, _: SessionId, _: &str, _: i64) -> anyhow::Result<(Session, String)> {
+            unimplemented!()
+        }
+        async fn revoke(&self, session_id: SessionId) -> anyhow::Result<bool> {
+            Ok(self
+                .sessions
+                .lock()
+                .unwrap()
+                .remove(&session_id.0)
+                .is_some())
         }
         async fn revoke_all_for_user(&self, _: UserId) -> anyhow::Result<usize> {
             unimplemented!()
@@ -1180,10 +1312,18 @@ mod tests {
     }
 
     fn build_auth_service(user_repo: Arc<MockUserRepo>) -> AuthService {
+        build_auth_service_with_sessions(user_repo, Arc::new(StubSessionRepo), false)
+    }
+
+    fn build_auth_service_with_sessions(
+        user_repo: Arc<MockUserRepo>,
+        session_repo: Arc<dyn SessionRepository>,
+        require_session_bound_access_tokens: bool,
+    ) -> AuthService {
         let bloom = Bloom::new_for_fp_rate(100, 0.01).expect("bloom filter creation failed");
         AuthService {
             user_repository: user_repo,
-            session_repository: Arc::new(StubSessionRepo),
+            session_repository: session_repo,
             api_key_repository: Arc::new(StubApiKeyRepo),
             organization_repository: Arc::new(StubOrgRepo),
             workspace_repository: Arc::new(StubWorkspaceRepo),
@@ -1191,6 +1331,7 @@ mod tests {
             api_key_cache: moka::future::Cache::builder().build(),
             api_key_bloom_filter: Arc::new(RwLock::new(bloom)),
             bloom_filter_ready: Arc::new(AtomicBool::new(false)),
+            require_session_bound_access_tokens,
         }
     }
 
@@ -1241,5 +1382,205 @@ mod tests {
             *repo.email_updated.lock().unwrap(),
             Some("new@example.com".to_string())
         );
+    }
+
+    const TEST_ENCODING_KEY: &str = "test_encoding_key";
+
+    #[tokio::test]
+    async fn test_create_session_binds_access_token_to_session() {
+        let user = make_user("alice@example.com", "google");
+        let user_repo = Arc::new(MockUserRepo::with_user(user.clone()));
+        let session_repo = Arc::new(InMemorySessionRepo::new());
+        let service = build_auth_service_with_sessions(user_repo, session_repo.clone(), false);
+
+        let (access_token, session, refresh_token) = service
+            .create_session(
+                user.id.clone(),
+                None,
+                "Test Agent".to_string(),
+                TEST_ENCODING_KEY.to_string(),
+                1,
+                24,
+            )
+            .await
+            .unwrap();
+        assert!(refresh_token.starts_with("rt_"));
+
+        // The access token carries the sid claim of the session it was minted from.
+        let claims = service
+            .validate_session_access_token(access_token.clone(), TEST_ENCODING_KEY.to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(claims.sid.as_ref().map(|s| s.0), Some(session.id.0));
+
+        // And it validates while the session is live.
+        let validated = service
+            .validate_session_access(access_token, TEST_ENCODING_KEY.to_string())
+            .await
+            .unwrap();
+        assert_eq!(validated.id, user.id);
+    }
+
+    #[tokio::test]
+    async fn test_logout_revokes_session_and_invalidates_access_token() {
+        let user = make_user("alice@example.com", "google");
+        let user_repo = Arc::new(MockUserRepo::with_user(user.clone()));
+        let session_repo = Arc::new(InMemorySessionRepo::new());
+        let service = build_auth_service_with_sessions(user_repo, session_repo.clone(), false);
+
+        let (access_token, session, _refresh_token) = service
+            .create_session(
+                user.id.clone(),
+                None,
+                "Test Agent".to_string(),
+                TEST_ENCODING_KEY.to_string(),
+                1,
+                24,
+            )
+            .await
+            .unwrap();
+
+        assert!(service.logout(session.id.clone()).await.unwrap());
+        assert!(!session_repo.contains(&session.id));
+
+        // The still-unexpired access token is rejected once its session is gone.
+        let result = service
+            .validate_session_access(access_token, TEST_ENCODING_KEY.to_string())
+            .await;
+        assert!(matches!(result, Err(AuthError::SessionNotFound)));
+
+        // Repeated logout is safe: reports nothing revoked, restores nothing.
+        assert!(!service.logout(session.id.clone()).await.unwrap());
+        assert!(!session_repo.contains(&session.id));
+    }
+
+    #[tokio::test]
+    async fn test_logout_revokes_only_target_session() {
+        let user = make_user("alice@example.com", "google");
+        let user_repo = Arc::new(MockUserRepo::with_user(user.clone()));
+        let session_repo = Arc::new(InMemorySessionRepo::new());
+        let service = build_auth_service_with_sessions(user_repo, session_repo.clone(), false);
+
+        let (token_a, session_a, _) = service
+            .create_session(
+                user.id.clone(),
+                None,
+                "Test Agent".to_string(),
+                TEST_ENCODING_KEY.to_string(),
+                1,
+                24,
+            )
+            .await
+            .unwrap();
+        let (token_b, session_b, _) = service
+            .create_session(
+                user.id.clone(),
+                None,
+                "Test Agent".to_string(),
+                TEST_ENCODING_KEY.to_string(),
+                1,
+                24,
+            )
+            .await
+            .unwrap();
+
+        assert!(service.logout(session_a.id.clone()).await.unwrap());
+
+        // Session A's access token dies immediately; session B is untouched.
+        assert!(matches!(
+            service
+                .validate_session_access(token_a, TEST_ENCODING_KEY.to_string())
+                .await,
+            Err(AuthError::SessionNotFound)
+        ));
+        assert!(session_repo.contains(&session_b.id));
+        assert!(service
+            .validate_session_access(token_b, TEST_ENCODING_KEY.to_string())
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_access_token_rejected_when_session_expired() {
+        let user = make_user("alice@example.com", "google");
+        let user_repo = Arc::new(MockUserRepo::with_user(user.clone()));
+        let session_repo = Arc::new(InMemorySessionRepo::new());
+        let service = build_auth_service_with_sessions(user_repo, session_repo.clone(), false);
+
+        // Session row exists but is already expired.
+        let expired_session =
+            session_repo.insert_session(user.id.clone(), Utc::now() - chrono::Duration::hours(1));
+        let access_token = service
+            .create_session_access_token(
+                user.id.clone(),
+                Some(expired_session.id),
+                TEST_ENCODING_KEY.to_string(),
+                1,
+            )
+            .unwrap();
+
+        let result = service
+            .validate_session_access(access_token, TEST_ENCODING_KEY.to_string())
+            .await;
+        assert!(matches!(result, Err(AuthError::SessionNotFound)));
+    }
+
+    #[tokio::test]
+    async fn test_legacy_access_token_without_sid_follows_compat_flag() {
+        let user = make_user("alice@example.com", "google");
+
+        // Flag off (default): legacy tokens keep validating during the cutover window.
+        let service = build_auth_service_with_sessions(
+            Arc::new(MockUserRepo::with_user(user.clone())),
+            Arc::new(InMemorySessionRepo::new()),
+            false,
+        );
+        let legacy_token = service
+            .create_session_access_token(user.id.clone(), None, TEST_ENCODING_KEY.to_string(), 1)
+            .unwrap();
+        assert!(service
+            .validate_session_access(legacy_token.clone(), TEST_ENCODING_KEY.to_string())
+            .await
+            .is_ok());
+
+        // Flag on: tokens that cannot be tied to a live session are rejected.
+        let strict_service = build_auth_service_with_sessions(
+            Arc::new(MockUserRepo::with_user(user.clone())),
+            Arc::new(InMemorySessionRepo::new()),
+            true,
+        );
+        assert!(matches!(
+            strict_service
+                .validate_session_access(legacy_token, TEST_ENCODING_KEY.to_string())
+                .await,
+            Err(AuthError::SessionNotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_access_token_rejected_when_sid_belongs_to_other_user() {
+        let user = make_user("alice@example.com", "google");
+        let user_repo = Arc::new(MockUserRepo::with_user(user.clone()));
+        let session_repo = Arc::new(InMemorySessionRepo::new());
+        let service = build_auth_service_with_sessions(user_repo, session_repo.clone(), false);
+
+        // Session belongs to a different user than the token subject.
+        let other_session = session_repo.insert_session(
+            UserId(Uuid::new_v4()),
+            Utc::now() + chrono::Duration::hours(24),
+        );
+        let access_token = service
+            .create_session_access_token(
+                user.id.clone(),
+                Some(other_session.id),
+                TEST_ENCODING_KEY.to_string(),
+                1,
+            )
+            .unwrap();
+
+        let result = service
+            .validate_session_access(access_token, TEST_ENCODING_KEY.to_string())
+            .await;
+        assert!(matches!(result, Err(AuthError::SessionNotFound)));
     }
 }

--- a/crates/services/src/auth/ports.rs
+++ b/crates/services/src/auth/ports.rs
@@ -30,6 +30,12 @@ pub struct AccessTokenClaims {
     pub sub: UserId,
     pub exp: i64,
     pub iat: i64,
+    /// Id of the refresh-token session this access token was minted from.
+    /// Validation rejects tokens whose session has been revoked (logout), so
+    /// revoking a session invalidates both credentials at once. `None` only
+    /// on legacy tokens issued before session binding was introduced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sid: Option<SessionId>,
 }
 
 impl From<Uuid> for UserId {
@@ -268,9 +274,13 @@ pub trait AuthServiceTrait: Send + Sync {
         refresh_expires_in_hours: i64,
     ) -> Result<(String, Session, String), AuthError>;
 
+    /// Mint a session access token (JWT). `session_id` binds the token to a
+    /// refresh-token session via the `sid` claim; pass `None` only where no
+    /// server-side session exists (mock/test flows).
     fn create_session_access_token(
         &self,
         user_id: UserId,
+        session_id: Option<SessionId>,
         encoding_key: String,
         expires_in_hours: i64,
     ) -> Result<String, AuthError>;
@@ -347,6 +357,9 @@ pub struct AuthService {
     pub api_key_cache: ApiKeyCache,
     pub api_key_bloom_filter: ApiKeyBloomFilter,
     pub bloom_filter_ready: BloomFilterReady,
+    /// Reject access tokens without a `sid` claim (legacy tokens issued
+    /// before session binding). See `AuthConfig::require_session_bound_access_tokens`.
+    pub require_session_bound_access_tokens: bool,
 }
 
 pub struct UserService {
@@ -425,11 +438,13 @@ impl MockAuthService {
         refresh_expires_in_hours: i64,
     ) -> (String, Session, String) {
         let expiration = chrono::Utc::now() + chrono::Duration::hours(expires_in_hours);
+        let session_id = SessionId(uuid::Uuid::new_v4());
 
         let claims = AccessTokenClaims {
             sub: user_id.clone(),
             exp: expiration.timestamp(),
             iat: chrono::Utc::now().timestamp(),
+            sid: Some(session_id.clone()),
         };
 
         let access_token = jsonwebtoken::encode(
@@ -438,8 +453,6 @@ impl MockAuthService {
             &jsonwebtoken::EncodingKey::from_secret(encoding_key.as_bytes()),
         )
         .unwrap();
-
-        let session_id = SessionId(uuid::Uuid::new_v4());
         // Generate token with same format as real session repository
         let session_token = format!("rt_{}", uuid::Uuid::new_v4().to_string().replace("-", ""));
         let expires_at = chrono::Utc::now() + chrono::Duration::hours(refresh_expires_in_hours);
@@ -482,6 +495,7 @@ impl AuthServiceTrait for MockAuthService {
     fn create_session_access_token(
         &self,
         user_id: UserId,
+        session_id: Option<SessionId>,
         encoding_key: String,
         expires_in_hours: i64,
     ) -> Result<String, AuthError> {
@@ -491,6 +505,7 @@ impl AuthServiceTrait for MockAuthService {
             sub: user_id,
             exp: expiration.timestamp(),
             iat: chrono::Utc::now().timestamp(),
+            sid: session_id,
         };
 
         jsonwebtoken::encode(

--- a/env.example
+++ b/env.example
@@ -64,6 +64,15 @@ AUTH_MOCK=false
 # Set for JWT access token encoding
 AUTH_ENCODING_KEY=YOUR_AUTH_ENCODING_KEY
 
+# Reject session access tokens without a `sid` (session id) claim.
+# Access tokens are bound to their refresh-token session and are invalidated
+# when that session is revoked (logout). Legacy tokens issued before session
+# binding carry no `sid` and cannot be checked against a live session.
+# Default false: legacy tokens keep validating until they expire naturally.
+# Set to true after one access-token lifetime has passed since deploying
+# session binding, to reject any token that cannot be tied to a live session.
+AUTH_REQUIRE_SESSION_BOUND_ACCESS_TOKENS=false
+
 # GitHub OAuth Configuration
 # To set up:
 # 1. Go to https://github.com/settings/developers


### PR DESCRIPTION
Logging out only cleared browser cookies: the refresh-token session stayed live server-side, and a captured access or refresh token kept working until natural expiry. This change makes logout revoke the server-side session and makes that revocation take effect on both credentials immediately.

## Changes

- **Refresh-token-authenticated logout.** `POST /v1/auth/logout` now runs behind the same `refresh_middleware` as token refresh, receives the current session from it, and revokes exactly that session via `AuthService::logout`. Other sessions (devices) of the same user are untouched. The previous handler only expired a placeholder `session_id` cookie and never touched the session store; it also extracted `AuthenticatedUser` without any auth layer mounted, so it could not have worked as intended.
- **Access tokens bound to their session.** `create_session` / `rotate_session` now mint JWTs with a `sid` claim carrying the refresh-token session id (rotation keeps the session id, so refreshed access tokens stay bound to the same session). `validate_session_access` rejects tokens whose session is missing, revoked, expired, or owned by a different user — so revoking the session on logout invalidates the still-unexpired access token too.
- **Per-request cost.** The binding check is one primary-key lookup on `refresh_tokens.id` per session-token request (management plane only; API-key inference traffic is unaffected). It is deliberately uncached: any cache TTL would re-open exactly the revocation window this check closes.
- **Staged cutover for legacy tokens.** Tokens minted before this change carry no `sid` and cannot be tied to a session. New config `AUTH_REQUIRE_SESSION_BOUND_ACCESS_TOKENS` (documented in `env.example`, **default `false`**) controls them: with the default, legacy tokens keep validating and age out naturally (access tokens live ≤ a few hours); set to `true` after one access-token lifetime to reject any token that cannot be tied to a live session. No forced reauthentication: sessions themselves are untouched, so browsers refresh into `sid`-bound tokens transparently.
- **Idempotency.** Revoking a session that disappeared between authentication and deletion still returns 200. Repeating logout with the already-revoked refresh token fails middleware auth with 401 and neither restores nor rotates anything.

## Test plan

All run locally against PostgreSQL:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --lib --bins` — 1211 passed, 0 failed (includes 7 new unit tests in `services::auth`: sid claim minting, revoked/expired/foreign-session rejection, single-session-only revocation, repeated logout, legacy-token compat flag on/off)
- `cargo test --test e2e_all -- session_logout auth_tokens near_auth vpc_login oauth_frontend_callback general` — new `session_logout` e2e suite (6 tests, running the **real** `AuthService` against the DB) passes along with the adjacent auth suites:
  - old access + refresh tokens get 401 immediately after logout, and the session row is gone
  - two-session test: logging out session A invalidates A immediately, session B keeps working and refreshing
  - repeated logout is a safe 401 no-op (nothing restored or rotated)
  - fresh login after logout works and is independently revocable
  - legacy token without `sid`: 200 with the flag off, 401 with the flag on, while `sid`-bound tokens keep working
  - logout requires refresh-token auth (401 without/with invalid token)

(`general::test_admin_update_model` is flaky when run in parallel with model suites — it asserts on the shared Qwen catalog entry that other tests mutate; passes in isolation, unrelated to this change.)

## Rollout

1. Deploy to **staging** with `AUTH_REQUIRE_SESSION_BOUND_ACCESS_TOKENS` unset (default `false`); verify login, refresh, logout, and that logout 401s previously-issued tokens.
2. Deploy to **production** with the flag unset. Legacy tokens continue validating during the compatibility window and age out on their own.
3. After at least one access-token lifetime, set `AUTH_REQUIRE_SESSION_BOUND_ACCESS_TOKENS=true` (staging, then production) to reject any access token that cannot be tied to a live session.
4. The companion UI change (nearai/nearai-cloud-ui — forwards the refresh cookie + User-Agent to this endpoint on logout) deploys **after** this API change is live.

Fixes nearai/infra#191
