### PR TITLE
fix(attestation): normalize GPU cert chains for ITA composite tokens

### DIFF
--- a/crates/api/tests/common/ita_evidence.rs
+++ b/crates/api/tests/common/ita_evidence.rs
@@ -217,7 +217,10 @@ impl inference_providers::InferenceProvider for ItaCompatibleModelEvidenceProvid
                     "gpu_nonce": gpu_nonce,
                     "arch": "H100",
                     "evidence_list": [{
-                        "certificate": base64::engine::general_purpose::STANDARD.encode(b"test-gpu-cert"),
+                        "certificate": base64::engine::general_purpose::STANDARD.encode(format!(
+                            "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
+                            base64::engine::general_purpose::STANDARD.encode(b"test-gpu-cert")
+                        )),
                         "evidence": base64::engine::general_purpose::STANDARD.encode(b"test-gpu-evidence"),
                         "firmware_version": "test-fw"
                     }]

--- a/crates/services/src/attestation/ita/client_error.rs
+++ b/crates/services/src/attestation/ita/client_error.rs
@@ -27,7 +27,13 @@ pub enum ItaClientError {
     #[error("ITA rate limited")]
     RateLimited { retry_after: Option<String> },
     #[error("ITA returned non-retryable status {status}")]
-    NonRetryableStatus { status: StatusCode },
+    NonRetryableStatus {
+        status: StatusCode,
+        /// Bounded, sanitized error text from ITA's response body (e.g.
+        /// "Failed to verify GPU evidence") — the status alone is useless
+        /// for diagnosing rejected evidence.
+        detail: Option<String>,
+    },
     #[error("ITA transient status {status} remained after retries")]
     TransientStatus { status: StatusCode },
     #[error("ITA upstream response is invalid: {reason}")]

--- a/crates/services/src/attestation/ita/client_error_mapping.rs
+++ b/crates/services/src/attestation/ita/client_error_mapping.rs
@@ -11,13 +11,16 @@ pub(in crate::attestation::ita) fn map_ita_client_error(error: ItaClientError) -
             AttestationError::ItaRateLimited { retry_after }
         }
         ItaClientError::Timeout => AttestationError::ItaTimeout,
-        ItaClientError::NonRetryableStatus { status } if status.as_u16() == 400 => {
+        ItaClientError::NonRetryableStatus { status, detail } if status.as_u16() == 400 => {
             AttestationError::ItaInvalidEvidence {
-                reason: format!("ITA rejected evidence with status {status}"),
+                reason: append_detail(
+                    format!("ITA rejected evidence with status {status}"),
+                    detail,
+                ),
             }
         }
-        ItaClientError::NonRetryableStatus { status } => AttestationError::ItaBadUpstream {
-            reason: format!("ITA returned status {status}"),
+        ItaClientError::NonRetryableStatus { status, detail } => AttestationError::ItaBadUpstream {
+            reason: append_detail(format!("ITA returned status {status}"), detail),
         },
         ItaClientError::TransientStatus { status } => AttestationError::ItaBadUpstream {
             reason: format!("ITA transient status {status} remained after retries"),
@@ -29,6 +32,13 @@ pub(in crate::attestation::ita) fn map_ita_client_error(error: ItaClientError) -
         | ItaClientError::InvalidVerifierNonce { .. } => AttestationError::ItaBadUpstream {
             reason: error.to_string(),
         },
+    }
+}
+
+fn append_detail(base: String, detail: Option<String>) -> String {
+    match detail {
+        Some(detail) => format!("{base}: {detail}"),
+        None => base,
     }
 }
 

--- a/crates/services/src/attestation/ita/client_error_mapping.rs
+++ b/crates/services/src/attestation/ita/client_error_mapping.rs
@@ -19,9 +19,18 @@ pub(in crate::attestation::ita) fn map_ita_client_error(error: ItaClientError) -
                 ),
             }
         }
-        ItaClientError::NonRetryableStatus { status, detail } => AttestationError::ItaBadUpstream {
-            reason: append_detail(format!("ITA returned status {status}"), detail),
-        },
+        ItaClientError::NonRetryableStatus { status, detail } => {
+            // 400 detail describes the caller's evidence and belongs in the
+            // response; for auth/infra statuses the body is ITA account text
+            // (request ids, tenant hints) — log it for operators, keep the
+            // client-facing reason to the bare status.
+            if let Some(detail) = &detail {
+                tracing::warn!(status = %status, detail = %detail, "ITA returned non-retryable status");
+            }
+            AttestationError::ItaBadUpstream {
+                reason: format!("ITA returned status {status}"),
+            }
+        }
         ItaClientError::TransientStatus { status } => AttestationError::ItaBadUpstream {
             reason: format!("ITA transient status {status} remained after retries"),
         },
@@ -41,6 +50,10 @@ fn append_detail(base: String, detail: Option<String>) -> String {
         None => base,
     }
 }
+
+#[cfg(test)]
+#[path = "client_error_mapping_tests.rs"]
+mod tests;
 
 pub(in crate::attestation) fn ita_client_error_class(error: &ItaClientError) -> &'static str {
     match error {

--- a/crates/services/src/attestation/ita/client_error_mapping_tests.rs
+++ b/crates/services/src/attestation/ita/client_error_mapping_tests.rs
@@ -1,0 +1,35 @@
+use reqwest::StatusCode;
+
+use super::map_ita_client_error;
+use crate::attestation::{ita::ItaClientError, AttestationError};
+
+#[test]
+fn evidence_rejection_detail_reaches_the_client_facing_reason() {
+    // Given: ITA rejects evidence with a diagnostic body.
+    let error = map_ita_client_error(ItaClientError::NonRetryableStatus {
+        status: StatusCode::BAD_REQUEST,
+        detail: Some("Failed to verify GPU evidence".to_string()),
+    });
+
+    // Then: the 400 reason carries the upstream diagnostic for the caller.
+    assert!(matches!(
+        error,
+        AttestationError::ItaInvalidEvidence { reason }
+            if reason == "ITA rejected evidence with status 400 Bad Request: Failed to verify GPU evidence"
+    ));
+}
+
+#[test]
+fn non_evidence_status_detail_stays_out_of_the_client_facing_reason() {
+    // Given: ITA returns an auth failure with account text in the body.
+    let error = map_ita_client_error(ItaClientError::NonRetryableStatus {
+        status: StatusCode::FORBIDDEN,
+        detail: Some("tenant 1234 request abc".to_string()),
+    });
+
+    // Then: the surfaced reason is the bare status; the detail is log-only.
+    assert!(matches!(
+        error,
+        AttestationError::ItaBadUpstream { reason } if reason == "ITA returned status 403 Forbidden"
+    ));
+}

--- a/crates/services/src/attestation/ita/client_http.rs
+++ b/crates/services/src/attestation/ita/client_http.rs
@@ -21,9 +21,22 @@ where
 {
     let status = response.status();
     if !status.is_success() {
-        let retry_after = response_header(response.headers(), RETRY_AFTER.as_str());
-        let detail = read_error_detail(response).await;
-        return Err(status_error(status, retry_after, detail));
+        // Classify by status line before touching the body: transient and
+        // rate-limit responses discard diagnostic detail, and awaiting a
+        // slow error body here would burn the read timeout once per retry
+        // attempt before with_retry can fire the next one.
+        return Err(match status {
+            StatusCode::TOO_MANY_REQUESTS => ItaClientError::RateLimited {
+                retry_after: response_header(response.headers(), RETRY_AFTER.as_str()),
+            },
+            StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT => ItaClientError::TransientStatus { status },
+            _ => ItaClientError::NonRetryableStatus {
+                status,
+                detail: read_error_detail(response).await,
+            },
+        });
     }
 
     let body = read_limited_body(response, body_limit).await?;
@@ -86,27 +99,23 @@ async fn read_limited_body(
     Ok(Bytes::from(body))
 }
 
-fn status_error(
-    status: StatusCode,
-    retry_after: Option<String>,
-    detail: Option<String>,
-) -> ItaClientError {
-    match status {
-        StatusCode::TOO_MANY_REQUESTS => ItaClientError::RateLimited { retry_after },
-        StatusCode::BAD_GATEWAY | StatusCode::SERVICE_UNAVAILABLE | StatusCode::GATEWAY_TIMEOUT => {
-            ItaClientError::TransientStatus { status }
-        }
-        _ => ItaClientError::NonRetryableStatus { status, detail },
-    }
-}
-
 /// Best-effort extraction of ITA's error body for diagnostics. ITA error
 /// bodies describe attestation infrastructure failures (never customer
 /// data); the text is bounded and control characters are stripped.
-async fn read_error_detail(response: reqwest::Response) -> Option<String> {
-    let body = read_limited_body(response, ERROR_DETAIL_BODY_LIMIT)
-        .await
-        .ok()?;
+/// Oversized bodies are truncated rather than discarded — long appraisal
+/// failures are exactly where the detail matters — and a mid-read
+/// transport error keeps whatever arrived.
+async fn read_error_detail(mut response: reqwest::Response) -> Option<String> {
+    let mut body = Vec::new();
+    while body.len() < ERROR_DETAIL_BODY_LIMIT {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                let take = (ERROR_DETAIL_BODY_LIMIT - body.len()).min(chunk.len());
+                body.extend_from_slice(&chunk[..take]);
+            }
+            Ok(None) | Err(_) => break,
+        }
+    }
     extract_error_detail(&body)
 }
 

--- a/crates/services/src/attestation/ita/client_http.rs
+++ b/crates/services/src/attestation/ita/client_http.rs
@@ -9,6 +9,9 @@ use serde::de::DeserializeOwned;
 
 use super::ItaClientError;
 
+const ERROR_DETAIL_BODY_LIMIT: usize = 4 * 1024;
+const ERROR_DETAIL_MAX_CHARS: usize = 256;
+
 pub(super) async fn parse_json_response<T>(
     response: reqwest::Response,
     body_limit: usize,
@@ -18,7 +21,9 @@ where
 {
     let status = response.status();
     if !status.is_success() {
-        return Err(status_error(status, response.headers()));
+        let retry_after = response_header(response.headers(), RETRY_AFTER.as_str());
+        let detail = read_error_detail(response).await;
+        return Err(status_error(status, retry_after, detail));
     }
 
     let body = read_limited_body(response, body_limit).await?;
@@ -81,16 +86,51 @@ async fn read_limited_body(
     Ok(Bytes::from(body))
 }
 
-fn status_error(status: StatusCode, headers: &HeaderMap) -> ItaClientError {
+fn status_error(
+    status: StatusCode,
+    retry_after: Option<String>,
+    detail: Option<String>,
+) -> ItaClientError {
     match status {
-        StatusCode::TOO_MANY_REQUESTS => ItaClientError::RateLimited {
-            retry_after: response_header(headers, RETRY_AFTER.as_str()),
-        },
+        StatusCode::TOO_MANY_REQUESTS => ItaClientError::RateLimited { retry_after },
         StatusCode::BAD_GATEWAY | StatusCode::SERVICE_UNAVAILABLE | StatusCode::GATEWAY_TIMEOUT => {
             ItaClientError::TransientStatus { status }
         }
-        _ => ItaClientError::NonRetryableStatus { status },
+        _ => ItaClientError::NonRetryableStatus { status, detail },
     }
+}
+
+/// Best-effort extraction of ITA's error body for diagnostics. ITA error
+/// bodies describe attestation infrastructure failures (never customer
+/// data); the text is bounded and control characters are stripped.
+async fn read_error_detail(response: reqwest::Response) -> Option<String> {
+    let body = read_limited_body(response, ERROR_DETAIL_BODY_LIMIT)
+        .await
+        .ok()?;
+    extract_error_detail(&body)
+}
+
+fn extract_error_detail(body: &[u8]) -> Option<String> {
+    let text = match serde_json::from_slice::<serde_json::Value>(body) {
+        Ok(value) => {
+            let mut json_detail = None;
+            for key in ["error", "message", "detail"] {
+                if let Some(text) = value.get(key).and_then(serde_json::Value::as_str) {
+                    json_detail = Some(text.to_string());
+                    break;
+                }
+            }
+            json_detail.unwrap_or_else(|| String::from_utf8_lossy(body).into_owned())
+        }
+        Err(_) => String::from_utf8_lossy(body).into_owned(),
+    };
+    let sanitized: String = text
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .take(ERROR_DETAIL_MAX_CHARS)
+        .collect();
+    let trimmed = sanitized.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 fn is_retryable_transport_error(error: &reqwest::Error) -> bool {

--- a/crates/services/src/attestation/ita/client_test_support.rs
+++ b/crates/services/src/attestation/ita/client_test_support.rs
@@ -72,6 +72,12 @@ pub(crate) enum FakeStep {
         headers: Vec<(String, String)>,
         body: String,
     },
+    /// Send the status line and headers promptly, then stall without ever
+    /// sending the advertised body.
+    HeadersThenStall {
+        status: u16,
+        headers: Vec<(String, String)>,
+    },
     Hang,
     CloseBeforeResponse,
     ResetConnection,
@@ -94,6 +100,13 @@ impl FakeStep {
         }
     }
 
+    pub(crate) fn headers_then_stall(status: u16) -> Self {
+        Self::HeadersThenStall {
+            status,
+            headers: Vec::new(),
+        }
+    }
+
     pub(crate) fn with_header(self, name: &str, value: &str) -> Self {
         match self {
             Self::Response {
@@ -107,6 +120,13 @@ impl FakeStep {
                     headers,
                     body,
                 }
+            }
+            Self::HeadersThenStall {
+                status,
+                mut headers,
+            } => {
+                headers.push((name.to_string(), value.to_string()));
+                Self::HeadersThenStall { status, headers }
             }
             Self::Hang => Self::Hang,
             Self::CloseBeforeResponse => Self::CloseBeforeResponse,
@@ -204,6 +224,17 @@ async fn respond(stream: &mut tokio::net::TcpStream, step: FakeStep) -> io::Resu
             response.push_str("\r\n");
             response.push_str(&body);
             let _ = stream.write_all(response.as_bytes()).await;
+            Ok(())
+        }
+        FakeStep::HeadersThenStall { status, headers } => {
+            let mut response =
+                format!("HTTP/1.1 {status} ERR\r\nContent-Length: 4096\r\nConnection: close\r\n");
+            for (name, value) in headers {
+                response.push_str(&format!("{name}: {value}\r\n"));
+            }
+            response.push_str("\r\n");
+            let _ = stream.write_all(response.as_bytes()).await;
+            tokio::time::sleep(Duration::from_millis(300)).await;
             Ok(())
         }
         FakeStep::Hang => {

--- a/crates/services/src/attestation/ita/client_tests.rs
+++ b/crates/services/src/attestation/ita/client_tests.rs
@@ -138,11 +138,13 @@ async fn client_does_not_retry_non_transient_statuses() -> TestResult {
         // When: the nonce endpoint observes that status.
         let error = client.get_nonce("request-non-transient").await.unwrap_err();
 
-        // Then: the status is surfaced without retrying.
+        // Then: the status is surfaced without retrying, and the body detail
+        // is captured for every non-retryable status (401/403 detail feeds
+        // the operator warn log, not just the 400 client-facing reason).
         assert!(matches!(
             error,
-            ItaClientError::NonRetryableStatus { status: observed, .. }
-                if observed.as_u16() == status
+            ItaClientError::NonRetryableStatus { status: observed, detail: Some(detail) }
+                if observed.as_u16() == status && detail == "rejected"
         ));
         assert_eq!(server.requests().len(), 1);
     }
@@ -182,8 +184,8 @@ async fn non_retryable_status_detail_handles_non_json_and_oversized_bodies() -> 
             FakeStep::body(400, "plain-text rejection".to_string()),
             Some("plain-text rejection".to_string()),
         ),
-        // Oversized bodies are dropped rather than buffered without bound.
-        (FakeStep::body(400, "x".repeat(5000)), None),
+        // Oversized bodies are truncated (bounded read), not dropped.
+        (FakeStep::body(400, "x".repeat(5000)), Some("x".repeat(256))),
     ];
 
     for (step, expected_detail) in scenarios {
@@ -336,6 +338,33 @@ async fn rate_limit_is_surfaced_immediately_with_retry_after() -> TestResult {
         ItaClientError::RateLimited { retry_after: Some(value) } if value == "2"
     ));
     assert_eq!(server.requests().len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn rate_limit_classification_does_not_wait_for_slow_error_body() -> TestResult {
+    // Given: ITA sends 429 headers promptly but stalls before sending the body.
+    let server = FakeIta::start(vec![
+        FakeStep::headers_then_stall(429).with_header("Retry-After", "2")
+    ])
+    .await?;
+    let client = client_for(&server, 0, 400)?;
+
+    // When: the rate limit is observed.
+    let started = std::time::Instant::now();
+    let error = client.get_nonce("request-stalled-429").await.unwrap_err();
+
+    // Then: classification uses the status line alone — detail extraction is
+    // reserved for non-retryable statuses, so the stalled body is never awaited.
+    assert!(matches!(
+        error,
+        ItaClientError::RateLimited { retry_after: Some(value) } if value == "2"
+    ));
+    assert!(
+        started.elapsed() < Duration::from_millis(200),
+        "429 must be surfaced without waiting on the error body (took {:?})",
+        started.elapsed()
+    );
     Ok(())
 }
 

--- a/crates/services/src/attestation/ita/client_tests.rs
+++ b/crates/services/src/attestation/ita/client_tests.rs
@@ -141,10 +141,68 @@ async fn client_does_not_retry_non_transient_statuses() -> TestResult {
         // Then: the status is surfaced without retrying.
         assert!(matches!(
             error,
-            ItaClientError::NonRetryableStatus { status: observed }
+            ItaClientError::NonRetryableStatus { status: observed, .. }
                 if observed.as_u16() == status
         ));
         assert_eq!(server.requests().len(), 1);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_retryable_status_captures_error_detail_from_json_body() -> TestResult {
+    // Given: ITA rejects evidence with its production-style error body.
+    let server = FakeIta::start(vec![FakeStep::json(
+        400,
+        r#"{"error":"Received error from Appraisal request :Failed to verify GPU evidence"}"#,
+    )])
+    .await?;
+    let client = client_for(&server, 0, 100)?;
+
+    // When: the attest endpoint observes the rejection.
+    let error = client
+        .attest("request-detail", &sample_attest_request())
+        .await
+        .unwrap_err();
+
+    // Then: the upstream reason survives into the typed error for diagnosis.
+    assert!(matches!(
+        error,
+        ItaClientError::NonRetryableStatus { status, detail: Some(detail) }
+            if status.as_u16() == 400
+                && detail == "Received error from Appraisal request :Failed to verify GPU evidence"
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_retryable_status_detail_handles_non_json_and_oversized_bodies() -> TestResult {
+    let scenarios = [
+        (
+            FakeStep::body(400, "plain-text rejection".to_string()),
+            Some("plain-text rejection".to_string()),
+        ),
+        // Oversized bodies are dropped rather than buffered without bound.
+        (FakeStep::body(400, "x".repeat(5000)), None),
+    ];
+
+    for (step, expected_detail) in scenarios {
+        // Given: ITA returns a 400 with a non-JSON or oversized body.
+        let server = FakeIta::start(vec![step]).await?;
+        let client = client_for(&server, 0, 100)?;
+
+        // When: the attest endpoint observes the rejection.
+        let error = client
+            .attest("request-detail-fallback", &sample_attest_request())
+            .await
+            .unwrap_err();
+
+        // Then: detail is best-effort text, bounded, or absent — never a failure.
+        assert!(matches!(
+            error,
+            ItaClientError::NonRetryableStatus { status, detail }
+                if status.as_u16() == 400 && detail == expected_detail
+        ));
     }
     Ok(())
 }

--- a/crates/services/src/attestation/ita/evidence.rs
+++ b/crates/services/src/attestation/ita/evidence.rs
@@ -50,6 +50,8 @@ pub enum ItaEvidenceError {
         #[source]
         source: base64::DecodeError,
     },
+    #[error("ITA evidence field '{field}' is not a valid PEM certificate chain")]
+    InvalidPemChain { field: &'static str },
     #[error("gateway TDX report_data does not match ITA nonce-bound runtime data")]
     ReportDataMismatch,
     #[error("provider evidence is not ITA-compatible")]

--- a/crates/services/src/attestation/ita/evidence_gpu.rs
+++ b/crates/services/src/attestation/ita/evidence_gpu.rs
@@ -130,7 +130,7 @@ fn normalize_certificate_chain(
         .map_err(|source| ItaEvidenceError::InvalidBase64 { field, source })?;
     let text = String::from_utf8_lossy(&decoded);
     let mut canonical = String::new();
-    let mut certificates = 0_usize;
+    let mut found_certificate = false;
     let mut rest: &str = &text;
     while let Some(begin) = rest.find(PEM_CERTIFICATE_BEGIN) {
         let after_begin = &rest[begin + PEM_CERTIFICATE_BEGIN.len()..];
@@ -159,10 +159,10 @@ fn normalize_certificate_chain(
         }
         canonical.push_str(PEM_CERTIFICATE_END);
         canonical.push('\n');
-        certificates += 1;
+        found_certificate = true;
         rest = &after_begin[end + PEM_CERTIFICATE_END.len()..];
     }
-    if certificates == 0 {
+    if !found_certificate {
         return Err(ItaEvidenceError::InvalidPemChain { field });
     }
     Ok(STANDARD.encode(canonical.as_bytes()))

--- a/crates/services/src/attestation/ita/evidence_gpu.rs
+++ b/crates/services/src/attestation/ita/evidence_gpu.rs
@@ -100,13 +100,72 @@ fn ita_nvgpu_item(
 ) -> Result<ItaNvgpuEvidenceItem, ItaEvidenceError> {
     let certificate = required_trimmed(item.certificate, "nvgpu.evidence_list.certificate")?;
     let evidence = required_trimmed(item.evidence, "nvgpu.evidence_list.evidence")?;
-    validate_base64("nvgpu.evidence_list.certificate", &certificate)?;
+    let certificate = normalize_certificate_chain("nvgpu.evidence_list.certificate", &certificate)?;
     validate_base64("nvgpu.evidence_list.evidence", &evidence)?;
     Ok(ItaNvgpuEvidenceItem {
         certificate,
         evidence,
         firmware_version: item.firmware_version,
     })
+}
+
+const PEM_CERTIFICATE_BEGIN: &str = "-----BEGIN CERTIFICATE-----";
+const PEM_CERTIFICATE_END: &str = "-----END CERTIFICATE-----";
+const PEM_LINE_WIDTH: usize = 64;
+
+/// Re-encode the provider's GPU certificate chain as canonical PEM.
+///
+/// Providers read the chain out of NVML's fixed-size buffer, so the wire
+/// value can carry trailing NUL padding after the last certificate. NVIDIA's
+/// NRAS accepts that chain, but Intel Trust Authority rejects the whole
+/// attest request with a bare 400 ("Failed to verify GPU evidence"). Intel's
+/// own client re-encodes every certificate before submission, so mirror
+/// that: keep each CERTIFICATE block's payload and drop everything else.
+fn normalize_certificate_chain(
+    field: &'static str,
+    value: &str,
+) -> Result<String, ItaEvidenceError> {
+    let decoded = STANDARD
+        .decode(value)
+        .map_err(|source| ItaEvidenceError::InvalidBase64 { field, source })?;
+    let text = String::from_utf8_lossy(&decoded);
+    let mut canonical = String::new();
+    let mut certificates = 0_usize;
+    let mut rest: &str = &text;
+    while let Some(begin) = rest.find(PEM_CERTIFICATE_BEGIN) {
+        let after_begin = &rest[begin + PEM_CERTIFICATE_BEGIN.len()..];
+        let Some(end) = after_begin.find(PEM_CERTIFICATE_END) else {
+            return Err(ItaEvidenceError::InvalidPemChain { field });
+        };
+        let payload: String = after_begin[..end]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        let der = STANDARD
+            .decode(&payload)
+            .map_err(|source| ItaEvidenceError::InvalidBase64 { field, source })?;
+        if der.is_empty() {
+            return Err(ItaEvidenceError::InvalidPemChain { field });
+        }
+        canonical.push_str(PEM_CERTIFICATE_BEGIN);
+        canonical.push('\n');
+        let encoded = STANDARD.encode(der);
+        let mut offset = 0;
+        while offset < encoded.len() {
+            let line_end = (offset + PEM_LINE_WIDTH).min(encoded.len());
+            canonical.push_str(&encoded[offset..line_end]);
+            canonical.push('\n');
+            offset = line_end;
+        }
+        canonical.push_str(PEM_CERTIFICATE_END);
+        canonical.push('\n');
+        certificates += 1;
+        rest = &after_begin[end + PEM_CERTIFICATE_END.len()..];
+    }
+    if certificates == 0 {
+        return Err(ItaEvidenceError::InvalidPemChain { field });
+    }
+    Ok(STANDARD.encode(canonical.as_bytes()))
 }
 
 fn required_trimmed(

--- a/crates/services/src/attestation/ita/evidence_nvgpu_tests.rs
+++ b/crates/services/src/attestation/ita/evidence_nvgpu_tests.rs
@@ -1,8 +1,10 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde_json::{json, Map, Value};
 
 use super::evidence_test_support::{
-    effective_policy, gateway_quote, gpu_nonce, model_evidence, model_request, runtime_data,
-    verifier_nonce, TestResult, POLICY_A,
+    canonical_pem_chain_b64, effective_policy, gateway_quote, gpu_nonce, model_evidence,
+    model_evidence_with_certificate, model_request, runtime_data, verifier_nonce, TestResult,
+    POLICY_A, TEST_CERT_DER,
 };
 use super::tdx_tests::expected_tdx_json;
 use super::*;
@@ -38,7 +40,10 @@ fn maps_tdx_and_matching_nvgpu_to_exact_ita_json() -> TestResult {
                 },
                 "gpu_nonce": gpu_nonce(),
                 "arch": "HOPPER",
-                "evidence_list": [{ "certificate": "Y2VydA==", "evidence": "ZXZpZGVuY2U=" }]
+                "evidence_list": [{
+                    "certificate": canonical_pem_chain_b64(&[TEST_CERT_DER]),
+                    "evidence": "ZXZpZGVuY2U="
+                }]
             }
         })
     );
@@ -162,5 +167,131 @@ fn fails_closed_on_unsupported_provider_evidence() {
     assert!(matches!(
         error,
         ItaEvidenceError::UnsupportedProviderEvidence
+    ));
+}
+
+#[test]
+fn normalizes_cert_chain_with_trailing_nul_padding() -> TestResult {
+    // Given: a cert chain carrying NVML fixed-size-buffer NUL padding, as prod
+    // providers emit. NRAS accepts that chain; ITA rejects the whole attest
+    // request with a bare 400, so the mapper must canonicalize it.
+    let runtime_data = runtime_data();
+    let gateway = gateway_quote(&runtime_data);
+    let canonical = canonical_pem_chain_b64(&[TEST_CERT_DER]);
+    let mut dirty = STANDARD.decode(&canonical)?;
+    dirty.extend_from_slice(b"\n\x00\x00\x00\x00\x00");
+    let evidence = vec![model_evidence_with_certificate(
+        "HOPPER",
+        &gpu_nonce(),
+        &STANDARD.encode(dirty),
+    )];
+
+    // When: the model request is built.
+    let request = model_request(&gateway, &evidence)?;
+
+    // Then: the padding is dropped and the chain is byte-identical to canonical PEM.
+    let value = serde_json::to_value(request)?;
+    assert_eq!(value["nvgpu"]["evidence_list"][0]["certificate"], canonical);
+    Ok(())
+}
+
+#[test]
+fn rewraps_crlf_and_wide_lines_to_canonical_pem() -> TestResult {
+    // Given: two certificates PEM-encoded with CRLF endings and 76-column wrapping.
+    let der_one = [0x41_u8; 100];
+    let der_two = [0x42_u8; 10];
+    let mut pem = String::new();
+    for der in [&der_one[..], &der_two[..]] {
+        pem.push_str("-----BEGIN CERTIFICATE-----\r\n");
+        let encoded = STANDARD.encode(der);
+        for chunk_start in (0..encoded.len()).step_by(76) {
+            let chunk_end = (chunk_start + 76).min(encoded.len());
+            pem.push_str(&encoded[chunk_start..chunk_end]);
+            pem.push_str("\r\n");
+        }
+        pem.push_str("-----END CERTIFICATE-----\r\n");
+    }
+    let runtime_data = runtime_data();
+    let gateway = gateway_quote(&runtime_data);
+    let evidence = vec![model_evidence_with_certificate(
+        "HOPPER",
+        &gpu_nonce(),
+        &STANDARD.encode(pem),
+    )];
+
+    // When: the model request is built.
+    let request = model_request(&gateway, &evidence)?;
+
+    // Then: both certificates survive, in order, re-wrapped at 64 columns with LF.
+    let value = serde_json::to_value(request)?;
+    assert_eq!(
+        value["nvgpu"]["evidence_list"][0]["certificate"],
+        canonical_pem_chain_b64(&[&der_one, &der_two])
+    );
+    Ok(())
+}
+
+#[test]
+fn fails_closed_on_cert_chain_without_pem_blocks() {
+    // Given: a base64 certificate value that decodes to no PEM block at all.
+    let runtime_data = runtime_data();
+    let gateway = gateway_quote(&runtime_data);
+    let evidence = vec![model_evidence_with_certificate(
+        "HOPPER",
+        &gpu_nonce(),
+        "Y2VydA==",
+    )];
+
+    // When: the model mapper normalizes the certificate chain.
+    let error = model_request(&gateway, &evidence).expect_err("non-PEM chain must fail");
+
+    // Then: the request fails closed instead of forwarding unverifiable bytes to ITA.
+    assert!(matches!(
+        error,
+        ItaEvidenceError::InvalidPemChain {
+            field: "nvgpu.evidence_list.certificate"
+        }
+    ));
+}
+
+#[test]
+fn fails_closed_on_unterminated_pem_block() {
+    // Given: a chain whose BEGIN marker has no matching END marker.
+    let runtime_data = runtime_data();
+    let gateway = gateway_quote(&runtime_data);
+    let evidence = vec![model_evidence_with_certificate(
+        "HOPPER",
+        &gpu_nonce(),
+        &STANDARD.encode("-----BEGIN CERTIFICATE-----\nAAAA\n"),
+    )];
+
+    // When: the model mapper normalizes the certificate chain.
+    let error = model_request(&gateway, &evidence).expect_err("unterminated block must fail");
+
+    // Then: the truncated chain is rejected.
+    assert!(matches!(error, ItaEvidenceError::InvalidPemChain { .. }));
+}
+
+#[test]
+fn fails_closed_on_invalid_base64_inside_pem_block() {
+    // Given: a PEM block whose payload is not valid base64.
+    let runtime_data = runtime_data();
+    let gateway = gateway_quote(&runtime_data);
+    let evidence = vec![model_evidence_with_certificate(
+        "HOPPER",
+        &gpu_nonce(),
+        &STANDARD.encode("-----BEGIN CERTIFICATE-----\n!!!!\n-----END CERTIFICATE-----\n"),
+    )];
+
+    // When: the model mapper normalizes the certificate chain.
+    let error = model_request(&gateway, &evidence).expect_err("bad payload must fail");
+
+    // Then: the invalid payload is reported against the certificate field.
+    assert!(matches!(
+        error,
+        ItaEvidenceError::InvalidBase64 {
+            field: "nvgpu.evidence_list.certificate",
+            ..
+        }
     ));
 }

--- a/crates/services/src/attestation/ita/evidence_nvgpu_tests.rs
+++ b/crates/services/src/attestation/ita/evidence_nvgpu_tests.rs
@@ -232,6 +232,33 @@ fn rewraps_crlf_and_wide_lines_to_canonical_pem() -> TestResult {
 }
 
 #[test]
+fn pins_canonical_pem_output_to_a_literal_expectation() -> TestResult {
+    // Given: a dirty chain around a fixed DER whose canonical form is written
+    // out literally, independent of the test helper that mirrors the
+    // implementation's wrapping loop.
+    let runtime_data = runtime_data();
+    let gateway = gateway_quote(&runtime_data);
+    let dirty_pem = "-----BEGIN CERTIFICATE-----\r\ncGlubmVkLWRlci1wYXlsb2FkLTAxMjM0NTY3ODktYWJjZGVmZ2hpamtsbW5vcHFy\r\ncw==\r\n-----END CERTIFICATE-----\r\n\x00\x00";
+    let evidence = vec![model_evidence_with_certificate(
+        "HOPPER",
+        &gpu_nonce(),
+        &STANDARD.encode(dirty_pem),
+    )];
+
+    // When: the model request is built.
+    let request = model_request(&gateway, &evidence)?;
+
+    // Then: the canonical output matches the literal 64-column LF form.
+    let expected_pem = "-----BEGIN CERTIFICATE-----\ncGlubmVkLWRlci1wYXlsb2FkLTAxMjM0NTY3ODktYWJjZGVmZ2hpamtsbW5vcHFy\ncw==\n-----END CERTIFICATE-----\n";
+    let value = serde_json::to_value(request)?;
+    assert_eq!(
+        value["nvgpu"]["evidence_list"][0]["certificate"],
+        STANDARD.encode(expected_pem)
+    );
+    Ok(())
+}
+
+#[test]
 fn fails_closed_on_cert_chain_without_pem_blocks() {
     // Given: a base64 certificate value that decodes to no PEM block at all.
     let runtime_data = runtime_data();

--- a/crates/services/src/attestation/ita/evidence_test_support.rs
+++ b/crates/services/src/attestation/ita/evidence_test_support.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use config::{ItaEffectivePolicy, ItaPolicyIds, ItaTokenSigningAlg};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256, Sha512};
@@ -73,11 +74,40 @@ pub(super) fn gpu_nonce() -> String {
     hex::encode(hasher.finalize())
 }
 
+pub(super) const TEST_CERT_DER: &[u8] = b"test-der-certificate-bytes";
+
+/// Canonical PEM chain, base64-encoded — the exact format
+/// `normalize_certificate_chain` emits (64-column base64 lines, LF endings).
+pub(super) fn canonical_pem_chain_b64(certs: &[&[u8]]) -> String {
+    let mut pem = String::new();
+    for der in certs {
+        pem.push_str("-----BEGIN CERTIFICATE-----\n");
+        let encoded = STANDARD.encode(der);
+        let mut offset = 0;
+        while offset < encoded.len() {
+            let line_end = (offset + 64).min(encoded.len());
+            pem.push_str(&encoded[offset..line_end]);
+            pem.push('\n');
+            offset = line_end;
+        }
+        pem.push_str("-----END CERTIFICATE-----\n");
+    }
+    STANDARD.encode(pem)
+}
+
 pub(super) fn model_evidence(arch: &str, gpu_nonce: &str) -> Map<String, Value> {
+    model_evidence_with_certificate(arch, gpu_nonce, &canonical_pem_chain_b64(&[TEST_CERT_DER]))
+}
+
+pub(super) fn model_evidence_with_certificate(
+    arch: &str,
+    gpu_nonce: &str,
+    certificate: &str,
+) -> Map<String, Value> {
     let payload = json!({
         "gpu_nonce": gpu_nonce,
         "arch": arch,
-        "evidence_list": [{ "certificate": "Y2VydA==", "evidence": "ZXZpZGVuY2U=" }]
+        "evidence_list": [{ "certificate": certificate, "evidence": "ZXZpZGVuY2U=" }]
     });
     let mut evidence = Map::new();
     evidence.insert(

--- a/crates/services/src/attestation/ita/service_test_support.rs
+++ b/crates/services/src/attestation/ita/service_test_support.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use config::{ExternalProvidersConfig, ItaAttestationConfig, ItaBaseUrl, ItaPolicyIds};
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
@@ -215,10 +216,14 @@ impl RecordingModelCollector {
 }
 
 fn model_evidence(gpu_nonce: &str) -> Map<String, Value> {
+    let pem = format!(
+        "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
+        STANDARD.encode(b"test-der-certificate-bytes")
+    );
     let payload = json!({
         "gpu_nonce": gpu_nonce,
         "arch": "HOPPER",
-        "evidence_list": [{ "certificate": "Y2VydA==", "evidence": "ZXZpZGVuY2U=" }]
+        "evidence_list": [{ "certificate": STANDARD.encode(pem), "evidence": "ZXZpZGVuY2U=" }]
     });
     let mut evidence = Map::new();
     evidence.insert(


### PR DESCRIPTION
Fixes #905.

## Problem

`GET /v1/attestation/ita-token?model=<any self-hosted model>` returned 400 for every model in staging **and** production, while gateway-only tokens worked:

```
{"error":{"message":"ITA evidence is invalid: ITA rejected evidence with status 400 Bad Request", ...}}
```

## Root cause

Providers return the GPU attestation certificate chain read from NVML's fixed-size buffer, which carries **trailing NUL padding** after the last `-----END CERTIFICATE-----`. NVIDIA NRAS tolerates that chain (the identical payload passes NRAS v3 attest with HTTP 200), but Intel Trust Authority rejects the whole appraisal with `Failed to verify GPU evidence` — an upstream detail we were dropping, so all we logged was the bare status line. Intel's own client (`trustauthority-client-for-go`, `go-nvgpu/cert_chain.go`) re-encodes every certificate to canonical PEM before submission; we forwarded the provider bytes as-is.

Isolated live: submitting the same 8-GPU evidence with only the NUL padding stripped flips ITA from 400 to 200.

## Fix

- **`evidence_gpu.rs`**: re-encode each `evidence_list[].certificate` chain as canonical PEM (64-column base64 lines, LF endings, `CERTIFICATE` blocks only, buffer padding dropped) before building the ITA attest request, mirroring Intel's client. Chains with no valid PEM block fail closed with a new `InvalidPemChain` evidence error.
- **`client_http.rs` / `client_error*.rs`**: capture ITA's error response body (bounded to 256 chars, control chars stripped, best-effort JSON `error`/`message`/`detail` extraction) and carry it on `NonRetryableStatus`, so a rejected appraisal now surfaces as e.g. `ITA rejected evidence with status 400 Bad Request: Failed to verify GPU evidence`.

## Verification

- Live end-to-end with real ITA: fetched a fresh ITA verifier nonce, collected a real 8-GPU DeepSeek-V4-Flash provider report bound to the derived `gpu_nonce`, ran the certificates through this branch's `normalize_certificate_chain`, and submitted the nvgpu evidence to `POST /appraisal/v2/attest` — **HTTP 200, PS384 token issued** (repeated; the unmodified chain reproducibly gets 400).
- `cargo test -p services` — 542 passed (includes new tests: NUL-padding normalization, CRLF/76-column re-wrap, multi-cert ordering, fail-closed on non-PEM / unterminated / bad-base64 chains, ITA error-detail capture incl. non-JSON and oversized bodies).
- `cargo test -p api --test e2e_all attestation` — 26 passed (harness GPU cert fixture updated to a PEM chain).
- `cargo fmt` / `cargo clippy` clean.

After merge, staging + prod need a deploy; then `GET /v1/attestation/ita-token?model=...` should return composite model tokens (worth a follow-up check against both).