### PR TITLE
fix(telemetry): emit stable Cloud API instance identity

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2647,6 +2647,7 @@ mod tests {
             otlp: config::OtlpConfig {
                 endpoint: "http://localhost:4317".to_string(),
                 protocol: "grpc".to_string(),
+                instance_id: None,
             },
             cors: config::CorsConfig::default(),
             external_providers: config::ExternalProvidersConfig::default(),
@@ -2756,6 +2757,7 @@ mod tests {
             otlp: config::OtlpConfig {
                 endpoint: "http://localhost:4317".to_string(),
                 protocol: "grpc".to_string(),
+                instance_id: None,
             },
             cors: config::CorsConfig::default(),
             external_providers: config::ExternalProvidersConfig::default(),

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -2,14 +2,16 @@ use api::{build_app_with_config, init_auth_services, init_database, init_domain_
 use config::{ApiConfig, LoggingConfig};
 use database::repositories::AdminCompositeRepository;
 use database::{Database, ShutdownCoordinator, ShutdownStage};
-use opentelemetry::{global, KeyValue};
+use opentelemetry::global;
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
-use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use services::admin::ModelPricingScheduler;
 use services::inference_provider_pool::InferenceProviderPool;
 use services::metrics::{MetricsServiceTrait, OtlpMetricsService};
 use std::sync::Arc;
 use std::time::Duration;
+
+mod telemetry;
 
 #[tokio::main]
 async fn main() {
@@ -37,12 +39,8 @@ async fn main() {
     // Get environment from env var (local, dev, staging, prod)
     let environment = std::env::var("ENVIRONMENT").unwrap_or_else(|_| "local".to_string());
 
-    let resource = Resource::builder()
-        .with_attributes(vec![
-            KeyValue::new("service.name", "cloud-api"),
-            KeyValue::new("environment", environment.clone()),
-        ])
-        .build();
+    let resource =
+        telemetry::build_telemetry_resource(&environment, config.otlp.instance_id.as_deref());
 
     let meter_provider = SdkMeterProvider::builder()
         .with_periodic_exporter(exporter)

--- a/crates/api/src/telemetry.rs
+++ b/crates/api/src/telemetry.rs
@@ -1,0 +1,54 @@
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::Resource;
+
+pub(crate) fn build_telemetry_resource(environment: &str, instance_id: Option<&str>) -> Resource {
+    let mut attributes = vec![
+        KeyValue::new("service.name", "cloud-api"),
+        KeyValue::new("environment", environment.to_string()),
+    ];
+    if let Some(instance_id) = instance_id {
+        attributes.push(KeyValue::new(
+            "service.instance.id",
+            instance_id.to_string(),
+        ));
+    }
+
+    Resource::builder().with_attributes(attributes).build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::Key;
+
+    #[test]
+    fn telemetry_resource_sets_configured_instance_id() {
+        let resource = build_telemetry_resource("staging", Some("vmm-instance-123"));
+
+        assert_eq!(
+            resource
+                .get(&Key::new("service.instance.id"))
+                .map(|value| value.to_string()),
+            Some("vmm-instance-123".to_string())
+        );
+    }
+
+    #[test]
+    fn telemetry_resource_omits_unset_instance_id() {
+        let resource = build_telemetry_resource("local", None);
+
+        assert_eq!(
+            resource
+                .get(&Key::new("service.name"))
+                .map(|value| value.to_string()),
+            Some("cloud-api".to_string())
+        );
+        assert_eq!(
+            resource
+                .get(&Key::new("environment"))
+                .map(|value| value.to_string()),
+            Some("local".to_string())
+        );
+        assert!(resource.get(&Key::new("service.instance.id")).is_none());
+    }
+}

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -118,6 +118,7 @@ pub fn test_config() -> ApiConfig {
             endpoint: std::env::var("TELEMETRY_OTLP_ENDPOINT")
                 .unwrap_or_else(|_| "http://localhost:4317".to_string()),
             protocol: std::env::var("TELEMETRY_OTLP_PROTOCOL").unwrap_or("grpc".to_string()),
+            instance_id: None,
         },
         cors: config::CorsConfig::default(),
         external_providers: config::ExternalProvidersConfig::default(),

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -1060,18 +1060,7 @@ pub(crate) fn non_empty_env(key: &str) -> Option<String> {
 }
 
 fn read_optional_secret_env(file_key: &str, value_key: &str) -> Result<Option<String>, String> {
-    if let Some(path) = non_empty_env(file_key) {
-        let value = std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read {file_key}: {e}"))?
-            .trim()
-            .to_string();
-        if value.is_empty() {
-            return Err(format!("{file_key} cannot be empty"));
-        }
-        return Ok(Some(value));
-    }
-
-    Ok(non_empty_env(value_key))
+    read_optional_non_empty_file_env(file_key, Some(value_key))
 }
 
 pub(crate) fn read_optional_secret_env_absent_empty(
@@ -1079,20 +1068,92 @@ pub(crate) fn read_optional_secret_env_absent_empty(
     value_key: &str,
 ) -> Result<Option<String>, String> {
     if let Some(path) = non_empty_env(file_key) {
-        let value = std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read {file_key}: {e}"))?
-            .trim()
-            .to_string();
+        let value = read_trimmed_file(file_key, &path)?;
         return Ok((!value.is_empty()).then_some(value));
     }
 
     Ok(non_empty_env(value_key))
 }
 
+fn read_trimmed_file(file_key: &str, path: &str) -> Result<String, String> {
+    std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read {file_key}: {e}"))
+        .map(|value| value.trim().to_string())
+}
+
+fn read_optional_non_empty_file_env(
+    file_key: &str,
+    fallback_key: Option<&str>,
+) -> Result<Option<String>, String> {
+    if let Some(path) = non_empty_env(file_key) {
+        let value = read_trimmed_file(file_key, &path)?;
+        if value.is_empty() {
+            return Err(format!("{file_key} cannot be empty"));
+        }
+        return Ok(Some(value));
+    }
+
+    Ok(fallback_key.and_then(non_empty_env))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn otlp_config_without_instance_file_preserves_existing_defaults() {
+        std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
+        std::env::remove_var("TELEMETRY_OTLP_ENDPOINT");
+        std::env::remove_var("TELEMETRY_OTLP_PROTOCOL");
+
+        let config = OtlpConfig::from_env().unwrap();
+
+        assert_eq!(config.endpoint, "http://localhost:4317");
+        assert_eq!(config.protocol, "grpc");
+        assert_eq!(config.instance_id, None);
+    }
+
+    #[test]
+    #[serial]
+    fn otlp_config_reads_and_trims_configured_instance_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), " vmm-instance-123 \n").unwrap();
+        std::env::set_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE", file.path());
+
+        let config = OtlpConfig::from_env().unwrap();
+
+        assert_eq!(config.instance_id.as_deref(), Some("vmm-instance-123"));
+        std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
+    }
+
+    #[test]
+    #[serial]
+    fn otlp_config_rejects_missing_configured_instance_file() {
+        std::env::set_var(
+            "TELEMETRY_SERVICE_INSTANCE_ID_FILE",
+            "/tmp/cloud-api-telemetry-instance-id-missing",
+        );
+
+        let error = OtlpConfig::from_env().unwrap_err();
+
+        assert!(error.contains("TELEMETRY_SERVICE_INSTANCE_ID_FILE"));
+        std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
+    }
+
+    #[test]
+    #[serial]
+    fn otlp_config_rejects_empty_configured_instance_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::env::set_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE", file.path());
+
+        let error = OtlpConfig::from_env().unwrap_err();
+
+        assert!(error.contains("TELEMETRY_SERVICE_INSTANCE_ID_FILE"));
+        assert!(error.contains("cannot be empty"));
+        std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
+    }
 
     #[test]
     fn reporting_database_timeout_leaves_headroom_for_http_response() {
@@ -1956,11 +2017,18 @@ impl ExternalProvidersConfig {
 pub struct OtlpConfig {
     pub endpoint: String,
     pub protocol: String,
+    pub instance_id: Option<String>,
 }
 
 impl OtlpConfig {
     pub fn from_env() -> Result<Self, String> {
-        Ok(Self::default())
+        let instance_id =
+            read_optional_non_empty_file_env("TELEMETRY_SERVICE_INSTANCE_ID_FILE", None)?;
+
+        Ok(Self {
+            instance_id,
+            ..Self::default()
+        })
     }
 }
 
@@ -1970,6 +2038,7 @@ impl Default for OtlpConfig {
             endpoint: env::var("TELEMETRY_OTLP_ENDPOINT")
                 .unwrap_or_else(|_| "http://localhost:4317".to_string()),
             protocol: env::var("TELEMETRY_OTLP_PROTOCOL").unwrap_or_else(|_| "grpc".to_string()),
+            instance_id: None,
         }
     }
 }

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -1100,10 +1100,41 @@ fn read_optional_non_empty_file_env(
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::ffi::OsString;
+
+    struct TelemetryEnvGuard {
+        values: [(&'static str, Option<OsString>); 3],
+    }
+
+    impl TelemetryEnvGuard {
+        fn new() -> Self {
+            const KEYS: [&str; 3] = [
+                "TELEMETRY_SERVICE_INSTANCE_ID_FILE",
+                "TELEMETRY_OTLP_ENDPOINT",
+                "TELEMETRY_OTLP_PROTOCOL",
+            ];
+
+            Self {
+                values: KEYS.map(|key| (key, std::env::var_os(key))),
+            }
+        }
+    }
+
+    impl Drop for TelemetryEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &mut self.values {
+                match value.take() {
+                    Some(value) => std::env::set_var(*key, value),
+                    None => std::env::remove_var(*key),
+                }
+            }
+        }
+    }
 
     #[test]
     #[serial]
     fn otlp_config_without_instance_file_preserves_existing_defaults() {
+        let _env = TelemetryEnvGuard::new();
         std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
         std::env::remove_var("TELEMETRY_OTLP_ENDPOINT");
         std::env::remove_var("TELEMETRY_OTLP_PROTOCOL");
@@ -1118,6 +1149,7 @@ mod tests {
     #[test]
     #[serial]
     fn otlp_config_reads_and_trims_configured_instance_file() {
+        let _env = TelemetryEnvGuard::new();
         let file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(file.path(), " vmm-instance-123 \n").unwrap();
         std::env::set_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE", file.path());
@@ -1125,34 +1157,59 @@ mod tests {
         let config = OtlpConfig::from_env().unwrap();
 
         assert_eq!(config.instance_id.as_deref(), Some("vmm-instance-123"));
-        std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
     }
 
     #[test]
     #[serial]
     fn otlp_config_rejects_missing_configured_instance_file() {
-        std::env::set_var(
-            "TELEMETRY_SERVICE_INSTANCE_ID_FILE",
-            "/tmp/cloud-api-telemetry-instance-id-missing",
-        );
+        let _env = TelemetryEnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let missing_path = dir.path().join("missing");
+        assert!(!missing_path.exists());
+        std::env::set_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE", &missing_path);
 
         let error = OtlpConfig::from_env().unwrap_err();
 
         assert!(error.contains("TELEMETRY_SERVICE_INSTANCE_ID_FILE"));
-        std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
     }
 
     #[test]
     #[serial]
-    fn otlp_config_rejects_empty_configured_instance_file() {
+    fn otlp_config_rejects_whitespace_only_configured_instance_file() {
+        let _env = TelemetryEnvGuard::new();
         let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "   \n\t").unwrap();
         std::env::set_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE", file.path());
 
         let error = OtlpConfig::from_env().unwrap_err();
 
         assert!(error.contains("TELEMETRY_SERVICE_INSTANCE_ID_FILE"));
         assert!(error.contains("cannot be empty"));
-        std::env::remove_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE");
+    }
+
+    #[test]
+    #[serial]
+    fn otlp_config_env_guard_restores_values_after_panic() {
+        let original = [
+            std::env::var_os("TELEMETRY_SERVICE_INSTANCE_ID_FILE"),
+            std::env::var_os("TELEMETRY_OTLP_ENDPOINT"),
+            std::env::var_os("TELEMETRY_OTLP_PROTOCOL"),
+        ];
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _env = TelemetryEnvGuard::new();
+            std::env::set_var("TELEMETRY_SERVICE_INSTANCE_ID_FILE", "temporary");
+            std::env::set_var("TELEMETRY_OTLP_ENDPOINT", "temporary-endpoint");
+            std::env::set_var("TELEMETRY_OTLP_PROTOCOL", "temporary-protocol");
+            panic!("simulate a test panic");
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::env::var_os("TELEMETRY_SERVICE_INSTANCE_ID_FILE"),
+            original[0]
+        );
+        assert_eq!(std::env::var_os("TELEMETRY_OTLP_ENDPOINT"), original[1]);
+        assert_eq!(std::env::var_os("TELEMETRY_OTLP_PROTOCOL"), original[2]);
     }
 
     #[test]

--- a/env.example
+++ b/env.example
@@ -240,6 +240,10 @@ ENVIRONMENT=local
 # OTLP endpoint for sending metrics (points to Datadog agent in docker-compose)
 # TELEMETRY_OTLP_ENDPOINT=http://datadog-agent:4317
 # TELEMETRY_OTLP_PROTOCOL=grpc
+# Optional stable producer identity. In deployed CVMs, point this at the
+# read-only staged VMM instance-id file; a configured file must be readable and
+# contain a non-empty value after trimming.
+# TELEMETRY_SERVICE_INSTANCE_ID_FILE=/run/cloud-api-identity/instance_id
 
 
 BRAVE_SEARCH_PRO_API_KEY=MY_KEY


### PR DESCRIPTION
## Outcome

Cloud API can emit a stable per-CVM OpenTelemetry `service.instance.id` from a file provisioned by deployment configuration. This is the application-side prerequisite for keeping cumulative counters from different replicas separate in Prometheus.

This PR is ready for code review, but it is **not effective in production by itself**. It requires an immutable Cloud API image release plus the companion Ansible rollout that provisions and mounts the identity file.

## Problem and RCA

Cloud API replicas currently do not have a deployment-owned stable identity in their OpenTelemetry resource. When otherwise-identical replicas export cumulative counters into the self-hosted pipeline, the downstream configuration cannot reliably keep those producers separate. A restart-scoped or synthesized identity is insufficient: it changes across restarts and can still create reset/out-of-order behavior.

The stable identity already exists at the CVM boundary. The application needs a narrow, explicit way to read that value without gaining access to the credential-bearing shared volume.

## Changes

- Add optional `TELEMETRY_SERVICE_INSTANCE_ID_FILE` configuration.
- Read the configured file once during configuration load, trim whitespace, and require a nonempty value.
- Fail startup deterministically for a configured missing, unreadable, invalid-UTF-8, empty, or whitespace-only file.
- Add only the validated value as OpenTelemetry `service.instance.id`.
- Preserve existing local/development behavior when the setting is unset.
- Keep telemetry resource construction in a focused module and document the setting in `env.example`.
- Add focused configuration/resource coverage without introducing a hostname, PID, random UUID, timestamp, or other fallback identity.
- Isolate telemetry environment tests with panic-safe restoration, use a guaranteed-unique missing-file path, and cover a whitespace-only identity file explicitly.

## Validation

Original implementation review: `4982b5a9ab74b4394a13b9f2e45b9dac292286af`. Test-isolation follow-up: `4d8bfc008e3b5b5e8dca250aa7f57d84c9170b81`. Both are directly on `main@5bb0f4b947368f3c0079021878ce55983285a40a`; replacement CI runs at the current head.

Passed at that commit:

- `cargo fmt --all -- --check`
- `cargo test -p config`: 50 passed
- `cargo test -p api --lib`: 255 passed, 2 intentionally ignored
- `cargo test -p api --bin api`: 2 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Ten consecutive focused identity-test runs
- Focused regression coverage for panic-safe environment restoration, whitespace-only rejection, and a guaranteed-uncreated missing path
- `git diff --check`

Manual boundary QA used the production resource constructor and tonic metric exporter against a disposable loopback OTLP gRPC receiver. The decoded resource contained exactly `service.instance.id=qa-vmm-instance-456` and one metric scope. Real binary starts with configured missing and empty files exited before service/database startup with the expected contextual errors; the unset setting passed configuration and continued to normal database discovery.

## Rollout

1. Merge after the required T2 human review and green CI.
2. Build and approve an immutable Cloud API image; do not deploy an unreviewed `main` image.
3. Land and revalidate companion Ansible PR #480 after its blocking monitoring PRs. #480 must provision the env var and identity file atomically: `api-init` stages the trimmed ID into the isolated `cloud-api-identity` volume, the Cloud API container mounts that volume read-only, and Cloud API waits for `api-init` to complete successfully.
4. Deploy that exact image and #480 contract to Cloud API staging together. Never set `TELEMETRY_SERVICE_INSTANCE_ID_FILE` before the staged read-only file exists; the application intentionally fails closed when a configured file is missing or blank.
5. Verify two staging replicas produce distinct `cloud_api_instance` series with no normal out-of-order rejections, then soak and roll production through the normal deployment workflow.

Until steps 2-5 happen, this code has no production effect.

## Rollback and risk

- If the setting is unset, behavior is unchanged.
- A configured invalid identity intentionally fails closed before startup; rollback by restoring the prior image or removing the setting and identity mount together.
- Do not replace the file value with a restart-scoped/generated fallback.
- No database, public API, auth, attestation, or customer-data behavior changes.

## Dependencies and cutover gate

- Companion deployment work: [nearai/cvm-ansible-playbooks#480](https://github.com/nearai/cvm-ansible-playbooks/pull/480).
- This PR does not deploy anything and does not authorize a Datadog shutdown.
- Datadog paging must remain active until the complete Grafana pipeline is deployed, notification delivery is proven, and the parallel-soak cutover gates pass.

## Tier

- [x] T2 - Prod-affecting application behavior
- [ ] T3 - Boundary / irreversible