### PR TITLE
fix: make prefix affinity deterministic without hot-prefix overload

### DIFF
--- a/crates/inference_providers/src/attested/nearai/fleet.rs
+++ b/crates/inference_providers/src/attested/nearai/fleet.rs
@@ -79,10 +79,9 @@ pub(super) struct Fleet {
     /// that don't fit the rotation scheme (one-label host, IP literal, …) — then
     /// rotation is a no-op and the canonical-SNI path is used.
     rotation_parts: Option<rotation::UrlParts>,
-    /// Message-prefix trie mapping a conversation prefix to a bucket id, so
-    /// requests sharing a prefix stick to the same backend (prefix-cache hit).
-    /// The bucket id is reduced modulo the live backend count to a rotation
-    /// index by `select_index`.
+    /// Stateless first-message router. Its stable key is reduced modulo the
+    /// live backend count by `select_index`, so every Cloud API process sends a
+    /// reusable prefix to the same indexed backend.
     pub(super) prefix_router: Arc<PrefixRouter>,
     /// Lazily-filled (or eagerly pre-created in legacy mode) per-backend-index
     /// clients, each pinning a persistent H2 connection to one verified
@@ -163,18 +162,15 @@ impl Fleet {
     /// is logged, the completion still streams). This matches the pre-existing
     /// rotation-fallback behavior; it is not introduced by index-addressing.
     ///
-    /// Reachability: `prefix_router.route()` returns a bucket id in
-    /// `0..NUM_PREFIX_BUCKETS` (default 64), reduced mod `count`. When `count >
-    /// NUM_PREFIX_BUCKETS` (more than 64 live backends for one model — far above
-    /// any current deployment) the high indices are unreachable as the
-    /// *preferred* pick, though latency steering / fallback can still reach
-    /// them. Raise `NUM_PREFIX_BUCKETS` if a model ever exceeds 64 backends.
+    /// Reachability: `prefix_router.route()` returns a deterministic `u64`
+    /// derived from the first message. Reducing it modulo `count` makes every
+    /// live backend index reachable without process-local routing state.
     pub(super) fn select_index(&self, messages: &[crate::ChatMessage]) -> Option<usize> {
         let count = self.rotation_count();
         if count == 0 {
             return None;
         }
-        let preferred = self.prefix_router.route(messages) % count;
+        let preferred = (self.prefix_router.route(messages) % count as u64) as usize;
         let stats = lock(&self.backend_stats);
         // Warmed EMA for index `i`, or None if out of range / not yet warmed.
         // `.get()` keeps this panic-free regardless of how `count` relates to

--- a/crates/inference_providers/src/attested/nearai/fleet.rs
+++ b/crates/inference_providers/src/attested/nearai/fleet.rs
@@ -18,6 +18,8 @@ use crate::rotation;
 use crate::spki_verifier::FingerprintState;
 use crate::BackendVerifier;
 use reqwest::Client;
+use sha2::{Digest, Sha256};
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
@@ -32,11 +34,11 @@ pub(super) const TTFT_WARMUP_SAMPLES: u32 = 8;
 /// fastest peer's EMA AND the absolute floor below.
 const TTFT_SLOW_RATIO: f64 = 2.0;
 const TTFT_SLOW_FLOOR_MS: f64 = 500.0;
-/// Keep a small burst for a reusable prefix on its deterministic primary
-/// before spilling overlapping requests to the next backend. This preserves a
-/// single cache copy for ordinary traffic while preventing one hot prefix from
-/// monopolizing a replica. The counter is process-local and tracks only live
-/// requests; it never stores message content.
+/// Keep a small first-turn burst for a reusable prefix on its deterministic
+/// primary before spilling overlapping requests to another backend. This
+/// preserves a single cache copy for ordinary traffic while preventing one hot
+/// prefix from monopolizing a replica. The counter is process-local and tracks
+/// only live requests; it never stores message content.
 const PREFIX_AFFINITY_BURST: u32 = 4;
 
 #[derive(Default, Clone, Copy)]
@@ -73,8 +75,8 @@ fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
 
 type PrefixLoads = HashMap<u64, Vec<u32>>;
 
-/// Reservation for one live prefix-routed request. Releasing is RAII-based so
-/// cancellation, errors, and dropped streams cannot leak routing load.
+/// Reservation for one live affinity-routed request. Releasing is RAII-based
+/// so cancellation, errors, and dropped streams cannot leak routing load.
 pub(super) struct RouteLease {
     route_key: u64,
     index: usize,
@@ -122,9 +124,9 @@ pub(super) struct Fleet {
     /// that don't fit the rotation scheme (one-label host, IP literal, …) — then
     /// rotation is a no-op and the canonical-SNI path is used.
     rotation_parts: Option<rotation::UrlParts>,
-    /// Stateless first-message router. Its stable key is reduced modulo the
-    /// live backend count, so every Cloud API process gives a reusable prefix
-    /// the same primary backend; only overlapping hot-prefix bursts may spill.
+    /// Stateless prefix/conversation router. Stable keys are reduced modulo the
+    /// live backend count, so every Cloud API process agrees on first-turn
+    /// prefix primaries and established-conversation homes.
     pub(super) prefix_router: Arc<PrefixRouter>,
     /// Lazily-filled (or eagerly pre-created in legacy mode) per-backend-index
     /// clients, each pinning a persistent H2 connection to one verified
@@ -210,33 +212,41 @@ impl Fleet {
     /// is logged, the completion still streams). This matches the pre-existing
     /// rotation-fallback behavior; it is not introduced by index-addressing.
     ///
-    /// Reachability: `prefix_router.route()` returns a deterministic `u64`
-    /// derived from the first message. Reducing it modulo `count` makes every
-    /// live backend index reachable as the stateless primary. Process-local
-    /// state affects only temporary spillover while requests overlap.
+    /// Reachability: the prefix or conversation router returns a deterministic
+    /// `u64`. Reducing it modulo `count` makes every live backend index
+    /// reachable as the stateless primary. Process-local state affects only
+    /// temporary first-turn spillover while requests overlap.
     #[cfg(test)]
     pub(super) fn select_index(&self, messages: &[crate::ChatMessage]) -> Option<usize> {
         let count = self.rotation_count();
         if count == 0 {
             return None;
         }
-        let route_key = self.prefix_router.route(messages);
+        let route_key = self.route_key(messages);
         self.candidate_indices(route_key, count).into_iter().next()
     }
 
-    /// Reserve a backend for this request. A reusable prefix stays on its
-    /// deterministic primary for a small burst, then overlapping requests
-    /// spill across the remaining healthy indices in deterministic order.
+    /// Reserve a backend for this request.
+    ///
+    /// Initial requests keep reusable-prefix affinity with bounded,
+    /// key-decorrelated spillover. Once assistant or tool history is present,
+    /// the stable first two messages select a conversation home instead. That
+    /// allows at most one deterministic handoff after the first turn and keeps
+    /// all later growing-history requests on the same backend.
     pub(super) fn acquire_index(&self, messages: &[crate::ChatMessage]) -> Option<RouteLease> {
         let count = self.rotation_count();
         if count == 0 {
             return None;
         }
-        let route_key = self.prefix_router.route(messages);
+        let has_history = has_conversation_history(messages);
+        let route_key = self.route_key(messages);
         if messages.is_empty() {
             return Some(self.reserve_index(route_key, 0));
         }
         let candidates = self.candidate_indices(route_key, count);
+        if has_history {
+            return Some(self.reserve_index(route_key, candidates[0]));
+        }
         let mut loads = lock(&self.prefix_loads);
         let counts = loads.entry(route_key).or_insert_with(|| vec![0; count]);
         if counts.len() < count {
@@ -284,7 +294,15 @@ impl Fleet {
         lock(&self.prefix_loads).len()
     }
 
-    fn candidate_indices(&self, route_key: u64, count: usize) -> Vec<usize> {
+    fn route_key(&self, messages: &[crate::ChatMessage]) -> u64 {
+        if has_conversation_history(messages) {
+            self.prefix_router.route_conversation(messages)
+        } else {
+            self.prefix_router.route(messages)
+        }
+    }
+
+    pub(super) fn candidate_indices(&self, route_key: u64, count: usize) -> Vec<usize> {
         let preferred = (route_key % count as u64) as usize;
         let stats = lock(&self.backend_stats);
         // Warmed EMA for index `i`, or None if out of range / not yet warmed.
@@ -304,10 +322,17 @@ impl Fleet {
                     && value > TTFT_SLOW_RATIO * min_warm
             })
         };
-        let mut candidates: Vec<usize> = (0..count)
-            .map(|offset| (preferred + offset) % count)
-            .filter(|index| !is_slow(*index))
-            .collect();
+        let mut candidates: Vec<usize> = (0..count).filter(|index| !is_slow(*index)).collect();
+        // Preserve the modulo primary, but give each colliding routing key a
+        // different deterministic spill order. A simple ring makes all keys
+        // with the same primary pile onto the same secondary under pressure.
+        candidates.sort_by_key(|index| {
+            (
+                *index != preferred,
+                Reverse(route_index_score(route_key, *index)),
+                *index,
+            )
+        });
         if candidates.is_empty() {
             candidates.push(preferred);
         } else if is_slow(preferred) {
@@ -437,4 +462,25 @@ impl Fleet {
     pub(super) fn backend_count(&self) -> usize {
         self.last_backend_count.load(Ordering::Relaxed)
     }
+}
+
+fn has_conversation_history(messages: &[crate::ChatMessage]) -> bool {
+    messages.iter().skip(1).any(|message| {
+        matches!(
+            message.role,
+            crate::MessageRole::Assistant | crate::MessageRole::Tool
+        )
+    })
+}
+
+fn route_index_score(route_key: u64, index: usize) -> u64 {
+    let mut hasher = Sha256::new();
+    hasher.update(route_key.to_be_bytes());
+    hasher.update((index as u64).to_be_bytes());
+    let digest = hasher.finalize();
+    u64::from_be_bytes(
+        digest[..8]
+            .try_into()
+            .expect("SHA-256 digest always contains eight bytes"),
+    )
 }

--- a/crates/inference_providers/src/attested/nearai/fleet.rs
+++ b/crates/inference_providers/src/attested/nearai/fleet.rs
@@ -32,6 +32,12 @@ pub(super) const TTFT_WARMUP_SAMPLES: u32 = 8;
 /// fastest peer's EMA AND the absolute floor below.
 const TTFT_SLOW_RATIO: f64 = 2.0;
 const TTFT_SLOW_FLOOR_MS: f64 = 500.0;
+/// Keep a small burst for a reusable prefix on its deterministic primary
+/// before spilling overlapping requests to the next backend. This preserves a
+/// single cache copy for ordinary traffic while preventing one hot prefix from
+/// monopolizing a replica. The counter is process-local and tracks only live
+/// requests; it never stores message content.
+const PREFIX_AFFINITY_BURST: u32 = 4;
 
 #[derive(Default, Clone, Copy)]
 pub(super) struct BackendStat {
@@ -65,6 +71,43 @@ fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
     m.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+type PrefixLoads = HashMap<u64, Vec<u32>>;
+
+/// Reservation for one live prefix-routed request. Releasing is RAII-based so
+/// cancellation, errors, and dropped streams cannot leak routing load.
+pub(super) struct RouteLease {
+    route_key: u64,
+    index: usize,
+    prefix_loads: Arc<Mutex<PrefixLoads>>,
+}
+
+impl RouteLease {
+    pub(super) fn index(&self) -> usize {
+        self.index
+    }
+
+    pub(super) fn route_key(&self) -> u64 {
+        self.route_key
+    }
+}
+
+impl Drop for RouteLease {
+    fn drop(&mut self) {
+        let mut loads = lock(&self.prefix_loads);
+        let remove = if let Some(counts) = loads.get_mut(&self.route_key) {
+            if let Some(count) = counts.get_mut(self.index) {
+                *count = count.saturating_sub(1);
+            }
+            counts.iter().all(|count| *count == 0)
+        } else {
+            false
+        };
+        if remove {
+            loads.remove(&self.route_key);
+        }
+    }
+}
+
 pub(super) struct Fleet {
     /// request_hash → rotation index during streaming (before the chat_id is
     /// known). Universal completion→signature index map for the streaming path.
@@ -80,8 +123,8 @@ pub(super) struct Fleet {
     /// rotation is a no-op and the canonical-SNI path is used.
     rotation_parts: Option<rotation::UrlParts>,
     /// Stateless first-message router. Its stable key is reduced modulo the
-    /// live backend count by `select_index`, so every Cloud API process sends a
-    /// reusable prefix to the same indexed backend.
+    /// live backend count, so every Cloud API process gives a reusable prefix
+    /// the same primary backend; only overlapping hot-prefix bursts may spill.
     pub(super) prefix_router: Arc<PrefixRouter>,
     /// Lazily-filled (or eagerly pre-created in legacy mode) per-backend-index
     /// clients, each pinning a persistent H2 connection to one verified
@@ -93,6 +136,9 @@ pub(super) struct Fleet {
     /// index. Arc so the stream-measurement wrapper can update it after the
     /// Fleet method returns. Sized to MAX_FANOUT.
     pub(super) backend_stats: Arc<Mutex<Vec<BackendStat>>>,
+    /// Live request counts by routing key and backend index. Entries exist only
+    /// while a request is in flight and contain no prompt or response content.
+    prefix_loads: Arc<Mutex<PrefixLoads>>,
     /// Provider config (base_url, api_key, timeouts).
     pub(super) config: Config,
     /// General-purpose client for non-completion requests (attestation, models).
@@ -134,6 +180,7 @@ impl Fleet {
                 BackendStat::default();
                 rotation::MAX_FANOUT
             ])),
+            prefix_loads: Arc::new(Mutex::new(HashMap::new())),
             config,
             client,
             fallback_client,
@@ -143,11 +190,12 @@ impl Fleet {
         }
     }
 
-    /// Select the backend rotation index for a request: prefix-affinity
-    /// (same prefix → same backend → KV-cache hit) with preemptive latency
-    /// steering away from a backend whose TTFT EMA is pathological. Returns
-    /// `None` when rotation is unavailable (count==0 / no rotation parts) →
-    /// caller uses the canonical fallback path.
+    /// Select the idle preferred backend for a request: deterministic
+    /// prefix-affinity with preemptive latency steering away from a backend
+    /// whose TTFT EMA is pathological. The live request path uses
+    /// `acquire_index`, which starts here and adds bounded hot-prefix spillover.
+    /// Returns `None` when rotation is unavailable (count==0 / no rotation
+    /// parts), so the caller uses the canonical fallback path.
     ///
     /// Index↔backend stability: `<canonical>-iN` routes to backend `N % count`
     /// at model-proxy by SNI (independent of which TCP connection we use), so a
@@ -164,13 +212,80 @@ impl Fleet {
     ///
     /// Reachability: `prefix_router.route()` returns a deterministic `u64`
     /// derived from the first message. Reducing it modulo `count` makes every
-    /// live backend index reachable without process-local routing state.
+    /// live backend index reachable as the stateless primary. Process-local
+    /// state affects only temporary spillover while requests overlap.
+    #[cfg(test)]
     pub(super) fn select_index(&self, messages: &[crate::ChatMessage]) -> Option<usize> {
         let count = self.rotation_count();
         if count == 0 {
             return None;
         }
-        let preferred = (self.prefix_router.route(messages) % count as u64) as usize;
+        let route_key = self.prefix_router.route(messages);
+        self.candidate_indices(route_key, count).into_iter().next()
+    }
+
+    /// Reserve a backend for this request. A reusable prefix stays on its
+    /// deterministic primary for a small burst, then overlapping requests
+    /// spill across the remaining healthy indices in deterministic order.
+    pub(super) fn acquire_index(&self, messages: &[crate::ChatMessage]) -> Option<RouteLease> {
+        let count = self.rotation_count();
+        if count == 0 {
+            return None;
+        }
+        let route_key = self.prefix_router.route(messages);
+        if messages.is_empty() {
+            return Some(self.reserve_index(route_key, 0));
+        }
+        let candidates = self.candidate_indices(route_key, count);
+        let mut loads = lock(&self.prefix_loads);
+        let counts = loads.entry(route_key).or_insert_with(|| vec![0; count]);
+        if counts.len() < count {
+            counts.resize(count, 0);
+        }
+        let index = candidates
+            .iter()
+            .copied()
+            .find(|index| counts[*index] < PREFIX_AFFINITY_BURST)
+            .unwrap_or_else(|| {
+                candidates
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(rank, index)| (counts[**index], *rank))
+                    .map(|(_, index)| *index)
+                    .expect("rotation count is non-zero")
+            });
+        counts[index] = counts[index].saturating_add(1);
+        drop(loads);
+        Some(RouteLease {
+            route_key,
+            index,
+            prefix_loads: self.prefix_loads.clone(),
+        })
+    }
+
+    /// Reserve an explicit fallback index for the same prefix key.
+    pub(super) fn reserve_index(&self, route_key: u64, index: usize) -> RouteLease {
+        let mut loads = lock(&self.prefix_loads);
+        let counts = loads.entry(route_key).or_default();
+        if counts.len() <= index {
+            counts.resize(index + 1, 0);
+        }
+        counts[index] = counts[index].saturating_add(1);
+        drop(loads);
+        RouteLease {
+            route_key,
+            index,
+            prefix_loads: self.prefix_loads.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_prefix_loads(&self) -> usize {
+        lock(&self.prefix_loads).len()
+    }
+
+    fn candidate_indices(&self, route_key: u64, count: usize) -> Vec<usize> {
+        let preferred = (route_key % count as u64) as usize;
         let stats = lock(&self.backend_stats);
         // Warmed EMA for index `i`, or None if out of range / not yet warmed.
         // `.get()` keeps this panic-free regardless of how `count` relates to
@@ -182,26 +297,33 @@ impl Fleet {
                 .map(|s| s.ttft_ewma_ms)
         };
         let min_warm = (0..count).filter_map(ema).fold(f64::MAX, f64::min);
-        if let Some(pref_ema) = ema(preferred) {
-            if pref_ema > TTFT_SLOW_FLOOR_MS
-                && min_warm.is_finite()
-                && pref_ema > TTFT_SLOW_RATIO * min_warm
-            {
-                // Steer to the fastest warmed backend; ties/unwarmed keep preferred.
-                let mut best = preferred;
-                let mut best_ms = pref_ema;
-                for i in 0..count {
-                    if let Some(e) = ema(i) {
-                        if e < best_ms {
-                            best = i;
-                            best_ms = e;
-                        }
-                    }
-                }
-                return Some(best);
+        let is_slow = |index: usize| {
+            ema(index).is_some_and(|value| {
+                value > TTFT_SLOW_FLOOR_MS
+                    && min_warm.is_finite()
+                    && value > TTFT_SLOW_RATIO * min_warm
+            })
+        };
+        let mut candidates: Vec<usize> = (0..count)
+            .map(|offset| (preferred + offset) % count)
+            .filter(|index| !is_slow(*index))
+            .collect();
+        if candidates.is_empty() {
+            candidates.push(preferred);
+        } else if is_slow(preferred) {
+            // Preserve the existing behavior: when the deterministic primary
+            // is pathological, lead with the fastest warmed healthy backend.
+            if let Some(fastest) = candidates.iter().copied().min_by(|a, b| {
+                ema(*a)
+                    .unwrap_or(f64::MAX)
+                    .partial_cmp(&ema(*b).unwrap_or(f64::MAX))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }) {
+                candidates.retain(|index| *index != fastest);
+                candidates.insert(0, fastest);
             }
         }
-        Some(preferred)
+        candidates
     }
 
     /// Record an observed TTFT (ms) for a backend index into its EMA.

--- a/crates/inference_providers/src/attested/nearai/mod.rs
+++ b/crates/inference_providers/src/attested/nearai/mod.rs
@@ -4104,7 +4104,7 @@ mod tests {
         // `prefix_router.route(messages) % count`.
         let provider = rotation_provider(8);
         let msgs = vec![user_msg("a stable system prompt")];
-        let expected = provider.fleet.prefix_router.route(&msgs) % 8;
+        let expected = (provider.fleet.prefix_router.route(&msgs) % 8) as usize;
         let got = provider.fleet.select_index(&msgs).expect("rotation active");
         assert_eq!(got, expected);
         // Deterministic / stable across calls (same prefix → same backend).
@@ -4112,10 +4112,29 @@ mod tests {
     }
 
     #[test]
+    fn select_index_is_stable_across_provider_histories() {
+        let provider_a = rotation_provider(3);
+        let provider_b = rotation_provider(3);
+
+        for index in 0..100 {
+            let message_a = vec![user_msg(&format!("provider-a-prefix-{index}"))];
+            let message_b = vec![user_msg(&format!("provider-b-prefix-{}", 100 - index))];
+            provider_a.fleet.select_index(&message_a);
+            provider_b.fleet.select_index(&message_b);
+        }
+
+        let shared = vec![user_msg("shared prefix across Cloud API processes")];
+        assert_eq!(
+            provider_a.fleet.select_index(&shared),
+            provider_b.fleet.select_index(&shared)
+        );
+    }
+
+    #[test]
     fn select_index_steers_off_pathologically_slow_preferred_backend() {
         let provider = rotation_provider(4);
         let msgs = vec![user_msg("route me")];
-        let preferred = provider.fleet.prefix_router.route(&msgs) % 4;
+        let preferred = (provider.fleet.prefix_router.route(&msgs) % 4) as usize;
 
         // Warm the preferred backend as pathologically slow (>floor and >2× the
         // fastest), and a different backend as fast. Pick the fast index to be
@@ -4134,7 +4153,7 @@ mod tests {
 
         // Below the slow ratio (only ~1.5× the fast peer) → keep affinity.
         let provider2 = rotation_provider(4);
-        let preferred2 = provider2.fleet.prefix_router.route(&msgs) % 4;
+        let preferred2 = (provider2.fleet.prefix_router.route(&msgs) % 4) as usize;
         let other2 = (preferred2 + 1) % 4;
         for _ in 0..super::fleet::TTFT_WARMUP_SAMPLES {
             provider2.fleet.record_ttft(preferred2, 900.0);

--- a/crates/inference_providers/src/attested/nearai/mod.rs
+++ b/crates/inference_providers/src/attested/nearai/mod.rs
@@ -910,6 +910,7 @@ impl Fleet {
     async fn try_chat_completion_fallback_indices(
         &self,
         indices: &[usize],
+        route_key: u64,
         params: &ChatCompletionParams,
         headers: &reqwest::header::HeaderMap,
         timeout: Duration,
@@ -930,6 +931,7 @@ impl Fleet {
                 Some(u) => u,
                 None => continue,
             };
+            let _route_lease = self.reserve_index(route_key, index);
             let client = match self.get_or_verify_index_client(index).await {
                 Ok(c) => c,
                 Err(e) => {
@@ -1038,6 +1040,7 @@ impl Fleet {
     async fn try_stream_fallback_indices(
         &self,
         indices: &[usize],
+        route_key: u64,
         params: &ChatCompletionParams,
         headers: &reqwest::header::HeaderMap,
         request_hash: &str,
@@ -1057,6 +1060,7 @@ impl Fleet {
                 Some(u) => u,
                 None => continue,
             };
+            let route_lease = self.reserve_index(route_key, index);
             let client = match self.get_or_verify_index_client(index).await {
                 Ok(c) => c,
                 Err(e) => {
@@ -1140,6 +1144,7 @@ impl Fleet {
                 self.backend_stats.clone(),
                 index,
                 started,
+                Some(route_lease),
             ));
             return Ok(probed);
         }
@@ -1209,6 +1214,9 @@ struct TtftProbe<S> {
     index: usize,
     /// Send instant; `None` once the first content TTFT has been recorded.
     start: Option<std::time::Instant>,
+    /// Keeps this backend counted as live until the stream completes or the
+    /// caller drops it. `None` is used only by focused unit tests.
+    _route_lease: Option<fleet::RouteLease>,
 }
 
 impl<S> TtftProbe<S> {
@@ -1217,12 +1225,14 @@ impl<S> TtftProbe<S> {
         stats: Arc<std::sync::Mutex<Vec<fleet::BackendStat>>>,
         index: usize,
         start: std::time::Instant,
+        route_lease: Option<fleet::RouteLease>,
     ) -> Self {
         Self {
             inner,
             stats,
             index,
             start: Some(start),
+            _route_lease: route_lease,
         }
     }
 }
@@ -1251,6 +1261,8 @@ where
                     }
                 }
             }
+        } else if matches!(polled, std::task::Poll::Ready(None)) {
+            self._route_lease.take();
         }
         polled
     }
@@ -1703,13 +1715,14 @@ impl InferenceProvider for Fleet {
         // Prepare encryption headers
         self.prepare_encryption_headers(&mut headers, &mut streaming_params.extra);
 
-        // Select the backend rotation index: prefix affinity → same backend →
-        // prefix cache hit, with latency steering off a pathologically slow
-        // backend. `None` means rotation is unavailable (cold-start before
-        // discovery's first count, or a non-rotation URL like `localhost`) —
-        // serve via the canonical fallback path (no index, no per-backend
-        // measurement) so those paths keep working unchanged.
-        let index = match self.select_index(&streaming_params.messages) {
+        // Reserve a backend rotation index: deterministic prefix affinity keeps
+        // the normal path cache-hot, a small per-prefix burst may spill across
+        // healthy replicas, and TTFT steering excludes pathological backends.
+        // `None` means rotation is unavailable (cold-start before discovery's
+        // first count, or a non-rotation URL like `localhost`) — serve via the
+        // canonical fallback path (no index, no per-backend measurement) so
+        // those paths keep working unchanged.
+        let route_lease = match self.acquire_index(&streaming_params.messages) {
             None => {
                 let url = format!("{}/v1/chat/completions", self.config.base_url);
                 let response = self
@@ -1723,8 +1736,10 @@ impl InferenceProvider for Fleet {
                 let sse_stream = new_sse_parser(response.bytes_stream(), true);
                 return Ok(Box::pin(sse_stream));
             }
-            Some(i) => i,
+            Some(lease) => lease,
         };
+        let index = route_lease.index();
+        let route_key = route_lease.route_key();
 
         // The index client maintains a persistent H2 connection to a verified
         // backend (`<canonical>-i<index>.<base>`) via L4 passthrough → prefix
@@ -1788,13 +1803,16 @@ impl InferenceProvider for Fleet {
                             self.backend_stats.clone(),
                             index,
                             started,
+                            Some(route_lease),
                         ));
                         Ok(probed)
                     }
                     Some(status_code) => {
                         drop(stream);
+                        drop(route_lease);
                         self.try_stream_fallback_indices(
                             &self.fallback_indices(index),
+                            route_key,
                             &streaming_params,
                             &headers,
                             &request_hash,
@@ -1812,8 +1830,10 @@ impl InferenceProvider for Fleet {
                 CompletionError::HttpError { status_code, .. }
                     if Fleet::is_rotation_retryable_status(*status_code) =>
                 {
+                    drop(route_lease);
                     self.try_stream_fallback_indices(
                         &self.fallback_indices(index),
+                        route_key,
                         &streaming_params,
                         &headers,
                         &request_hash,
@@ -1867,10 +1887,11 @@ impl InferenceProvider for Fleet {
             }
         };
 
-        // Select the backend rotation index (prefix affinity + latency
-        // steering). `None` → canonical fallback path (cold-start / non-rotation
-        // URL): one shot via the non-pinned fallback client, no index recorded.
-        let index = match self.select_index(&non_streaming_params.messages) {
+        // Reserve the backend rotation index (deterministic prefix affinity,
+        // bounded hot-prefix spillover, and latency steering). `None` →
+        // canonical fallback path (cold-start / non-rotation URL): one shot via
+        // the non-pinned fallback client, no index recorded.
+        let route_lease = match self.acquire_index(&non_streaming_params.messages) {
             None => {
                 let url = format!("{}/v1/chat/completions", self.config.base_url);
                 let response = self
@@ -1905,8 +1926,10 @@ impl InferenceProvider for Fleet {
                     serving_tier: crate::ProviderTier::Near,
                 });
             }
-            Some(i) => i,
+            Some(lease) => lease,
         };
+        let index = route_lease.index();
+        let route_key = route_lease.route_key();
 
         // Route to the index's verified client, posting at the index's rotation
         // SNI so completion + signature land on the same backend.
@@ -1968,9 +1991,11 @@ impl InferenceProvider for Fleet {
             // the request succeeds and we record the index for signature
             // retrieval.
             if Fleet::is_rotation_retryable_status(status_code) {
+                drop(route_lease);
                 return self
                     .try_chat_completion_fallback_indices(
                         &self.fallback_indices(index),
+                        route_key,
                         &non_streaming_params,
                         &headers,
                         timeout,
@@ -4131,6 +4156,222 @@ mod tests {
     }
 
     #[test]
+    fn acquire_index_keeps_a_small_burst_then_spills_deterministically() {
+        let provider = rotation_provider(3);
+        let messages = vec![user_msg("shared hot prefix")];
+        let primary = provider
+            .fleet
+            .select_index(&messages)
+            .expect("rotation active");
+        let second = (primary + 1) % 3;
+        let third = (primary + 2) % 3;
+
+        let leases: Vec<_> = (0..9)
+            .map(|_| {
+                provider
+                    .fleet
+                    .acquire_index(&messages)
+                    .expect("rotation active")
+            })
+            .collect();
+        let indices: Vec<_> = leases.iter().map(|lease| lease.index()).collect();
+        assert_eq!(&indices[..4], &[primary; 4]);
+        assert_eq!(&indices[4..8], &[second; 4]);
+        assert_eq!(indices[8], third);
+        assert_eq!(provider.fleet.active_prefix_loads(), 1);
+
+        drop(leases);
+        assert_eq!(provider.fleet.active_prefix_loads(), 0);
+        let after_release = provider
+            .fleet
+            .acquire_index(&messages)
+            .expect("rotation active");
+        assert_eq!(after_release.index(), primary);
+    }
+
+    #[test]
+    fn acquire_index_scopes_live_load_to_each_prefix() {
+        let provider = rotation_provider(3);
+        let first = vec![user_msg("first prefix")];
+        let second = vec![user_msg("unrelated prefix")];
+        let second_primary = provider
+            .fleet
+            .select_index(&second)
+            .expect("rotation active");
+
+        let held: Vec<_> = (0..8)
+            .map(|_| {
+                provider
+                    .fleet
+                    .acquire_index(&first)
+                    .expect("rotation active")
+            })
+            .collect();
+        let unrelated = provider
+            .fleet
+            .acquire_index(&second)
+            .expect("rotation active");
+
+        assert_eq!(unrelated.index(), second_primary);
+        drop(unrelated);
+        drop(held);
+        assert_eq!(provider.fleet.active_prefix_loads(), 0);
+    }
+
+    #[test]
+    fn acquire_index_is_deterministic_across_independent_fleets() {
+        let provider_a = rotation_provider(3);
+        let provider_b = rotation_provider(3);
+        let messages = vec![user_msg("shared prefix across processes")];
+
+        let leases_a: Vec<_> = (0..12)
+            .map(|_| {
+                provider_a
+                    .fleet
+                    .acquire_index(&messages)
+                    .expect("rotation active")
+            })
+            .collect();
+        let leases_b: Vec<_> = (0..12)
+            .map(|_| {
+                provider_b
+                    .fleet
+                    .acquire_index(&messages)
+                    .expect("rotation active")
+            })
+            .collect();
+
+        assert_eq!(
+            leases_a
+                .iter()
+                .map(|lease| lease.index())
+                .collect::<Vec<_>>(),
+            leases_b
+                .iter()
+                .map(|lease| lease.index())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn acquire_index_respects_backend_counts_one_through_four() {
+        let messages = vec![user_msg("backend count coverage")];
+        for count in 1..=4 {
+            let provider = rotation_provider(count);
+            let leases: Vec<_> = (0..20)
+                .map(|_| {
+                    provider
+                        .fleet
+                        .acquire_index(&messages)
+                        .expect("rotation active")
+                })
+                .collect();
+            assert!(leases.iter().all(|lease| lease.index() < count));
+            if count > 1 {
+                assert!(
+                    leases
+                        .iter()
+                        .map(|lease| lease.index())
+                        .collect::<std::collections::HashSet<_>>()
+                        .len()
+                        > 1
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn acquire_index_tolerates_backend_count_changes_with_live_leases() {
+        let provider = rotation_provider(3);
+        let messages = vec![user_msg("topology change prefix")];
+        let held: Vec<_> = (0..9)
+            .map(|_| {
+                provider
+                    .fleet
+                    .acquire_index(&messages)
+                    .expect("rotation active")
+            })
+            .collect();
+
+        provider.set_backend_count(2);
+        let after_shrink: Vec<_> = (0..8)
+            .map(|_| {
+                provider
+                    .fleet
+                    .acquire_index(&messages)
+                    .expect("rotation active")
+            })
+            .collect();
+        assert!(after_shrink.iter().all(|lease| lease.index() < 2));
+
+        provider.set_backend_count(4);
+        let after_growth: Vec<_> = (0..16)
+            .map(|_| {
+                provider
+                    .fleet
+                    .acquire_index(&messages)
+                    .expect("rotation active")
+            })
+            .collect();
+        assert!(after_growth.iter().all(|lease| lease.index() < 4));
+
+        drop(after_growth);
+        drop(after_shrink);
+        drop(held);
+        assert_eq!(provider.fleet.active_prefix_loads(), 0);
+    }
+
+    #[test]
+    fn acquire_index_is_thread_safe_and_balances_a_sustained_hot_prefix() {
+        use std::sync::{Arc, Barrier};
+
+        let provider = rotation_provider(3);
+        let fleet = provider.fleet.clone();
+        let messages = Arc::new(vec![user_msg("concurrent hot prefix")]);
+        let acquired = Arc::new(Barrier::new(13));
+        let release = Arc::new(Barrier::new(13));
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let workers: Vec<_> = (0..12)
+            .map(|_| {
+                let fleet = fleet.clone();
+                let messages = messages.clone();
+                let acquired = acquired.clone();
+                let release = release.clone();
+                let sender = sender.clone();
+                std::thread::spawn(move || {
+                    let lease = fleet.acquire_index(&messages).expect("rotation active");
+                    sender.send(lease.index()).expect("send selected index");
+                    acquired.wait();
+                    release.wait();
+                    drop(lease);
+                })
+            })
+            .collect();
+        drop(sender);
+
+        acquired.wait();
+        let mut counts = [0usize; 3];
+        for index in receiver.iter().take(12) {
+            counts[index] += 1;
+        }
+        assert_eq!(counts, [4, 4, 4]);
+        release.wait();
+        for worker in workers {
+            worker.join().expect("routing worker should not panic");
+        }
+        assert_eq!(fleet.active_prefix_loads(), 0);
+    }
+
+    #[test]
+    fn acquire_index_keeps_empty_messages_on_zero() {
+        let provider = rotation_provider(4);
+        let leases: Vec<_> = (0..20)
+            .map(|_| provider.fleet.acquire_index(&[]).expect("rotation active"))
+            .collect();
+        assert!(leases.iter().all(|lease| lease.index() == 0));
+    }
+
+    #[test]
     fn select_index_steers_off_pathologically_slow_preferred_backend() {
         let provider = rotation_provider(4);
         let msgs = vec![user_msg("route me")];
@@ -4164,6 +4405,17 @@ mod tests {
             Some(preferred2),
             "below the 2x slow ratio, prefix affinity wins"
         );
+
+        // Load spillover must not reintroduce the pathological backend.
+        let leases: Vec<_> = (0..32)
+            .map(|_| {
+                provider
+                    .fleet
+                    .acquire_index(&msgs)
+                    .expect("rotation active")
+            })
+            .collect();
+        assert!(leases.iter().all(|lease| lease.index() != preferred));
     }
 
     #[test]
@@ -4323,7 +4575,7 @@ mod tests {
         // (a 0ms reading is dropped by the EMA guard) — deterministic regardless
         // of how fast the test polls.
         let start = std::time::Instant::now() - std::time::Duration::from_millis(5);
-        let probe = TtftProbe::new(inner, stats.clone(), index, start);
+        let probe = TtftProbe::new(inner, stats.clone(), index, start, None);
         tokio::pin!(probe);
         let mut count = 0;
         while let Some(_ev) = probe.next().await {
@@ -4336,6 +4588,31 @@ mod tests {
             "exactly one TTFT sample recorded on the first content chunk"
         );
         assert!(s.ttft_ewma_ms >= 0.0);
+    }
+
+    #[tokio::test]
+    async fn ttft_probe_releases_route_lease_at_end_of_stream() {
+        use tokio_stream::StreamExt;
+
+        let provider = rotation_provider(3);
+        let messages = vec![user_msg("streamed prefix")];
+        let lease = provider
+            .fleet
+            .acquire_index(&messages)
+            .expect("rotation active");
+        assert_eq!(provider.fleet.active_prefix_loads(), 1);
+        let inner: StreamingResult = Box::pin(futures_util::stream::empty());
+        let probe = TtftProbe::new(
+            inner,
+            provider.fleet.backend_stats.clone(),
+            lease.index(),
+            std::time::Instant::now(),
+            Some(lease),
+        );
+        tokio::pin!(probe);
+
+        assert!(probe.next().await.is_none());
+        assert_eq!(provider.fleet.active_prefix_loads(), 0);
     }
 
     #[test]

--- a/crates/inference_providers/src/attested/nearai/mod.rs
+++ b/crates/inference_providers/src/attested/nearai/mod.rs
@@ -1716,8 +1716,8 @@ impl InferenceProvider for Fleet {
         self.prepare_encryption_headers(&mut headers, &mut streaming_params.extra);
 
         // Reserve a backend rotation index: deterministic prefix affinity keeps
-        // the normal path cache-hot, a small per-prefix burst may spill across
-        // healthy replicas, and TTFT steering excludes pathological backends.
+        // initial requests cache-hot, established conversations stay on a
+        // stable home, and TTFT steering excludes pathological backends.
         // `None` means rotation is unavailable (cold-start before discovery's
         // first count, or a non-rotation URL like `localhost`) — serve via the
         // canonical fallback path (no index, no per-backend measurement) so
@@ -1887,10 +1887,10 @@ impl InferenceProvider for Fleet {
             }
         };
 
-        // Reserve the backend rotation index (deterministic prefix affinity,
-        // bounded hot-prefix spillover, and latency steering). `None` →
-        // canonical fallback path (cold-start / non-rotation URL): one shot via
-        // the non-pinned fallback client, no index recorded.
+        // Reserve the backend rotation index (deterministic first-turn prefix
+        // affinity, stable conversation homes, and latency steering). `None`
+        // → canonical fallback path (cold-start / non-rotation URL): one shot
+        // via the non-pinned fallback client, no index recorded.
         let route_lease = match self.acquire_index(&non_streaming_params.messages) {
             None => {
                 let url = format!("{}/v1/chat/completions", self.config.base_url);
@@ -4105,8 +4105,12 @@ mod tests {
     }
 
     fn user_msg(content: &str) -> crate::ChatMessage {
+        role_msg(crate::MessageRole::User, content)
+    }
+
+    fn role_msg(role: crate::MessageRole, content: &str) -> crate::ChatMessage {
         crate::ChatMessage {
-            role: crate::MessageRole::User,
+            role,
             content: Some(serde_json::Value::String(content.to_string())),
             name: None,
             tool_call_id: None,
@@ -4163,8 +4167,6 @@ mod tests {
             .fleet
             .select_index(&messages)
             .expect("rotation active");
-        let second = (primary + 1) % 3;
-        let third = (primary + 2) % 3;
 
         let leases: Vec<_> = (0..9)
             .map(|_| {
@@ -4176,8 +4178,10 @@ mod tests {
             .collect();
         let indices: Vec<_> = leases.iter().map(|lease| lease.index()).collect();
         assert_eq!(&indices[..4], &[primary; 4]);
-        assert_eq!(&indices[4..8], &[second; 4]);
-        assert_eq!(indices[8], third);
+        assert!(indices[4..8].iter().all(|index| *index == indices[4]));
+        assert_ne!(indices[4], primary);
+        assert_ne!(indices[8], primary);
+        assert_ne!(indices[8], indices[4]);
         assert_eq!(provider.fleet.active_prefix_loads(), 1);
 
         drop(leases);
@@ -4187,6 +4191,35 @@ mod tests {
             .acquire_index(&messages)
             .expect("rotation active");
         assert_eq!(after_release.index(), primary);
+    }
+
+    #[test]
+    fn colliding_prefixes_have_key_dependent_spill_orders() {
+        let provider = rotation_provider(3);
+        let mut by_primary: std::collections::HashMap<usize, (u64, Vec<usize>)> =
+            std::collections::HashMap::new();
+        let mut collision = None;
+
+        for index in 0..1_000 {
+            let messages = vec![user_msg(&format!("collision-prefix-{index}"))];
+            let route_key = provider.fleet.prefix_router.route(&messages);
+            let candidates = provider.fleet.candidate_indices(route_key, 3);
+            let primary = candidates[0];
+            if let Some((other_key, other_candidates)) = by_primary.get(&primary) {
+                if candidates[1..] != other_candidates[1..] {
+                    collision = Some((*other_key, other_candidates.clone(), route_key, candidates));
+                    break;
+                }
+            } else {
+                by_primary.insert(primary, (route_key, candidates));
+            }
+        }
+
+        let (first_key, first, second_key, second) =
+            collision.expect("find same-primary keys with different spill orders");
+        assert_eq!(first_key % 3, second_key % 3);
+        assert_eq!(first[0], second[0]);
+        assert_ne!(first[1..], second[1..]);
     }
 
     #[test]
@@ -4251,6 +4284,94 @@ mod tests {
                 .map(|lease| lease.index())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn follow_up_conversation_is_sticky_across_later_history_and_fleets() {
+        let provider_a = rotation_provider(3);
+        let provider_b = rotation_provider(3);
+        let initial = [
+            role_msg(crate::MessageRole::System, "shared system prefix"),
+            user_msg("synthetic conversation one"),
+        ];
+        let turn_two = vec![
+            initial[0].clone(),
+            initial[1].clone(),
+            role_msg(crate::MessageRole::Assistant, "synthetic answer one"),
+            user_msg("synthetic follow-up two"),
+        ];
+        let turn_three = vec![
+            turn_two[0].clone(),
+            turn_two[1].clone(),
+            turn_two[2].clone(),
+            turn_two[3].clone(),
+            role_msg(crate::MessageRole::Assistant, "synthetic answer two"),
+            user_msg("synthetic follow-up three"),
+        ];
+
+        let turn_two_a = provider_a
+            .fleet
+            .acquire_index(&turn_two)
+            .expect("rotation active");
+        let turn_three_a = provider_a
+            .fleet
+            .acquire_index(&turn_three)
+            .expect("rotation active");
+        let turn_three_b = provider_b
+            .fleet
+            .acquire_index(&turn_three)
+            .expect("rotation active");
+
+        assert_eq!(turn_two_a.index(), turn_three_a.index());
+        assert_eq!(turn_two_a.index(), turn_three_b.index());
+    }
+
+    #[test]
+    fn follow_up_conversation_does_not_spill_while_requests_overlap() {
+        let provider = rotation_provider(3);
+        let messages = vec![
+            role_msg(crate::MessageRole::System, "shared system prefix"),
+            user_msg("synthetic initial turn"),
+            role_msg(crate::MessageRole::Assistant, "synthetic answer"),
+            user_msg("synthetic follow-up"),
+        ];
+
+        let leases: Vec<_> = (0..12)
+            .map(|_| {
+                provider
+                    .fleet
+                    .acquire_index(&messages)
+                    .expect("rotation active")
+            })
+            .collect();
+
+        assert!(leases
+            .iter()
+            .all(|lease| lease.index() == leases[0].index()));
+    }
+
+    #[test]
+    fn distinct_conversations_with_one_prefix_can_reach_all_backends() {
+        let provider = rotation_provider(3);
+        let mut seen = [false; 3];
+
+        for index in 0..1_000 {
+            let messages = vec![
+                role_msg(crate::MessageRole::System, "shared system prefix"),
+                user_msg(&format!("synthetic conversation {index}")),
+                role_msg(crate::MessageRole::Assistant, "synthetic answer"),
+            ];
+            let lease = provider
+                .fleet
+                .acquire_index(&messages)
+                .expect("rotation active");
+            seen[lease.index()] = true;
+            if seen.iter().all(|value| *value) {
+                break;
+            }
+        }
+
+        assert!(seen.into_iter().all(|value| value));
     }
 
     #[test]

--- a/crates/inference_providers/src/attested/nearai/prefix_router.rs
+++ b/crates/inference_providers/src/attested/nearai/prefix_router.rs
@@ -1,246 +1,264 @@
 //! Prefix-aware routing for inference cache hit optimization.
 //!
-//! Maintains a trie where each level corresponds to a message in the conversation.
-//! Requests sharing the same system prompt route to the same bucket regardless of
-//! subsequent user messages. Each bucket maps to a persistent TLS connection pinned
-//! to a specific backend via L4 passthrough.
+//! Requests sharing the same first message (typically the system prompt) receive
+//! the same deterministic routing key in every Cloud API process. The fleet
+//! reduces that key modulo the current backend count, keeping the request on the
+//! same indexed backend and its KV cache while the backend membership is stable.
 
-use crate::models::ChatMessage;
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::RwLock;
+use crate::models::{ChatMessage, MessageRole};
+use sha2::{Digest, Sha256};
 
-/// Number of prefix routing buckets (persistent connections per provider).
-fn num_buckets() -> usize {
-    std::env::var("NUM_PREFIX_BUCKETS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(64)
-        .min(1024) // Cap to prevent excessive memory from misconfiguration
-}
-
-/// Maximum number of messages to consider for routing.
-fn max_trie_depth() -> usize {
-    std::env::var("PREFIX_MAX_MESSAGES")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(8)
-}
-
-struct TrieNode {
-    children: HashMap<u64, Box<TrieNode>>,
-    /// Bucket ID. Only root's direct children get fresh buckets (one per unique
-    /// first message, typically the system prompt). All deeper nodes inherit
-    /// their parent's bucket, keeping conversations with the same prefix on
-    /// the same backend.
-    bucket: usize,
-}
-
-/// Routes requests to buckets based on conversation prefix similarity.
-///
-/// Each trie level represents one message (role + content hash).
-/// Requests sharing the same system prompt → same bucket → same backend → cache hit.
-pub struct PrefixRouter {
-    trie: RwLock<TrieNode>,
-    next_bucket: AtomicUsize,
-    num_buckets: usize,
-    max_depth: usize,
-}
+/// Stateless router that derives a stable key from the reusable request prefix.
+#[derive(Default)]
+pub struct PrefixRouter;
 
 impl PrefixRouter {
     pub fn new() -> Self {
-        Self::with_config(num_buckets(), max_trie_depth())
+        Self
     }
 
-    fn with_config(num_buckets: usize, max_depth: usize) -> Self {
-        Self {
-            trie: RwLock::new(TrieNode {
-                children: HashMap::new(),
-                bucket: 0,
-            }),
-            next_bucket: AtomicUsize::new(1),
-            num_buckets,
-            max_depth,
-        }
-    }
-
-    // Bucket count is internal to the router now that the Fleet reduces the
-    // routed bucket id modulo the live backend count; kept for tests + clarity.
-    #[allow(dead_code)]
-    pub fn num_buckets(&self) -> usize {
-        self.num_buckets
-    }
-
-    /// Route a request to a bucket based on its conversation prefix.
-    pub fn route(&self, messages: &[ChatMessage]) -> usize {
-        let hashes = hash_messages(messages, self.max_depth);
-        if hashes.is_empty() {
+    /// Return a deterministic routing key based on the first message.
+    ///
+    /// Only the first message is considered to preserve the existing affinity
+    /// contract: conversations that share a system prompt remain on one backend
+    /// even as later user and assistant messages change.
+    pub fn route(&self, messages: &[ChatMessage]) -> u64 {
+        let Some(message) = messages.first() else {
             return 0;
-        }
+        };
 
-        // Fast path: read-only lookup. Since deeper nodes inherit parent buckets,
-        // this always returns a valid bucket even for partially-unseen prefixes.
-        // Only take write lock when the first message (system prompt) is brand new.
-        let trie = self.trie.read().unwrap_or_else(|e| e.into_inner());
-        let first_msg_exists = trie.children.contains_key(&hashes[0]);
-        let bucket = Self::lookup_readonly(&trie, &hashes);
-        drop(trie);
+        let mut hasher = Sha256::new();
+        // Fixed-width role and content-kind tags make the outer fields
+        // unambiguous; every variable-width text value is length-prefixed.
+        hasher.update([role_tag(&message.role)]);
 
-        if first_msg_exists {
-            return bucket;
-        }
-
-        // Slow path: first message unseen — need to assign a new bucket
-        let mut trie = self.trie.write().unwrap_or_else(|e| e.into_inner());
-        self.lookup_or_insert(&mut trie, &hashes)
-    }
-
-    /// Read-only lookup. Returns the deepest matching node's bucket.
-    /// Since deeper nodes inherit the parent's bucket, we can return early
-    /// when we hit an unseen message — the parent's bucket is correct.
-    fn lookup_readonly(node: &TrieNode, hashes: &[u64]) -> usize {
-        let mut current = node;
-        for h in hashes {
-            match current.children.get(h) {
-                Some(child) => current = child,
-                None => break, // Unseen message — parent's bucket is inherited
+        match message.content.as_ref() {
+            None => hasher.update([0]),
+            Some(serde_json::Value::String(text)) => {
+                hasher.update([1]);
+                hash_text(&mut hasher, text);
+            }
+            Some(serde_json::Value::Array(parts)) => {
+                hasher.update([2]);
+                for part in parts {
+                    if let Some(text) = part.get("text").and_then(|value| value.as_str()) {
+                        hash_text(&mut hasher, text);
+                    }
+                }
+            }
+            Some(other) => {
+                hasher.update([3]);
+                hash_text(&mut hasher, &other.to_string());
             }
         }
-        current.bucket
-    }
 
-    /// Only root's direct children get fresh buckets. All deeper nodes inherit
-    /// their parent's bucket.
-    fn lookup_or_insert(&self, root: &mut TrieNode, hashes: &[u64]) -> usize {
-        let mut node = root;
-        let mut is_root = true;
-
-        for h in hashes {
-            let parent_bucket = node.bucket;
-
-            if !node.children.contains_key(h) {
-                let bucket = if is_root {
-                    self.next_bucket.fetch_add(1, Ordering::Relaxed) % self.num_buckets
-                } else {
-                    parent_bucket
-                };
-                node.children.insert(
-                    *h,
-                    Box::new(TrieNode {
-                        children: HashMap::new(),
-                        bucket,
-                    }),
-                );
-            }
-
-            node = node.children.get_mut(h).unwrap();
-            is_root = false;
-        }
-        node.bucket
+        let digest = hasher.finalize();
+        u64::from_be_bytes(
+            digest[..8]
+                .try_into()
+                .expect("SHA-256 digest always contains eight bytes"),
+        )
     }
 }
 
-/// Hash each message to produce trie edge keys.
-fn hash_messages(messages: &[ChatMessage], max_depth: usize) -> Vec<u64> {
-    let limit = messages.len().min(max_depth);
-    let mut hashes = Vec::with_capacity(limit);
-
-    for msg in &messages[..limit] {
-        let mut hasher = DefaultHasher::new();
-        let role_tag: u8 = match msg.role {
-            crate::models::MessageRole::System => 0,
-            crate::models::MessageRole::User => 1,
-            crate::models::MessageRole::Assistant => 2,
-            crate::models::MessageRole::Tool => 3,
-        };
-        role_tag.hash(&mut hasher);
-        if let Some(ref content) = msg.content {
-            match content {
-                serde_json::Value::String(s) => s.hash(&mut hasher),
-                serde_json::Value::Array(parts) => {
-                    for part in parts {
-                        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                            text.hash(&mut hasher);
-                        }
-                    }
-                }
-                other => other.to_string().hash(&mut hasher),
-            }
-        }
-        hashes.push(hasher.finish());
+fn role_tag(role: &MessageRole) -> u8 {
+    match role {
+        MessageRole::System => 0,
+        MessageRole::User => 1,
+        MessageRole::Assistant => 2,
+        MessageRole::Tool => 3,
     }
-    hashes
+}
+
+fn hash_text(hasher: &mut Sha256, text: &str) {
+    hasher.update((text.len() as u64).to_be_bytes());
+    hasher.update(text.as_bytes());
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::MessageRole;
+    use serde_json::json;
+    use std::sync::Arc;
+    use std::thread;
 
-    fn msg(role: MessageRole, content: &str) -> ChatMessage {
+    fn message(role: MessageRole, content: Option<serde_json::Value>) -> ChatMessage {
         ChatMessage {
             role,
-            content: Some(serde_json::Value::String(content.to_string())),
+            content,
             name: None,
             tool_call_id: None,
             tool_calls: None,
         }
     }
 
-    fn router() -> PrefixRouter {
-        PrefixRouter::with_config(64, 8)
+    fn text_message(role: MessageRole, content: &str) -> ChatMessage {
+        message(role, Some(serde_json::Value::String(content.to_string())))
     }
 
     #[test]
-    fn test_same_system_prompt_same_bucket() {
-        let router = router();
-        let msgs1 = vec![
-            msg(MessageRole::System, "You are a helpful assistant."),
-            msg(MessageRole::User, "What is 2+2?"),
+    fn same_first_message_has_same_key_when_later_messages_differ() {
+        let router = PrefixRouter::new();
+        let messages_a = vec![
+            text_message(MessageRole::System, "You are a helpful assistant."),
+            text_message(MessageRole::User, "What is 2+2?"),
         ];
-        let msgs2 = vec![
-            msg(MessageRole::System, "You are a helpful assistant."),
-            msg(MessageRole::User, "What is the meaning of life?"),
+        let messages_b = vec![
+            text_message(MessageRole::System, "You are a helpful assistant."),
+            text_message(MessageRole::User, "What is the meaning of life?"),
         ];
-        let b1 = router.route(&msgs1);
-        let b2 = router.route(&msgs2);
-        assert_eq!(b1, b2, "Same system prompt → same bucket");
+
+        assert_eq!(router.route(&messages_a), router.route(&messages_b));
     }
 
     #[test]
-    fn test_identical_conversations_same_bucket() {
-        let router = router();
-        let msgs = vec![
-            msg(MessageRole::System, "You are helpful."),
-            msg(MessageRole::User, "Hi"),
-        ];
-        assert_eq!(router.route(&msgs), router.route(&msgs));
+    fn independent_routers_ignore_first_seen_order() {
+        let router_a = PrefixRouter::new();
+        let router_b = PrefixRouter::new();
+        let target = vec![text_message(MessageRole::System, "shared prefix")];
+
+        for index in 0..100 {
+            let other = vec![text_message(
+                MessageRole::System,
+                &format!("router-a-prefix-{index}"),
+            )];
+            router_a.route(&other);
+        }
+
+        for index in (0..100).rev() {
+            let other = vec![text_message(
+                MessageRole::System,
+                &format!("router-b-prefix-{index}"),
+            )];
+            router_b.route(&other);
+        }
+
+        assert_eq!(router_a.route(&target), router_b.route(&target));
     }
 
     #[test]
-    fn test_different_system_prompts_different_buckets() {
-        let router = router();
-        let msgs1 = vec![msg(MessageRole::System, "You are a Python expert.")];
-        let msgs2 = vec![msg(MessageRole::System, "You are a Rust expert.")];
-        assert_ne!(router.route(&msgs1), router.route(&msgs2));
+    fn routing_key_has_stable_test_vector() {
+        let messages = vec![text_message(MessageRole::System, "shared prefix")];
+
+        assert_eq!(
+            PrefixRouter::new().route(&messages),
+            15_400_765_393_054_233_284
+        );
     }
 
     #[test]
-    fn test_empty_messages() {
-        let router = router();
-        assert_eq!(router.route(&[]), 0);
+    fn routing_is_stable_under_concurrency() {
+        let router = Arc::new(PrefixRouter::new());
+        let messages = Arc::new(vec![text_message(
+            MessageRole::System,
+            "concurrent shared prefix",
+        )]);
+        let expected = router.route(&messages);
+
+        let workers: Vec<_> = (0..16)
+            .map(|_| {
+                let router = Arc::clone(&router);
+                let messages = Arc::clone(&messages);
+                thread::spawn(move || {
+                    for _ in 0..100 {
+                        assert_eq!(router.route(&messages), expected);
+                    }
+                })
+            })
+            .collect();
+
+        for worker in workers {
+            worker.join().expect("routing worker should not panic");
+        }
     }
 
     #[test]
-    fn test_bucket_range() {
-        let router = router();
-        for i in 0..100 {
-            let msgs = vec![msg(MessageRole::User, &format!("message {i}"))];
-            assert!(router.route(&msgs) < router.num_buckets());
+    fn role_is_part_of_the_key() {
+        let router = PrefixRouter::new();
+        let content = "same content";
+        let keys = [
+            MessageRole::System,
+            MessageRole::User,
+            MessageRole::Assistant,
+            MessageRole::Tool,
+        ]
+        .map(|role| router.route(&[text_message(role, content)]));
+
+        for (index, key) in keys.iter().enumerate() {
+            assert!(!keys[..index].contains(key));
+        }
+    }
+
+    #[test]
+    fn multipart_text_is_length_delimited_and_stable() {
+        let router_a = PrefixRouter::new();
+        let router_b = PrefixRouter::new();
+        let multipart = vec![message(
+            MessageRole::User,
+            Some(json!([
+                {"type": "text", "text": "ab"},
+                {"type": "image_url", "image_url": {"url": "ignored"}},
+                {"type": "text", "text": "c"}
+            ])),
+        )];
+        let ambiguous_without_lengths = vec![message(
+            MessageRole::User,
+            Some(json!([
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "bc"}
+            ])),
+        )];
+
+        assert_eq!(router_a.route(&multipart), router_b.route(&multipart));
+        assert_ne!(
+            router_a.route(&multipart),
+            router_a.route(&ambiguous_without_lengths)
+        );
+    }
+
+    #[test]
+    fn non_text_json_content_is_stable() {
+        let router_a = PrefixRouter::new();
+        let router_b = PrefixRouter::new();
+        let messages = vec![message(
+            MessageRole::Tool,
+            Some(json!({"status": "ok", "count": 3})),
+        )];
+
+        assert_eq!(router_a.route(&messages), router_b.route(&messages));
+    }
+
+    #[test]
+    fn changed_first_message_changes_key() {
+        let router = PrefixRouter::new();
+        let first = vec![text_message(MessageRole::System, "first prefix")];
+        let second = vec![text_message(MessageRole::System, "second prefix")];
+
+        assert_ne!(router.route(&first), router.route(&second));
+    }
+
+    #[test]
+    fn empty_messages_route_to_zero() {
+        assert_eq!(PrefixRouter::new().route(&[]), 0);
+    }
+
+    #[test]
+    fn deterministic_keys_reach_each_small_backend_index() {
+        let router = PrefixRouter::new();
+
+        for backend_count in 1_u64..=4 {
+            let mut seen = vec![false; backend_count as usize];
+            for index in 0..1_000 {
+                let messages = vec![text_message(
+                    MessageRole::System,
+                    &format!("distribution-prefix-{index}"),
+                )];
+                seen[(router.route(&messages) % backend_count) as usize] = true;
+            }
+            assert!(
+                seen.into_iter().all(|value| value),
+                "every index should be reachable with {backend_count} backends"
+            );
         }
     }
 }

--- a/crates/inference_providers/src/attested/nearai/prefix_router.rs
+++ b/crates/inference_providers/src/attested/nearai/prefix_router.rs
@@ -1,9 +1,9 @@
 //! Prefix-aware routing for inference cache hit optimization.
 //!
 //! Requests sharing the same first message (typically the system prompt) receive
-//! the same deterministic routing key in every Cloud API process. The fleet
-//! reduces that key modulo the current backend count, keeping the request on the
-//! same indexed backend and its KV cache while the backend membership is stable.
+//! the same deterministic first-turn routing key in every Cloud API process.
+//! Established conversations use their stable first two messages instead, so
+//! growing history remains on one indexed backend after the first follow-up.
 
 use crate::models::{ChatMessage, MessageRole};
 use sha2::{Digest, Sha256};
@@ -28,37 +28,65 @@ impl PrefixRouter {
         };
 
         let mut hasher = Sha256::new();
-        // Fixed-width role and content-kind tags make the outer fields
-        // unambiguous; every variable-width text value is length-prefixed.
-        hasher.update([role_tag(&message.role)]);
+        hash_message(&mut hasher, message);
+        key_from(hasher)
+    }
 
-        match message.content.as_ref() {
-            None => hasher.update([0]),
-            Some(serde_json::Value::String(text)) => {
-                hasher.update([1]);
-                hash_text(&mut hasher, text);
-            }
-            Some(serde_json::Value::Array(parts)) => {
-                hasher.update([2]);
-                for part in parts {
-                    if let Some(text) = part.get("text").and_then(|value| value.as_str()) {
-                        hash_text(&mut hasher, text);
-                    }
-                }
-            }
-            Some(other) => {
-                hasher.update([3]);
-                hash_text(&mut hasher, &other.to_string());
-            }
+    /// Return a deterministic routing key for an established conversation.
+    ///
+    /// The first two messages remain stable as later assistant, tool, and user
+    /// turns are appended. Hashing only that pair therefore gives
+    /// follow-up requests a process-independent home without making the first
+    /// turn give up shared-system-prefix affinity.
+    pub fn route_conversation(&self, messages: &[ChatMessage]) -> u64 {
+        if messages.is_empty() {
+            return 0;
         }
 
-        let digest = hasher.finalize();
-        u64::from_be_bytes(
-            digest[..8]
-                .try_into()
-                .expect("SHA-256 digest always contains eight bytes"),
-        )
+        let count = messages.len().min(2);
+        let mut hasher = Sha256::new();
+        hasher.update(b"nearai-conversation-route-v1");
+        hasher.update((count as u64).to_be_bytes());
+        for message in messages.iter().take(count) {
+            hash_message(&mut hasher, message);
+        }
+        key_from(hasher)
     }
+}
+
+fn hash_message(hasher: &mut Sha256, message: &ChatMessage) {
+    // Fixed-width role and content-kind tags make the outer fields
+    // unambiguous; every variable-width text value is length-prefixed.
+    hasher.update([role_tag(&message.role)]);
+
+    match message.content.as_ref() {
+        None => hasher.update([0]),
+        Some(serde_json::Value::String(text)) => {
+            hasher.update([1]);
+            hash_text(hasher, text);
+        }
+        Some(serde_json::Value::Array(parts)) => {
+            hasher.update([2]);
+            for part in parts {
+                if let Some(text) = part.get("text").and_then(|value| value.as_str()) {
+                    hash_text(hasher, text);
+                }
+            }
+        }
+        Some(other) => {
+            hasher.update([3]);
+            hash_text(hasher, &other.to_string());
+        }
+    }
+}
+
+fn key_from(hasher: Sha256) -> u64 {
+    let digest = hasher.finalize();
+    u64::from_be_bytes(
+        digest[..8]
+            .try_into()
+            .expect("SHA-256 digest always contains eight bytes"),
+    )
 }
 
 fn role_tag(role: &MessageRole) -> u8 {
@@ -109,6 +137,71 @@ mod tests {
         ];
 
         assert_eq!(router.route(&messages_a), router.route(&messages_b));
+    }
+
+    #[test]
+    fn conversation_key_uses_first_two_messages_and_ignores_later_history() {
+        let router = PrefixRouter::new();
+        let initial = vec![
+            text_message(MessageRole::System, "You are a helpful assistant."),
+            text_message(MessageRole::User, "Start a synthetic task."),
+        ];
+        let follow_up = vec![
+            initial[0].clone(),
+            initial[1].clone(),
+            text_message(MessageRole::Assistant, "Synthetic answer."),
+            text_message(MessageRole::User, "Continue the synthetic task."),
+        ];
+
+        assert_eq!(
+            router.route_conversation(&initial),
+            router.route_conversation(&follow_up)
+        );
+    }
+
+    #[test]
+    fn conversation_key_changes_with_the_initial_user_turn() {
+        let router = PrefixRouter::new();
+        let first = vec![
+            text_message(MessageRole::System, "shared system prefix"),
+            text_message(MessageRole::User, "conversation one"),
+        ];
+        let second = vec![
+            text_message(MessageRole::System, "shared system prefix"),
+            text_message(MessageRole::User, "conversation two"),
+        ];
+
+        assert_ne!(
+            router.route_conversation(&first),
+            router.route_conversation(&second)
+        );
+    }
+
+    #[test]
+    fn conversation_routing_key_has_stable_test_vector() {
+        let messages = vec![
+            text_message(MessageRole::System, "shared prefix"),
+            text_message(MessageRole::User, "initial turn"),
+        ];
+
+        assert_eq!(
+            PrefixRouter::new().route_conversation(&messages),
+            11_280_323_719_959_491_568
+        );
+    }
+
+    #[test]
+    fn independent_routers_return_the_same_conversation_key() {
+        let messages = vec![
+            text_message(MessageRole::System, "shared system prefix"),
+            text_message(MessageRole::User, "stable initial turn"),
+            text_message(MessageRole::Assistant, "later history"),
+        ];
+
+        assert_eq!(
+            PrefixRouter::new().route_conversation(&messages),
+            PrefixRouter::new().route_conversation(&messages)
+        );
     }
 
     #[test]
@@ -239,7 +332,9 @@ mod tests {
 
     #[test]
     fn empty_messages_route_to_zero() {
-        assert_eq!(PrefixRouter::new().route(&[]), 0);
+        let router = PrefixRouter::new();
+        assert_eq!(router.route(&[]), 0);
+        assert_eq!(router.route_conversation(&[]), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace process-local first-seen prefix allocation with a stable SHA-256
  routing key over the first message role and normalized content
- keep ordinary traffic on the deterministic primary, but spill overlapping
  requests for the same hot prefix in deterministic bursts of four with a
  key-dependent spill order
- after assistant/tool history appears, route by the stable first two messages
  so later growing-history turns stay on one conversation home
- scope live-load accounting to the same prefix and release it with RAII on
  success, error, cancellation, or stream drop
- preserve empty-message routing, indexed backend selection, fallback,
  signature pinning, and pathological-TTFT steering

There are no HTTP, request, response, or database interface changes.

## Why

The old router assigned bucket IDs in local arrival order. Separate Cloud API
processes could therefore send the same reusable prefix to different backend
indices, duplicating cache entries and producing zero/high cache-hit behavior.

The first revision used deterministic modulo only. Follow-up testing confirmed
the review concern: with only a few hot prefixes, modulo can overload one
backend even when the fleet has spare capacity. This revision keeps the stable
primary but adds bounded, prefix-local spillover for overlapping initial
requests.

Review follow-up also confirmed that applying transient burst load to every
turn can move a growing conversation between replicas. The final router uses
shared-prefix affinity for the initial request, then a deterministic
first-two-message conversation home once assistant/tool history exists.

## Isolated inference evidence

Tests used three DeepSeek-V4-Flash TP2 backends, synthetic reusable prefixes,
two and four independent gateway histories, identical request order between
arms, and minimal decode output. No prompts, responses, credentials, host
addresses, or customer data are included here.

- one hot prefix, four gateways, concurrency 96: current had 0/192 failures,
  p95 1.70 s, and 51.4 req/s; modulo had 4/192 failures, p95 3.83 s, and
  26.0 req/s; burst four had 0/192 failures, p95 1.59 s, and 69.6 req/s
- 64 prefixes, four gateways, concurrency 96: current had 386/960 failures,
  82.27% cached-token share, and p95 3.60 s; burst four had 0/960 failures,
  98.78% cached-token share, and p95 1.69 s
- 64 prefixes, two gateways, concurrency 96: current had 183/960 failures,
  95.06% cached-token share, and p95 2.67 s; burst four had 0/960 failures,
  98.68% cached-token share, and p95 1.60 s
- lower burst thresholds one, two, and three produced 107, 27, and 12 failures
  respectively in their 64-prefix concurrency-96 runs; burst four was the
  smallest threshold with zero failures across all tested gateway counts and
  workloads
- three prefixes deliberately colliding on one modulo primary at concurrency
  96: ring spill had 4/960 failures, 2.23x load skew, 98.79% cached-token share,
  and p95 1.98 s; key-dependent spill had 0/960 failures, 1.55x load skew, the
  same cached-token share, and p95 1.93 s
- 24 synthetic conversations with five growing turns: burst-only routing moved
  43.75% of transitions, returned 71.76% cached tokens, and had p95 3.87 s;
  hierarchical routing returned 78.60% cached tokens with 0 failures and p95
  3.59 s. The only moves were the permitted first-to-second-turn handoff;
  turns two through five stayed fixed, with an 8/7/9 backend distribution

Single-replica quiet retention stayed above 99% through 180 seconds. Separate
pressure tests also found a separate engine-side SWA capacity limit that caused
eviction under pressure. This change fixes cross-process affinity but does not
eliminate intrinsic SGLang capacity eviction.

## Known trade-offs

- Initial requests may spill while they overlap. Established conversations pin
  to one backend, so the first follow-up may make one deterministic handoff
  from the shared-prefix backend before all later turns stay fixed.
- Concurrent calls for one established conversation do not spill. Distinct
  conversations hash independently across the fleet; this favors reuse of the
  larger growing-history prefix over balancing one conversation itself.
- The initial-request burst counter is process-local. Independent processes
  agree on the primary and spill order, while the exact aggregate spill point
  scales with the number of API processes. Both two- and four-process
  simulations passed.
- Modulo selection remaps most prefixes when the live backend count changes.
  Stable-handle rendezvous hashing is a follow-up because the current Cloud API
  discovery contract provides a count, not stable backend identities.
- A rolling deployment briefly mixes the old and new mappings, so prefixes can
  be duplicated until all Cloud API instances run the new router.

## Validation

- `make preflight` passed with an isolated test database and the repository's
  required local debug/test settings
- focused NEAR AI provider tests: 82 passed
- strict all-target inference-provider clippy and formatting checks passed
- experiment-runner unit tests: 21 passed
- all 13 authoritative artifact checksum manifests revalidated
- semantic smoke on all three backends: HTTP 200, usable content,
  `finish_reason=stop`, and usage fields
