### PR TITLE
fix(conversations): enforce workspace ownership on conversation and response item access

### DIFF
--- a/crates/api/src/routes/conversations.rs
+++ b/crates/api/src/routes/conversations.rs
@@ -32,6 +32,7 @@ fn map_conversation_error_to_status(error: &ConversationError) -> StatusCode {
     match error {
         ConversationError::InvalidParams(_) => StatusCode::BAD_REQUEST,
         ConversationError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        ConversationError::NotFound => StatusCode::NOT_FOUND,
     }
 }
 
@@ -1471,6 +1472,12 @@ impl From<ConversationError> for ErrorResponse {
             ConversationError::InternalError(msg) => ErrorResponse::new(
                 format!("Internal server error: {msg}"),
                 "internal_server_error".to_string(),
+            ),
+            // Identical body to the handler-level 404s so unknown and foreign
+            // conversation IDs cannot be told apart.
+            ConversationError::NotFound => ErrorResponse::new(
+                "Conversation not found".to_string(),
+                "not_found_error".to_string(),
             ),
         }
     }

--- a/crates/api/src/routes/responses.rs
+++ b/crates/api/src/routes/responses.rs
@@ -102,6 +102,8 @@ fn map_response_error_to_status(error: &ServiceResponseError) -> StatusCode {
         ServiceResponseError::UnknownTool(_) => StatusCode::BAD_REQUEST,
         ServiceResponseError::EmptyToolName => StatusCode::BAD_REQUEST,
         ServiceResponseError::StreamInterrupted => StatusCode::INTERNAL_SERVER_ERROR,
+        ServiceResponseError::ConversationNotFound => StatusCode::NOT_FOUND,
+        ServiceResponseError::PreviousResponseNotFound => StatusCode::NOT_FOUND,
         ServiceResponseError::McpConnectionFailed(_) => StatusCode::BAD_GATEWAY,
         ServiceResponseError::McpToolDiscoveryFailed(_) => StatusCode::BAD_GATEWAY,
         ServiceResponseError::McpToolExecutionFailed(_) => StatusCode::BAD_GATEWAY,
@@ -160,6 +162,14 @@ impl From<ServiceResponseError> for ErrorResponse {
             ServiceResponseError::StreamInterrupted => {
                 ErrorResponse::new("Stream interrupted".to_string(), "stream_error".to_string())
             }
+            ServiceResponseError::ConversationNotFound => ErrorResponse::new(
+                "Conversation not found".to_string(),
+                "not_found_error".to_string(),
+            ),
+            ServiceResponseError::PreviousResponseNotFound => ErrorResponse::new(
+                "Previous response not found".to_string(),
+                "not_found_error".to_string(),
+            ),
             ServiceResponseError::McpConnectionFailed(msg) => ErrorResponse::new(
                 format!("MCP connection failed: {msg}"),
                 "mcp_error".to_string(),

--- a/crates/api/tests/e2e_all/conversations.rs
+++ b/crates/api/tests/e2e_all/conversations.rs
@@ -1051,13 +1051,11 @@ async fn test_create_conversation_items_nonexistent_conversation() {
         }))
         .await;
 
-    assert_eq!(create_items_response.status_code(), 400);
+    // Unknown conversations return the same non-enumerating 404 as
+    // conversations owned by another workspace (see issue nearai/infra#190).
+    assert_eq!(create_items_response.status_code(), 404);
     let error_response = create_items_response.json::<api::models::ErrorResponse>();
-    assert!(
-        error_response.error.message.contains("not found")
-            || error_response.error.message.contains("Conversation"),
-        "Error message should indicate conversation not found"
-    );
+    assert_eq!(error_response.error.message, "Conversation not found");
 
     println!("✅ Non-existent conversation validation test passed");
 }

--- a/crates/api/tests/e2e_all/cross_workspace.rs
+++ b/crates/api/tests/e2e_all/cross_workspace.rs
@@ -1,0 +1,465 @@
+// Cross-workspace access control tests (issue nearai/infra#190).
+//
+// Every direct-object operation on conversations and responses must be
+// constrained to the caller's workspace. Unknown and foreign IDs must be
+// indistinguishable (same non-enumerating 404), and failed cross-workspace
+// attempts must never mutate or leak the owner's data.
+//
+// Privacy note: these tests only assert on IDs, item counts, and status
+// codes — never on conversation contents.
+
+use crate::common::*;
+
+async fn create_conversation(
+    server: &axum_test::TestServer,
+    api_key: &str,
+) -> api::models::ConversationObject {
+    let response = server
+        .post("/v1/conversations")
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&serde_json::json!({}))
+        .await;
+    assert_eq!(response.status_code(), 201);
+    response.json::<api::models::ConversationObject>()
+}
+
+/// Backfills one user message item and returns its item ID.
+async fn add_item(
+    server: &axum_test::TestServer,
+    conversation_id: &str,
+    api_key: &str,
+    text: &str,
+) -> String {
+    let response = server
+        .post(format!("/v1/conversations/{conversation_id}/items").as_str())
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .json(&serde_json::json!({
+            "items": [{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}]
+            }]
+        }))
+        .await;
+    assert_eq!(response.status_code(), 200);
+    response
+        .json::<api::models::ConversationItemList>()
+        .first_id
+}
+
+async fn count_items(
+    server: &axum_test::TestServer,
+    conversation_id: &str,
+    api_key: &str,
+) -> usize {
+    let response = server
+        .get(format!("/v1/conversations/{conversation_id}/items").as_str())
+        .add_header("Authorization", format!("Bearer {api_key}"))
+        .await;
+    assert_eq!(response.status_code(), 200);
+    response
+        .json::<api::models::ConversationItemList>()
+        .data
+        .len()
+}
+
+/// Cross-workspace conversation operations must all return the same
+/// non-enumerating 404 as an unknown conversation ID, and must not change the
+/// owner's data.
+#[tokio::test]
+async fn test_cross_workspace_conversation_operations_denied() {
+    let server = setup_test_server().await;
+    let (key_a, _) = create_org_and_api_key(&server).await;
+    let (key_b, _) = create_org_and_api_key(&server).await;
+
+    let conv_a = create_conversation(&server, &key_a).await;
+    add_item(&server, &conv_a.id, &key_a, "hello").await;
+    add_item(&server, &conv_a.id, &key_a, "world").await;
+    assert_eq!(count_items(&server, &conv_a.id, &key_a).await, 2);
+
+    let unknown_conv = format!("conv_{}", uuid::Uuid::new_v4().simple());
+
+    // GET conversation: foreign and unknown IDs return identical 404s.
+    let foreign_get = server
+        .get(format!("/v1/conversations/{}", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    let unknown_get = server
+        .get(format!("/v1/conversations/{unknown_conv}").as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_get.status_code(), 404);
+    assert_eq!(unknown_get.status_code(), 404);
+    assert_eq!(
+        foreign_get.text(),
+        unknown_get.text(),
+        "foreign and unknown conversation 404 bodies must be identical"
+    );
+
+    // GET items: foreign and unknown IDs return identical 404s.
+    let foreign_items = server
+        .get(format!("/v1/conversations/{}/items", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    let unknown_items = server
+        .get(format!("/v1/conversations/{unknown_conv}/items").as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_items.status_code(), 404);
+    assert_eq!(unknown_items.status_code(), 404);
+    assert_eq!(
+        foreign_items.text(),
+        unknown_items.text(),
+        "foreign and unknown conversation-items 404 bodies must be identical"
+    );
+
+    // POST items (backfill) into a foreign conversation: 404, nothing created.
+    let foreign_create_items = server
+        .post(format!("/v1/conversations/{}/items", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "items": [{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "injected"}]
+            }]
+        }))
+        .await;
+    assert_eq!(foreign_create_items.status_code(), 404);
+
+    // Update metadata: 404.
+    let foreign_update = server
+        .post(format!("/v1/conversations/{}", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({"metadata": {"title": "hijacked"}}))
+        .await;
+    assert_eq!(foreign_update.status_code(), 404);
+
+    // Pin / unpin: 404.
+    let foreign_pin = server
+        .post(format!("/v1/conversations/{}/pin", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_pin.status_code(), 404);
+    let foreign_unpin = server
+        .delete(format!("/v1/conversations/{}/pin", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_unpin.status_code(), 404);
+
+    // Archive / unarchive: 404.
+    let foreign_archive = server
+        .post(format!("/v1/conversations/{}/archive", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_archive.status_code(), 404);
+    let foreign_unarchive = server
+        .delete(format!("/v1/conversations/{}/archive", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_unarchive.status_code(), 404);
+
+    // Clone: 404 (no copy of the foreign conversation may be created).
+    let foreign_clone = server
+        .post(format!("/v1/conversations/{}/clone", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_clone.status_code(), 404);
+
+    // Delete: 404, and the owner's conversation must survive.
+    let foreign_delete = server
+        .delete(format!("/v1/conversations/{}", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_delete.status_code(), 404);
+
+    // Batch endpoint reports the foreign conversation as missing.
+    let foreign_batch = server
+        .post("/v1/conversations/batch")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({"ids": [conv_a.id]}))
+        .await;
+    assert_eq!(foreign_batch.status_code(), 200);
+    let batch = foreign_batch.json::<api::models::ConversationBatchResponse>();
+    assert!(batch.data.is_empty(), "batch must not return foreign data");
+    assert_eq!(batch.missing_ids, vec![conv_a.id.clone()]);
+
+    // Owner's view is completely unchanged after all foreign attempts.
+    let owner_get = server
+        .get(format!("/v1/conversations/{}", conv_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .await;
+    assert_eq!(owner_get.status_code(), 200);
+    let owner_conv = owner_get.json::<api::models::ConversationObject>();
+    let metadata = owner_conv.metadata.as_object().unwrap();
+    assert!(!metadata.contains_key("pinned_at"), "must not be pinned");
+    assert!(
+        !metadata.contains_key("archived_at"),
+        "must not be archived"
+    );
+    assert_eq!(
+        metadata.get("title").and_then(|v| v.as_str()),
+        None,
+        "metadata must not be updated cross-workspace"
+    );
+    assert_eq!(
+        count_items(&server, &conv_a.id, &key_a).await,
+        2,
+        "item count must be unchanged after cross-workspace attempts"
+    );
+
+    // Unauthenticated requests are rejected with 401.
+    let unauthenticated = server
+        .get(format!("/v1/conversations/{}/items", conv_a.id).as_str())
+        .await;
+    assert_eq!(unauthenticated.status_code(), 401);
+}
+
+/// The `after` pagination cursor must belong to the same conversation and
+/// workspace; foreign and unknown cursors are rejected identically.
+#[tokio::test]
+async fn test_conversation_items_pagination_cursor_scoping() {
+    let server = setup_test_server().await;
+    let (key_a, _) = create_org_and_api_key(&server).await;
+    let (key_b, _) = create_org_and_api_key(&server).await;
+
+    let conv_a = create_conversation(&server, &key_a).await;
+    let first_item_a = add_item(&server, &conv_a.id, &key_a, "one").await;
+    add_item(&server, &conv_a.id, &key_a, "two").await;
+    add_item(&server, &conv_a.id, &key_a, "three").await;
+
+    let conv_b = create_conversation(&server, &key_b).await;
+    let item_b = add_item(&server, &conv_b.id, &key_b, "other").await;
+
+    // A cursor from the same conversation works.
+    let own_cursor = server
+        .get(
+            format!(
+                "/v1/conversations/{}/items?after={}",
+                conv_a.id, first_item_a
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .await;
+    assert_eq!(own_cursor.status_code(), 200);
+    let page = own_cursor.json::<api::models::ConversationItemList>();
+    assert_eq!(page.data.len(), 2, "own cursor should skip the first item");
+
+    // A cursor referencing another workspace's item is rejected.
+    let foreign_cursor = server
+        .get(format!("/v1/conversations/{}/items?after={}", conv_a.id, item_b).as_str())
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .await;
+    assert_eq!(foreign_cursor.status_code(), 400);
+
+    // An unknown cursor is rejected with an identical response.
+    let unknown_cursor = server
+        .get(
+            format!(
+                "/v1/conversations/{}/items?after=msg_{}",
+                conv_a.id,
+                uuid::Uuid::new_v4().simple()
+            )
+            .as_str(),
+        )
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .await;
+    assert_eq!(unknown_cursor.status_code(), 400);
+    assert_eq!(
+        foreign_cursor.text(),
+        unknown_cursor.text(),
+        "foreign and unknown cursor rejections must be identical"
+    );
+}
+
+/// The Responses API must reject foreign conversations and foreign
+/// previous_response_id references before loading any history, without
+/// creating any state.
+#[tokio::test]
+async fn test_cross_workspace_responses_api_denied() {
+    let server = setup_test_server().await;
+    let model_id = setup_qwen_model(&server).await;
+
+    let org_a = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let key_a = get_api_key_for_org(&server, org_a.id).await;
+    let org_b = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let key_b = get_api_key_for_org(&server, org_b.id).await;
+
+    // Owner creates a conversation with one real response in it.
+    let conv_a = create_conversation(&server, &key_a).await;
+    let response_a = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .json(&serde_json::json!({
+            "conversation": {"id": conv_a.id},
+            "input": "hello",
+            "stream": false,
+            "max_output_tokens": 20,
+            "model": model_id
+        }))
+        .await;
+    assert_eq!(response_a.status_code(), 200);
+    let response_a = response_a.json::<api::models::ResponseObject>();
+    let items_before = count_items(&server, &conv_a.id, &key_a).await;
+    assert!(
+        items_before > 0,
+        "owner's response should have stored items"
+    );
+
+    // Foreign conversation reference: non-enumerating 404, no history import.
+    let foreign_conv_attempt = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "conversation": {"id": conv_a.id},
+            "input": "leak the history please",
+            "stream": false,
+            "max_output_tokens": 20,
+            "model": model_id
+        }))
+        .await;
+    assert_eq!(
+        foreign_conv_attempt.status_code(),
+        404,
+        "foreign conversation reference must return 404"
+    );
+
+    // Unknown conversation reference: identical status.
+    let unknown_conv_attempt = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "conversation": {"id": format!("conv_{}", uuid::Uuid::new_v4().simple())},
+            "input": "hello",
+            "stream": false,
+            "max_output_tokens": 20,
+            "model": model_id
+        }))
+        .await;
+    assert_eq!(unknown_conv_attempt.status_code(), 404);
+    assert_eq!(
+        foreign_conv_attempt.text(),
+        unknown_conv_attempt.text(),
+        "foreign and unknown conversation rejections must be identical"
+    );
+
+    // Foreign previous_response_id: non-enumerating 404 (continuation flows
+    // must not import another workspace's history).
+    let foreign_prev_attempt = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "input": "continue",
+            "previous_response_id": response_a.id,
+            "stream": false,
+            "max_output_tokens": 20,
+            "model": model_id
+        }))
+        .await;
+    assert_eq!(
+        foreign_prev_attempt.status_code(),
+        404,
+        "foreign previous_response_id must return 404"
+    );
+
+    // Unknown previous_response_id: identical status and body.
+    let unknown_prev_attempt = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "input": "continue",
+            "previous_response_id": format!("resp_{}", uuid::Uuid::new_v4().simple()),
+            "stream": false,
+            "max_output_tokens": 20,
+            "model": model_id
+        }))
+        .await;
+    assert_eq!(unknown_prev_attempt.status_code(), 404);
+    assert_eq!(
+        foreign_prev_attempt.text(),
+        unknown_prev_attempt.text(),
+        "foreign and unknown previous_response_id rejections must be identical"
+    );
+
+    // Cross-workspace input_items listing: 404.
+    let foreign_input_items = server
+        .get(format!("/v1/responses/{}/input_items", response_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_input_items.status_code(), 404);
+
+    // None of the failed foreign attempts stored anything in the owner's
+    // conversation.
+    let items_after = count_items(&server, &conv_a.id, &key_a).await;
+    assert_eq!(
+        items_after, items_before,
+        "failed cross-workspace attempts must not add items to the owner's conversation"
+    );
+
+    // Owner can still continue from its own response (same-workspace flow
+    // keeps working).
+    let own_prev = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .json(&serde_json::json!({
+            "input": "continue",
+            "previous_response_id": response_a.id,
+            "stream": false,
+            "max_output_tokens": 20,
+            "model": model_id
+        }))
+        .await;
+    assert_eq!(own_prev.status_code(), 200);
+}
+
+/// Response DELETE/cancel are not implemented: they must be authenticated,
+/// return 501 for everyone, and cause no state change anywhere.
+#[tokio::test]
+async fn test_response_delete_and_cancel_unsupported_but_safe() {
+    let server = setup_test_server().await;
+    let model_id = setup_qwen_model(&server).await;
+
+    let org_a = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let key_a = get_api_key_for_org(&server, org_a.id).await;
+    let (key_b, _) = create_org_and_api_key(&server).await;
+
+    let conv_a = create_conversation(&server, &key_a).await;
+    let response_a = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .json(&serde_json::json!({
+            "conversation": {"id": conv_a.id},
+            "input": "hello",
+            "stream": false,
+            "max_output_tokens": 20,
+            "model": model_id
+        }))
+        .await;
+    assert_eq!(response_a.status_code(), 200);
+    let response_a = response_a.json::<api::models::ResponseObject>();
+    let items_before = count_items(&server, &conv_a.id, &key_a).await;
+
+    // Unauthenticated delete: 401 from the auth middleware.
+    let unauthenticated_delete = server
+        .delete(format!("/v1/responses/{}", response_a.id).as_str())
+        .await;
+    assert_eq!(unauthenticated_delete.status_code(), 401);
+
+    // Foreign authenticated delete: 501 (unimplemented), never 200.
+    let foreign_delete = server
+        .delete(format!("/v1/responses/{}", response_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_delete.status_code(), 501);
+
+    // Foreign cancel: 501 as well.
+    let foreign_cancel = server
+        .post(format!("/v1/responses/{}/cancel", response_a.id).as_str())
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .await;
+    assert_eq!(foreign_cancel.status_code(), 501);
+
+    // No state change: the owner's conversation items are intact.
+    assert_eq!(count_items(&server, &conv_a.id, &key_a).await, items_before);
+}

--- a/crates/api/tests/e2e_all/main.rs
+++ b/crates/api/tests/e2e_all/main.rs
@@ -32,6 +32,7 @@ mod client_disconnect;
 mod concurrent_limit;
 mod conversations;
 mod credit_types;
+mod cross_workspace;
 mod deser_error_envelope;
 mod duplicate_names;
 mod embeddings;

--- a/crates/api/tests/e2e_all/mcp.rs
+++ b/crates/api/tests/e2e_all/mcp.rs
@@ -296,3 +296,202 @@ async fn test_mcp_multi_turn_conversation_with_approval() {
     println!("  ✓ Response completed successfully");
     println!("\n✅ MCP multi-turn conversation with approval test passed!");
 }
+
+/// A foreign or unknown MCP approval_request_id must be rejected BEFORE the
+/// response row is created (issue nearai/infra#190): no response.created event
+/// is emitted and nothing is persisted, so no orphaned in-progress response is
+/// left behind, and unknown vs foreign IDs are indistinguishable.
+#[tokio::test]
+async fn test_mcp_foreign_approval_request_rejected_before_response_creation() {
+    // Mock MCP server with one tool that always requires approval.
+    let mut mock_factory = MockMcpClientFactory::new();
+    mock_factory
+        .expect_create_client()
+        .withf(|url: &str, _| url == "https://example.com/mcp")
+        .returning(move |_, _| {
+            let mut client = MockMcpClient::new();
+            client.expect_list_tools().returning(move || {
+                Ok(vec![McpDiscoveredTool {
+                    name: "get_weather".to_string(),
+                    description: Some("Get weather for a location".to_string()),
+                    input_schema: Some(serde_json::json!({
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"]
+                    })),
+                    annotations: None,
+                }])
+            });
+            client
+                .expect_call_tool()
+                .returning(|_, _| Ok("Weather: Sunny".to_string()));
+            Ok(Box::new(client) as Box<dyn services::responses::tools::mcp::McpClient>)
+        });
+
+    let mcp_factory = Arc::new(mock_factory);
+    let (server, _pool, mock) = setup_test_server_with_mcp_factory(mcp_factory).await;
+    setup_qwen_model(&server).await;
+
+    let org_a = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let key_a = get_api_key_for_org(&server, org_a.id).await;
+    let org_b = setup_org_with_credits(&server, 10_000_000_000i64).await;
+    let key_b = get_api_key_for_org(&server, org_b.id).await;
+
+    let mcp_tool = serde_json::json!({
+        "type": "mcp",
+        "server_label": "weather_server",
+        "server_url": "https://example.com/mcp",
+        "require_approval": "always"
+    });
+
+    // Org A: trigger a tool call so a real approval request gets stored.
+    use crate::common::mock_prompts;
+    let prompt = mock_prompts::build_prompt("What's the weather in San Francisco?");
+    mock.when(inference_providers::mock::RequestMatcher::ExactPrompt(
+        prompt,
+    ))
+    .respond_with(
+        inference_providers::mock::ResponseTemplate::new("").with_tool_calls(vec![
+            inference_providers::mock::ToolCall::new(
+                "weather_server:get_weather",
+                r#"{"location": "San Francisco"}"#,
+            ),
+        ]),
+    )
+    .await;
+
+    let resp_a = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input": "What's the weather in San Francisco?",
+            "stream": false,
+            "tools": [mcp_tool.clone()]
+        }))
+        .await;
+    assert_eq!(
+        resp_a.status_code(),
+        200,
+        "org A turn failed: {}",
+        resp_a.text()
+    );
+    let resp_a_obj = resp_a.json::<api::models::ResponseObject>();
+    assert_eq!(resp_a_obj.status, api::models::ResponseStatus::Incomplete);
+
+    let approval_request_id = resp_a_obj
+        .output
+        .iter()
+        .find_map(|item| {
+            if let api::models::ResponseOutputItem::McpApprovalRequest { id, .. } = item {
+                Some(id.clone())
+            } else {
+                None
+            }
+        })
+        .expect("org A should receive an mcp_approval_request");
+
+    // Org B: non-streaming attempt referencing org A's approval request.
+    let foreign_attempt = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input": [{
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request_id,
+                "approve": true
+            }],
+            "stream": false,
+            "tools": [mcp_tool.clone()]
+        }))
+        .await;
+    assert_eq!(
+        foreign_attempt.status_code(),
+        404,
+        "foreign approval_request_id must be a non-enumerating 404: {}",
+        foreign_attempt.text()
+    );
+
+    // Org B: unknown approval id gives the same status (non-enumerating).
+    let unknown_attempt = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input": [{
+                "type": "mcp_approval_response",
+                "approval_request_id": format!("mcpr_{}", uuid::Uuid::new_v4().simple()),
+                "approve": true
+            }],
+            "stream": false,
+            "tools": [mcp_tool.clone()]
+        }))
+        .await;
+    assert_eq!(unknown_attempt.status_code(), 404);
+
+    // Org B: streaming attempt proves the rejection happens BEFORE the
+    // response row is created: the stream must contain response.failed but
+    // never response.created (which is emitted right after persistence).
+    let streaming_attempt = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_b}"))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "input": [{
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request_id,
+                "approve": true
+            }],
+            "stream": true,
+            "tools": [mcp_tool.clone()]
+        }))
+        .await;
+    assert_eq!(streaming_attempt.status_code(), 200, "SSE transport is 200");
+    let sse_body = streaming_attempt.text();
+    assert!(
+        !sse_body.contains("response.created"),
+        "no response may be created for a foreign approval_request_id"
+    );
+    assert!(
+        sse_body.contains("response.failed"),
+        "stream must emit response.failed for a foreign approval_request_id"
+    );
+    assert!(
+        sse_body.contains("\"status_code\":404"),
+        "failure must carry the non-enumerating 404 status"
+    );
+
+    // Org A can still resolve its own approval request afterwards.
+    let approve_prompt =
+        mock_prompts::build_prompt("What's the weather in San Francisco? Weather: Sunny");
+    mock.when(inference_providers::mock::RequestMatcher::ExactPrompt(
+        approve_prompt,
+    ))
+    .respond_with(inference_providers::mock::ResponseTemplate::new(
+        "It is sunny in San Francisco.",
+    ))
+    .await;
+
+    let own_approval = server
+        .post("/v1/responses")
+        .add_header("Authorization", format!("Bearer {key_a}"))
+        .json(&serde_json::json!({
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "previous_response_id": resp_a_obj.id,
+            "input": [{
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request_id,
+                "approve": true
+            }],
+            "stream": false,
+            "tools": [mcp_tool.clone()]
+        }))
+        .await;
+    assert_eq!(
+        own_approval.status_code(),
+        200,
+        "owner approval must still work: {}",
+        own_approval.text()
+    );
+}

--- a/crates/api/tests/e2e_all/repositories.rs
+++ b/crates/api/tests/e2e_all/repositories.rs
@@ -113,3 +113,202 @@ async fn test_state_replay_protection() {
     let second = repo.get_and_delete(&state).await.unwrap();
     assert!(second.is_none());
 }
+
+// ============================================
+// Response Item Repository workspace scoping (issue nearai/infra#190)
+// ============================================
+
+mod response_item_workspace_scoping {
+    use crate::common::*;
+    use database::PgResponseItemsRepository;
+    use services::conversations::models::ConversationId;
+    use services::responses::ports::ResponseItemRepositoryTrait;
+    use services::workspace::WorkspaceId;
+    use uuid::Uuid;
+
+    struct WorkspaceFixture {
+        workspace_id: WorkspaceId,
+        conversation_id: ConversationId,
+        /// Item IDs (e.g. "msg_<uuid>") in chronological order.
+        item_ids: Vec<String>,
+    }
+
+    fn parse_conv_uuid(conversation_id: &str) -> Uuid {
+        let raw = conversation_id
+            .strip_prefix("conv_")
+            .unwrap_or(conversation_id);
+        Uuid::parse_str(raw).expect("conversation id should contain a UUID")
+    }
+
+    /// Creates an org + API key, a conversation, and `item_count` backfilled
+    /// items via the public API; returns the raw IDs for repository-level use.
+    async fn seed_workspace(server: &axum_test::TestServer, item_count: usize) -> WorkspaceFixture {
+        let org = create_org(server).await;
+        let workspaces = list_workspaces(server, org.id.clone()).await;
+        let workspace = workspaces.first().expect("org should have a workspace");
+        let workspace_id =
+            WorkspaceId(Uuid::parse_str(&workspace.id).expect("workspace id should be a UUID"));
+        let api_key = get_api_key_for_org(server, org.id.clone()).await;
+
+        let create_response = server
+            .post("/v1/conversations")
+            .add_header("Authorization", format!("Bearer {api_key}"))
+            .json(&serde_json::json!({}))
+            .await;
+        assert_eq!(create_response.status_code(), 201);
+        let conversation = create_response.json::<api::models::ConversationObject>();
+        let conversation_id = ConversationId(parse_conv_uuid(&conversation.id));
+
+        let mut item_ids = Vec::new();
+        for i in 0..item_count {
+            let response = server
+                .post(format!("/v1/conversations/{}/items", conversation.id).as_str())
+                .add_header("Authorization", format!("Bearer {api_key}"))
+                .json(&serde_json::json!({
+                    "items": [{
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": format!("item {i}")}]
+                    }]
+                }))
+                .await;
+            assert_eq!(response.status_code(), 200);
+            let created = response.json::<api::models::ConversationItemList>();
+            item_ids.push(created.first_id.clone());
+        }
+
+        WorkspaceFixture {
+            workspace_id,
+            conversation_id,
+            item_ids,
+        }
+    }
+
+    fn is_cursor_rejection(error: &anyhow::Error) -> bool {
+        error
+            .chain()
+            .filter_map(|cause| cause.downcast_ref::<services::common::RepositoryError>())
+            .any(|e| matches!(e, services::common::RepositoryError::NotFound(_)))
+    }
+
+    #[tokio::test]
+    async fn test_list_by_conversation_constrained_by_workspace() {
+        let (server, database) = setup_test_server_with_database().await;
+        let repo = PgResponseItemsRepository::new(database.pool().clone());
+
+        let ws_a = seed_workspace(&server, 3).await;
+        let ws_b = seed_workspace(&server, 1).await;
+
+        // Owner sees its own items.
+        let own_items = repo
+            .list_by_conversation(ws_a.conversation_id, ws_a.workspace_id.clone(), None, 10)
+            .await
+            .expect("owner listing should succeed");
+        assert_eq!(own_items.len(), 3, "owner should see all 3 items");
+
+        // The same conversation queried with a foreign workspace returns
+        // nothing, even though the conversation ID is known.
+        let foreign_items = repo
+            .list_by_conversation(ws_a.conversation_id, ws_b.workspace_id.clone(), None, 10)
+            .await
+            .expect("foreign listing should not error");
+        assert!(
+            foreign_items.is_empty(),
+            "workspace constraint must exclude foreign conversation items"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_by_conversation_rejects_foreign_and_unknown_cursors() {
+        let (server, database) = setup_test_server_with_database().await;
+        let repo = PgResponseItemsRepository::new(database.pool().clone());
+
+        let ws_a = seed_workspace(&server, 3).await;
+        let ws_b = seed_workspace(&server, 1).await;
+
+        // A cursor from the same conversation works.
+        let page = repo
+            .list_by_conversation(
+                ws_a.conversation_id,
+                ws_a.workspace_id.clone(),
+                Some(ws_a.item_ids[0].clone()),
+                10,
+            )
+            .await
+            .expect("own cursor should be accepted");
+        assert_eq!(page.len(), 2, "cursor should skip the first item");
+
+        // A cursor that belongs to another workspace's conversation is rejected.
+        let foreign_cursor = repo
+            .list_by_conversation(
+                ws_a.conversation_id,
+                ws_a.workspace_id.clone(),
+                Some(ws_b.item_ids[0].clone()),
+                10,
+            )
+            .await;
+        let err = foreign_cursor.expect_err("foreign cursor must be rejected");
+        assert!(
+            is_cursor_rejection(&err),
+            "foreign cursor should surface as a cursor rejection, got: {err:?}"
+        );
+
+        // An unknown cursor is rejected the same way (non-enumerating).
+        let unknown_cursor = repo
+            .list_by_conversation(
+                ws_a.conversation_id,
+                ws_a.workspace_id.clone(),
+                Some(format!("msg_{}", Uuid::new_v4().simple())),
+                10,
+            )
+            .await;
+        let err = unknown_cursor.expect_err("unknown cursor must be rejected");
+        assert!(is_cursor_rejection(&err));
+
+        // A cursor from the caller's own OTHER workspace conversation is also
+        // rejected: it must belong to this exact conversation.
+        let ws_b_own_listing = repo
+            .list_by_conversation(
+                ws_b.conversation_id,
+                ws_b.workspace_id.clone(),
+                Some(ws_a.item_ids[0].clone()),
+                10,
+            )
+            .await;
+        assert!(
+            ws_b_own_listing.is_err(),
+            "cross-conversation cursor rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_by_id_constrained_by_workspace() {
+        let (server, database) = setup_test_server_with_database().await;
+        let repo = PgResponseItemsRepository::new(database.pool().clone());
+
+        let ws_a = seed_workspace(&server, 1).await;
+        let ws_b = seed_workspace(&server, 1).await;
+
+        let raw_item_id = ws_a.item_ids[0]
+            .rsplit('_')
+            .next()
+            .expect("item id should have a UUID suffix");
+        let item_uuid = Uuid::parse_str(raw_item_id).expect("item id should parse");
+        let item_id = services::responses::models::ResponseItemId(item_uuid);
+
+        // Owner can fetch the item.
+        let own = repo
+            .get_by_id(item_id.clone(), ws_a.workspace_id.clone())
+            .await
+            .expect("owner get_by_id should succeed");
+        assert!(own.is_some(), "owner should see its own item");
+
+        // A foreign workspace gets None for the same item ID, identical to a
+        // nonexistent item (non-enumerating).
+        let foreign = repo
+            .get_by_id(item_id, ws_b.workspace_id.clone())
+            .await
+            .expect("foreign get_by_id should not error");
+        assert!(foreign.is_none(), "foreign workspace must not see the item");
+    }
+}

--- a/crates/database/src/repositories/response.rs
+++ b/crates/database/src/repositories/response.rs
@@ -172,6 +172,38 @@ impl ResponseRepositoryTrait for PgResponseRepository {
             None
         };
 
+        // Defense in depth: never attach a response to a conversation that does
+        // not belong to the caller's workspace, even if a service-level check
+        // was bypassed. Unknown and foreign conversations fail identically.
+        if let Some(conv_uuid) = conversation_uuid {
+            let conversation_row = retry_db!("verify_conversation_ownership", {
+                let client = self
+                    .pool
+                    .get()
+                    .await
+                    .context("Failed to get database connection")
+                    .map_err(RepositoryError::PoolError)?;
+
+                client
+                    .query_opt(
+                        r#"
+                        SELECT 1
+                        FROM conversations
+                        WHERE id = $1 AND workspace_id = $2 AND deleted_at IS NULL
+                        "#,
+                        &[&conv_uuid, &workspace_id.0],
+                    )
+                    .await
+                    .map_err(map_db_error)
+            })?;
+
+            if conversation_row.is_none() {
+                return Err(anyhow::Error::new(RepositoryError::NotFound(
+                    "conversation".to_string(),
+                )));
+            }
+        }
+
         // Extract previous_response_id if present (this is the parent response)
         // If not provided but conversation is provided, find the latest "real" response
         // in the conversation to link to it. If there is no such response yet, we
@@ -182,40 +214,47 @@ impl ResponseRepositoryTrait for PgResponseRepository {
                 .unwrap_or(prev_id);
             let prev_uuid = Uuid::parse_str(uuid_str).context("Invalid previous response ID")?;
 
+            // Fetch the previous response, scoped to the caller's workspace.
+            // Defense in depth: a previous response that does not exist in this
+            // workspace must never be linked as a parent edge (unknown and
+            // foreign IDs fail identically).
+            let prev_response = retry_db!("fetch_previous_response_conversation", {
+                let client = self
+                    .pool
+                    .get()
+                    .await
+                    .context("Failed to get database connection")
+                    .map_err(RepositoryError::PoolError)?;
+
+                client
+                    .query_opt(
+                        r#"
+                        SELECT conversation_id
+                        FROM responses
+                        WHERE id = $1 AND workspace_id = $2
+                        "#,
+                        &[&prev_uuid, &workspace_id.0],
+                    )
+                    .await
+                    .map_err(map_db_error)
+            })?;
+
+            let Some(row) = prev_response else {
+                return Err(anyhow::Error::new(RepositoryError::NotFound(
+                    "previous response".to_string(),
+                )));
+            };
+
             // If conversation_uuid is not explicitly set, inherit it from the previous response
             if conversation_uuid.is_none() {
-                // Fetch the previous response to get its conversation_id
-                let prev_response = retry_db!("fetch_previous_response_conversation", {
-                    let client = self
-                        .pool
-                        .get()
-                        .await
-                        .context("Failed to get database connection")
-                        .map_err(RepositoryError::PoolError)?;
+                let prev_conversation_id: Option<Uuid> = row.get("conversation_id");
+                conversation_uuid = prev_conversation_id;
 
-                    client
-                        .query_opt(
-                            r#"
-                            SELECT conversation_id
-                            FROM responses
-                            WHERE id = $1 AND workspace_id = $2
-                            "#,
-                            &[&prev_uuid, &workspace_id.0],
-                        )
-                        .await
-                        .map_err(map_db_error)
-                })?;
-
-                if let Some(row) = prev_response {
-                    let prev_conversation_id: Option<Uuid> = row.get("conversation_id");
-                    conversation_uuid = prev_conversation_id;
-
-                    if conversation_uuid.is_some() {
-                        tracing::debug!(
-                            "Inherited conversation_id from previous response {}",
-                            prev_id
-                        );
-                    }
+                if conversation_uuid.is_some() {
+                    tracing::debug!(
+                        "Inherited conversation_id from previous response {}",
+                        prev_id
+                    );
                 }
             }
 

--- a/crates/database/src/repositories/response_item.rs
+++ b/crates/database/src/repositories/response_item.rs
@@ -27,8 +27,9 @@
 //! };
 //! repo.create(response_id, user_id, Some(conversation_id), item).await?;
 //!
-//! // Get all items for a conversation (useful for context building)
-//! let items = repo.list_by_conversation(conversation_id).await?;
+//! // Get all items for a conversation (useful for context building).
+//! // Queries are always constrained to the owning workspace.
+//! let items = repo.list_by_conversation(conversation_id, workspace_id, None, 100).await?;
 //!
 //! // Get all items for a specific response
 //! let items = repo.list_by_response(response_id).await?;
@@ -302,8 +303,15 @@ impl ResponseItemRepositoryTrait for PgResponseItemsRepository {
         self.row_to_item(row)
     }
 
-    /// Get a response item by its ID
-    async fn get_by_id(&self, id: ResponseItemId) -> Result<Option<ResponseOutputItem>> {
+    /// Get a response item by its ID, constrained to the owning workspace.
+    ///
+    /// The workspace constraint goes through the owning response so a caller
+    /// can never read another workspace's item, even with a known item ID.
+    async fn get_by_id(
+        &self,
+        id: ResponseItemId,
+        workspace_id: services::workspace::WorkspaceId,
+    ) -> Result<Option<ResponseOutputItem>> {
         let row = retry_db!("get_response_item_by_id", {
             let client = self
                 .pool
@@ -313,7 +321,21 @@ impl ResponseItemRepositoryTrait for PgResponseItemsRepository {
                 .map_err(RepositoryError::PoolError)?;
 
             client
-                .query_opt("SELECT * FROM response_items WHERE id = $1", &[&id.0])
+                .query_opt(
+                    r#"
+                    SELECT
+                        ri.*,
+                        r.previous_response_id,
+                        r.next_response_ids,
+                        r.created_at as response_created_at,
+                        r.model
+                    FROM response_items ri
+                    JOIN responses r ON ri.response_id = r.id
+                    WHERE ri.id = $1
+                      AND r.workspace_id = $2
+                    "#,
+                    &[&id.0, &workspace_id.0],
+                )
                 .await
                 .map_err(map_db_error)
         })?;
@@ -457,14 +479,62 @@ impl ResponseItemRepositoryTrait for PgResponseItemsRepository {
 
     /// List all items for a specific conversation (useful for building context)
     /// Supports cursor-based pagination using the `after` parameter
+    ///
+    /// Every query is constrained to the owning workspace through the joined
+    /// response row (defense in depth on top of the service-level ownership
+    /// check), and an `after` cursor is only accepted when it references an
+    /// item of this exact conversation and workspace.
     async fn list_by_conversation(
         &self,
         conversation_id: ConversationId,
+        workspace_id: services::workspace::WorkspaceId,
         after: Option<String>,
         limit: i64,
     ) -> Result<Vec<ResponseOutputItem>> {
         // Extract UUID from the after item ID if provided
         let after_uuid = after.as_ref().map(|id| Self::extract_uuid_from_item_id(id));
+
+        // Validate the pagination cursor before using it: it must reference an
+        // item that belongs to this conversation and this workspace. Unknown
+        // and foreign cursors are rejected identically so they cannot be used
+        // to probe other conversations or workspaces.
+        let after_position = if let Some(after_uuid) = after_uuid {
+            let cursor_row = retry_db!("validate_conversation_item_cursor", {
+                let client = self
+                    .pool
+                    .get()
+                    .await
+                    .context("Failed to get database connection")
+                    .map_err(RepositoryError::PoolError)?;
+
+                client
+                    .query_opt(
+                        r#"
+                        SELECT ri.created_at, ri.id
+                        FROM response_items ri
+                        JOIN responses r ON ri.response_id = r.id
+                        WHERE ri.id = $1
+                          AND ri.conversation_id = $2
+                          AND r.workspace_id = $3
+                        "#,
+                        &[&after_uuid, &conversation_id.0, &workspace_id.0],
+                    )
+                    .await
+                    .map_err(map_db_error)
+            })?;
+
+            let Some(cursor_row) = cursor_row else {
+                return Err(anyhow::Error::new(RepositoryError::NotFound(
+                    "pagination cursor".to_string(),
+                )));
+            };
+
+            let cursor_created_at: chrono::DateTime<Utc> = cursor_row.try_get("created_at")?;
+            let cursor_id: Uuid = cursor_row.try_get("id")?;
+            Some((cursor_created_at, cursor_id))
+        } else {
+            None
+        };
 
         let rows = retry_db!("list_response_items_by_conversation", {
             let client = self
@@ -474,7 +544,7 @@ impl ResponseItemRepositoryTrait for PgResponseItemsRepository {
                 .context("Failed to get database connection")
                 .map_err(RepositoryError::PoolError)?;
 
-            if let Some(after_uuid) = after_uuid {
+            if let Some((cursor_created_at, cursor_id)) = after_position {
                 // Query items after the reference item using composite (created_at, id) comparison
                 // This handles cases where multiple items have the same created_at timestamp
                 // We fetch limit + 1 to determine if there are more items
@@ -490,13 +560,18 @@ impl ResponseItemRepositoryTrait for PgResponseItemsRepository {
                         FROM response_items ri
                         JOIN responses r ON ri.response_id = r.id
                         WHERE ri.conversation_id = $1
-                          AND (ri.created_at, ri.id) > (
-                              SELECT created_at, id FROM response_items WHERE id = $2
-                          )
+                          AND r.workspace_id = $2
+                          AND (ri.created_at, ri.id) > ($3, $4)
                         ORDER BY ri.created_at ASC, ri.id ASC
-                        LIMIT $3
+                        LIMIT $5
                         "#,
-                        &[&conversation_id.0, &after_uuid, &limit],
+                        &[
+                            &conversation_id.0,
+                            &workspace_id.0,
+                            &cursor_created_at,
+                            &cursor_id,
+                            &limit,
+                        ],
                     )
                     .await
                     .map_err(map_db_error)
@@ -514,10 +589,11 @@ impl ResponseItemRepositoryTrait for PgResponseItemsRepository {
                         FROM response_items ri
                         JOIN responses r ON ri.response_id = r.id
                         WHERE ri.conversation_id = $1
+                          AND r.workspace_id = $2
                         ORDER BY ri.created_at ASC, ri.id ASC
-                        LIMIT $2
+                        LIMIT $3
                         "#,
-                        &[&conversation_id.0, &limit],
+                        &[&conversation_id.0, &workspace_id.0, &limit],
                     )
                     .await
                     .map_err(map_db_error)

--- a/crates/services/src/conversations/errors.rs
+++ b/crates/services/src/conversations/errors.rs
@@ -4,4 +4,10 @@ pub enum ConversationError {
     InternalError(String),
     #[error("Invalid parameters: {0}")]
     InvalidParams(String),
+    /// The conversation does not exist in the caller's workspace.
+    ///
+    /// Deliberately carries no detail: unknown IDs and IDs owned by another
+    /// workspace must be indistinguishable to the caller (non-enumerating 404).
+    #[error("Conversation not found")]
+    NotFound,
 }

--- a/crates/services/src/conversations/service.rs
+++ b/crates/services/src/conversations/service.rs
@@ -34,6 +34,15 @@ pub fn parse_uuid_from_prefixed(id: &str, prefix: &str) -> Result<Uuid, errors::
     })
 }
 
+/// Returns true when a repository error indicates the pagination cursor was
+/// rejected (it does not exist, or belongs to another conversation/workspace).
+fn is_invalid_cursor_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<crate::common::RepositoryError>())
+        .any(|e| matches!(e, crate::common::RepositoryError::NotFound(_)))
+}
+
 /// Conversation service for managing conversations
 pub struct ConversationServiceImpl {
     pub conv_repo: Arc<dyn ports::ConversationRepository>,
@@ -418,25 +427,51 @@ impl ports::ConversationServiceTrait for ConversationServiceImpl {
     async fn list_conversation_items(
         &self,
         conversation_id: models::ConversationId,
-        _workspace_id: WorkspaceId,
+        workspace_id: WorkspaceId,
         after: Option<String>,
         limit: i64,
     ) -> Result<Vec<crate::responses::models::ResponseOutputItem>, errors::ConversationError> {
         tracing::debug!(
-            "Listing conversation items for conversation_id={}, after={:?}, limit={}",
+            "Listing conversation items for conversation_id={}, workspace_id={}, after={:?}, limit={}",
             conversation_id,
+            workspace_id.0,
             after,
             limit
         );
 
-        // Get items from response_items repository
-        self.response_items_repo
-            .list_by_conversation(conversation_id, after, limit)
+        // Enforce workspace ownership before touching any items. Unknown and
+        // foreign conversation IDs both surface as the same NotFound so callers
+        // cannot enumerate other workspaces' conversation IDs.
+        let conversation = self
+            .conv_repo
+            .get_by_id(conversation_id, workspace_id.clone())
             .await
             .map_err(|e| {
                 errors::ConversationError::InternalError(format!(
-                    "Failed to list conversation items: {e}"
+                    "Failed to verify conversation: {e}"
                 ))
+            })?;
+
+        if conversation.is_none() {
+            return Err(errors::ConversationError::NotFound);
+        }
+
+        // Get items from response_items repository. The repository additionally
+        // constrains the query by workspace (defense in depth) and rejects
+        // pagination cursors that do not belong to this conversation.
+        self.response_items_repo
+            .list_by_conversation(conversation_id, workspace_id, after, limit)
+            .await
+            .map_err(|e| {
+                if is_invalid_cursor_error(&e) {
+                    errors::ConversationError::InvalidParams(
+                        "Invalid 'after' cursor for this conversation".to_string(),
+                    )
+                } else {
+                    errors::ConversationError::InternalError(format!(
+                        "Failed to list conversation items: {e}"
+                    ))
+                }
             })
     }
 
@@ -467,9 +502,8 @@ impl ports::ConversationServiceTrait for ConversationServiceImpl {
             })?;
 
         if conversation.is_none() {
-            return Err(errors::ConversationError::InvalidParams(format!(
-                "Conversation not found: {conversation_id}"
-            )));
+            // Same non-enumerating response for unknown and foreign conversations.
+            return Err(errors::ConversationError::NotFound);
         }
 
         // Create a minimal response for backfilled items
@@ -713,5 +747,399 @@ mod tests {
         let empty_ids: Vec<models::ConversationId> = Vec::new();
         assert_eq!(empty_ids.len(), 0, "Empty vector should have length 0");
         assert!(empty_ids.is_empty(), "Empty vector should report as empty");
+    }
+
+    // ============================================
+    // Workspace ownership enforcement (issue nearai/infra#190)
+    // ============================================
+
+    use crate::conversations::ports::ConversationServiceTrait;
+    use crate::responses::models as resp_models;
+    use std::sync::Mutex;
+
+    fn test_conversation(
+        id: models::ConversationId,
+        workspace_id: WorkspaceId,
+    ) -> models::Conversation {
+        let now = chrono::Utc::now();
+        models::Conversation {
+            id,
+            workspace_id,
+            api_key_id: Uuid::new_v4(),
+            pinned_at: None,
+            archived_at: None,
+            deleted_at: None,
+            cloned_from_id: None,
+            root_response_id: None,
+            metadata: serde_json::json!({}),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Conversation repository that owns exactly one conversation in one
+    /// workspace. `get_by_id` behaves like the real repository: it only
+    /// returns the conversation when both the ID and the workspace match.
+    struct MockConversationRepo {
+        conversation: models::Conversation,
+    }
+
+    #[async_trait]
+    impl ports::ConversationRepository for MockConversationRepo {
+        async fn create(
+            &self,
+            _workspace_id: WorkspaceId,
+            _api_key_id: Uuid,
+            _metadata: serde_json::Value,
+        ) -> Result<models::Conversation> {
+            panic!("create must not be called");
+        }
+
+        async fn get_by_id(
+            &self,
+            id: models::ConversationId,
+            workspace_id: WorkspaceId,
+        ) -> Result<Option<models::Conversation>> {
+            if id.0 == self.conversation.id.0 && workspace_id == self.conversation.workspace_id {
+                Ok(Some(self.conversation.clone()))
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn update(
+            &self,
+            _id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+            _metadata: serde_json::Value,
+        ) -> Result<Option<models::Conversation>> {
+            panic!("update must not be called");
+        }
+
+        async fn set_pinned(
+            &self,
+            _id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+            _is_pinned: bool,
+        ) -> Result<Option<models::Conversation>> {
+            panic!("set_pinned must not be called");
+        }
+
+        async fn set_archived(
+            &self,
+            _id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+            _is_archived: bool,
+        ) -> Result<Option<models::Conversation>> {
+            panic!("set_archived must not be called");
+        }
+
+        async fn clone_conversation(
+            &self,
+            _id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+            _api_key_id: Uuid,
+        ) -> Result<Option<models::Conversation>> {
+            panic!("clone_conversation must not be called");
+        }
+
+        async fn delete(
+            &self,
+            _id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+        ) -> Result<bool> {
+            panic!("delete must not be called");
+        }
+
+        async fn batch_get_by_ids(
+            &self,
+            _ids: Vec<models::ConversationId>,
+            _workspace_id: WorkspaceId,
+        ) -> Result<Vec<models::Conversation>> {
+            panic!("batch_get_by_ids must not be called");
+        }
+    }
+
+    /// Response repository that panics on any write: the ownership check must
+    /// reject foreign conversations before any response row is created.
+    struct RejectingResponseRepo;
+
+    #[async_trait]
+    impl ResponseRepositoryTrait for RejectingResponseRepo {
+        async fn create(
+            &self,
+            _workspace_id: WorkspaceId,
+            _api_key_id: Uuid,
+            _request: resp_models::CreateResponseRequest,
+        ) -> anyhow::Result<resp_models::ResponseObject> {
+            panic!("response create must not be called for a foreign conversation");
+        }
+
+        async fn get_by_id(
+            &self,
+            _id: resp_models::ResponseId,
+            _workspace_id: WorkspaceId,
+        ) -> anyhow::Result<Option<resp_models::ResponseObject>> {
+            Ok(None)
+        }
+
+        async fn update(
+            &self,
+            _id: resp_models::ResponseId,
+            _workspace_id: WorkspaceId,
+            _output_message: Option<String>,
+            _status: resp_models::ResponseStatus,
+            _usage: Option<serde_json::Value>,
+        ) -> anyhow::Result<Option<resp_models::ResponseObject>> {
+            panic!("response update must not be called for a foreign conversation");
+        }
+
+        async fn delete(
+            &self,
+            _id: resp_models::ResponseId,
+            _workspace_id: WorkspaceId,
+        ) -> anyhow::Result<bool> {
+            panic!("response delete must not be called");
+        }
+
+        async fn cancel(
+            &self,
+            _id: resp_models::ResponseId,
+            _workspace_id: WorkspaceId,
+        ) -> anyhow::Result<Option<resp_models::ResponseObject>> {
+            panic!("response cancel must not be called");
+        }
+
+        async fn list_by_workspace(
+            &self,
+            _workspace_id: WorkspaceId,
+            _limit: i64,
+            _offset: i64,
+        ) -> anyhow::Result<Vec<resp_models::ResponseObject>> {
+            panic!("list_by_workspace must not be called");
+        }
+
+        async fn list_by_conversation(
+            &self,
+            _conversation_id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+            _limit: i64,
+        ) -> anyhow::Result<Vec<resp_models::ResponseObject>> {
+            panic!("list_by_conversation must not be called");
+        }
+
+        async fn get_previous(
+            &self,
+            _response_id: resp_models::ResponseId,
+            _workspace_id: WorkspaceId,
+        ) -> anyhow::Result<Option<resp_models::ResponseObject>> {
+            panic!("get_previous must not be called");
+        }
+
+        async fn get_latest_in_conversation(
+            &self,
+            _conversation_id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+        ) -> anyhow::Result<Option<resp_models::ResponseObject>> {
+            panic!("get_latest_in_conversation must not be called");
+        }
+
+        async fn get_or_create_root_response(
+            &self,
+            _conversation_id: models::ConversationId,
+            _workspace_id: WorkspaceId,
+            _api_key_id: Uuid,
+        ) -> anyhow::Result<String> {
+            panic!("get_or_create_root_response must not be called");
+        }
+    }
+
+    /// Response-item repository that records list calls and panics on writes.
+    #[derive(Default)]
+    struct RecordingItemsRepo {
+        list_calls: Mutex<Vec<(Uuid, Uuid, Option<String>)>>,
+    }
+
+    #[async_trait]
+    impl ResponseItemRepositoryTrait for RecordingItemsRepo {
+        async fn create(
+            &self,
+            _response_id: resp_models::ResponseId,
+            _api_key_id: Uuid,
+            _conversation_id: Option<models::ConversationId>,
+            _item: resp_models::ResponseOutputItem,
+        ) -> anyhow::Result<resp_models::ResponseOutputItem> {
+            panic!("item create must not be called for a foreign conversation");
+        }
+
+        async fn get_by_id(
+            &self,
+            _id: resp_models::ResponseItemId,
+            _workspace_id: WorkspaceId,
+        ) -> anyhow::Result<Option<resp_models::ResponseOutputItem>> {
+            Ok(None)
+        }
+
+        async fn update(
+            &self,
+            _id: resp_models::ResponseItemId,
+            _item: resp_models::ResponseOutputItem,
+        ) -> anyhow::Result<resp_models::ResponseOutputItem> {
+            panic!("item update must not be called");
+        }
+
+        async fn delete(&self, _id: resp_models::ResponseItemId) -> anyhow::Result<bool> {
+            panic!("item delete must not be called");
+        }
+
+        async fn list_by_response(
+            &self,
+            _response_id: resp_models::ResponseId,
+        ) -> anyhow::Result<Vec<resp_models::ResponseOutputItem>> {
+            panic!("list_by_response must not be called");
+        }
+
+        async fn list_by_api_key(
+            &self,
+            _api_key_id: Uuid,
+        ) -> anyhow::Result<Vec<resp_models::ResponseOutputItem>> {
+            panic!("list_by_api_key must not be called");
+        }
+
+        async fn list_by_conversation(
+            &self,
+            conversation_id: models::ConversationId,
+            workspace_id: WorkspaceId,
+            after: Option<String>,
+            _limit: i64,
+        ) -> anyhow::Result<Vec<resp_models::ResponseOutputItem>> {
+            self.list_calls
+                .lock()
+                .unwrap()
+                .push((conversation_id.0, workspace_id.0, after));
+            Ok(vec![])
+        }
+    }
+
+    fn service_with_owned_conversation(
+        conversation_id: models::ConversationId,
+        owner_workspace: WorkspaceId,
+    ) -> (ConversationServiceImpl, Arc<RecordingItemsRepo>) {
+        let items_repo = Arc::new(RecordingItemsRepo::default());
+        let service = ConversationServiceImpl::new(
+            Arc::new(MockConversationRepo {
+                conversation: test_conversation(conversation_id, owner_workspace),
+            }),
+            Arc::new(RejectingResponseRepo),
+            items_repo.clone(),
+        );
+        (service, items_repo)
+    }
+
+    #[tokio::test]
+    async fn test_list_conversation_items_foreign_workspace_not_found() {
+        let conversation_id = models::ConversationId(Uuid::new_v4());
+        let owner_workspace = WorkspaceId(Uuid::new_v4());
+        let foreign_workspace = WorkspaceId(Uuid::new_v4());
+
+        let (service, items_repo) =
+            service_with_owned_conversation(conversation_id, owner_workspace);
+
+        let result = service
+            .list_conversation_items(conversation_id, foreign_workspace, None, 10)
+            .await;
+
+        assert!(
+            matches!(result, Err(errors::ConversationError::NotFound)),
+            "foreign-workspace lookup must return NotFound, got: {result:?}"
+        );
+        assert!(
+            items_repo.list_calls.lock().unwrap().is_empty(),
+            "item repository must not be queried for a foreign conversation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_conversation_items_unknown_conversation_not_found() {
+        let owner_workspace = WorkspaceId(Uuid::new_v4());
+        let (service, items_repo) = service_with_owned_conversation(
+            models::ConversationId(Uuid::new_v4()),
+            owner_workspace.clone(),
+        );
+
+        // Same workspace, unknown conversation ID: identical NotFound outcome
+        // as the foreign-workspace case (non-enumerating behavior).
+        let result = service
+            .list_conversation_items(
+                models::ConversationId(Uuid::new_v4()),
+                owner_workspace,
+                None,
+                10,
+            )
+            .await;
+
+        assert!(matches!(result, Err(errors::ConversationError::NotFound)));
+        assert!(items_repo.list_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_conversation_items_same_workspace_passes_workspace_to_repo() {
+        let conversation_id = models::ConversationId(Uuid::new_v4());
+        let owner_workspace = WorkspaceId(Uuid::new_v4());
+
+        let (service, items_repo) =
+            service_with_owned_conversation(conversation_id, owner_workspace.clone());
+
+        let result = service
+            .list_conversation_items(conversation_id, owner_workspace.clone(), None, 10)
+            .await;
+
+        assert!(result.is_ok(), "owner lookup must succeed: {result:?}");
+        let calls = items_repo.list_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "item repository queried exactly once");
+        assert_eq!(calls[0].0, conversation_id.0);
+        assert_eq!(
+            calls[0].1, owner_workspace.0,
+            "workspace must be threaded through to the repository query"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_conversation_items_foreign_workspace_not_found() {
+        let conversation_id = models::ConversationId(Uuid::new_v4());
+        let owner_workspace = WorkspaceId(Uuid::new_v4());
+        let foreign_workspace = WorkspaceId(Uuid::new_v4());
+
+        let (service, _items_repo) =
+            service_with_owned_conversation(conversation_id, owner_workspace);
+
+        let item = resp_models::ResponseOutputItem::Message {
+            id: format!("msg_{}", Uuid::new_v4().simple()),
+            response_id: String::new(),
+            previous_response_id: None,
+            next_response_ids: vec![],
+            created_at: 0,
+            status: resp_models::ResponseItemStatus::Completed,
+            role: "user".to_string(),
+            content: vec![],
+            model: String::new(),
+            metadata: None,
+        };
+
+        // The mock response/item repositories panic on create, so this also
+        // proves no response or response item is created on the foreign path.
+        let result = service
+            .create_conversation_items(
+                conversation_id,
+                foreign_workspace,
+                Uuid::new_v4(),
+                vec![item],
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(errors::ConversationError::NotFound)),
+            "foreign-workspace item creation must return NotFound, got: {result:?}"
+        );
     }
 }

--- a/crates/services/src/responses/errors.rs
+++ b/crates/services/src/responses/errors.rs
@@ -13,6 +13,18 @@ pub enum ResponseError {
     #[error("Stream interrupted")]
     StreamInterrupted,
 
+    /// The referenced conversation does not exist in the caller's workspace.
+    /// Unknown and foreign conversation IDs are deliberately indistinguishable
+    /// (non-enumerating 404).
+    #[error("Conversation not found")]
+    ConversationNotFound,
+
+    /// The referenced previous response does not exist in the caller's
+    /// workspace. Unknown and foreign response IDs are deliberately
+    /// indistinguishable (non-enumerating 404).
+    #[error("Previous response not found")]
+    PreviousResponseNotFound,
+
     // ============================================
     // MCP (Model Context Protocol) Errors
     // ============================================
@@ -70,7 +82,9 @@ impl ResponseError {
             | ResponseError::McpApprovalRequired { .. }
             | ResponseError::FunctionCallRequired { .. } => 400,
             ResponseError::McpApprovalRequestNotFound(_)
-            | ResponseError::FunctionCallNotFound(_) => 404,
+            | ResponseError::FunctionCallNotFound(_)
+            | ResponseError::ConversationNotFound
+            | ResponseError::PreviousResponseNotFound => 404,
             ResponseError::McpConnectionFailed(_)
             | ResponseError::McpToolDiscoveryFailed(_)
             | ResponseError::McpToolExecutionFailed(_) => 502,
@@ -99,7 +113,9 @@ impl ResponseError {
             | ResponseError::McpApprovalRequired { .. }
             | ResponseError::McpApprovalRequestNotFound(_)
             | ResponseError::FunctionCallRequired { .. }
-            | ResponseError::FunctionCallNotFound(_) => true,
+            | ResponseError::FunctionCallNotFound(_)
+            | ResponseError::ConversationNotFound
+            | ResponseError::PreviousResponseNotFound => true,
             ResponseError::Completion(error) => matches!(
                 error,
                 crate::completions::CompletionError::InvalidModel(_)
@@ -135,6 +151,12 @@ impl ResponseError {
             ),
             ResponseError::StreamInterrupted => {
                 response_error("Stream interrupted", "stream_error", None)
+            }
+            ResponseError::ConversationNotFound => {
+                response_error("Conversation not found", "not_found", None)
+            }
+            ResponseError::PreviousResponseNotFound => {
+                response_error("Previous response not found", "not_found", None)
             }
             ResponseError::McpConnectionFailed(msg) => {
                 response_error(&format!("MCP connection failed: {msg}"), "mcp_error", None)

--- a/crates/services/src/responses/ports.rs
+++ b/crates/services/src/responses/ports.rs
@@ -92,9 +92,14 @@ pub trait ResponseItemRepositoryTrait: Send + Sync {
         conversation_id: Option<ConversationId>,
         item: models::ResponseOutputItem,
     ) -> anyhow::Result<models::ResponseOutputItem>;
+    /// Get a response item by ID, constrained to the given workspace.
+    ///
+    /// Returns `None` for unknown items and for items owned by another
+    /// workspace so the two cases are indistinguishable to callers.
     async fn get_by_id(
         &self,
         id: models::ResponseItemId,
+        workspace_id: WorkspaceId,
     ) -> anyhow::Result<Option<models::ResponseOutputItem>>;
     async fn update(
         &self,
@@ -110,9 +115,16 @@ pub trait ResponseItemRepositoryTrait: Send + Sync {
         &self,
         api_key_id: uuid::Uuid,
     ) -> anyhow::Result<Vec<models::ResponseOutputItem>>;
+    /// List items for a conversation, constrained to the given workspace.
+    ///
+    /// Callers must additionally verify conversation ownership before calling;
+    /// the workspace constraint here is defense in depth. An `after` cursor
+    /// that does not belong to this conversation and workspace is rejected
+    /// with a `RepositoryError::NotFound`-based error.
     async fn list_by_conversation(
         &self,
         conversation_id: ConversationId,
+        workspace_id: WorkspaceId,
         after: Option<String>,
         limit: i64,
     ) -> anyhow::Result<Vec<models::ResponseOutputItem>>;

--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -969,6 +969,19 @@ impl ResponseServiceImpl {
             }
         }
 
+        // Validate MCP approval-request references before creating the
+        // response row. setup_mcp() re-resolves them later (workspace-scoped),
+        // but that runs after the response has been persisted and
+        // response.created has been emitted — failing only there would leave
+        // an orphaned in-progress response. Unknown and foreign IDs produce
+        // the same not-found error here as in the approval processing itself.
+        Self::validate_mcp_approval_references(
+            &context.request,
+            &context.response_items_repository,
+            workspace_id_domain.clone(),
+        )
+        .await?;
+
         let mut messages = Self::load_conversation_context(
             &context.request,
             &context.conversation_service,
@@ -1834,6 +1847,76 @@ impl ResponseServiceImpl {
         }
 
         Ok(tools::ToolExecutionResult::Success)
+    }
+
+    /// Validate MCP approval-response references from the request input.
+    ///
+    /// Runs before the response row is created so an invalid, unknown, or
+    /// foreign `approval_request_id` fails fast without persisting anything.
+    /// Mirrors the checks in `tools::mcp::process_approval_responses` (which
+    /// still runs later as defense in depth): workspace-scoped lookup, same
+    /// non-enumerating not-found for unknown and foreign IDs, and a type
+    /// check that the referenced item is an approval request.
+    ///
+    /// Only active when the request configures MCP tools, matching when
+    /// approval responses are actually processed.
+    async fn validate_mcp_approval_references(
+        request: &models::CreateResponseRequest,
+        response_items_repository: &Arc<dyn ports::ResponseItemRepositoryTrait>,
+        workspace_id: crate::workspace::WorkspaceId,
+    ) -> Result<(), errors::ResponseError> {
+        let has_mcp_tools = request.tools.as_ref().is_some_and(|tools| {
+            tools
+                .iter()
+                .any(|t| matches!(t, models::ResponseTool::Mcp { .. }))
+        });
+        if !has_mcp_tools {
+            return Ok(());
+        }
+
+        let approval_ids: Vec<&str> = match &request.input {
+            Some(models::ResponseInput::Items(items)) => items
+                .iter()
+                .filter_map(|item| item.as_mcp_approval())
+                .map(|(approval_request_id, _approve)| approval_request_id)
+                .collect(),
+            _ => return Ok(()),
+        };
+
+        for approval_request_id in approval_ids {
+            let uuid_str = approval_request_id
+                .strip_prefix(crate::id_prefixes::PREFIX_MCPR)
+                .unwrap_or(approval_request_id);
+            let item_uuid = Uuid::parse_str(uuid_str).map_err(|e| {
+                errors::ResponseError::InvalidParams(format!("Invalid approval_request_id: {e}"))
+            })?;
+
+            let item = response_items_repository
+                .get_by_id(models::ResponseItemId(item_uuid), workspace_id.clone())
+                .await
+                .map_err(|e| {
+                    errors::ResponseError::InternalError(format!(
+                        "Failed to fetch approval request: {e}"
+                    ))
+                })?;
+
+            match item {
+                None => {
+                    return Err(errors::ResponseError::McpApprovalRequestNotFound(
+                        approval_request_id.to_string(),
+                    ));
+                }
+                Some(models::ResponseOutputItem::McpApprovalRequest { .. }) => {}
+                Some(_) => {
+                    return Err(errors::ResponseError::InvalidParams(format!(
+                        "Item {} is not an MCP approval request",
+                        approval_request_id
+                    )));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Process function call outputs from the request input.

--- a/crates/services/src/responses/service.rs
+++ b/crates/services/src/responses/service.rs
@@ -942,6 +942,33 @@ impl ResponseServiceImpl {
         )
         .await?;
 
+        // Verify previous_response_id ownership before loading any history or
+        // creating the response. Unknown and foreign response IDs get the same
+        // non-enumerating 404-style error; without this check a foreign ID
+        // would be persisted as this response's parent edge.
+        if let Some(prev_response_id) = &context.request.previous_response_id {
+            let uuid_str = prev_response_id
+                .strip_prefix(crate::id_prefixes::PREFIX_RESP)
+                .unwrap_or(prev_response_id);
+            let prev_uuid = Uuid::parse_str(uuid_str).map_err(|e| {
+                errors::ResponseError::InvalidParams(format!("invalid previous_response_id: {e}"))
+            })?;
+
+            let prev_response = context
+                .response_repository
+                .get_by_id(models::ResponseId(prev_uuid), workspace_id_domain.clone())
+                .await
+                .map_err(|e| {
+                    errors::ResponseError::InternalError(format!(
+                        "Failed to verify previous response ownership: {e}"
+                    ))
+                })?;
+
+            if prev_response.is_none() {
+                return Err(errors::ResponseError::PreviousResponseNotFound);
+            }
+        }
+
         let mut messages = Self::load_conversation_context(
             &context.request,
             &context.conversation_service,
@@ -1045,6 +1072,7 @@ impl ResponseServiceImpl {
             &context.request,
             context.mcp_client_factory.as_ref(),
             &context.response_items_repository,
+            workspace_id_domain.clone(),
             &mut ctx,
             &mut emitter,
         )
@@ -2202,18 +2230,27 @@ impl ResponseServiceImpl {
                     })?,
             };
 
-            // Load conversation metadata to verify it exists
-            let _conversation = conversation_service
+            // Verify the conversation exists AND belongs to the caller's
+            // workspace before reading any history. A missing or foreign
+            // conversation is rejected with the same non-enumerating error so
+            // another workspace's history can never be imported into a
+            // completion context.
+            let conversation = conversation_service
                 .get_conversation(conversation_id, workspace_id.clone())
                 .await
                 .map_err(|e| {
                     errors::ResponseError::InternalError(format!("Failed to get conversation: {e}"))
                 })?;
 
+            if conversation.is_none() {
+                return Err(errors::ResponseError::ConversationNotFound);
+            }
+
             // Load all response items from the conversation
-            // Use high limit (1000) and no 'after' cursor for context loading
+            // Use high limit (1000) and no 'after' cursor for context loading.
+            // The repository constrains the query by workspace as defense in depth.
             let conversation_items = response_items_repository
-                .list_by_conversation(conversation_id, None, 1000)
+                .list_by_conversation(conversation_id, workspace_id.clone(), None, 1000)
                 .await
                 .map_err(|e| {
                     errors::ResponseError::InternalError(format!(

--- a/crates/services/src/responses/tools/mcp.rs
+++ b/crates/services/src/responses/tools/mcp.rs
@@ -737,6 +737,7 @@ pub async fn setup_mcp(
     request: &models::CreateResponseRequest,
     client_factory: Option<&Arc<dyn McpClientFactory>>,
     response_items_repository: &Arc<dyn ResponseItemRepositoryTrait>,
+    workspace_id: crate::workspace::WorkspaceId,
     ctx: &mut ResponseStreamContext,
     emitter: &mut EventEmitter,
 ) -> Result<Option<McpSetupResult>, ResponseError> {
@@ -769,9 +770,10 @@ pub async fn setup_mcp(
 
     let executor = Arc::new(mcp_executor);
 
-    // Process any approval responses
+    // Process any approval responses (workspace-scoped lookup)
     let approval_messages =
-        process_approval_responses(&executor, request, response_items_repository).await?;
+        process_approval_responses(&executor, request, response_items_repository, workspace_id)
+            .await?;
 
     Ok(Some(McpSetupResult {
         executor,
@@ -854,7 +856,8 @@ pub async fn initialize_mcp_executor(
 /// Process MCP approval responses from the request input.
 ///
 /// For each approval response:
-/// - Fetches the approval request directly by ID from the database
+/// - Fetches the approval request by ID, constrained to the caller's workspace
+///   (unknown and foreign IDs surface as the same not-found error)
 /// - If approved: executes the tool and adds result to messages
 /// - If rejected: adds rejection message for LLM context
 ///
@@ -863,6 +866,7 @@ pub async fn process_approval_responses(
     mcp_executor: &McpToolExecutor,
     request: &models::CreateResponseRequest,
     response_items_repository: &Arc<dyn ResponseItemRepositoryTrait>,
+    workspace_id: crate::workspace::WorkspaceId,
 ) -> Result<Vec<crate::completions::ports::CompletionMessage>, ResponseError> {
     let mut messages = Vec::new();
 
@@ -891,9 +895,9 @@ pub async fn process_approval_responses(
         })?;
         let item_id = models::ResponseItemId(item_uuid);
 
-        // Fetch the approval request directly by ID
+        // Fetch the approval request by ID, scoped to the caller's workspace
         let item = response_items_repository
-            .get_by_id(item_id)
+            .get_by_id(item_id, workspace_id.clone())
             .await
             .map_err(|e| {
                 ResponseError::InternalError(format!("Failed to fetch approval request: {e}"))


### PR DESCRIPTION
A caller with a valid API key could read conversation items owned by another organization/workspace when the conversation ID was known (IDOR on `GET /v1/conversations/{conversation_id}/items`), and the Responses API context loader would import a conversation's history without rejecting a missing or foreign conversation. This PR enforces workspace ownership on every direct-object operation around conversations and responses, with the repository SQL constrained by workspace as defense in depth. Unknown and foreign IDs now return the same non-enumerating `404`; UUID unguessability is no longer load-bearing for authorization.

## Changes

- **`GET /v1/conversations/{id}/items`**: the service now verifies the conversation belongs to the caller's workspace before touching any items; unknown and foreign conversation IDs return an identical `404` body.
- **`POST /v1/conversations/{id}/items`**: same non-enumerating `404` (previously a `400` with different semantics for unknown IDs).
- **Repository contract**: `ResponseItemRepositoryTrait::list_by_conversation` and `get_by_id` now take `workspace_id`, and the SQL constrains through the owning response row (`JOIN responses … AND r.workspace_id = $n`) — defense in depth under the service-level check.
- **Pagination cursor**: an `after` cursor is validated to reference an item of the same conversation and workspace before use. Unknown and foreign cursors are rejected identically with a `400` (previously the cursor subquery was unconstrained, allowing cross-conversation timestamp probing).
- **Responses API context loading**: `load_conversation_context` rejects a missing/foreign conversation with a `404` before reading any history (previously the `get_conversation` result was ignored and history was loaded regardless).
- **`previous_response_id`**: verified against the caller's workspace before any history load or response creation; unknown and foreign response IDs both return `404`. Previously a foreign ID was silently persisted as the new response's parent edge.
- **MCP approval requests**: `mcpr_*` lookups during approval processing are now workspace-scoped (previously fetched by raw item ID, exposing another workspace's tool name/arguments).
- **`PgResponseRepository::create`**: refuses to attach a response to a conversation or previous response outside the caller's workspace, even if a service-level check were bypassed. This also closes a write path where a caller could insert a root response into a foreign legacy conversation.
- Audit of the remaining direct-object surface (details in test plan): conversation get/update/pin/unpin/archive/unarchive/clone/delete/batch were already workspace-scoped in `PgConversationRepository`; `GET /v1/responses/{id}/input_items` already verified ownership; response GET/DELETE/cancel remain authenticated `501` stubs with `unimplemented!()` repository methods (no state change possible).

## Test plan

All run locally against Postgres 15:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --lib --bins` — 1210 tests pass. Includes new unit tests with mock repositories proving a foreign-workspace lookup returns not-found without querying or creating any response items, and that the workspace is threaded into the repository query.
- `cargo test --test integration_tests` — 8 pass.
- `cargo test --test e2e_all` — 674 pass, 0 fail. New coverage:
  - `repositories::response_item_workspace_scoping` — repository queries constrained by workspace; foreign, unknown, and cross-conversation pagination cursors rejected; `get_by_id` returns `None` for foreign workspaces.
  - `cross_workspace` (two orgs, two API keys) — every conversation op (get, list items, create items, update, pin/unpin, archive/unarchive, clone, delete, batch) returns the same non-enumerating `404` for foreign and unknown IDs with byte-identical bodies, and the owner's data is verified unchanged afterwards; Responses API rejects foreign conversation refs and foreign `previous_response_id` with identical `404`s and stores nothing; unauthenticated requests get `401`; response DELETE/cancel stay authenticated `501` with no state change.
  - Existing same-workspace conversation, pagination, function-tool, MCP, and Responses API suites all pass unchanged (one test updated: unknown-conversation backfill now expects the non-enumerating `404` instead of `400`).

## Rollout

1. Deploy to staging first.
2. Staging retest of the original two-account scenario: with two orgs/keys, confirm cross-workspace `GET /v1/conversations/{id}/items` returns `404` and the owner still reads its items (regression tests for this live in the companion infra-tests PR and skip unless `CLOUD_STG_API_KEY`/`CLOUD_STG_API_KEY_B` are configured).
3. Then production. No schema changes; behavior changes are limited to rejecting cross-workspace and unknown-ID access (`400`→`404` for unknown backfill targets, `200 []`→`404` for unknown item listings, and invalid pagination cursors now `400` instead of empty results).

Fixes nearai/infra#190
